### PR TITLE
feat: xhtml 에서 숨겨진 문자를 먼저 삭제합니다.

### DIFF
--- a/scripts/confluence_xhtml_to_markdown.py
+++ b/scripts/confluence_xhtml_to_markdown.py
@@ -20,6 +20,11 @@ from bs4 import BeautifulSoup, Tag, NavigableString
 from bs4.element import CData
 import logging
 
+# Hidden characters constants
+ZWSP = '\u200b'  # Zero Width Space
+LRM = '\u200e'   # Left-to-Right Mark
+HANGUL_FILLER = '\u3164'  # Hangul Filler
+
 
 def backtick_curly_braces(text):
     """
@@ -383,6 +388,11 @@ class ConfluenceToMarkdown:
         # Replace XML namespace prefixes
         html_content = re.sub(r'\sac:', ' ', html_content)
         html_content = re.sub(r'\sri:', ' ', html_content)
+        
+        # Remove special characters before parsing
+        html_content = html_content.replace(ZWSP, '')
+        html_content = html_content.replace(LRM, '')
+        html_content = html_content.replace(HANGUL_FILLER, '')
         
         # Parse HTML with BeautifulSoup
         soup = BeautifulSoup(html_content, 'html.parser')

--- a/src/content/ko/administrator-manual/audit/database-logs/policy-audit-logs.mdx
+++ b/src/content/ko/administrator-manual/audit/database-logs/policy-audit-logs.mdx
@@ -9,6 +9,15 @@
 ## Policy Audit Logs에 기록되는 내용
 ### 목록 표시 항목
 * Action At : 행위 (이벤트 발생) 시점입니다.
+* Event Type : 기록되는 이벤트의 유형입니다. **[11.1.0]**
+    * Access Denied : Column 또는 Table Data Access 정책에 의해 접근이 차단된 이벤트
+    * Data Masked : Column Data Masking 정책에 의해 접근이 차단된 이벤트
+    * Alert Triggered : Sensitive Data Access Monitoring 정책에 의해 Alert 을 발생시킨 이벤트
+    * Justification Requirement Triggered : Table Access Justification Requirement 정책에 의해 사유입력 하도록 한 이벤트
+    * Approval Enforcement Triggered : DML Query Approval Enforcement 정책에 의해 결재 요구된 이벤트
+    * Exception Column Access : Column Data Access 정책이 걸려있는 대상에 접근하였으나 정책 예외에 의해 접근이 허용된 이벤트
+    * Exception Table Access : Table Data Access 정책이 걸려있는 대상에 접근하였으나 정책 예외에 의해 접근이 허용된 이벤트
+    * Exception Unmasking : Column Data Masking 정책이 걸려있는 대상에 접근하였으나 정책 예외에 의해 마스킹이 해제된 이벤트
 * Policy Type (정책 유형) : 정책 유형을 표시합니다.
 * Policy Name (정책 이름): 적용된 정책의 이름을 표시하고 링크를 누르면 해당 정책 페이지로 이동할 수 있습니다.
 * Name (사용자 이름): 데이터를 조회한 사용자의 이름입니다.

--- a/src/content/ko/administrator-manual/audit/database-logs/policy-exception-logs.mdx
+++ b/src/content/ko/administrator-manual/audit/database-logs/policy-exception-logs.mdx
@@ -1,0 +1,27 @@
+## Overview
+정책 예외 처리의 상태 변화를 기록하고 기능입니다. 정책 예외가 생성, 수정, 삭제, 만료, 활성화, 비활성화될 때마다 해당 이벤트를 로그로 기록하여 추적할 수 있습니다. 목록에서 행을 클릭하면 특정 정책 예외의 상세 내용을 볼 수 있습니다.
+
+<p align="center">
+<div>[image-20250725-132239.png]()</div>
+*Policy Exception Logs*
+</p>
+
+## Policy Exception Logs에 기록되는 내용
+* **Action At ** : Event가 발생한 시점
+* **Event Type**  : 이벤트의 유형별 구분입니다.
+    * **Created**  : Workflow 또는 관리자에 의해 정책 예외가 생성된 이벤트
+    * **Modified ** : 관리자에 의해 정책 예외가 수정된 이벤트
+    * **Deleted**  : 관리자가 특정 정책 예외를 수동으로 삭제한 이벤트
+    * **Expired**  : Workflow 또는 관리자가 지정한 만료기간이 도래하여 정책 예외가 만료된 이벤트
+    * **Activated**  : 관리자에 의해 특정 정책 예외가 활성화 상태가 된 이벤트
+    * **Deactivated**  : 관리자에 의해 특정 정책 예외가 비활성화(Inactive) 상태가 된 이벤트
+* **Exception Type**  : 현재 존재하는 정책예외는 Restricted Data Access, Unmasking 두가지 유형이 있습니다.
+* **Allowed Users**  : 정책 예외 대상 사용자 또는 그룹이 기록됩니다. 또한 관리자가 지정한 사용자의 속성 (Attribute of Users)이 기록됩니다.
+* **Description ** : 정잭 예외에 설정된 설명입니다.
+* **Excepted By**  : 정책 예외를 발생시킨 주체입니다.
+    * **Workflow**  : 정책 예외 요청 및 승인이 workflow를 통해 이뤄진 경우 workflow로 기록됩니다.
+    * **User(Admin)**  : 정책 예외가 관리자에 의해 수동으로 생성된 경우 사용자 Display Name이 표시됩니다.
+* **Start Time ** : 정책 예외의 시작 시점입니다.
+* **End Time**  : 정책 예외의 종료 시점입니다.
+* **Action By : ** 기존 정책 예외의 수정, 삭제, Active 또는 Inactive 로 상태 변경, 만료를 발생시킨 주체입니다. (만료 주체는 만료시점에 발생되므로 항상 System으로 기록됩니다.)
+* **Exception Name : ** workflow로 수행된 경우 workflow 제목이 표시됩니다. 관리자의 수동 정책 예외인 경우 Exception Name이 표시됩니다.

--- a/src/content/ko/administrator-manual/general/company-management.mdx
+++ b/src/content/ko/administrator-manual/general/company-management.mdx
@@ -7,7 +7,7 @@ Company Management는 쿼리파이 제품의 기본 보안 및 알림 설정 등
 </p>
 
 ## 메뉴 설명
-* [**General**](General​) ** : ** 쿼리파이의 기본 시스템 설정을 적용하는 메뉴입니다.
+* [**General**](General) ** : ** 쿼리파이의 기본 시스템 설정을 적용하는 메뉴입니다.
 * [**Security**](Security) : 쿼리파이의 보안 설정을 적용하는 메뉴입니다.
 * [**Allowed Zones**](Allowed Zones) ** ** : 쿼리파이의 허용 네트워크 존 설정을 구성하는 메뉴입니다.
 * [**Channels**](Channels) : 쿼리파이의 알림을 받을 채널을 구성하는 메뉴입니다.

--- a/src/content/ko/release-notes/980-9812.mdx
+++ b/src/content/ko/release-notes/980-9812.mdx
@@ -1,12 +1,12 @@
 ## QueryPie 9.8.12 Release
-&lt;Bug Fix & Enhancement&gt;
+Bug Fix & Enhancement
 
 * [External API] List of Access Approval API 에 id 항목 추가
 
 ---
 
 ## QueryPie 9.8.11 Release
-&lt;Bug Fix & Enhancement&gt;
+Bug Fix & Enhancement
 
 * [PostgreSQL] Insert 구문 실행 관련 오류 해결
 * [Performance] Hub 서버 CPU 증가 관련 이슈 해결
@@ -14,7 +14,7 @@
 ---
 
 ## QueryPie 9.8.10 Release
-&lt;Bug Fix & Enhancement&gt;
+Bug Fix & Enhancement
 
 * [External API] Proxies 관련 리소스 추가
 * [External API] Cloud Sync 후 프록시 옵션에 따라 자동 포트 할당 API 추가
@@ -25,7 +25,7 @@
 ---
 
 ## QueryPie 9.8.9 Release
-&lt;Bug Fix & Enhancement&gt;
+Bug Fix & Enhancement
 
 * Redshift 특정 쿼리 실행 시 연결 해제 현상 수정
 * Proxy 환경 내 timeout 현상 개선
@@ -39,7 +39,7 @@
 ---
 
 ## QueryPie 9.8.8 Release
-&lt;Bug Fix & Enhancement&gt;
+Bug Fix & Enhancement
 
 * Oracle Procedure 수행 관련 이슈 수정
 * OKTA SDK 버전 수정
@@ -47,14 +47,14 @@
 ---
 
 ## QueryPie 9.8.7 Release
-&lt;Bug Fix & Enhancement&gt;
+Bug Fix & Enhancement
 
 * 에이전트 로그인 후 넘어가지 않는 이슈 조치
 
 ---
 
 ## QueryPie 9.8.6 Release
-&lt;Bug Fix & Enhancement&gt;
+Bug Fix & Enhancement
 
 * LDAP OU 변경시 사용자 커넥션 권한 회수 처리
 * LDAP 연동 옵션에 Email Attribute 항목 추가
@@ -65,14 +65,14 @@
 ---
 
 ## QueryPie 9.8.5 Release
-&lt;Bug Fix & Enhancement&gt;
+Bug Fix & Enhancement
 
 * DocumentDB 관련 SSH 터널링 이슈 개선
 
 ---
 
 ## QueryPie 9.8.3-9.8.4 Release
-&lt;Bug Fix & Enhancement&gt;
+Bug Fix & Enhancement
 
 * SQL History 관련 기능 개선 (페이징 및 로딩 이슈 해결, 검색 기능 제외)
 * Audit admin 관리자에게 Reports 및 All Requests 메뉴 접근 권한 추가
@@ -81,7 +81,7 @@
 ---
 
 ## QueryPie 9.8.2 Release
-&lt;Bug Fix & Enhancement&gt;
+Bug Fix & Enhancement
 
 * Export 시도시 Zip 파일로 압축 및 PW 걸기 기능 추가
 * MongoDB Report (Beta) CSV 추출 결과 개선
@@ -99,7 +99,7 @@
 ---
 
 ## QueryPie 9.8.1 Release
-&lt;Bug Fix & Enhancement&gt;
+Bug Fix & Enhancement
 
 * Agent 사용성 개선 (Connection Guide 및 Data Integration 기능)
 * QueryPie Agent 앱 방식을 트레이에서 윈도우창UI 로 변경
@@ -113,10 +113,7 @@
 * Security 메뉴에 SQL Audit first 10 rows 기능 활성화 옵션 추가
 * Presto에서 order by 결과 표시 개선
 * MongoDB 데이터 표시 형식 개선
-* Request 및 Audit Log 사이 연결링크 추가
-
-(SQL Audit 메뉴 'Executed From' 컬럼, Role History 메뉴 'Action By' 컬럼)
-
+* Request 및 Audit Log 사이 연결링크 추가 (SQL Audit 메뉴 'Executed From' 컬럼, Role History 메뉴 'Action By' 컬럼)
 * 장기미접속 사용자 계정 잠금 처리 오류 수정
 * 동일한 커넥션에 대해 2개 이상의 세션 접속시 발생하는 타임아웃 현상 해결
 

--- a/src/content/ko/user-manual/database-access-control/connecting-with-web-sql-editor.mdx
+++ b/src/content/ko/user-manual/database-access-control/connecting-with-web-sql-editor.mdx
@@ -84,7 +84,7 @@ QueryPie에서는 웹 브라우저를 통해 쿼리를 실행하고 데이터를
 * `Queries` : Query Sharing 활성화 시, 연결된 GitHub Repository에서 SQL 쿼리 가져오기/내보내기가 가능합니다.
 
 <Callout type="info">
-해당 기능을 사용하기 위해서는 관리자가 쿼리 공유 설정을 사전에 해야 합니다. ( [General](General​) &gt; **쿼리 공유 설정** 참고) 
+해당 기능을 사용하기 위해서는 관리자가 쿼리 공유 설정을 사전에 해야 합니다. ( [General](General) &gt; **쿼리 공유 설정** 참고) 
 </Callout>
 
 ### 4. Object Info 패널


### PR DESCRIPTION
## Description
- confluence_xhtml_to_markdown.py 가 xhtml 을 parsing 하기 전에, 숨겨진 문자를 먼저 삭제합니다.
  - 변환된 markdown 파일에서 사후적으로 특수문자를 제거할 때, 유지해야 할 공백 문자를 잘못 삭제하게 되는 리스크가 있습니다.
  - xhtml 에서 먼저 데이터를 정제하여, markdown 변환 후 가공 과정에서 복잡한 데이터 처리 부담을 줄입니다.
- 문제가 되어 삭제하는 문자는 다음과 같습니다.
  - ZWSP = '\u200b'  # Zero Width Space
  - LRM = '\u200e'   # Left-to-Right Mark
  - HANGUL_FILLER = '\u3164'  # Hangul Filler
- Markdown 문서를 모두 재변환하고, 변경사항을 PR 에 포함합니다.

## Additional notes
- 
