### PR TITLE
feat: atlas_doc_format 데이터를 page.adf 로 저장합니다.

### DIFF
--- a/scripts/pages_of_confluence.py
+++ b/scripts/pages_of_confluence.py
@@ -5,16 +5,11 @@ Confluence Page Tree Generator
 This script generates a list of all subpages from a specified document in a Confluence space.
 Output format: page_id \t breadcrumbs \t title
 
-By default, the script creates a directory for each page_id and saves:
-- The document content in XHTML format as page.xhtml
-- Page information in YAML format as page.yaml
-- Child page information in YAML format as children.yaml
-- Attachments are not downloaded by default
-
-In local mode (--local flag), the script reads from the local YAML files instead of making API calls:
-- Page information is read from page.yaml
-- Child page information is read from children.yaml
-- Navigation is performed using the information in these files
+The document processing follows 4 distinct stages:
+1. API Data Collection: Fetch and save API responses to YAML files
+2. Content Extraction: Extract and save page content (XHTML, HTML, ADF)
+3. Attachment Download: Download attachments if specified
+4. Document Listing: Generate and output document list with breadcrumbs
 
 Usage examples:
   python pages_of_confluence.py
@@ -28,465 +23,451 @@ import requests
 from requests.auth import HTTPBasicAuth
 import sys
 import os
-import io
 import argparse
 import traceback
 import yaml
 import logging
-import re
+from typing import Dict, List, Optional, Any, Generator
 
-# Hidden characters constants
-NBSP = '\u00A0'  # Non-Breaking Space
-ZWSP = '\u200b'  # Zero Width Space
-LRM = '\u200e'   # Left-to-Right Mark
-HANGUL_FILLER = '\u3164'  # Hangul Filler
-
-# Function to clean text by removing or replacing hidden characters
-def clean_text(text):
-    if text is None:
-        return None
-    
-    # Replace NBSP with regular space
-    text = text.replace(NBSP, ' ')
-    
-    # Remove ZWSP, LRM, and HANGUL_FILLER
-    text = text.replace(ZWSP, '')
-    text = text.replace(LRM, '')
-    text = text.replace(HANGUL_FILLER, '')
-    
-    return text
-
-# User configuration
+# Configuration constants
 BASE_URL = "https://querypie.atlassian.net/wiki"
 SPACE_KEY = "QM"
 DEFAULT_START_PAGE_ID = "608501837"  # Root Page ID of "QueryPie Docs"
-EMAIL = "your-email@example.com"
-API_TOKEN = "your-api-token"
-
-# Default output directory
+QUICK_START_PAGE_ID = "544375784"  # QueryPie Overview having less children
 DEFAULT_OUTPUT_DIR = "docs/latest-ko-confluence"
 
-# Parse command line arguments
-parser = argparse.ArgumentParser(description="Generate a list of all subpages from a specified Confluence document")
-parser.add_argument("--page-id", default=DEFAULT_START_PAGE_ID, help="ID of the starting page (default: %(default)s)")
-parser.add_argument("--space-key", default=SPACE_KEY, help="Confluence space key (default: %(default)s)")
-parser.add_argument("--base-url", default=BASE_URL, help="Confluence base URL (default: %(default)s)")
-parser.add_argument("--email", default=EMAIL, help="Confluence email for authentication")
-parser.add_argument("--api-token", default=API_TOKEN, help="Confluence API token for authentication")
-parser.add_argument("--attachments", action="store_true", help="Download page content with attachments")
-parser.add_argument("--local", action="store_true", help="Use local page.yaml files instead of making API calls")
-parser.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR, 
-                    help="Directory to store output files (default: %(default)s)")
-parser.add_argument("--log-level", default="WARNING", choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-                    help="Set the logging level (default: %(default)s)")
-args = parser.parse_args()
+# Environment variables for authentication
+EMAIL = os.environ.get('ATLASSIAN_USERNAME', 'your-email@example.com')
+API_TOKEN = os.environ.get('ATLASSIAN_API_TOKEN', 'your-api-token')
 
-# Set up logging configuration
-logging.basicConfig(
-    level=getattr(logging, args.log_level),
-    format='%(levelname)s - %(filename)s:%(lineno)d - %(message)s',
-    stream=sys.stderr
-)
-logger = logging.getLogger(__name__)
-
-# Log the current configuration
-logger.debug(f"Logging initialized with level: {args.log_level}")
-logger.debug(f"Using base URL: {args.base_url}")
-logger.debug(f"Using space key: {args.space_key}")
-logger.debug(f"Starting with page ID: {args.page_id}")
-logger.debug(f"Download attachments: {args.attachments}")
-logger.debug(f"Using local mode: {args.local}")
-logger.debug(f"Output directory: {args.output_dir}")
-
-# Check if output directory exists
-if not os.path.exists(args.output_dir):
-    error_msg = f"Error: Output directory '{args.output_dir}' does not exist. Please create it first."
-    logger.critical(error_msg)
-    print(error_msg, file=sys.stderr)
-    sys.exit(1)
-
-# Set up authentication
-auth = HTTPBasicAuth(args.email, args.api_token)
-headers = {
-    "Accept": "application/json"
+# Hidden characters for text cleaning
+HIDDEN_CHARACTERS = {
+    '\u00A0': ' ',  # Non-Breaking Space
+    '\u200b': '',  # Zero Width Space
+    '\u200e': '',  # Left-to-Right Mark
+    '\u3164': ''  # Hangul Filler
 }
 
-# Function to save content to a file
-def save_to_file(directory, filename, content):
-    try:
-        filepath = os.path.join(directory, filename)
-        logger.info(f"Saving content to file: {filepath}")
-        with open(filepath, 'w', encoding='utf-8') as f:
-            f.write(content)
-        return True
-    except Exception as e:
-        logger.error(f"Error saving file {filepath}: {str(e)}")
-        return False
 
-# Function to download and save attachments
-def download_attachments(page_id, directory):
-    try:
-        # Get attachments list
-        attachment_url = f"{args.base_url}/rest/api/content/{page_id}/child/attachment"
-        logger.info(f"Fetching attachments list from: {attachment_url}")
-        response = requests.get(attachment_url, headers=headers, auth=auth)
-        response.raise_for_status()
-        attachments = response.json().get("results", [])
-        logger.info(f"Found {len(attachments)} attachments for page ID {page_id}")
-        
-        # Save attachment information as YAML
+class ConfluencePageProcessor:
+    """Main class for Confluence page processing"""
+
+    def __init__(self, args):
+        self.args = args
+        self.logger = logging.getLogger(__name__)
+        self.auth = HTTPBasicAuth(args.email, args.api_token)
+        self.headers = {"Accept": "application/json"}
+
+        # Handle quick-start option
+        if args.quick_start:
+            args.page_id = QUICK_START_PAGE_ID
+            self.logger.info(f"Quick start mode enabled, using page ID: {QUICK_START_PAGE_ID}")
+
+    def clean_text(self, text: Optional[str]) -> Optional[str]:
+        """Clean text by removing hidden characters"""
+        if text is None:
+            return None
+
+        cleaned_text = text
+        for hidden_char, replacement in HIDDEN_CHARACTERS.items():
+            cleaned_text = cleaned_text.replace(hidden_char, replacement)
+        return cleaned_text
+
+    def _save_file(self, filepath: str, content: Any, is_binary: bool = False) -> bool:
+        """Save content to file"""
         try:
-            yaml_filepath = os.path.join(directory, "attachments.yaml")
-            logger.info(f"Saving attachment information to: {yaml_filepath}")
-            with open(yaml_filepath, 'w', encoding='utf-8') as f:
-                yaml.dump(attachments, f, allow_unicode=True, sort_keys=False)
-            logger.info(f"Saved attachment information to: {yaml_filepath}")
+            os.makedirs(os.path.dirname(filepath), exist_ok=True)
+            mode = 'wb' if is_binary else 'w'
+            encoding = None if is_binary else 'utf-8'
+            
+            with open(filepath, mode, encoding=encoding) as f:
+                f.write(content)
+            
+            self.logger.debug(f"Saved {len(content)} bytes to {filepath}")
+            return True
         except Exception as e:
-            logger.error(f"Error saving attachment information as YAML: {str(e)}")
-        
-        for attachment in attachments:
-            try:
-                attachment_id = attachment["id"]
-                filename = attachment["title"]
-                download_url = f"{args.base_url}/rest/api/content/{page_id}/child/attachment/{attachment_id}/download"
-                
-                # Download attachment
-                logger.info(f"Downloading attachment: {filename} from {download_url}")
-                download_response = requests.get(download_url, headers={"Accept": "*/*"}, auth=auth)
-                download_response.raise_for_status()
-                
-                # Save attachment
-                filepath = os.path.join(directory, filename)
-                logger.info(f"Saving attachment to: {filepath}")
-                with open(filepath, 'wb') as f:
-                    f.write(download_response.content)
-                
-                logger.info(f"Saved attachment: {filename}")
-            except Exception as e:
-                logger.error(f"Error downloading attachment {attachment.get('title', 'unknown')}: {str(e)}")
-                # Continue with next attachment
-        
-        return True
-    except Exception as e:
-        logger.error(f"Error processing attachments for page ID {page_id}: {str(e)}")
-        return False
+            self.logger.error(f"Error saving file {filepath}: {str(e)}")
+            return False
 
-# Function to process page data and generate output
-# This function handles the common logic for processing page data from both API and local files
-def process_page_data(page_id, data, directory=None, start_page_id=None):
-    try:
-        # Clean title by removing/replacing hidden characters
-        title = clean_text(data["title"])
-        ancestors = data.get("ancestors", [])
+    def _save_yaml(self, filepath: str, data: Any) -> bool:
+        """Save YAML data to a file"""
+        return self._save_file(filepath, yaml.dump(data, allow_unicode=True, sort_keys=False))
+
+    def _load_yaml(self, filepath: str) -> Optional[Dict]:
+        """Read YAML from a file"""
+        try:
+            if os.path.exists(filepath):
+                with open(filepath, 'r', encoding='utf-8') as f:
+                    return yaml.safe_load(f)
+        except Exception as e:
+            self.logger.error(f"Error loading YAML from {filepath}: {str(e)}")
+        return None
+
+    def _make_api_request(self, url: str, description: str) -> Optional[Dict]:
+        """Make API request and return response"""
+        try:
+            self.logger.debug(f"Making {description} request to: {url}")
+            response = requests.get(url, headers=self.headers, auth=self.auth)
+            response.raise_for_status()
+            return response.json()
+        except Exception as e:
+            self.logger.error(f"Error making {description} request to {url}: {str(e)}")
+            return None
+
+    def _get_page_directory(self, page_id: str) -> str:
+        """Get page directory path"""
+        return os.path.join(self.args.output_dir, page_id)
+
+    # ============================================================================
+    # STAGE 1: API Data Collection - Fetch and save API responses to YAML files
+    # ============================================================================
+
+    def stage1_collect_api_data(self, page_id: str) -> None:
+        """Stage 1: API Data Collection - Fetch and save API responses to YAML files"""
+        self.logger.info(f"Stage 1: Collecting API data for page ID {page_id}")
+
+        if self.args.local:
+            self.logger.info(f"Stage 1 skipped for page ID {page_id} (local mode)")
+            return
+
+        directory = self._get_page_directory(page_id)
+
+        # Define API endpoints to fetch
+        api_endpoints = [
+            {
+                'url': f"{self.args.base_url}/rest/api/content/{page_id}?expand=title,ancestors,body.storage,body.view",
+                'description': "V1 API page data",
+                'filename': "page.v1.yaml"
+            },
+            {
+                'url': f"{self.args.base_url}/api/v2/pages/{page_id}?body-format=atlas_doc_format",
+                'description': "V2 API page data",
+                'filename': "page.v2.yaml"
+            },
+            {
+                'url': f"{self.args.base_url}/api/v2/pages/{page_id}/children?type=page&limit=100",
+                'description': "V2 API child pages",
+                'filename': "children.v2.yaml"
+            },
+            {
+                'url': f"{self.args.base_url}/rest/api/content/{page_id}/child/attachment",
+                'description': "V1 API attachments",
+                'filename': "attachments.v1.yaml"
+            }
+        ]
+
+        # Fetch all API data
+        for endpoint in api_endpoints:
+            data = self._make_api_request(endpoint['url'], endpoint['description'])
+            if data:
+                filepath = os.path.join(directory, endpoint['filename'])
+                self._save_yaml(filepath, data)
+                
+                # Log specific information for children and attachments
+                if 'children' in endpoint['filename']:
+                    child_count = len(data.get("results", []))
+                    self.logger.info(f"Saved {child_count} children for page ID {page_id}")
+                elif 'attachments' in endpoint['filename']:
+                    attachment_count = len(data.get("results", []))
+                    self.logger.info(f"Saved metadata for {attachment_count} attachments for page ID {page_id}")
+                else:
+                    self.logger.info(f"Saved {endpoint['description']} for ID {page_id}")
+
+        self.logger.info(f"Stage 1 completed for page ID {page_id}")
+
+    # ============================================================================
+    # STAGE 2: Content Extraction - Extract and save page content
+    # ============================================================================
+
+    def stage2_extract_content(self, page_id: str) -> bool:
+        """Stage 2: Content Extraction - Extract and save page content"""
+        self.logger.info(f"Stage 2: Extracting content for page ID {page_id}")
+        directory = self._get_page_directory(page_id)
+
+        # Extract V1 content
+        v1_data = self._load_yaml(os.path.join(directory, "page.v1.yaml"))
+        if v1_data:
+            self._extract_v1_content(page_id, v1_data, directory)
+
+        # Extract V2 content
+        v2_data = self._load_yaml(os.path.join(directory, "page.v2.yaml"))
+        if v2_data:
+            self._extract_v2_content(page_id, v2_data, directory)
+
+        self.logger.info(f"Stage 2 completed for page ID {page_id}")
+        return True
+
+    def _extract_v1_content(self, page_id: str, v1_data: Dict, directory: str) -> None:
+        """Extract content from V1 API data"""
+        body = v1_data.get("body", {})
         
-        # Special case for the start page: only include its own title in the breadcrumbs
-        if page_id == start_page_id:
-            # For document 608501837, only include its own title in the breadcrumbs
-            path = [title]
-        else:
-            # Filter out the starting page and its parent from the breadcrumbs
-            filtered_ancestors = []
-            found_start_page = False
-            for ancestor in ancestors:
-                if ancestor["type"] == "page":
-                    if ancestor["id"] == start_page_id:
-                        # Found the starting page
-                        found_start_page = True
-                        # Skip the starting page
-                        continue
-                    if not found_start_page:
-                        # Skip ancestors that come before the starting page (parent documents)
-                        continue
-                    # Include ancestors that come after the starting page (sub-documents)
-                    # Clean ancestor title before adding it to filtered_ancestors
-                    filtered_ancestors.append(clean_text(ancestor["title"]))
-            
-            path = filtered_ancestors + [title]
-        
-        # Create breadcrumbs by joining the path elements
-        breadcrumbs = " > ".join(path)
-        
-        logger.info(f"Processing page: {title} (ID: {page_id})")
-        
-        # Process file operations if directory is provided
-        if directory:
-            # Create directory for the page if it doesn't exist
-            try:
-                if not os.path.exists(directory):
-                    logger.info(f"Creating directory: {directory}")
-                    os.makedirs(directory)
-            except Exception as e:
-                logger.error(f"Error creating directory for page ID {page_id}: {str(e)}")
-                # Continue processing even if directory creation fails
-            
-            # Save the data as YAML if not in local mode (already saved in local mode)
-            if not args.local:
-                try:
-                    yaml_filepath = os.path.join(directory, "page.yaml")
-                    logger.info(f"Saving page information to: {yaml_filepath}")
-                    with open(yaml_filepath, 'w', encoding='utf-8') as f:
-                        yaml.dump(data, f, allow_unicode=True, sort_keys=False)
-                    logger.info(f"Saved page information to: {yaml_filepath}")
-                except Exception as e:
-                    logger.error(f"Error saving page information as YAML: {str(e)}")
-            
-            # Save page content in XHTML format
-            try:
-                logger.info(f"Extracting XHTML content for page ID {page_id}")
-                xhtml_content = data.get("body", {}).get("storage", {}).get("value", "")
-                save_to_file(directory, "page.xhtml", xhtml_content)
-            except Exception as e:
-                logger.error(f"Error saving XHTML content for page ID {page_id}: {str(e)}")
-            
-            # Save page content in HTML format
-            try:
-                logger.info(f"Extracting HTML content for page ID {page_id}")
-                html_content = data.get("body", {}).get("view", {}).get("value", "")
-                save_to_file(directory, "page.html", html_content)
-            except Exception as e:
-                logger.error(f"Error saving HTML content for page ID {page_id}: {str(e)}")
-            
-            
-            # Download and save attachments if specified and not in local mode
-            if args.attachments and not args.local:
-                logger.info(f"Downloading attachments for page ID {page_id}")
-                download_attachments(page_id, directory)
+        # Extract XHTML content
+        xhtml_content = body.get("storage", {}).get("value", "")
+        if xhtml_content:
+            self._save_file(os.path.join(directory, "page.xhtml"), xhtml_content)
+            self.logger.info(f"Extracted XHTML content for page ID {page_id} ({len(xhtml_content)} characters)")
+
+        # Extract HTML content
+        html_content = body.get("view", {}).get("value", "")
+        if html_content:
+            self._save_file(os.path.join(directory, "page.html"), html_content)
+            self.logger.info(f"Extracted HTML content for page ID {page_id} ({len(html_content)} characters)")
+
+        # Extract ancestors
+        ancestors = v1_data.get("ancestors", [])
+        if ancestors:
+            self._save_yaml(os.path.join(directory, "ancestors.v1.yaml"), {'results': ancestors})
+            self.logger.info(f"Extracted {len(ancestors)} ancestors for page ID {page_id}")
+
+    def _extract_v2_content(self, page_id: str, v2_data: Dict, directory: str) -> None:
+        """Extract content from V2 API data"""
+        adf_content = v2_data.get("body", {}).get("atlas_doc_format", {}).get("value", "")
+        if adf_content:
+            self._save_file(os.path.join(directory, "page.adf"), adf_content)
+            self.logger.info(f"Extracted ADF content for page ID {page_id} ({len(adf_content)} characters)")
+
+    # ============================================================================
+    # STAGE 3: Attachment Download - Download attachments if specified
+    # ============================================================================
+
+    def stage3_download_attachments(self, page_id: str) -> bool:
+        """Stage 3: Attachment Download - Download attachments if specified"""
+        if not self.args.attachments or self.args.local:
+            return True
+
+        self.logger.info(f"Stage 3: Downloading attachments for page ID {page_id}")
+        directory = self._get_page_directory(page_id)
+        attachments_filepath = os.path.join(directory, "attachments.v1.yaml")
+
+        if not os.path.exists(attachments_filepath):
+            return True
+
+        attachments_data = self._load_yaml(attachments_filepath)
+        if not attachments_data:
+            return True
+
+        attachments = attachments_data.get("results", [])
+        self.logger.info(f"Found {len(attachments)} attachments for page ID {page_id}")
+
+        # Download each attachment
+        for attachment in attachments:
+            self._download_single_attachment(page_id, attachment, directory)
+
+        self.logger.info(f"Stage 3 completed for page ID {page_id}")
+        return True
+
+    def _download_single_attachment(self, page_id: str, attachment: Dict, directory: str) -> None:
+        """Download a single attachment"""
+        try:
+            attachment_id = attachment["id"]
+            filename = attachment["title"]
+            download_url = f"{self.args.base_url}/rest/api/content/{page_id}/child/attachment/{attachment_id}/download"
+
+            response = requests.get(download_url, headers={"Accept": "*/*"}, auth=self.auth)
+            response.raise_for_status()
+
+            filepath = os.path.join(directory, filename)
+            self._save_file(filepath, response.content, is_binary=True)
+            self.logger.info(f"Downloaded attachment: {filename}")
+        except Exception as e:
+            self.logger.error(f"Error downloading attachment {attachment.get('title', 'unknown')}: {str(e)}")
+
+    # ============================================================================
+    # STAGE 4: Document Listing - Generate and output document list
+    # ============================================================================
+
+    def stage4_generate_document_list(self, page_id: str, start_page_id: Optional[str] = None) -> Optional[Dict]:
+        """Stage 4: Document Listing - Generate document information for output listing"""
+        self.logger.info(f"Stage 4: Generating document list for page ID {page_id}")
+
+        directory = self._get_page_directory(page_id)
+        v1_data = self._load_yaml(os.path.join(directory, "page.v1.yaml"))
+
+        if not v1_data:
+            self.logger.error(f"V1 data not available for document listing for page ID {page_id}")
+            return None
+
+        # Extract title from V1 data
+        title = self.clean_text(v1_data.get("title"))
+        if not title:
+            return None
+
+        # Extract ancestors from V1 data
+        ancestors = v1_data.get("ancestors", []) if v1_data else []
+
+        # Build breadcrumbs
+        breadcrumbs = self._build_breadcrumbs(page_id, ancestors, title, start_page_id)
+
+        self.logger.info(f"Stage 4 completed for page ID {page_id}: {title}")
 
         return {
             "id": page_id,
             "breadcrumbs": breadcrumbs,
             "title": title
         }
-    except Exception as e:
-        logger.error(f"Error processing page data for ID {page_id}: {str(e)}")
-        logger.debug(traceback.format_exc())
-        return None
 
-# Function to read page data from local YAML file
-# This function reads and returns the page data from the local page.yaml file
-def read_local_page_data(page_id):
-    try:
-        directory = os.path.join(args.output_dir, page_id)
-        yaml_filepath = os.path.join(directory, "page.yaml")
-        
-        logger.info(f"Reading local page data from: {yaml_filepath}")
-        
-        if not os.path.exists(yaml_filepath):
-            logger.error(f"Error: page.yaml not found for page ID {page_id}")
-            return None
-            
-        logger.info(f"Opening file for reading: {yaml_filepath}")
-        with open(yaml_filepath, 'r', encoding='utf-8') as f:
-            data = yaml.safe_load(f)
-            
-        logger.info(f"Successfully loaded page data for ID {page_id}")
-        return data
-    except Exception as e:
-        logger.error(f"Error reading local page data for ID {page_id}: {str(e)}")
-        logger.debug(traceback.format_exc())
-        return None
-
-# Function to read children data from local YAML file
-def read_local_children_data(page_id):
-    try:
-        directory = os.path.join(args.output_dir, page_id)
-        yaml_filepath = os.path.join(directory, "children.yaml")
-        
-        logger.info(f"Reading local children data from: {yaml_filepath}")
-        
-        if not os.path.exists(yaml_filepath):
-            logger.warning(f"Warning: children.yaml not found for page ID {page_id}")
-            # Create an empty children.yaml file with proper structure
-            try:
-                if not os.path.exists(directory):
-                    logger.info(f"Creating directory: {directory}")
-                    os.makedirs(directory)
-                
-                # Create empty children data structure
-                empty_data = {"results": []}
-                
-                logger.info(f"Creating empty children.yaml for page ID {page_id}")
-                with open(yaml_filepath, 'w', encoding='utf-8') as f:
-                    yaml.dump(empty_data, f, allow_unicode=True, sort_keys=False)
-                
-                logger.info(f"Created empty children.yaml for page ID {page_id}")
-                return empty_data
-            except Exception as e:
-                logger.error(f"Error creating empty children.yaml for page ID {page_id}: {str(e)}")
-                return None
-            
-        logger.info(f"Opening file for reading: {yaml_filepath}")
-        with open(yaml_filepath, 'r', encoding='utf-8') as f:
-            data = yaml.safe_load(f)
-            
-        logger.info(f"Successfully loaded children data for ID {page_id}")
-        return data
-    except Exception as e:
-        logger.error(f"Error reading local children data for ID {page_id}: {str(e)}")
-        logger.debug(traceback.format_exc())
-        return None
-
-# Function to find child pages from local directories
-# This function reads children information from children.yaml
-def find_local_child_pages(page_id):
-    try:
-        child_ids = []
-        
-        logger.info(f"Finding local child pages for page ID {page_id}")
-        
-        # Read the children.yaml file to get child page information
-        children_data = read_local_children_data(page_id)
-        
-        if children_data and "results" in children_data:
-            logger.info(f"Reading children information from children.yaml for {page_id}")
-            for child in children_data["results"]:
-                if "id" in child:
-                    child_ids.append(child["id"])
-                    logger.info(f"Found child page: {child['id']}")
-        else:
-            # Fallback to legacy method: try to read from page.yaml
-            logger.info(f"Falling back to page.yaml for children information")
-            data = read_local_page_data(page_id)
-            if data and "children" in data and "page" in data["children"] and "results" in data["children"]["page"]:
-                logger.info(f"Reading children information from page.yaml for {page_id}")
-                for child in data["children"]["page"]["results"]:
-                    if "id" in child:
-                        child_ids.append(child["id"])
-                        logger.info(f"Found child page: {child['id']}")
-        
-        # If no child pages were found, log a warning
-        if not child_ids:
-            logger.info(f"No child pages found for page ID {page_id}")
-        else:
-            logger.info(f"Found {len(child_ids)} child pages for page ID {page_id}")
-        
-        return child_ids
-    except Exception as e:
-        logger.error(f"Error finding local child pages for ID {page_id}: {str(e)}")
-        logger.debug(traceback.format_exc())
-        return []
-
-# Function to get page data from API
-def get_page_data_from_api(page_id):
-    try:
-        # Get page details with expanded content
-        expand_params = "title,ancestors,body.storage,body.view"
-        
-        url = f"{args.base_url}/rest/api/content/{page_id}?expand={expand_params}"
-        logger.info(f"Fetching page data from API: {url}")
-        response = requests.get(url, headers=headers, auth=auth)
-        response.raise_for_status()
-        logger.info(f"Successfully fetched page data for ID {page_id}")
-        return response.json()
-    except Exception as e:
-        logger.error(f"Error fetching page data from API for ID {page_id}: {str(e)}")
-        return None
-
-# Function to get child page IDs from API
-def get_child_page_ids_from_api(page_id):
-    try:
-        child_url = f"{args.base_url}/rest/api/content/{page_id}/child/page?limit=100"
-        logger.info(f"Fetching child pages from API: {child_url}")
-        child_response = requests.get(child_url, headers=headers, auth=auth)
-        child_response.raise_for_status()
-        child_data = child_response.json()
-        
-        # Save child data to children.yaml (even if there are no children)
+    def _build_breadcrumbs(self, page_id: str, ancestors: List[Dict], title: str,
+                          start_page_id: Optional[str] = None) -> str:
+        """Build breadcrumb string"""
         try:
-            directory = os.path.join(args.output_dir, page_id)
-            if not os.path.exists(directory):
-                logger.info(f"Creating directory: {directory}")
-                os.makedirs(directory)
-                
-            yaml_filepath = os.path.join(directory, "children.yaml")
-            logger.info(f"Saving children information to: {yaml_filepath}")
-            with open(yaml_filepath, 'w', encoding='utf-8') as f:
-                yaml.dump(child_data, f, allow_unicode=True, sort_keys=False)
-            logger.info(f"Saved children information to: {yaml_filepath}")
+            # Special case for the start page
+            if start_page_id and page_id == start_page_id:
+                return title
+
+            # Filter ancestors based on start_page_id
+            if start_page_id:
+                filtered_ancestors = []
+                found_start_page = False
+                for ancestor in ancestors:
+                    if ancestor.get("type") == "page":
+                        if ancestor["id"] == start_page_id:
+                            found_start_page = True
+                            continue
+                        elif not found_start_page:
+                            continue
+                        if "title" in ancestor:
+                            filtered_ancestors.append(self.clean_text(ancestor["title"]))
+
+                path = filtered_ancestors + [title]
+            else:
+                # Include all ancestors
+                ancestor_titles = [self.clean_text(ancestor["title"]) for ancestor in ancestors
+                                 if ancestor.get("type") == "page" and "title" in ancestor]
+                path = ancestor_titles + [title]
+
+            return " > ".join(path)
         except Exception as e:
-            logger.error(f"Error saving children information as YAML: {str(e)}")
-        
-        child_ids = [child["id"] for child in child_data.get("results", [])]
-        if not child_ids:
-            logger.info(f"No child pages found for page ID {page_id}, but children.yaml was still created")
-        else:
-            logger.info(f"Found {len(child_ids)} child pages for page ID {page_id}")
-        return child_ids
-    except Exception as e:
-        logger.error(f"Error fetching child pages from API for ID {page_id}: {str(e)}")
-        return []
+            self.logger.error(f"Error building breadcrumbs for page {page_id}: {str(e)}")
+            return title
 
-# Generic recursive function to fetch page tree
-def fetch_page_tree_generic(page_id, get_data_func, get_children_func, start_page_id=None):
-    try:
-        logger.info(f"Processing page tree for page ID {page_id}")
-        
-        # If start_page_id is not provided, use the current page_id as the starting point
-        if start_page_id is None:
-            start_page_id = page_id
-        
-        # Get page data using the provided function
-        data = get_data_func(page_id)
-        
-        if data:
-            # Process the page data
-            directory = os.path.join(args.output_dir, page_id)
-            page_info = process_page_data(page_id, data, directory, start_page_id)
-            
-            if page_info:
-                yield page_info
+    # ============================================================================
+    # Main Processing Functions
+    # ============================================================================
 
-                # Find and process child pages using the provided function
-                child_ids = get_children_func(page_id)
+    def process_page_complete(self, page_id: str, start_page_id: Optional[str] = None) -> Optional[Dict]:
+        """Process a single page through all 4 stages"""
+        try:
+            self.logger.info(f"Processing page ID {page_id} through all stages")
+
+            # Stage 1: API Data Collection
+            self.stage1_collect_api_data(page_id)
+
+            # Stage 2: Content Extraction
+            self.stage2_extract_content(page_id)
+
+            # Stage 3: Attachment Download
+            self.stage3_download_attachments(page_id)
+
+            # Stage 4: Document Listing
+            document_info = self.stage4_generate_document_list(page_id, start_page_id)
+
+            self.logger.info(f"Completed all stages for page ID {page_id}")
+            return document_info
+
+        except Exception as e:
+            self.logger.error(f"Error processing page ID {page_id}: {str(e)}")
+            return None
+
+    def get_child_page_ids(self, page_id: str) -> List[str]:
+        """Get child page IDs for recursive processing"""
+        try:
+            directory = self._get_page_directory(page_id)
+            yaml_filepath = os.path.join(directory, "children.v2.yaml")
+
+            if os.path.exists(yaml_filepath):
+                data = self._load_yaml(yaml_filepath)
+                if data:
+                    child_ids = [child["id"] for child in data.get("results", [])]
+                    self.logger.info(f"Found {len(child_ids)} child pages for page ID {page_id}")
+                    return child_ids
+            else:
+                self.logger.warning(f"No children.v2.yaml found for page ID {page_id}")
+                return []
+        except Exception as e:
+            self.logger.error(f"Error getting child page IDs for page ID {page_id}: {str(e)}")
+            return []
+
+    def fetch_page_tree_recursive(self, page_id: str, start_page_id: Optional[str] = None) -> Generator[Dict, None, None]:
+        """Recursively fetch page tree through all 4 stages"""
+        try:
+            self.logger.info(f"Processing page tree for page ID {page_id}")
+
+            # If start_page_id is not provided, use the current page_id as the starting point
+            if start_page_id is None:
+                start_page_id = page_id
+
+            # Process current page through all 4 stages
+            document_info = self.process_page_complete(page_id, start_page_id)
+
+            if document_info:
+                yield document_info
+
+                # Process child pages recursively
+                child_ids = self.get_child_page_ids(page_id)
                 for child_id in child_ids:
-                    yield from fetch_page_tree_generic(child_id, get_data_func, get_children_func, start_page_id)
-    except Exception as e:
-        logger.error(f"Error processing page ID {page_id}: {str(e)}")
-        logger.debug(traceback.format_exc())
-        # Continue with next pages
+                    yield from self.fetch_page_tree_recursive(child_id, start_page_id)
+        except Exception as e:
+            self.logger.error(f"Error processing page ID {page_id}: {str(e)}")
+            self.logger.debug(traceback.format_exc())
 
-# Recursive function to fetch page tree from API
-def fetch_page_tree_api(page_id, start_page_id=None):
-    yield from fetch_page_tree_generic(
-        page_id,
-        get_page_data_from_api,
-        get_child_page_ids_from_api,
-        start_page_id
+    def run(self) -> None:
+        """Main execution function"""
+        try:
+            self.logger.info(f"Starting to fetch page tree from page ID: {self.args.page_id}")
+
+            # Check if output directory exists
+            if not os.path.exists(self.args.output_dir):
+                error_msg = f"Error: Output directory '{self.args.output_dir}' does not exist. Please create it first."
+                self.logger.critical(error_msg)
+                print(error_msg, file=sys.stderr)
+                sys.exit(1)
+
+            # Fetch page tree through all 4 stages
+            page_count = 0
+            for page_info in self.fetch_page_tree_recursive(self.args.page_id):
+                if page_info:
+                    print(f"{page_info['id']}\t{page_info['breadcrumbs']}\t{page_info['title']}")
+                    page_count += 1
+
+            self.logger.info(f"Completed processing {page_count} pages through all 4 stages")
+        except Exception as e:
+            self.logger.error(f"Error in main execution: {str(e)}")
+            self.logger.debug(traceback.format_exc())
+            sys.exit(1)
+
+
+def main():
+    """Main function"""
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(description="Generate a list of all subpages from a specified Confluence document")
+    parser.add_argument("--page-id", default=DEFAULT_START_PAGE_ID,
+                        help="ID of the starting page (default: %(default)s)")
+    parser.add_argument("--quick-start", action="store_true",
+                        help=f"Use QUICK_START_PAGE_ID ({QUICK_START_PAGE_ID}) for faster testing")
+    parser.add_argument("--space-key", default=SPACE_KEY, help="Confluence space key (default: %(default)s)")
+    parser.add_argument("--base-url", default=BASE_URL, help="Confluence base URL (default: %(default)s)")
+    parser.add_argument("--email", default=EMAIL, help="Confluence email for authentication")
+    parser.add_argument("--api-token", default=API_TOKEN, help="Confluence API token for authentication")
+    parser.add_argument("--attachments", action="store_true", help="Download page content with attachments")
+    parser.add_argument("--local", action="store_true",
+                        help="Use local page.v1.yaml and page.v2.yaml files instead of making API calls")
+    parser.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR,
+                        help="Directory to store output files (default: %(default)s)")
+    parser.add_argument("--log-level", default="WARNING", choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+                        help="Set the logging level (default: %(default)s)")
+    args = parser.parse_args()
+
+    # Set up logging configuration
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format='%(levelname)s - %(filename)s:%(lineno)d - %(message)s',
+        stream=sys.stderr
     )
 
-# Recursive function to fetch page tree from local files
-def fetch_page_tree_local(page_id, start_page_id=None):
-    yield from fetch_page_tree_generic(
-        page_id,
-        read_local_page_data,
-        find_local_child_pages,
-        start_page_id
-    )
+    # Create processor and run
+    processor = ConfluencePageProcessor(args)
+    processor.run()
 
-# Main function to fetch page tree (decides which mode to use)
-def fetch_page_tree(page_id, start_page_id=None):
-    # If start_page_id is not provided, use the page_id as the starting point
-    if start_page_id is None:
-        start_page_id = page_id
-        
-    if args.local:
-        # Use local mode: read from local page.yaml files
-        yield from fetch_page_tree_local(page_id, start_page_id)
-    else:
-        # Use API mode: fetch data from the Confluence API
-        yield from fetch_page_tree_api(page_id, start_page_id)
 
-# Output to stdout in tab-separated format
-try:
-    logger.info(f"Starting to fetch page tree from page ID: {args.page_id}")
-    page_count = 0
-    for page in fetch_page_tree(args.page_id):
-        print(f"{page['id']}\t{page['breadcrumbs']}\t{page['title']}")
-        page_count += 1
-    logger.info(f"Completed processing {page_count} pages")
-except Exception as e:
-    logger.critical(f"Fatal error: {str(e)}")
-    print(f"Fatal error: {str(e)}", file=sys.stderr)
-    traceback.print_exc(file=sys.stderr)
-    sys.exit(1)
-
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description
- pages_of_confluence.py 를 개선하여, V2 REST API 의 결과를 page.v2.yaml 에 저장합니다.
  - V2 REST API 에서 atlas_doc_format 의 본문 데이터를 page.adf 로 저장합니다.
  - atlas_doc_format 는 이후, markdown 을 생성하는데 활용할 수 있습니다. AI Hub 의 Confluence MCP Tool 은 atlas_doc_format 을 markdown 형식으로 변환하는 기능을 갖고 있습니다.
- prompt-1-ko.md 의 프롬프트를 업데이트하여, pages_of_confluence.py 의 기능을 구현합니다.
  - Cursor 를 활용하여, pages_of_confluence.py 를 리팩토링합니다.

## Additional notes
- 기존 pages_of_confluence.py 와 동일한 문서 목록을 생성하는 것을 확인하였습니다.
`python3 scripts/pages_of_confluence.py --local > docs/latest-ko-confluence/list.txt`