### PR TITLE
feat: `<ac:adf-fragment-mark>`

### DIFF
--- a/scripts/tests/confluence_xhtml_to_markdown/testcases/544384417/expected.mdx
+++ b/scripts/tests/confluence_xhtml_to_markdown/testcases/544384417/expected.mdx
@@ -17,10 +17,7 @@ QueryPie 보고서는 감사 대응에 필요한 데이터를 보고서 형태�
 10.2.2 버전 현재 지원하는 보고서 항목 및 필터는 아래의 표를 참고하시기 바랍니다.
 
 <table data-table-width="958" data-layout="center" local-id="cfcbf091-3775-4454-bff4-924bf43e88f4">
-[ac:adf-fragment-mark]
-[ac:adf-fragment-mark-detail]
-
-
+<a id="table-1"></a>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/ko/administrator-manual/audit/reports/reports.mdx
+++ b/src/content/ko/administrator-manual/audit/reports/reports.mdx
@@ -17,10 +17,7 @@ QueryPie 보고서는 감사 대응에 필요한 데이터를 보고서 형태�
 10.2.2 버전 현재 지원하는 보고서 항목 및 필터는 아래의 표를 참고하시기 바랍니다.
 
 <table data-table-width="958" data-layout="center" local-id="cfcbf091-3775-4454-bff4-924bf43e88f4">
-[ac:adf-fragment-mark]
-[ac:adf-fragment-mark-detail]
-
-
+<a id="table-1"></a>
 <colgroup>
 <col/>
 <col/>


### PR DESCRIPTION
## Description
- `<ac:adf-fragment-mark>`는 Confluence 문서 내에서 문서 내 위치를 표시합니다.
  - HTML의 `<a id="name"></a>`에 대응하는 기능입니다.
  - Markdown 에는 이에 대응하는 기능이 별도로 없습니다. 이에 따라, HTML `<a id="name"></a>` 로 변환하는 것이 적절합니다.
- SingleLineParser 에서 adf-fragment-mark 를 변환합니다.
- 해당 문서의 변경을 업데이트합니다.

## Additional notes
- 
