### PR TITLE
feat: TableToNativeMarkdown, TableToHtmlTable 도입

### DIFF
--- a/src/content/ko/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-clusters-through-reverse-tunnel.mdx
+++ b/src/content/ko/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-clusters-through-reverse-tunnel.mdx
@@ -10,7 +10,7 @@ QueryPie와 다른 Network Zone에 있는 리소스와 통신을 하는 수단�
 </p>
 
 1. Administrator &gt; Kubernetes &gt; Connection Management &gt; Clusters 메뉴로 이동합니다.
-2. 리스트 내 클러스터를 선택합니다. 클러스터 신규 등록시 [수동으로 쿠버네티스 클러스터 등록하기]((10.2.0-ko) 수동으로 쿠버네티스 클러스터 등록하기)를 참고 바랍니다.
+2. 리스트 내 클러스터를 선택합니다. 클러스터 신규 등록시 [수동으로 쿠버네티스 클러스터 등록하기](수동으로 쿠버네티스 클러스터 등록하기)를 참고 바랍니다.
 3. Clusters의 List Detail 페이지 내에서 Tags 항목에 아래 Tag를 추가합니다.
     1. `RTS = TRUE` : 이 Tag가 있는 클러스터는 Reverse Tunnels을 통해 통신을 시도합니다.
     2. Reverse Tunnel Agent의 Tag : 동일한 Tag가 있는 Reverse Tunnel Agent를 통해서 클러스터와 통신합니다. 동일한 Tag가 있는 Reverse Tunnel Agent가 없는 경우, 통신은 실패합니다.

--- a/src/content/ko/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-servers-through-reverse-tunnel.mdx
+++ b/src/content/ko/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-servers-through-reverse-tunnel.mdx
@@ -10,7 +10,7 @@ QueryPie와 다른 Network Zone에 있는 리소스와 통신을 하는 수단�
 </p>
 
 1. Administrator &gt; Servers &gt; Connection Management &gt; Servers 메뉴로 이동합니다.
-2. 리스트 내 서버를 선택합니다. 서버 신규 등록시 [수동으로 개별 서버 등록하기]((10.2.0-ko) 수동으로 개별 서버 등록하기)를 참고 바랍니다.
+2. 리스트 내 서버를 선택합니다. 서버 신규 등록시 [수동으로 개별 서버 등록하기](수동으로 개별 서버 등록하기)를 참고 바랍니다.
 3. Server의 List Detail 페이지 내에서 Tags 항목에 아래 Tag를 추가합니다.
     1. `RTS = TRUE` : 이 Tag가 있는 Server는 Reverse Tunnels을 통해 접속을 시도합니다.
     2. Reverse Tunnel Agent의 Tag : 동일한 Tag가 있는 Reverse Tunnel Agent를 통해서 서버에 접속합니다. 동일한 Tag가 있는 Reverse Tunnel Agent가 없는 경우, 접속은 실패합니다.

--- a/src/content/ko/administrator-manual/databases/connection-management/db-connections.mdx
+++ b/src/content/ko/administrator-manual/databases/connection-management/db-connections.mdx
@@ -143,7 +143,7 @@ DB 커넥션 상세 페이지 내 Connection Information 영역에서 생성 시
 변경 내용을 저장하려면, 상세 페이지 우상단 `Save Changes` 버튼을 클릭하세요.
 
 <Callout type="info">
-Secret Store 항목은 Security 설정 메뉴에서 Secret Store 사용을 활성화하였을 때 표시되며, 실제 Secret Store 사용을 위해서는 Admin &gt; General &gt; Integration &gt; HashiCorp Vault 페이지에서 Vault 등록이 필요합니다. 자세한 내용은 [Secret Store 연동]((10.2.0-ko) Secret Store 연동) 문서를 참고하세요. 
+Secret Store 항목은 Security 설정 메뉴에서 Secret Store 사용을 활성화하였을 때 표시되며, 실제 Secret Store 사용을 위해서는 Admin &gt; General &gt; Integration &gt; HashiCorp Vault 페이지에서 Vault 등록이 필요합니다. 자세한 내용은 [Secret Store 연동](Secret Store 연동) 문서를 참고하세요. 
 </Callout>
 
 ### 참고. Secret Store 설정 방법
@@ -215,8 +215,8 @@ QueryPie 9.17부터 Proxy에서 지정한 계정정보 사용시 보안강화 �
 
 <Callout type="info">
 SSL/SSH 구성 정보는 사전에 등록되어 있어야 합니다. 아래 문서를 참고해보세요. 
-* [SSL Configurations]((10.2.0-ko) SSL Configurations)
-* [SSH Configurations]((10.2.0-ko) SSH Configurations)
+* [SSL Configurations](SSL Configurations)
+* [SSH Configurations](SSH Configurations)
 </Callout>
 
 ### Connection Owner
@@ -243,7 +243,7 @@ Tags 탭에서 DB 커넥션별로 태그를 등록하여 관리할 수 있습니
 DB 커넥션에 Privilege 별로 사용해야할 접속 계정을 강제 지정하는 기능입니다.
 
 <Callout type="info">
-해당 탭은 Security에서 Advanced Privilege Setting을 활성화할 경우에만 표시됩니다. 자세한 내용은 [Security]((10.2.0-ko) Security) 내 **DB 커넥션 보안 설정** 문서를 참고하세요. 
+해당 탭은 Security에서 Advanced Privilege Setting을 활성화할 경우에만 표시됩니다. 자세한 내용은 [Security](Security) 내 **DB 커넥션 보안 설정** 문서를 참고하세요. 
 </Callout>
 
 <p align="center">

--- a/src/content/ko/administrator-manual/general/system/integrations/integrating-with-email.mdx
+++ b/src/content/ko/administrator-manual/general/system/integrations/integrating-with-email.mdx
@@ -51,8 +51,8 @@ Email 발송을 위해서는 SMTP 서버가 필요하며, QueryPie에서는 SMTP
 
 Email을 통해 사용자가 자신의 비밀번호를 초기화하도록 하는 방법에 대해 아래 내용을 참고하세요.
 
-* [관리자가 특정 사용자의 비밀 번호를 초기화](https://chequer.atlassian.net/wiki/spaces/QM/pages/736395906/10.2.0-ko+Users#%EC%82%AC%EC%9A%A9%EC%9E%90-%EB%B9%84%EB%B0%80%EB%B2%88%ED%98%B8-%EC%9E%AC%EC%84%A4%EC%A0%95%ED%95%98%EA%B8%B0)
-* [사용자가 자신의 비밀 번호를 직접 초기화](https://chequer.atlassian.net/wiki/x/AQD1Lg)
+* [관리자가 특정 사용자의 비밀 번호를 초기화](Users)
+* [사용자가 자신의 비밀 번호를 직접 초기화](Email을 통한 사용자 비밀 번호 초기화)
 
 ## 2차인증 수단으로 Email 사용
 <Callout type="info">


### PR DESCRIPTION
## Description
- confluence_xhtml_to_markdown.py 을 개선합니다. table 을 markdown 으로 변환하는데, 크게 두 가지 유형으로 접근합니다.
  - 모든 cell 을 한 줄 markdown 으로 바꿀 수 있는 경우 : TableToNativeMarkdown 으로 대응
  - `<UL>`, `<LI>` 등을 포함하여, 여러 줄 markdown 으로 바꾸어야 하는 경우 : TableToHtmlTable
  - MDX 에서는 `<UL>`, `<LI>` 등 여러 줄 markdown 을 포함해야 하는 경우, HTML `<table>` 을 적용하여, 테이블을 표현하도록 가이드합니다.
- TableToNativeMarkdown 를 구현하고, 기존 table 변환을 일부 대체합니다.
  - `TableToNativeMarkdown.applicable()` method 를 제공합니다. 해당 node 아래에, 모든 cell 을 한 줄 markdown 으로 바꿀 있는지 여부를 검사해 줍니다. child node 의 name 이 모두 한 줄 markdown 전환하기에 적당한 node 인지 여부를 self.applicable_nodes set 과 비교하여 판단합니다.
- TableToHtmlTable 는 skeleton 으로 구현합니다.
- .mdx 파일을 모두 업데이트합니다.

## Additional notes
- 
