### PR TITLE
feat(scripts): convert_xhtml_to_md.sh

### DIFF
--- a/scripts/convert_xhtml_to_md.sh
+++ b/scripts/convert_xhtml_to_md.sh
@@ -41,7 +41,7 @@ if ! check_python_package bs4; then
 fi
 
 # Check if the list file path is provided
-if [ $# -lt 1 ]; then
+if [[ $# -lt 1 ]]; then
     echo "Usage: $0 <list_file_path>"
     echo "Example: $0 docs/latest-ko-confluence/list.txt"
     exit 1
@@ -108,7 +108,7 @@ while IFS=$'\t' read -r page_id rest; do
     python3 "$CONVERTER_SCRIPT" "$XHTML_FILE" "$MD_FILE"
     
     # Check if conversion was successful
-    if [ $? -eq 0 ]; then
+    if [[ $? -eq 0 ]]; then
         echo "Successfully converted page_id $page_id"
         CONVERTED_COUNT=$((CONVERTED_COUNT + 1))
     else


### PR DESCRIPTION
## Description
- convert_xhtml_to_md.sh
  - Confluence 문서를 저장한 page.xhtml 을 page.md 로 변환하는 batch program 을 작성합니다.
  - bash shell script 이며, `confluence_xhtml_to_markdown.py` 를 이용해 page.xhtml 파일을 page.md 로 변환합니다.

## Additional notes
- venv 환경에서 실행하여야 합니다. 잘 작동합니다. 
