### PR TITLE
feat: { blah } 에 backquote 적용 규칙 개선

### DIFF
--- a/scripts/confluence_xhtml_to_markdown.py
+++ b/scripts/confluence_xhtml_to_markdown.py
@@ -182,7 +182,8 @@ class ConfluenceToMarkdown:
         """
         # Use regex to find all occurrences of text within curly braces
         # that contain 20 or fewer word characters
-        pattern = r'(\{\{?[\w\s\-]{1,20}\}\}?)'
+        # \u2026 is the ellipsis character, `...` which is often used in Confluence
+        pattern = r'(\{\{?[\w\s\-\|\u2026]{1,60}\}\}?)'
         if not re.search(pattern, text):
             return text
 

--- a/src/content/ko/querypie-manual/querypie-docs/administrator-manual/audit/general-logs/activity-logs.mdx
+++ b/src/content/ko/querypie-manual/querypie-docs/administrator-manual/audit/general-logs/activity-logs.mdx
@@ -1,0 +1,28 @@
+## Overview
+Activity logs에서는 관리자에 의하여 수행되는 리소스 등록 및 설정 변경 이력을 조회할 수 있습니다.
+
+## Activity Logs 조회하기
+Administrator &gt; Audit &gt; General &gt; Activity Logs
+
+1. Administrator > Audit > General > Activity Logs 메뉴로 접근합니다.
+2. 조회 기간 : 기본적으로 이번 달의 로그 목록이 최신 순으로 조회됩니다.조회 기간 변경을 위해서는 필터 패널을 열고, Action At 에서 조회 기준일을 변경하시기 바랍니다.
+  1. 조회 기간 변경을 위해서는 필터 패널을 열고, Action At 에서 조회 기준일을 변경하시기 바랍니다.
+3. Action Type : 리소스 변경 내용을 간략하게 확인할 수 있습니다. 형식은 다음과 같습니다.`{변경이 가해진 리소스 타입}` `{Created | Updated | Deleted…}` : 특정 리소스가 생성, 변경, 또는 삭제된 경우예: DB Connection Created, Server Updated, Kubernetes Policy Deleted`{변경이 가해진 리소스 타입}` `{수정이 매개된 리소스 타입}` `{Created | Updated | Deleted | Assigned | Unassigned…}` : 특정 리소스에 다른 리소스가 추가, 변경, 삭제, 할당, 또는 회수된 경우예: Server Group Server Added, Server Group Account Updated , Kubernetes Role Policy Unassigned특정 Action Type 으로 로그 목록을 필터링할 수 있습니다.
+  1. `{변경이 가해진 리소스 타입}` `{Created | Updated | Deleted…}` : 특정 리소스가 생성, 변경, 또는 삭제된 경우예: DB Connection Created, Server Updated, Kubernetes Policy Deleted
+    * 예: DB Connection Created, Server Updated, Kubernetes Policy Deleted
+  2. `{변경이 가해진 리소스 타입}` `{수정이 매개된 리소스 타입}` `{Created | Updated | Deleted | Assigned | Unassigned…}` : 특정 리소스에 다른 리소스가 추가, 변경, 삭제, 할당, 또는 회수된 경우예: Server Group Server Added, Server Group Account Updated , Kubernetes Role Policy Unassigned
+    * 예: Server Group Server Added, Server Group Account Updated , Kubernetes Role Policy Unassigned
+  3. 특정 Action Type 으로 로그 목록을 필터링할 수 있습니다.
+4. Target : Activity Logs에서, 관리자의 행위로 인해 변경이 가해진 리소스 타입의 이름을 확인할 수 있습니다.
+
+## Activity Logs 상세 내용 조회하기
+Administrator &gt; Audit &gt; General &gt; Activity Logs &gt; Activity Logs Details
+
+1. 목록의 한 행을 클릭하면 Drawer가 열리고, 상세 내용을 확인할 수 있습니다.
+2. Affected Data : 해당 행위에 의하여 변경된 데이터 내역을 표시합니다. 각 컬럼의 의미는 다음과 같습니다.Label : 데이터 컬럼명Before : 액션 이전의 값After : 액션 이후의 값
+  1. Label : 데이터 컬럼명
+  2. Before : 액션 이전의 값
+  3. After : 액션 이후의 값
+3. Related Logs : 해당 행위에 대해, 연쇄적으로 또는 동시에 발생한 로그를 표시합니다. 전후 로그를 모두 포함합니다.관리자가 직접 일으킨 행위 뿐만 아니라, 그에 따라 파생된 시스템의 자동 행위들을 확인할 수 있습니다.Related Logs에 표시된 행위 로그들은 각각 개별 로그로도 남아있습니다.
+  1. 관리자가 직접 일으킨 행위 뿐만 아니라, 그에 따라 파생된 시스템의 자동 행위들을 확인할 수 있습니다.
+  2. Related Logs에 표시된 행위 로그들은 각각 개별 로그로도 남아있습니다.

--- a/src/content/ko/querypie-manual/querypie-docs/administrator-manual/general/company-management/alerts.mdx
+++ b/src/content/ko/querypie-manual/querypie-docs/administrator-manual/general/company-management/alerts.mdx
@@ -1,0 +1,252 @@
+## Overview
+Alerts 페이지에서는 리소스 접근과 관련한 알림 기능을 제공합니다. 주요 이상 징후에 대한 트리거 조건을 미리 설정함으로써 정책 위반사항을 실시간으로 탐지할 수 있습니다. 잠재적인 보안 사고를 신속하게 식별하고 해결할 수 있으며, 사전 정의된 임계값을 초과하는 조회 또는 유출 등 민감한 정보를 보호할 수 있습니다.
+
+Administrator &gt; General &gt; Company Management &gt; Alerts
+
+이 문서에서는 다음과 같은 내용을 다룹니다.
+
+1
+3
+false
+default
+Overview
+list
+true
+## 지원하는 알림 유형
+공통 알림을 비롯하여 DB 접근에 특화된 알림과 시스템 접근에 특화된 알림을 지원합니다.
+
+서비스 별로 지원하는 알림 유형은 다음과 같습니다.
+
+| 서비스 구분        | 알림 타입명                    | 설명                               |
+| ------------- | ------------------------- | -------------------------------- |
+| SAC, DAC, KAC | New Request               | 새로운 결재 요청 등록 알림                  |
+| General       | Unusual Login Attempt     | IP 대역에 따른 사용자 로그인 행위 알림          |
+| DAC           | SQL Execution             | 정의된 조건에 해당하는 SQL 구문 실행 알림        |
+| DAC           | Prevented SQL Execution   | 권한 없는 구문 실행 알림                   |
+| DAC           | DB Connection Attempt     | DB 접속 성공 또는 실패 알림                |
+| DAC           | Sensitive Data Access     | 정의된 조건에 해당하는 민감데이터 조회 알림         |
+| DAC           | SQL Export                | 정의된 조건에 해당하는 SQL 내보내기 실행 알림      |
+| SAC           | Server Connection Attempt | 서버 접속 성공 또는 실패 알림                |
+| SAC           | Restricted Command        | 서버/서버 그룹별 차단된 명령어 실행 알림          |
+| SAC           | Specific Command          | 특정 명령어 실행 알림                     |
+| SAC           | File Transfer (SFTP)      | SFTP를 통한 파일 전송 실행 알림             |
+| KAC           | K8s API Request           | 쿠버네티스 API 요청 알림10.2.2 이후 버전에서 지원 |
+
+## 알림 생성하기
+Alerts 페이지 우상단 Create Alert 버튼을 클릭하여 새로운 알림을 생성합니다. OK 버튼을 클릭하여 알림 생성을 완료합니다.
+
+Administrator &gt; General &gt; Company Management &gt; Alerts &gt; Create Alert
+
+1. Name : 알림 이름
+2. Alert Type : 알림 유형을 선택합니다. 알림 유형별로 설정 가능한 조건이 상이합니다. 자세한 내용은 하단 문서를 참고해주세요.
+  1. 알림 유형별로 설정 가능한 조건이 상이합니다. 자세한 내용은 하단 문서를 참고해주세요.
+3. Message Template : 알림 메시지 템플릿을 설정합니다.Message Template Variable에서 지원하는 템플릿 변수를 활용하여 커스텀한 메시지를 작성할 수 있습니다.Message Template Variable은 Alert Type 별로 상이합니다.
+  1. Message Template Variable에서 지원하는 템플릿 변수를 활용하여 커스텀한 메시지를 작성할 수 있습니다.
+  2. Message Template Variable은 Alert Type 별로 상이합니다.
+4. Channel : 알림 발송 채널 Administrator > General > Channels 에 등록된 채널 중 하나를 선택합니다.채널에 대한 자세한 설명은 Channels 문서를 참고하세요.
+  1. Administrator > General > Channels 에 등록된 채널 중 하나를 선택합니다.
+  2. 채널에 대한 자세한 설명은 Channels 문서를 참고하세요.
+5. Send Test Message : 알림 테스트 메시지 발송선택한 채널로, 입력한 메시지 템플릿 내용을 테스트 메시지로 전송합니다.
+  1. 선택한 채널로, 입력한 메시지 템플릿 내용을 테스트 메시지로 전송합니다.
+
+### New Request
+새로운 결재 요청 등록 알림
+
+* Request Type : Workflow 요청 유형DB Access Request, SQL Request, SQL Export Request, Server Access Request, Access Role Request, Unmasking Request 중 택 일All Requests (*) : 모든 요청 타입에 대해 알림 발송
+  * DB Access Request, SQL Request, SQL Export Request, Server Access Request, Access Role Request, Unmasking Request 중 택 일
+  * All Requests (*) : 모든 요청 타입에 대해 알림 발송
+* Urgent Mode : 사후 승인 여부All : 모든 승인 요청 건에 알림 발송Urgent Mode Only : 사후 승인 요청 건만 알림 발송
+  * All : 모든 승인 요청 건에 알림 발송
+  * Urgent Mode Only : 사후 승인 요청 건만 알림 발송
+
+10.2.2 슬랙 메시지 템플릿 변경 사항
+
+* Slack > API 방식의 Channel로 전송되는 알림 메시지에서 `{{assignees}}` 에 대한 Slack 사용자 멘션이 지원됩니다.
+* Request Type 선택에 따라 지원되는 템플릿 변수가 상이합니다. 자세한 내용은 별도의 New Request > 요청 타입별 템플릿 변수 문서를 참고해주세요.
+
+10.2.8 슬랙 메시지 템플릿 변경 사항
+
+* Sensitive Data Access 이벤트에서 슬랙 메시지에 쿼리를 포함하여 전송하도록 개선되면서  `{{queryPreview}}` 변수가 추가되었습니다. 슬랙 특성상 3000자 이상의 메시지 발송 요청을 하면 에러 반환 없이 메시지 발송이 실패하므로 queryPreview를 통해 볼 수 있는 쿼리는 100자로 제한되어 있습니다.
+
+### Unusual Login Attempt
+IP 대역에 따른 사용자 로그인 행위 알림
+
+* Action Count : 알림 발송할 인증 실패 횟수2 이상 입력 가능합니다.
+  * 2 이상 입력 가능합니다.
+* Specific Time Interval (Minutes) : 알림 발송 기준 시간(분)1 이상 입력 가능합니다.
+  * 1 이상 입력 가능합니다.
+
+예) 비정상적인 로그인 시도시 알림 발송 - 5분간 QueryPie 로그인 실패 3회 누적시
+
+* Action Count : 3
+* Specific Time Internal (Minutes) : 5
+
+### SQL Execution
+정의된 조건에 해당하는 SQL 구문 실행 알림
+
+* Rows : 알림 발송 기준 행 수레코드 변경이 없는 SQL Event : 0 입력 시 정상 작동합니다.Create, Drop, Revoke, Truncate 등그 외 SQL Events : 1 이상 입력 시 정상 작동합니다.
+  * 레코드 변경이 없는 SQL Event : 0 입력 시 정상 작동합니다.Create, Drop, Revoke, Truncate 등
+    * Create, Drop, Revoke, Truncate 등
+  * 그 외 SQL Events : 1 이상 입력 시 정상 작동합니다.
+* Specific Time Interval (Minutes) : 알림 발송 기준 시간(분) (10.2.2 이후 버전)0 입력 시, 시간 조건 없이 단건의 SQL 실행을 기준으로 합니다.최대 1440까지 입력 가능합니다.
+  * 0 입력 시, 시간 조건 없이 단건의 SQL 실행을 기준으로 합니다.
+  * 최대 1440까지 입력 가능합니다.
+* SQL Events : 알림 발송할 SQL 쿼리 (다중 선택)
+* Connection : 쿼리 실행 시 알림 발송할 대상 커넥션 (10.2.2 이후 버전 - 다중 선택)All Connections (*) : 추후 추가될 모든 커넥션 대상으로 알림 조건 생성
+  * All Connections (*) : 추후 추가될 모든 커넥션 대상으로 알림 조건 생성
+
+예 1) 100건 이상의 대량 데이터 조회시 알림 발송
+
+* Rows : 100
+* SQL Events : SELECT
+
+예 2) 데이터 변경 및 삭제 시도시 알림 발송
+
+* Rows : 1
+* SQL Events : UPDATE, DELETE
+
+### Prevented SQL Execution
+권한 없는 구문 실행 알림
+
+* Connection : 쿼리 실행 시 알림 발송할 대상 커넥션 (10.2.2 이후 버전 - 다중 선택)All Connections (*) : 추후 추가될 모든 커넥션 대상으로 알림 조건 생성
+  * All Connections (*) : 추후 추가될 모든 커넥션 대상으로 알림 조건 생성
+
+### DB Connection Attempt
+DB 접속 성공 또는 실패 알림
+
+* Alert Trigger Condition : 알림 발송 조건 (복수 선택)Success : DB 접속 성공 시 알림 발송Failure : DB 접속 실패 시 알림 발송
+  * Success : DB 접속 성공 시 알림 발송
+  * Failure : DB 접속 실패 시 알림 발송
+* Connection Failure Trigger with Interval : 접속 실패 횟수/기간 알림 조건 설정Failure가 선택된 경우에만 활성화 가능합니다. 활성화 시 추가 입력 조건이 노출됩니다.Action Count : 횟수 기준1 이상 입력 가능합니다.Specific Time Interval (Minutes) : 기간 기준 (분)1 이상 입력 가능합니다.
+  * Failure가 선택된 경우에만 활성화 가능합니다. 활성화 시 추가 입력 조건이 노출됩니다.
+  * Action Count : 횟수 기준1 이상 입력 가능합니다.
+    * 1 이상 입력 가능합니다.
+  * Specific Time Interval (Minutes) : 기간 기준 (분)1 이상 입력 가능합니다.
+    * 1 이상 입력 가능합니다.
+* Connection : 쿼리 실행 시 알림 발송할 대상 커넥션 (10.2.2 이후 버전 - 다중 선택)All Connections (*) : 추후 추가될 모든 커넥션 대상으로 알림 조건 생성
+  * All Connections (*) : 추후 추가될 모든 커넥션 대상으로 알림 조건 생성
+
+예) 비정상적인 데이터베이스 접속 시도시 알림 발송 - 5분간 DB 접속 실패 3회 누적시
+
+* Alert Trigger Condition : Failure
+* Connection Failure Trigger with Internal : On
+* Action Count : 3
+* Specified Time Internal (Minutes) : 5
+
+### Sensitive Data Access
+정의된 조건에 해당하는 민감데이터 조회 알림
+
+* Criteria : 알림 발송 기준을 선택합니다.Sensitive Level : Sensitive Data Policy > Rule에 설정된 데이터별 민감 레벨 기준Low, Medium, High 중 택 일Policy : 특정 Sensitive Data Policy 기준등록된 Sensitive Data Policy 중 택 일
+  * Sensitive Level : Sensitive Data Policy > Rule에 설정된 데이터별 민감 레벨 기준Low, Medium, High 중 택 일
+    * Low, Medium, High 중 택 일
+  * Policy : 특정 Sensitive Data Policy 기준등록된 Sensitive Data Policy 중 택 일
+    * 등록된 Sensitive Data Policy 중 택 일
+* Rows : 알림 발송 기준 행 수 (10.2.2 이후 버전)1 이상 입력 가능합니다.
+  * 1 이상 입력 가능합니다.
+* Specific Time Interval (Minutes) : 알림 발송 기준 시간(분) (10.2.2 이후 버전)0 입력 시, 시간 조건 없이 단건의 SQL 실행을 기준으로 합니다.최대 1440까지 입력 가능합니다.
+  * 0 입력 시, 시간 조건 없이 단건의 SQL 실행을 기준으로 합니다.
+  * 최대 1440까지 입력 가능합니다.
+
+Sensitive Data Access 알림 타입 사용을 위해서는 민감 데이터 정책에 개인정보가 포함된 테이블 및 컬럼을 사전 정의해야 합니다. 자세한 내용은 Sensitive Data 문서를 참고해주세요.
+
+예1) 민감레벨 High 로 설정된 개인정보 데이터 조회시 알림 발송
+
+* Criteria : Sensitive Level
+* Sensitive Level : High
+
+예2) 특정 데이터베이스에 포함된 개인정보 데이터 조회시 알림 발송
+
+* Criteria : Policy
+* Policy : `{사전에 등록된 Sensitive Data 정책}`
+
+### SQL Export
+정의된 조건에 해당하는 SQL 내보내기 실행 알림
+
+* Rows : 알림 발송 기준 행 수1 이상 입력 가능합니다.
+  * 1 이상 입력 가능합니다.
+* Specific Time Interval (Minutes) : 알림 발송 기준 시간(분) (10.2.2 이후 버전)0 입력 시, 시간 조건 없이 단건의 SQL 내보내기를 기준으로 합니다.최대 1440까지 입력 가능합니다.
+  * 0 입력 시, 시간 조건 없이 단건의 SQL 내보내기를 기준으로 합니다.
+  * 최대 1440까지 입력 가능합니다.
+* Connection : SQL 내보내기 실행 시 알림 발송할 대상 커넥션 (10.2.2 이후 버전 - 다중 선택)All Connections (*) : 추후 추가될 모든 커넥션 대상으로 알림 조건 생성
+  * All Connections (*) : 추후 추가될 모든 커넥션 대상으로 알림 조건 생성
+
+예) 100건 이상의 대량 데이터 내보내기 시도시 알림 발송
+
+* Alert Type : SQL Export
+* Trigger Condition (Rows) : 100
+
+### Server Connection Attempt
+서버 접속 성공 또는 실패 알림
+
+* Alert Trigger Condition : 알림 발송 조건Success : DB 접속 성공 시 알림 발송Failure : DB 접속 실패 시 알림 발송
+  * Success : DB 접속 성공 시 알림 발송
+  * Failure : DB 접속 실패 시 알림 발송
+* Connection : 알림 발송할 대상 커넥션 (다중 선택)서버 및 서버 그룹 선택 가능하며, 중복 선택 가능다중 선택으로 인하여 대상이 중복 선택된 경우에도 알림은 1회만 발송All Connections (*) : 추후 추가될 모든 커넥션 대상으로 알림 조건 생성
+  * 서버 및 서버 그룹 선택 가능하며, 중복 선택 가능다중 선택으로 인하여 대상이 중복 선택된 경우에도 알림은 1회만 발송
+    * 다중 선택으로 인하여 대상이 중복 선택된 경우에도 알림은 1회만 발송
+  * All Connections (*) : 추후 추가될 모든 커넥션 대상으로 알림 조건 생성
+
+예) 사용자가 서버 접속을 시도했으나 실패할 경우에만 알림 발송
+
+* Alert Type : Server Connection Attempt
+* Alert Trigger Condition : Failure 에만 체크
+
+### Restrict Command
+서버/서버 그룹별 차단된 명령어 실행 알림
+
+* Connection : 알림 발송할 대상 커넥션 (다중 선택)서버 및 서버 그룹 선택 가능하며, 중복 선택 가능다중 선택으로 인하여 대상이 중복 선택된 경우에도 알림은 1회만 발송All Connections (*) : 추후 추가될 모든 커넥션 대상으로 알림 조건 생성
+  * 서버 및 서버 그룹 선택 가능하며, 중복 선택 가능다중 선택으로 인하여 대상이 중복 선택된 경우에도 알림은 1회만 발송
+    * 다중 선택으로 인하여 대상이 중복 선택된 경우에도 알림은 1회만 발송
+  * All Connections (*) : 추후 추가될 모든 커넥션 대상으로 알림 조건 생성
+
+### Specific Command
+특정 명령어 실행 알림
+
+* Connection : 알림 발송할 대상 커넥션 (다중 선택)서버 및 서버 그룹 선택 가능하며, 중복 선택 가능다중 선택으로 인하여 대상이 중복 선택된 경우에도 알림은 1회만 발송All Connections (*) : 추후 추가될 모든 커넥션 대상으로 알림 조건 생성
+  * 서버 및 서버 그룹 선택 가능하며, 중복 선택 가능다중 선택으로 인하여 대상이 중복 선택된 경우에도 알림은 1회만 발송
+    * 다중 선택으로 인하여 대상이 중복 선택된 경우에도 알림은 1회만 발송
+  * All Connections (*) : 추후 추가될 모든 커넥션 대상으로 알림 조건 생성
+* Command : 실행 시 알림 발송할 명령어 조건Keyword : 명령어에 입력된 키워드 포함시 알림 발송RegExr : 정규표현식에 해당하는 명령어 실행시 알림 발송
+  * Keyword : 명령어에 입력된 키워드 포함시 알림 발송
+  * RegExr : 정규표현식에 해당하는 명령어 실행시 알림 발송
+
+### File Transfer (SFTP)
+SFTP를 통한 파일 전송 실행 알림
+
+* Alert Trigger Condition : 알림 발송 조건 (다중 선택)FIle Upload : 파일 업로드 시 알림 발송File Download : 파일 다운로드 시 알림 발송
+  * FIle Upload : 파일 업로드 시 알림 발송
+  * File Download : 파일 다운로드 시 알림 발송
+* Connection : 알림 발송할 대상 커넥션 (다중 선택)서버 및 서버 그룹 선택 가능하며, 중복 선택 가능다중 선택으로 인하여 대상이 중복 선택된 경우에도 알림은 1회만 발송All Connections (*) : 추후 추가될 모든 커넥션 대상으로 알림 조건 생성
+  * 서버 및 서버 그룹 선택 가능하며, 중복 선택 가능다중 선택으로 인하여 대상이 중복 선택된 경우에도 알림은 1회만 발송
+    * 다중 선택으로 인하여 대상이 중복 선택된 경우에도 알림은 1회만 발송
+  * All Connections (*) : 추후 추가될 모든 커넥션 대상으로 알림 조건 생성
+
+### K8s API Request  10.2.2
+쿠버네티스 API 요청 알림
+
+* Result : API 요청 결과 (다중 선택)Success : 요청 성공 시 알림 발송Failure : 요청 실패 시 알림 발송
+  * Success : 요청 성공 시 알림 발송
+  * Failure : 요청 실패 시 알림 발송
+* Clusters : API 요청 알림 발송 대상 클러스터All Clusters (*) : 추후 추가될 모든 클러스터를 대상으로 알림 조건 생성
+  * All Clusters (*) : 추후 추가될 모든 클러스터를 대상으로 알림 조건 생성
+* Verbs : 알림 발송 대상 Verb현재 지원 대상 - create, update, patch, delete, deletecollection  (5종)
+  * 현재 지원 대상 - create, update, patch, delete, deletecollection  (5종)
+* Resource Kind : 알림 발송 대상 리소스 종류현재 지원 대상 - pods, pods/exec, pods/log, pods/portforward, services, ingresses, deployments, replicasets 등 (총 24종)All Resources (*) : 추후 추가될 모든 리소스 종류를 대상으로 알림 조건 생성
+  * 현재 지원 대상 - pods, pods/exec, pods/log, pods/portforward, services, ingresses, deployments, replicasets 등 (총 24종)
+  * All Resources (*) : 추후 추가될 모든 리소스 종류를 대상으로 알림 조건 생성
+
+## 알림 상세 정보 조회 및 수정
+Alerts 페이지에서 상세 내용을 조회하려는 알림을 선택합니다. 상세 페이지 Details 탭에서 알림 생성 시에 입력한 알림 조건 및 메시지를 조회하고 수정할 수 있습니다. 우상단 Save Changes 버튼을 클릭하면 수정 내용이 반영됩니다.
+
+Administrator &gt; General &gt; Company Management &gt; Alerts &gt; List Details (Details)
+
+## 알림 발송 내역 조회
+Alerts 목록에서 발송 내역을 조회하려는 알림을 선택합니다. 이후 상세 페이지 내 Log에서 내역을 조회할 수 있습니다.
+
+Administrator &gt; General &gt; Company Management &gt; Alerts &gt; List Details (Logs)
+
+## 알림 삭제하기
+기존에 등록된 알림을 삭제하는 두 가지 경로를 제공합니다.
+
+1. Alerts 페이지에서 삭제하기 : Alerts 목록 내 삭제하고자 하는 알림을 체크박스로 선택하면 Delete 버튼이 노출됩니다. 버튼을 클릭하면 확인 모달이 노출되며, OK 버튼을 클릭하여 삭제를 완료합니다.
+2. 알림 상세 페이지에서 삭제하기 : 삭제하고자 하는 알림의 상세 페이지 우상단 Delete 버튼을 클릭하면 확인 모달이 노출되며, OK 버튼을 클릭하여 삭제를 완료합니다.


### PR DESCRIPTION
## Description
- confluence_xhtml_to_markdown.py 개선
  - {, } 사이에 1개~60개 글자, 공백, -, \u2026 ...(ellipsis) 가 포함된 경우, backquote ` 로 감싸줍니다.
- 이 변경으로 `npm run build` 에 성공하는 문서를 추가합니다.

## Additional notes
다음의 절차를 통해, python code 변경과 markdown 문서 업데이트 작업을 수행합니다.
- python code 개선과 markdown 변환을 반복합니다.
  - `./scripts/confluence_xhtml_to_markdown.py` 를 변경합니다.
  - `./scripts/xhtml2markdown.sh` 를 실행합니다.
  - git diff 를 참조하여, 변경사항의 영향을 검토합니다.
- `./scripts/repeat_npm_run_build.sh` 를 실행하여, build 에 실패하는 문서를 삭제합니다.
- PR 을 생성합니다.