### PR TITLE
feat: <time datetime="2025-07-02"> 처리

### DIFF
--- a/src/content/ko/release-notes/1000-1002.mdx
+++ b/src/content/ko/release-notes/1000-1002.mdx
@@ -1,5 +1,5 @@
 ## QueryPie 10.0.2 Release 
-[time]
+2024년 09월 06일
 
 ** **
 
@@ -10,7 +10,7 @@
 
 
 ## QueryPie 10.0.1 Release
-[time]
+2024년 08월 09일
 
 
 
@@ -22,7 +22,7 @@
 
 
 ## QueryPie 10.0.0 Release
-[time]
+2024년 07월 22일
 
 
 

--- a/src/content/ko/release-notes/1010-10111.mdx
+++ b/src/content/ko/release-notes/1010-10111.mdx
@@ -1,5 +1,5 @@
 ## QueryPie 10.1.11 Release
-[time]
+2025년 01월 22일
 
 
 
@@ -12,7 +12,7 @@
 
 
 ## QueryPie 10.1.10 Release
-[time]
+2025년 01월 08일
 
 **Bug Fix**
 
@@ -22,7 +22,7 @@
 
 
 ## QueryPie 10.1.9 Release
-[time]
+2024년 12월 13일
 
 
 
@@ -42,7 +42,7 @@
 
 
 ## QueryPie 10.1.8 Release
-[time]
+2024년 12월 06일
 
 
 
@@ -71,7 +71,7 @@
 
 
 ## QueryPie 10.1.7 Release
-[time]
+2024년 11월 25일
 
 
 
@@ -97,7 +97,7 @@
 
 
 ## QueryPie 10.1.6 Release
-[time]
+2024년 11월 12일
 
 
 
@@ -113,7 +113,7 @@
 * [DAC] Workflow Status 변경 관련 오작동 수정
 
 ## QueryPie 10.1.5 Release
-[time]
+2024년 11월 01일
 
 
 
@@ -127,7 +127,7 @@
 * [DAC] 장기미접속 처리된 권한이 있는 경우 커넥션 상세 페이지 표시 오류 수정
 
 ## QueryPie 10.1.4 Release
-[time]
+2024년 10월 22일
 
 
 
@@ -138,7 +138,7 @@
 
 
 ## QueryPie 10.1.3 Release
-[time]
+2024년 10월 17일
 
 
 
@@ -154,7 +154,7 @@
 
 
 ## QueryPie 10.1.2 Release
-[time]
+2024년 10월 02일
 
 
 
@@ -182,7 +182,7 @@
 
 
 ## QueryPie 10.1.1 Release 
-[time]
+2024년 09월 20일
 
 ** **
 
@@ -200,7 +200,7 @@
 
 
 ## QueryPie 10.1.0 Release
-[time]
+2024년 09월 09일
 
 
 

--- a/src/content/ko/release-notes/1020-10212.mdx
+++ b/src/content/ko/release-notes/1020-10212.mdx
@@ -1,5 +1,5 @@
 ## QueryPie 10.2.12 Release
-[time]
+2025년 06월 13일
 
 
 
@@ -14,7 +14,7 @@
 
 
 ## QueryPie 10.2.11 Release
-[time]
+2025년 05월 28일
 
 
 
@@ -33,7 +33,7 @@
 
 
 ## QueryPie 10.2.9 Release
-[time]
+2025년 05월 02일
 
 
 
@@ -57,7 +57,7 @@
 
 
 ## QueryPie 10.2.8 Release
-[time]
+2025년 04월 11일
 
 
 
@@ -111,7 +111,7 @@
 
 
 ## QueryPie 10.2.7 Release
-[time]
+2025년 03월 20일
 
 
 
@@ -134,7 +134,7 @@
 
 
 ## QueryPie 10.2.6 Release
-[time]
+2025년 03월 07일
 
 
 
@@ -178,7 +178,7 @@
 
 
 ## QueryPie 10.2.5 Release
-[time]
+2025년 02월 14일
 
 
 
@@ -212,7 +212,7 @@
 
 
 ## QueryPie 10.2.4 Release
-[time]
+2025년 01월 24일
 
 
 
@@ -266,7 +266,7 @@
 
 
 ## QueryPie 10.2.3 Release
-[time]
+2024년 12월 24일
 
 
 
@@ -277,7 +277,7 @@
 
 
 ## QueryPie 10.2.2 Release
-[time]
+2024년 12월 19일
 
 
 
@@ -322,7 +322,7 @@
 
 
 ## QueryPie 10.2.1 Release
-[time]
+2024년 12월 06일
 
 
 
@@ -357,7 +357,7 @@
 
 
 ## QueryPie 10.2.0 Release
-[time]
+2024년 11월 08일
 
 
 

--- a/src/content/ko/release-notes/1030-1034.mdx
+++ b/src/content/ko/release-notes/1030-1034.mdx
@@ -1,5 +1,5 @@
 ## QueryPie 10.3.4 Release
-[time]
+2025년 06월 16일
 
 
 
@@ -10,7 +10,7 @@
 
 
 ## QueryPie 10.3.3 Release
-[time]
+2025년 06월 10일
 
 
 
@@ -21,7 +21,7 @@
 
 
 ## QueryPie 10.3.2 Release
-[time]
+2025년 06월 05일
 
 
 
@@ -34,7 +34,7 @@
 
 
 ## QueryPie 10.3.1 Release
-[time]
+2025년 05월 28일
 
 
 
@@ -52,7 +52,7 @@
 
 
 ## QueryPie 10.3.0 Release
-[time]
+2025년 05월 14일
 
 
 

--- a/src/content/ko/release-notes/1100.mdx
+++ b/src/content/ko/release-notes/1100.mdx
@@ -1,5 +1,5 @@
 ## QueryPie 11.0.0 Release
-[time]
+2025년 07월 02일
 
 
 

--- a/src/content/ko/release-notes/9100-9104.mdx
+++ b/src/content/ko/release-notes/9100-9104.mdx
@@ -11,7 +11,7 @@ External API 변경사항은 아래 링크를 참고해주세요.
 
 
 ## QueryPie 9.10.4 Release
-[time]
+2023년 05월 03일
 
 **Bug Fix **
 
@@ -20,7 +20,7 @@ External API 변경사항은 아래 링크를 참고해주세요.
 ---
 
 ## QueryPie 9.10.3 Release
-[time]
+2023년 04월 19일
 
 **Bug Fix **
 
@@ -29,7 +29,7 @@ External API 변경사항은 아래 링크를 참고해주세요.
 ---
 
 ## QueryPie 9.10.2 Release
-[time]
+2023년 02월 22일
 
 **Bug Fix **
 
@@ -38,7 +38,7 @@ External API 변경사항은 아래 링크를 참고해주세요.
 ---
 
 ## QueryPie 9.10.1 Release
-[time]
+2023년 01월 30일
 
 **Bug Fix **
 
@@ -54,7 +54,7 @@ External API 변경사항은 아래 링크를 참고해주세요.
 ---
 
 ## QueryPie 9.10.0 Release
-[time]
+2023년 01월 12일
 
 **New Features**
 

--- a/src/content/ko/release-notes/9110-9115.mdx
+++ b/src/content/ko/release-notes/9110-9115.mdx
@@ -1,5 +1,5 @@
 ## QueryPie 9.11.5 Release
-[time]
+2023년 05월 09일
 
 **Bug Fix & Enhancement**
 
@@ -11,7 +11,7 @@
 ---
 
 ## QueryPie 9.11.4 Release
-[time]
+2023년 04월 18일
 
 **Bug Fix & Enhancement**
 
@@ -23,7 +23,7 @@
 ---
 
 ## QueryPie 9.11.3 Release
-[time]
+2023년 04월 12일
 
 **Bug Fix & Enhancement**
 
@@ -34,7 +34,7 @@
 ---
 
 ## QueryPie 9.11.2 Release
-[time]
+2023년 04월 03일
 
 **Bug Fix & Enhancement**
 
@@ -46,7 +46,7 @@
 ---
 
 ## QueryPie 9.11.1 Release
-[time]
+2023년 03월 22일
 
 **Bug Fix & Enhancement**
 
@@ -61,7 +61,7 @@
 ---
 
 ## QueryPie 9.11.0 Release
-[time]
+2023년 02월 24일
 
 **New Features**
 

--- a/src/content/ko/release-notes/9120-91214.mdx
+++ b/src/content/ko/release-notes/9120-91214.mdx
@@ -1,5 +1,5 @@
 ## QueryPie 9.12.14 Release
-[time]
+2024년 01월 30일
 
 
 
@@ -10,7 +10,7 @@
 ---
 
 ## QueryPie 9.12.13 Release
-[time]
+2024년 01월 08일
 
 
 
@@ -21,7 +21,7 @@
 ---
 
 ## QueryPie 9.12.12 Release
-[time]
+2023년 12월 08일
 
 
 
@@ -32,7 +32,7 @@
 ---
 
 ## QueryPie 9.12.11 Release
-[time]
+2023년 10월 25일
 
 
 
@@ -43,7 +43,7 @@
 ---
 
 ## QueryPie 9.12.10 Release
-[time]
+2023년 09월 08일
 
 
 
@@ -71,7 +71,7 @@
 ---
 
 ## QueryPie 9.12.9 Release
-[time]
+2023년 07월 26일
 
 **New Feature**
 
@@ -97,7 +97,7 @@
 ---
 
 ## QueryPie 9.12.8 Release
-[time]
+2023년 07월 04일
 
 **Bug Fix & Enhancement**
 
@@ -108,7 +108,7 @@
 ---
 
 ## QueryPie 9.12.7 Release
-[time]
+2023년 06월 15일
 
 **Bug Fix & Enhancement**
 
@@ -117,7 +117,7 @@
 ---
 
 ## QueryPie 9.12.6 Release
-[time]
+2023년 06월 12일
 
 **Bug Fix & Enhancement**
 
@@ -133,7 +133,7 @@
 ---
 
 ## QueryPie 9.12.5 Release
-[time]
+2023년 05월 19일
 
 **Bug Fix & Enhancement**
 
@@ -146,7 +146,7 @@
 ---
 
 ## QueryPie 9.12.4 Release
-[time]
+2023년 05월 17일
 
 **Bug Fix & Enhancement**
 
@@ -168,7 +168,7 @@
 ---
 
 ## QueryPie 9.12.3 Release
-[time]
+2023년 05월 10일
 
 **Bug Fix **
 
@@ -178,7 +178,7 @@
 ---
 
 ## QueryPie 9.12.2 Release
-[time]
+2023년 05월 02일
 
 **Bug Fix **
 
@@ -191,7 +191,7 @@
 ---
 
 ## QueryPie 9.12.1 Release
-[time]
+2023년 04월 25일
 
 **Bug Fix **
 
@@ -204,7 +204,7 @@
 ---
 
 ## QueryPie 9.12.0 Release
-[time]
+2023년 04월 13일
 
 **New Feature**
 

--- a/src/content/ko/release-notes/9130-9135.mdx
+++ b/src/content/ko/release-notes/9130-9135.mdx
@@ -1,5 +1,5 @@
 ## QueryPie 9.13.5 Release
-[time]
+2023년 09월 14일
 
 **Bug Fix & Enhancement**
 
@@ -8,7 +8,7 @@
 
 
 ## QueryPie 9.13.4 Release
-[time]
+2023년 08월 02일
 
 **Bug Fix & Enhancement**
 
@@ -17,7 +17,7 @@
 
 
 ## QueryPie 9.13.3 Release 
-[time]
+2023년 07월 03일
 
 **Bug Fix & Enhancement**
 
@@ -26,7 +26,7 @@
 
 
 ## QueryPie 9.13.2 Release 
-[time]
+2023년 06월 23일
 
 **Bug Fix & Enhancement**
 
@@ -35,7 +35,7 @@
 
 
 ## QueryPie 9.13.1 Release
-[time]
+2023년 06월 19일
 
 **New Features**
 
@@ -56,7 +56,7 @@
 
 
 ## QueryPie 9.13.0 Release
-[time]
+2023년 05월 15일
 
 **New Features**
 

--- a/src/content/ko/release-notes/9140-9143.mdx
+++ b/src/content/ko/release-notes/9140-9143.mdx
@@ -1,5 +1,5 @@
 ## QueryPie 9.14.3 Release
-[time]
+2024년 02월 18일
 
 
 
@@ -12,7 +12,7 @@
 ---
 
 ## QueryPie 9.14.2 Release
-[time]
+2023년 11월 27일
 
 
 
@@ -25,7 +25,7 @@
 ---
 
 ## QueryPie 9.14.1 Release
-[time]
+2023년 10월 05일
 
 
 
@@ -50,7 +50,7 @@
 ---
 
 ## QueryPie 9.14.0 Release
-[time]
+2023년 09월 13일
 
 
 

--- a/src/content/ko/release-notes/9150-9154.mdx
+++ b/src/content/ko/release-notes/9150-9154.mdx
@@ -1,5 +1,5 @@
 ## QueryPie 9.15.4 Release
-[time]
+2024년 02월 18일
 
 
 
@@ -12,7 +12,7 @@
 ---
 
 ## QueryPie 9.15.3 Release
-[time]
+2024년 01월 31일
 
 
 
@@ -23,7 +23,7 @@
 ---
 
 ## QueryPie 9.15.2 Release
-[time]
+2024년 01월 16일
 
 
 
@@ -36,7 +36,7 @@
 ---
 
 ## QueryPie 9.15.1 Release
-[time]
+2024년 01월 12일
 
 
 
@@ -49,7 +49,7 @@
 ---
 
 ## QueryPie 9.15.0 Release
-[time]
+2023년 12월 08일
 
 
 

--- a/src/content/ko/release-notes/9160-9164.mdx
+++ b/src/content/ko/release-notes/9160-9164.mdx
@@ -1,5 +1,5 @@
 ## QueryPie 9.16.4 Release
-[time]
+2024년 04월 04일
 
 
 
@@ -10,7 +10,7 @@
 ---
 
 ## QueryPie 9.16.3 Release
-[time]
+2024년 03월 05일
 
 
 
@@ -21,7 +21,7 @@
 ---
 
 ## QueryPie 9.16.2 Release
-[time]
+2024년 02월 15일
 
 
 
@@ -36,7 +36,7 @@
 ---
 
 ## QueryPie 9.16.1 Release
-[time]
+2024년 01월 30일
 
 
 
@@ -56,7 +56,7 @@
 ---
 
 ## QueryPie 9.16.0 Release
-[time]
+2024년 01월 26일
 
 
 

--- a/src/content/ko/release-notes/9170-9171.mdx
+++ b/src/content/ko/release-notes/9170-9171.mdx
@@ -1,5 +1,5 @@
 ## QueryPie 9.17.1 Release
-[time]
+2024년 03월 25일
 
 
 
@@ -17,7 +17,7 @@
 ---
 
 ## QueryPie 9.17.0 Release
-[time]
+2024년 03월 11일
 
 
 

--- a/src/content/ko/release-notes/9180-9183.mdx
+++ b/src/content/ko/release-notes/9180-9183.mdx
@@ -1,5 +1,5 @@
 ## QueryPie 9.18.3 Hotfix
-[time]
+2024년 05월 07일
 
 
 
@@ -17,7 +17,7 @@
 
 
 ## QueryPie 9.18.2 Hotfix
-[time]
+2024년 04월 26일
 
 
 
@@ -32,7 +32,7 @@
 
 
 ## QueryPie 9.18.1 Hotfix
-[time]
+2024년 04월 22일
 
 
 
@@ -52,7 +52,7 @@
 
 
 ## QueryPie 9.18.0 Release
-[time]
+2024년 04월 04일
 
 
 

--- a/src/content/ko/release-notes/9190.mdx
+++ b/src/content/ko/release-notes/9190.mdx
@@ -1,5 +1,5 @@
 ## QueryPie 9.19.0 Release
-[time]
+2024년 06월 03일
 
 
 

--- a/src/content/ko/release-notes/9200-9202.mdx
+++ b/src/content/ko/release-notes/9200-9202.mdx
@@ -1,5 +1,5 @@
 ## QueryPie 9.20.2 Hotfix
-[time]
+2024년 08월 27일
 
 
 
@@ -16,7 +16,7 @@
 
 
 ## QueryPie 9.20.1 Hotfix
-[time]
+2024년 07월 08일
 
 
 
@@ -28,7 +28,7 @@
 
 
 ## QueryPie 9.20.0 Release
-[time]
+2024년 06월 14일
 
 
 

--- a/src/content/ko/release-notes/980-9812.mdx
+++ b/src/content/ko/release-notes/980-9812.mdx
@@ -1,7 +1,7 @@
 
 
 ## QueryPie 9.8.12 Release 
-[time]
+2022년 11월 30일
 
 **Bug Fix & Enhancement**
 
@@ -12,7 +12,7 @@
 ---
 
 ## QueryPie 9.8.11 Release 
-[time]
+2022년 11월 14일
 
 **Bug Fix & Enhancement**
 
@@ -24,7 +24,7 @@
 ---
 
 ## QueryPie 9.8.10 Release 
-[time]
+2022년 10월 06일
 
 **Bug Fix & Enhancement**
 
@@ -39,7 +39,7 @@
 ---
 
 ## QueryPie 9.8.9 Release 
-[time]
+2022년 09월 19일
 
 **Bug Fix & Enhancement**
 
@@ -57,7 +57,7 @@
 ---
 
 ## QueryPie 9.8.8 Release
-[time]
+2022년 08월 11일
 
 **Bug Fix & Enhancement**
 
@@ -69,7 +69,7 @@
 ---
 
 ## QueryPie 9.8.7 Release
-[time]
+2022년 08월 09일
 
 **Bug Fix & Enhancement**
 
@@ -80,7 +80,7 @@
 ---
 
 ## QueryPie 9.8.6 Release 
-[time]
+2022년 07월 20일
 
 **Bug Fix & Enhancement**
 
@@ -95,7 +95,7 @@
 ---
 
 ## QueryPie 9.8.5 Release
-[time]
+2022년 07월 06일
 
 **Bug Fix & Enhancement**
 
@@ -106,7 +106,7 @@
 ---
 
 ## QueryPie 9.8.3-9.8.4 Release 
-[time]
+2022년 06월 22일
 
 **Bug Fix & Enhancement**
 
@@ -119,7 +119,7 @@
 ---
 
 ## QueryPie 9.8.2 Release 
-[time]
+2022년 06월 21일
 
 **Bug Fix & Enhancement**
 
@@ -141,7 +141,7 @@
 ---
 
 ## QueryPie 9.8.1 Release
-[time]
+2022년 06월 02일
 
 **Bug Fix & Enhancement**
 

--- a/src/content/ko/release-notes/990-998.mdx
+++ b/src/content/ko/release-notes/990-998.mdx
@@ -12,7 +12,7 @@ External API 변경사항은 아래 링크를 참고해주세요.
 
 
 ## QueryPie 9.9.8 Release
-[time]
+2023년 01월 18일
 
 * HBase 벤더 지원 중단
 
@@ -21,7 +21,7 @@ External API 변경사항은 아래 링크를 참고해주세요.
 ---
 
 ## QueryPie 9.9.7 Release
-[time]
+2023년 01월 09일
 
 **Enhancement**
 
@@ -32,7 +32,7 @@ External API 변경사항은 아래 링크를 참고해주세요.
 ---
 
 ## QueryPie 9.9.6 Release
-[time]
+2023년 01월 04일
 
 **Enhancement**
 
@@ -43,7 +43,7 @@ External API 변경사항은 아래 링크를 참고해주세요.
 ---
 
 ## QueryPie 9.9.5 Release
-[time]
+2022년 12월 06일
 
 **Enhancement**
 
@@ -79,7 +79,7 @@ External API 변경사항은 아래 링크를 참고해주세요.
 ---
 
 ## QueryPie 9.9.4 Release
-[time]
+2022년 11월 14일
 
 **Bug Fix**
 
@@ -90,7 +90,7 @@ External API 변경사항은 아래 링크를 참고해주세요.
 ---
 
 ## QueryPie 9.9.3 Release
-[time]
+2022년 11월 04일
 
 **New Features**
 
@@ -128,7 +128,7 @@ External API 변경사항은 아래 링크를 참고해주세요.
 ---
 
 ## QueryPie 9.9.2 Release 
-[time]
+2022년 10월 17일
 
 **New Features**
 
@@ -163,7 +163,7 @@ External API 변경사항은 아래 링크를 참고해주세요.
 ---
 
 ## QueryPie 9.9.1 Release 
-[time]
+2022년 09월 14일
 
 **New Features**
 


### PR DESCRIPTION
## Description
- SingleLineParser 에서 `<time datetime="2025-07-02">` node 를 처리합니다.
  - 전역변수 LANGUAGE 에 따라, 적절히 날짜 형식을 선택합니다.
- output_file 의 경로를 참조하여, 해당 문서의 언어를 탐지합니다.
  - `/ko/`, `/ja/`, `/en/` 등 경로가 포함된 경우, 해당 언어로 간주합니다.
  - 기본 언어는 `en`으로 둡니다.
- .mdx 파일을 업데이트합니다.

## Additional notes
- 
