### PR TITLE
feat(scripts): Confluence 로부터 문서 저장, 변환하는 프로그램 추가

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -75,6 +75,44 @@ python generate_ko_contents.py \
   --output_dir src/content/ko
 ```
 
+## pages_of_confluence.py
+
+`pages_of_confluence.py`는 Confluence 공간에서 지정된 문서의 모든 하위 페이지 목록을 생성하는 스크립트입니다. 이 스크립트는 다음과 같은 기능을 수행합니다:
+
+- 각 페이지의 ID, 탐색 경로(breadcrumbs), 제목을 탭으로 구분된 형식으로 출력합니다.
+- 기본적으로 각 페이지 ID에 대한 디렉토리를 생성하고 다음 파일을 저장합니다:
+  - XHTML 형식의 문서 내용 (page.xhtml)
+  - Markdown 형식의 문서 내용 (page.md)
+  - 첨부 파일(있는 경우)
+
+실행 방법:
+```bash
+# 기본 설정으로 실행
+python pages_of_confluence.py
+
+# 특정 페이지 ID와 공간 키 지정
+python pages_of_confluence.py --page-id 123456789 --space-key DOCS
+
+# 인증 정보 지정
+python pages_of_confluence.py --email user@example.com --api-token your-api-token
+
+# 목록만 출력하고 파일 다운로드 없음
+python pages_of_confluence.py --list-only
+```
+
+## confluence_xhtml_to_markdown.py
+
+`confluence_xhtml_to_markdown.py`는 Confluence XHTML 내보내기를 깔끔한 Markdown으로 변환하는 스크립트입니다. 이 스크립트는 다음과 같은 특수 케이스를 처리합니다:
+
+- 코드 블록의 CDATA 섹션
+- colspan 및 rowspan 속성이 있는 테이블
+- 구조화된 매크로 및 기타 Confluence 특정 요소
+
+실행 방법:
+```bash
+python confluence_xhtml_to_markdown.py input_file.xhtml output_file.md
+```
+
 ## 가상환경 비활성화
 
 작업이 끝난 후 가상환경을 비활성화하려면 아래 명령어를 입력하세요.

--- a/scripts/confluence_xhtml_to_markdown.py
+++ b/scripts/confluence_xhtml_to_markdown.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""
+Confluence XHTML to Markdown Converter
+
+This script converts Confluence XHTML export to clean Markdown,
+handling special cases like:
+- CDATA sections in code blocks
+- Tables with colspan and rowspan attributes
+- Structured macros and other Confluence-specific elements
+"""
+
+import re
+import sys
+import html
+import xml.etree.ElementTree as ET
+from html.parser import HTMLParser
+import argparse
+from bs4 import BeautifulSoup, Tag, NavigableString
+import logging
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+class ConfluenceToMarkdown:
+    def __init__(self):
+        self.in_table = False
+        self.table_data = []
+        self.current_row = []
+        self.rowspan_tracker = {}
+        self.colspan_tracker = {}
+        self.current_table_row = 0
+        self.is_header_row = False
+        self.markdown_lines = []
+        self.list_stack = []
+        self.inside_code_block = False
+        self.code_language = ""
+        
+    def convert(self, html_content):
+        # Replace XML namespace prefixes
+        html_content = re.sub(r'\sac:', ' ', html_content)
+        
+        # Parse HTML with BeautifulSoup
+        soup = BeautifulSoup(html_content, 'html.parser')
+        
+        # Start conversion
+        self.process_node(soup)
+        
+        # Join all markdown lines and return
+        return "\n".join(self.markdown_lines)
+    
+    def process_node(self, node):
+        if isinstance(node, NavigableString):
+            text = node.strip()
+            if text and not self.inside_code_block:
+                if self.in_table:
+                    # Only add text to current cell if we're in a table
+                    if self.current_row:
+                        if isinstance(self.current_row[-1], str):
+                            self.current_row[-1] += text
+                        else:
+                            self.current_row.append(text)
+                else:
+                    self.markdown_lines.append(text)
+            elif self.inside_code_block:
+                # For code blocks, preserve original text including whitespace
+                self.markdown_lines.append(str(node))
+            return
+            
+        if node.name == 'h1':
+            self.markdown_lines.append(f"# {self.get_text(node)}")
+        elif node.name == 'h2':
+            self.markdown_lines.append(f"## {self.get_text(node)}")
+        elif node.name == 'h3':
+            self.markdown_lines.append(f"### {self.get_text(node)}")
+        elif node.name == 'h4':
+            self.markdown_lines.append(f"#### {self.get_text(node)}")
+        elif node.name == 'h5':
+            self.markdown_lines.append(f"##### {self.get_text(node)}")
+        elif node.name == 'h6':
+            self.markdown_lines.append(f"###### {self.get_text(node)}")
+        elif node.name == 'p':
+            text = self.get_text(node)
+            if text:
+                self.markdown_lines.append(text)
+                self.markdown_lines.append("")  # Add an empty line after paragraphs
+        elif node.name == 'strong' or node.name == 'b':
+            text = self.get_text(node)
+            self.markdown_lines.append(f"**{text}**")
+        elif node.name == 'em' or node.name == 'i':
+            text = self.get_text(node)
+            self.markdown_lines.append(f"*{text}*")
+        elif node.name == 'a':
+            href = node.get('href', '#')
+            text = self.get_text(node)
+            self.markdown_lines.append(f"[{text}]({href})")
+        elif node.name == 'ul':
+            self.list_stack.append('ul')
+            for child in node.children:
+                if child.name == 'li':
+                    self.process_list_item(child, 'ul')
+            self.list_stack.pop()
+            self.markdown_lines.append("")  # Add empty line after list
+        elif node.name == 'ol':
+            self.list_stack.append('ol')
+            counter = 1
+            for child in node.children:
+                if child.name == 'li':
+                    self.process_list_item(child, 'ol', counter)
+                    counter += 1
+            self.list_stack.pop()
+            self.markdown_lines.append("")  # Add empty line after list
+        elif node.name == 'table':
+            self.process_table(node)
+        elif node.name == 'code' or node.name == 'pre':
+            self.process_code(node)
+        elif node.name == 'structured-macro' and node.get('name') == 'code':
+            self.process_code_macro(node)
+        elif node.name == 'div' or node.name == 'span':
+            # Process children of div/span elements
+            for child in node.children:
+                self.process_node(child)
+        elif node.name == 'br':
+            self.markdown_lines.append("\n")
+        elif node.name == 'hr':
+            self.markdown_lines.append("---")
+            self.markdown_lines.append("")
+        elif node.name == 'img':
+            alt = node.get('alt', '')
+            src = node.get('src', '')
+            self.markdown_lines.append(f"![{alt}]({src})")
+        elif node.name == 'tr' or node.name == 'td' or node.name == 'th':
+            # These are handled in the process_table method
+            pass
+        elif node.name == 'body' or node.name == 'html' or node.name == None:
+            # Just process children
+            for child in node.children:
+                self.process_node(child)
+        else:
+            # Default behavior for other tags: process children
+            for child in node.children:
+                self.process_node(child)
+    
+    def get_text(self, node):
+        if isinstance(node, NavigableString):
+            return str(node)
+        
+        if hasattr(node, 'get_text'):
+            return node.get_text()
+        
+        text = ""
+        for child in node.children:
+            if isinstance(child, NavigableString):
+                text += str(child)
+            elif hasattr(child, 'get_text'):
+                text += child.get_text()
+        
+        return text.strip()
+    
+    def process_list_item(self, node, list_type, counter=None):
+        indent = "  " * (len(self.list_stack) - 1)
+        if list_type == 'ul':
+            prefix = f"{indent}* "
+        else:
+            prefix = f"{indent}{counter}. "
+        
+        text = self.get_text(node)
+        self.markdown_lines.append(f"{prefix}{text}")
+        
+        # Handle nested lists
+        for child in node.children:
+            if child.name == 'ul' or child.name == 'ol':
+                self.list_stack.append(child.name)
+                new_counter = 1
+                for subchild in child.children:
+                    if subchild.name == 'li':
+                        self.process_list_item(subchild, child.name, new_counter)
+                        if child.name == 'ol':
+                            new_counter += 1
+                self.list_stack.pop()
+    
+    def process_table(self, table_node):
+        self.in_table = True
+        self.table_data = []
+        self.current_table_row = 0
+        self.rowspan_tracker = {}
+        
+        # Process all rows
+        rows = table_node.find_all(['tr'])
+        
+        for row_idx, row in enumerate(rows):
+            self.current_row = []
+            cells = row.find_all(['th', 'td'])
+            
+            # Apply rowspan from previous rows
+            col_idx = 0
+            for tracked_col, (span_left, content) in sorted(self.rowspan_tracker.items()):
+                if span_left > 0:
+                    # Insert content from cells spanning from previous rows
+                    self.current_row.append(content)
+                    # Decrement the remaining rowspan
+                    self.rowspan_tracker[tracked_col] = (span_left - 1, content)
+                    col_idx += 1
+            
+            # Process current row cells
+            for cell_idx, cell in enumerate(cells):
+                colspan = int(cell.get('colspan', 1))
+                rowspan = int(cell.get('rowspan', 1))
+                
+                cell_content = self.get_text(cell)
+                
+                # Add cell content to current row
+                self.current_row.append(cell_content)
+                
+                # Handle colspan by adding empty cells
+                for _ in range(1, colspan):
+                    self.current_row.append("")
+                
+                # Track cells with rowspan > 1 for next rows
+                if rowspan > 1:
+                    self.rowspan_tracker[col_idx + cell_idx] = (rowspan - 1, cell_content)
+            
+            # Add the row to table data
+            self.table_data.append(self.current_row)
+            
+            # Check if it's a header row (contains th elements)
+            if row.find('th') and row_idx == 0:
+                self.is_header_row = True
+        
+        # Convert table data to markdown
+        markdown_table = self.table_data_to_markdown()
+        self.markdown_lines.append(markdown_table)
+        self.markdown_lines.append("")  # Add empty line after table
+        self.in_table = False
+    
+    def table_data_to_markdown(self):
+        if not self.table_data or not any(self.table_data):
+            return ""
+        
+        # Determine the number of columns based on the row with the most cells
+        num_cols = max(len(row) for row in self.table_data)
+        
+        # Ensure all rows have the same number of columns
+        normalized_data = []
+        for row in self.table_data:
+            normalized_row = row + [""] * (num_cols - len(row))
+            normalized_data.append(normalized_row)
+        
+        # Calculate the maximum width of each column
+        col_widths = [0] * num_cols
+        for row in normalized_data:
+            for i, cell in enumerate(row):
+                col_widths[i] = max(col_widths[i], len(str(cell)))
+        
+        # Build the markdown table
+        md_table = []
+        
+        # Header row
+        header_row = "| " + " | ".join(str(cell).ljust(col_widths[i]) for i, cell in enumerate(normalized_data[0])) + " |"
+        md_table.append(header_row)
+        
+        # Separator row
+        separator = "| " + " | ".join("-" * col_widths[i] for i in range(num_cols)) + " |"
+        md_table.append(separator)
+        
+        # Data rows
+        for row in normalized_data[1:]:
+            data_row = "| " + " | ".join(str(cell).ljust(col_widths[i]) for i, cell in enumerate(row)) + " |"
+            md_table.append(data_row)
+        
+        return "\n".join(md_table)
+    
+    def process_code(self, node):
+        self.inside_code_block = True
+        
+        # Try to determine the language
+        language = node.get('class', '')
+        if language and isinstance(language, str) and language.startswith('language-'):
+            language = language.split('-')[1]
+        else:
+            language = ""
+        
+        code_content = node.get_text()
+        
+        # Start the code block
+        self.markdown_lines.append(f"```{language}")
+        self.markdown_lines.append(code_content)
+        self.markdown_lines.append("```")
+        self.markdown_lines.append("")  # Add empty line after code block
+        
+        self.inside_code_block = False
+    
+    def process_code_macro(self, macro_node):
+        self.inside_code_block = True
+        
+        # Find language parameter and code content
+        language = ""
+        code_content = ""
+        
+        # Look for language parameter
+        language_param = macro_node.find('parameter', {'name': 'language'})
+        if language_param:
+            language = language_param.get_text()
+        
+        # Look for code content in CDATA section
+        plain_text_body = macro_node.find('plain-text-body')
+        if plain_text_body:
+            # Extract CDATA content
+            cdata_match = re.search(r'<!\[CDATA\[(.*?)\]\]>', str(plain_text_body), re.DOTALL)
+            if cdata_match:
+                code_content = cdata_match.group(1)
+        
+        # Write the code block
+        self.markdown_lines.append(f"```{language}")
+        self.markdown_lines.append(code_content)
+        self.markdown_lines.append("```")
+        self.markdown_lines.append("")  # Add empty line after code block
+        
+        self.inside_code_block = False
+
+def main():
+    parser = argparse.ArgumentParser(description='Convert Confluence XHTML to Markdown')
+    parser.add_argument('input_file', help='Input XHTML file path')
+    parser.add_argument('output_file', help='Output Markdown file path')
+    args = parser.parse_args()
+    
+    try:
+        with open(args.input_file, 'r', encoding='utf-8') as f:
+            html_content = f.read()
+        
+        converter = ConfluenceToMarkdown()
+        markdown_content = converter.convert(html_content)
+        
+        with open(args.output_file, 'w', encoding='utf-8') as f:
+            f.write(markdown_content)
+        
+        logging.info(f"Successfully converted {args.input_file} to {args.output_file}")
+    
+    except Exception as e:
+        logging.error(f"Error during conversion: {e}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pages_of_confluence.py
+++ b/scripts/pages_of_confluence.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+Confluence Page Tree Generator
+
+This script generates a list of all subpages from a specified document in a Confluence space.
+Output format: page_id \t breadcrumbs \t title
+
+By default, the script also creates a directory for each page_id and saves:
+- The document content in XHTML format as page.xhtml
+- The document content in Markdown format as page.md
+- All attachments, if any
+
+Usage examples:
+  python pages_of_confluence.py
+  python pages_of_confluence.py --page-id 123456789 --space-key DOCS
+  python pages_of_confluence.py --email user@example.com --api-token your-api-token
+  python pages_of_confluence.py --list-only  # Only output the list without downloading files
+"""
+
+import requests
+from requests.auth import HTTPBasicAuth
+import sys
+import os
+import io
+import argparse
+import traceback
+
+# User configuration
+BASE_URL = "https://querypie.atlassian.net/wiki"
+SPACE_KEY = "QM"
+DEFAULT_START_PAGE_ID = "608501837"  # Root Page ID for "QueryPie Docs"
+EMAIL = "your-email@example.com"
+API_TOKEN = "your-api-token"
+
+# Parse command line arguments
+parser = argparse.ArgumentParser(description="Generate a list of all subpages from a specified Confluence document")
+parser.add_argument("--page-id", default=DEFAULT_START_PAGE_ID, help="ID of the starting page (default: %(default)s)")
+parser.add_argument("--space-key", default=SPACE_KEY, help="Confluence space key (default: %(default)s)")
+parser.add_argument("--base-url", default=BASE_URL, help="Confluence base URL (default: %(default)s)")
+parser.add_argument("--email", default=EMAIL, help="Confluence email for authentication")
+parser.add_argument("--api-token", default=API_TOKEN, help="Confluence API token for authentication")
+parser.add_argument("--list-only", action="store_true", help="Only output the list of pages without downloading content or attachments")
+args = parser.parse_args()
+
+# Set up authentication
+auth = HTTPBasicAuth(args.email, args.api_token)
+headers = {
+    "Accept": "application/json"
+}
+
+# Function to save content to a file
+def save_to_file(directory, filename, content):
+    try:
+        filepath = os.path.join(directory, filename)
+        with open(filepath, 'w', encoding='utf-8') as f:
+            f.write(content)
+        return True
+    except Exception as e:
+        print(f"Error saving file {filepath}: {str(e)}", file=sys.stderr)
+        return False
+
+# Function to download and save attachments
+def download_attachments(page_id, directory):
+    try:
+        # Get attachments list
+        attachment_url = f"{args.base_url}/rest/api/content/{page_id}/child/attachment"
+        response = requests.get(attachment_url, headers=headers, auth=auth)
+        response.raise_for_status()
+        attachments = response.json().get("results", [])
+        
+        for attachment in attachments:
+            try:
+                attachment_id = attachment["id"]
+                filename = attachment["title"]
+                download_url = f"{args.base_url}/rest/api/content/{page_id}/child/attachment/{attachment_id}/download"
+                
+                # Download attachment
+                download_response = requests.get(download_url, headers={"Accept": "*/*"}, auth=auth)
+                download_response.raise_for_status()
+                
+                # Save attachment
+                filepath = os.path.join(directory, filename)
+                with open(filepath, 'wb') as f:
+                    f.write(download_response.content)
+                
+                print(f"Saved attachment: {filename}", file=sys.stderr)
+            except Exception as e:
+                print(f"Error downloading attachment {attachment.get('title', 'unknown')}: {str(e)}", file=sys.stderr)
+                # Continue with next attachment
+        
+        return True
+    except Exception as e:
+        print(f"Error processing attachments for page ID {page_id}: {str(e)}", file=sys.stderr)
+        return False
+
+# Recursive function to track navigation path
+def fetch_page_tree(page_id):
+    try:
+        # Get page details with expanded content
+        # Only fetch body content if not in list-only mode
+        expand_params = "title,ancestors"
+        if not args.list_only:
+            expand_params += ",body.storage,body.view"
+        
+        url = f"{args.base_url}/rest/api/content/{page_id}?expand={expand_params}"
+        response = requests.get(url, headers=headers, auth=auth)
+        response.raise_for_status()
+        data = response.json()
+        
+        title = data["title"]
+        ancestors = data.get("ancestors", [])
+        path = [a["title"] for a in ancestors if a["type"] == "page"] + [title]
+        breadcrumbs = " > ".join(path)
+        
+        # Skip file operations if list-only mode is enabled
+        if not args.list_only:
+            # Create directory for the page
+            directory = os.path.join(os.getcwd(), page_id)
+            try:
+                if not os.path.exists(directory):
+                    os.makedirs(directory)
+            except Exception as e:
+                print(f"Error creating directory for page ID {page_id}: {str(e)}", file=sys.stderr)
+                # Continue processing even if directory creation fails
+            
+            # Save page content in XHTML format
+            try:
+                xhtml_content = data.get("body", {}).get("storage", {}).get("value", "")
+                save_to_file(directory, "page.xhtml", xhtml_content)
+            except Exception as e:
+                print(f"Error saving XHTML content for page ID {page_id}: {str(e)}", file=sys.stderr)
+            
+            # Get and save page content in Markdown format
+            try:
+                # Use the Confluence API to get content in Markdown format
+                view_content = data.get("body", {}).get("view", {}).get("value", "")
+                
+                # For simplicity, we're using the view content as a basic approximation
+                # A more accurate conversion would require a proper HTML to Markdown converter
+                save_to_file(directory, "page.md", view_content)
+            except Exception as e:
+                print(f"Error saving Markdown content for page ID {page_id}: {str(e)}", file=sys.stderr)
+            
+            # Download and save attachments
+            download_attachments(page_id, directory)
+
+        yield {
+            "id": page_id,
+            "breadcrumbs": breadcrumbs,
+            "title": title
+        }
+
+        # Explore child pages
+        child_url = f"{args.base_url}/rest/api/content/{page_id}/child/page?limit=100"
+        child_response = requests.get(child_url, headers=headers, auth=auth)
+        child_response.raise_for_status()
+        child_data = child_response.json()
+
+        for child in child_data.get("results", []):
+            child_id = child["id"]
+            yield from fetch_page_tree(child_id)
+    except Exception as e:
+        print(f"Error processing page ID {page_id}: {str(e)}", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
+        # Continue with next pages
+
+# Output to stdout in tab-separated format
+try:
+    for page in fetch_page_tree(args.page_id):
+        print(f"{page['id']}\t{page['breadcrumbs']}\t{page['title']}")
+except Exception as e:
+    print(f"Fatal error: {str(e)}", file=sys.stderr)
+    traceback.print_exc(file=sys.stderr)
+    sys.exit(1)
+


### PR DESCRIPTION
## Description
- scripts/pages_of_confluence.py 를 추가합니다.
  - 지정한 문서의 하위 문서를 탐색하여 목록으로 만들어 줍니다.
  - 문서를 confluence xhtml 포맷으로 저장해 줍니다.
  - 첨부파일을 모두 내려 받아 저장합니다.
- scripts/confluence_xhtml_to_markdown.py 를 추가합니다.
  - confluence xhtml 을 markdown 으로 변환합니다.
  - @Brant 가 구현한 python code 를 그대로 옮겨왔습니다.

## Additional notes
- 
