### PR TITLE
feat: Attachment.as_markdown() 으로 이미지 링크를 만듭니다

### DIFF
--- a/scripts/tests/confluence_xhtml_to_markdown/testcases/544112828/expected.mdx
+++ b/scripts/tests/confluence_xhtml_to_markdown/testcases/544112828/expected.mdx
@@ -9,13 +9,13 @@ QueryPie Agent를 설치하면, DataGrip, DBeaver와 같은 SQL Client, iTerm/Se
 
 1. QueryPie 로그인 후 우측 상단 프로필을 클릭하여 `Agent Download` 버튼을 클릭합니다.
 <p align="center">
-<div>[스크린샷 2024-08-04 오후 5.30.02.png]()</div>
+![screenshot-20240804-173002.png](./output/screenshot-20240804-173002.png)
 *QueryPie Web &gt; 프로필 메뉴*
 </p>
 
 2. QueryPie Agent Downloads 팝업창이 실행되면 Step 1에서 사용 중인 PC 운영체제에 맞는 설치 파일을 다운로드한 후 Step 3에 있는 QueryPie URL을 복사해 둡니다.
 <p align="center">
-<div>[image-20240723-154847.png]()</div>
+![image-20240723-154847.png](./output/image-20240723-154847.png)
 *QueryPie Web &gt; Agent Downloads 팝업창*
 </p>
 
@@ -25,13 +25,13 @@ QueryPie Agent는 Mac, Windows, Linux OS를 지원합니다.
 
 3. 다운로드받은 QueryPie Agent 설치 프로그램을 실행하여 설치를 완료합니다.
 <p align="center">
-<div>[스크린샷 2024-08-04 오후 5.40.02.png]()</div>
+![screenshot-20240804-174002.png](./output/screenshot-20240804-174002.png)
 *Mac OS 설치 프로그램*
 </p>
 
 4. 설치 완료된 QueryPie Agent를 실행합니다. QueryPie Host 입력란에 미리 복사해뒀던 QueryPie URL을 입력하고 `Next` 버튼을 클릭하면 로그인 화면으로 진입하게 됩니다.
 <p align="center">
-<div>[agent-03.png]()</div>
+![agent-03.png](./output/agent-03.png)
 *Agent &gt; QueryPie Host 입력*
 </p>
 
@@ -40,24 +40,24 @@ QueryPie Agent는 Mac, Windows, Linux OS를 지원합니다.
 
 1. Agent 앱 내 로그인 화면에서 `Login` 버튼을 클릭합니다.
 <p align="center">
-<div>[스크린샷 2024-08-04 오후 5.37.13.png]()</div>
+![screenshot-20240804-173713.png](./output/screenshot-20240804-173713.png)
 </p>
 
 2. 웹 브라우저가 열리면, 로그인 페이지에서 인증정보를 입력하고, `Continue` 버튼을 클릭합니다.
 <p align="center">
-<div>[스크린샷 2024-07-29 오후 5.12.36.png]()</div>
+![screenshot-20240729-171236.png](./output/screenshot-20240729-171236.png)
 *QueryPie Web &gt; Agent Login Page*
 </p>
 
 3. 로그인을 성공하면 아래와 같이 로그인 성공 화면이 표시되며 이후 Agent로 돌아갑니다.
 <p align="center">
-<div>[스크린샷 2024-07-29 오후 5.13.14.png]()</div>
+![screenshot-20240729-171314.png](./output/screenshot-20240729-171314.png)
 *QueryPie Web &gt; Agent Login Success Page*
 </p>
 
 4. Agent 열기를 명시적으로 수행하여 인증정보를 Agent로 전달합니다.
 <p align="center">
-<div>[스크린샷 2024-08-04 오후 5.42.09.png]()</div>
+![screenshot-20240804-174209.png](./output/screenshot-20240804-174209.png)
 *Chrome - Agent App 열기 모달*
 </p>
 
@@ -65,13 +65,13 @@ QueryPie Agent는 Mac, Windows, Linux OS를 지원합니다.
 
 1. 로그인이 정상적으로 완료되면 Agent 앱 내 Databases 탭에서 권한 있는 커넥션들의 접속 정보를 확인할 수 있습니다.<br/>접속할 커넥션에 할당된 `Port` 를 클릭하면, 해당 커넥션의 `Proxy Credentials` 정보를 확인할 수 있습니다.
 <p align="center">
-<div>[스크린샷 2024-07-30 오후 3.10.01.png]()</div>
+![screenshot-20240730-151001.png](./output/screenshot-20240730-151001.png)
 *Agent &gt; DB Connection Information*
 </p>
 
 2. 위의 접속 정보를 3rd Party 클라이언트에 입력하면 DB 커넥션 접속이 가능합니다.
 <p align="center">
-<div>[agent-07.png]()</div>
+![agent-07.png](./output/agent-07.png)
 *3rd Party Client를 이용한 DB 커넥션 접속*
 </p>
 
@@ -85,7 +85,7 @@ QueryPie Agent는 Mac, Windows, Linux OS를 지원합니다.
 * 사용자 프로필 영역 하단의 `Role` 버튼을 클릭하여 원하는 역할을 고르고 `OK` 버튼을 클릭하세요.
 * Default 역할 선택시, Workflow &gt; Server Access Request 요청에 의해 할당받은 서버 권한을 사용합니다. 
 <p align="center">
-<div>[스크린샷 2024-07-30 오후 4.26.53.png]()</div>
+![screenshot-20240730-162653.png](./output/screenshot-20240730-162653.png)
 *Agent &gt; Server &gt; Select a Role*
 </p>
 
@@ -97,14 +97,14 @@ QueryPie Agent는 Mac, Windows, Linux OS를 지원합니다.
 
 * 접속할 서버를 우클릭 후 Open Connection with 메뉴를 선택하여, 사용하려는 터미널 툴을 선택합니다.
 <p align="center">
-<div>[스크린샷 2024-07-30 오후 4.17.29.png]()</div>
+![screenshot-20240730-161729.png](./output/screenshot-20240730-161729.png)
 *Agent &gt; Server &gt; Open Connection with*
 </p>
 
 * 이후 해당 서버에 접속 가능한 계정이 여러개라면, Account 선택창이 열립니다. 
 * 사용하려는 계정을 선택하고 필요시 비밀번호를 입력한 뒤, `OK` 버튼을 클릭하여 세션을 엽니다.
 <p align="center">
-<div>[스크린샷 2024-07-30 오후 4.25.32.png]()</div>
+![screenshot-20240730-162532.png](./output/screenshot-20240730-162532.png)
 *Agent &gt; Server &gt; Open New Session*
 </p>
 
@@ -147,7 +147,7 @@ $ ssh deploy@{{Server Name}}
 ## 에이전트를 통한 쿠버네티스 접속
 
 <p align="center">
-<div>[kubernetes-agent-access-flow.png]()</div>
+![kubernetes-agent-access-flow.png](./output/kubernetes-agent-access-flow.png)
 </p>
 
 * 권한을 부여 받은 사용자는 에이전트 실행 시 현재 정책에 따른 `kubeconfig` 파일이 자동으로 수신됩니다.
@@ -159,7 +159,7 @@ $ ssh deploy@{{Server Name}}
 
 사용자 프로필 영역 하단의 `Role` 버튼을 클릭하면 역할 선택 모달이 열립니다. 원하는 역할을 고르고 `OK` 버튼을 클릭하세요.
 <p align="center">
-<div>[스크린샷 2024-07-30 오후 3.27.05.png]()</div>
+![screenshot-20240730-152705.png](./output/screenshot-20240730-152705.png)
 *Agent &gt; Kubernetes &gt; Select a Role*
 </p>
 
@@ -172,7 +172,7 @@ $ ssh deploy@{{Server Name}}
 
 선택된 역할에 따라 접근 가능한 리소스가 표시됩니다. 각 클러스터 우측의 `🔍` 버튼을 누르면 Policy Information 팝업창이 나타나며 이곳에서 해당 클러스터에 적용된 정책 목록을 자세히 확인할 수 있습니다.
 <p align="center">
-<div>[스크린샷 2024-07-30 오후 4.11.41.png]()</div>
+![screenshot-20240730-161141.png](./output/screenshot-20240730-161141.png)
 *Agent &gt; Policy Information*
 </p>
 
@@ -180,7 +180,7 @@ $ ssh deploy@{{Server Name}}
 
 Agent 설정 메뉴에서 `KubeConfig Path` 버튼을 클릭하여 Kubeconfig 경로 설정 모달을 엽니다.
 <p align="center">
-<div>[스크린샷 2024-07-30 오후 3.46.23.png]()</div>
+![screenshot-20240730-154623.png](./output/screenshot-20240730-154623.png)
 *Agent &gt; Settings &gt; Configure Kubeconfig Path*
 </p>
 
@@ -190,7 +190,7 @@ Agent 설정 메뉴에서 `KubeConfig Path` 버튼을 클릭하여 Kubeconfig �
 
 
 <p align="center">
-<div>[스크린샷 2024-07-30 오후 4.35.30.png]()</div>
+![screenshot-20240730-163530.png](./output/screenshot-20240730-163530.png)
 *경로 지정 팝업*
 </p>
 
@@ -226,7 +226,7 @@ export KUBECONFIG="${KUBECONFIG}:${HOME}/.kube/querypie-kubeconfig"
 
 프로필 영역 우측 `⚙️` 버튼을 클릭하여 설정 메뉴를 엽니다. `Reset All Settings` 버튼을 클릭합니다.
 <p align="center">
-<div>[스크린샷 2024-07-30 오후 3.35.18.png]()</div>
+![screenshot-20240730-153518.png](./output/screenshot-20240730-153518.png)
 *Agent &gt; Settings*
 </p>
 
@@ -235,7 +235,7 @@ export KUBECONFIG="${KUBECONFIG}:${HOME}/.kube/querypie-kubeconfig"
 
 메뉴 막대에서 QueryPie Agent 아이콘을 클릭하여 앱 메뉴를 엽니다. `Reset All Settings` 버튼을 클릭합니다.
 <p align="center">
-<div>[스크린샷 2024-07-30 오후 3.35.24.png]()</div>
+![screenshot-20240730-153524.png](./output/screenshot-20240730-153524.png)
 *Agent &gt; App menu*
 </p>
 

--- a/scripts/tests/confluence_xhtml_to_markdown/testcases/544113141/expected.mdx
+++ b/scripts/tests/confluence_xhtml_to_markdown/testcases/544113141/expected.mdx
@@ -5,7 +5,7 @@
 ## DB Access History 조회하기
 
 <p align="center">
-<div>[image-20240730-070842.png]()</div>
+![image-20240730-070842.png](./output/image-20240730-070842.png)
 *Administrator &gt; Audit &gt; Databases &gt; DB Access History*
 </p>
 
@@ -48,7 +48,7 @@
 
 각 행을 클릭하면 세부 정보 조회가 가능합니다.
 <p align="center">
-<div>[image-20240730-065045.png]()</div>
+![image-20240730-065045.png](./output/image-20240730-065045.png)
 *Administrator &gt; Audit &gt; Databases &gt; DB Access History &gt; DB Access History Details*
 </p>
 

--- a/scripts/tests/confluence_xhtml_to_markdown/testcases/544178405/expected.mdx
+++ b/scripts/tests/confluence_xhtml_to_markdown/testcases/544178405/expected.mdx
@@ -4,7 +4,7 @@ QueryPie의 관리자는 QueryPie Web 또는 API를 통하여 리소스 및 권�
 
 관리자 페이지를 진입하기 위해서는 먼저 QueryPie 로그인을 진행합니다. 로그인이 정상적으로 완료되었다면 사용자 대시보드 이동하게 되며 만약 QueryPie 관리자 역할을 할당받은 사용자일 경우 우측 상단에 `Go to Admin Page` 버튼이 표시됩니다. 이 버튼을 클릭하여 관리자 페이지를 새 탭으로 열 수 있습니다.
 <p align="center">
-<div>[스크린샷 2024-08-01 오후 2.50.06.png]()</div>
+![screenshot-20240801-145006.png](./output/screenshot-20240801-145006.png)
 *GNB 내 관리자 페이지 진입점*
 </p>
 

--- a/scripts/tests/confluence_xhtml_to_markdown/testcases/544377869/expected.mdx
+++ b/scripts/tests/confluence_xhtml_to_markdown/testcases/544377869/expected.mdx
@@ -9,7 +9,7 @@ import { Callout } from 'nextra/components'
 
 기본적으로는 Proxy 사용 옵션이 비활성화되어 있습니다. 접속을 허용할 커넥션에서 Proxy 사용 여부를 활성화합니다.
 <p align="center">
-<div>[image-20240725-070857.png]()</div>
+![image-20240725-070857.png](./output/image-20240725-070857.png)
 *Administrator &gt; Databases &gt; Connection Management &gt; DB Connections &gt; Connection Details &gt; Proxy Usage*
 </p>
 
@@ -31,7 +31,7 @@ Proxy Usage 옵션을 활성화하면 Proxy 로 접속할 수 있는 Port 가 �
 10.3.0 부터 Databases &gt; Connection Management &gt; Proxy Management 는 Databases &gt; Monitoring &gt; Proxy Management 로 이동되었습니다. 10.3.0 이후 버전 사용자는 링크의 [문서](https://querypie.atlassian.net/wiki/x/LgPgO)를 참고하시기 바랍니다.
 </Callout>
 <p align="center">
-<div>[image-20240725-071030.png]()</div>
+![image-20240725-071030.png](./output/image-20240725-071030.png)
 *Administrator &gt; Databases &gt; Connection Management &gt; DB Connections &gt; Proxy Management*
 </p>
 

--- a/scripts/tests/confluence_xhtml_to_markdown/testcases/544379140/expected.mdx
+++ b/scripts/tests/confluence_xhtml_to_markdown/testcases/544379140/expected.mdx
@@ -48,7 +48,7 @@ Audit Log Export 기능 추가에 따라, 각 로그 화면에서 제공되던 �
 ## Audit Log Export 목록 조회하기
 
 <p align="center">
-<div>[image-20240714-063656.png]()</div>
+![image-20240714-063656.png](./output/image-20240714-063656.png)
 *Administrator &gt; Audit &gt; General &gt; Audit Log Export*
 </p>
 
@@ -65,7 +65,7 @@ Audit Log Export 기능 추가에 따라, 각 로그 화면에서 제공되던 �
 
 감사 로그 추출을 시작하기 위해서는 ‘Audit &gt; General &gt; Audit Log Export’ 메뉴 접근 후, 우측 상단의 `Create Task` 버튼을 클릭해야 합니다. 해당 버튼 클릭시 아래와 같은 화면이 나타납니다.
 <p align="center">
-<div>[스크린샷 2025-01-16 오후 1.18.05.png]()</div>
+![screenshot-20250116-131805.png](./output/screenshot-20250116-131805.png)
 *Administrator &gt; Audit &gt; General &gt; Audit Log Export &gt; Create New Task*
 </p>
 

--- a/scripts/tests/confluence_xhtml_to_markdown/testcases/544381877/expected.mdx
+++ b/scripts/tests/confluence_xhtml_to_markdown/testcases/544381877/expected.mdx
@@ -7,7 +7,7 @@ QueryPie에서는 접근 제어를 적용할 온프레미스 등에 위치한 �
 
 개별 서버를 수동으로 등록하기 위해서는 서버의 기본적인 정보 입력이 필요합니다.
 <p align="center">
-<div>[image-20240721-054859.png]()</div>
+![image-20240721-054859.png](./output/image-20240721-054859.png)
 </p>
 
 1. Administrator &gt; Kubernetes &gt; Connection Management &gt; Clusters 메뉴로 이동합니다.
@@ -56,7 +56,7 @@ QueryPie에서는 접근 제어를 적용할 온프레미스 등에 위치한 �
 ## 쿠버네티스 클러스터 연동용 스크립트 이용 안내
 
 <p align="center">
-<div>[image-20240511-033842.png]()</div>
+![image-20240511-033842.png](./output/image-20240511-033842.png)
 </p>
 
 * 관리자는 사전에 해당 대상 쿠버네티스 클러스터에 접속이 가능하여야 합니다.

--- a/scripts/tests/confluence_xhtml_to_markdown/testcases/544384417/expected.mdx
+++ b/scripts/tests/confluence_xhtml_to_markdown/testcases/544384417/expected.mdx
@@ -663,7 +663,7 @@ Audit 메뉴에서 Reports &gt; Reports 메뉴로 진입하면 보고서 생성 
 
 
 <p align="center">
-<div>[스크린샷 2024-12-23 오전 11.22.38.png]()</div>
+![screenshot-20241223-112238.png](./output/screenshot-20241223-112238.png)
 *Administrator &gt; Audit &gt; Reports &gt; Reports*
 </p>
 
@@ -700,7 +700,7 @@ Audit 메뉴에서 Reports &gt; Reports 메뉴로 진입하면 보고서 생성 
 
 
 <p align="center">
-<div>[스크린샷 2024-12-23 오전 11.25.24.png]()</div>
+![screenshot-20241223-112524.png](./output/screenshot-20241223-112524.png)
 *Administrator &gt; Audit &gt; Reports &gt; Reports &gt; Report Detail*
 </p>
 
@@ -736,7 +736,7 @@ Audit 메뉴에서 Reports &gt; Reports 메뉴로 진입하면 보고서 생성 
 
 태스크 이름, 보고서 유형, 스케줄링 관련 내용을 입력하고, 섹션 단위로 보고서 출력 항목 및 적용할 필터를 지정할 수 있습니다. `+ Add Section` 버튼을 클릭하여 섹션을 추가할 수 있습니다.
 <p align="center">
-<div>[스크린샷 2024-12-09 오전 10.43.37.png]()</div>
+![screenshot-20241209-104337.png](./output/screenshot-20241209-104337.png)
 *Administrator &gt; Audit &gt; Reports &gt; Reports &gt; Create*
 </p>
 
@@ -770,7 +770,7 @@ Audit 메뉴에서 Reports &gt; Reports 메뉴로 진입하면 보고서 생성 
 ## 보고서 복제하기**[10.2.2]**
 
 <p align="center">
-<div>[스크린샷 2024-12-23 오전 10.45.29.png]()</div>
+![screenshot-20241223-104529.png](./output/screenshot-20241223-104529.png)
 *Administrator &gt; Audit &gt; Reports &gt; Reports - Duplicate Task*
 </p>
 

--- a/scripts/tests/confluence_xhtml_to_markdown/testcases/568918170/expected.mdx
+++ b/scripts/tests/confluence_xhtml_to_markdown/testcases/568918170/expected.mdx
@@ -8,7 +8,7 @@ Workflow 사용 시 편리함을 더해주는 부가 기능을 소개합니다.
 ## 참조된 요청 확인 처리하기
 
 <p align="center">
-<div>[스크린샷 2024-08-02 오전 11.41.29.png]()</div>
+![screenshot-20240802-114129.png](./output/screenshot-20240802-114129.png)
 *Workflow &gt; Reviews &gt; All Reviews &gt; Review Details*
 </p>
 
@@ -25,7 +25,7 @@ Workflow 사용 시 편리함을 더해주는 부가 기능을 소개합니다.
 ### 1. 대리 결재 사용 설정하기
 
 <p align="center">
-<div>[스크린샷 2024-08-02 오후 12.04.01.png]()</div>
+![screenshot-20240802-120401.png](./output/screenshot-20240802-120401.png)
 *User &gt; 상단 메뉴바에서 프로필 클릭 &gt; Preferences*
 </p>
 
@@ -39,11 +39,11 @@ Workflow 사용 시 편리함을 더해주는 부가 기능을 소개합니다.
 
 대리 결재 설정 기간에는 원 결재자와 대리 결재자의 접속 시 상단 메뉴바에 다음과 같이 표시됩니다.
 <p align="center">
-<div>[스크린샷 2024-08-02 오후 12.07.41.png]()</div>
+![screenshot-20240802-120741.png](./output/screenshot-20240802-120741.png)
 *원 결재자 기준 표시 내용*
 </p>
 <p align="center">
-<div>[스크린샷 2024-08-02 오후 12.08.54.png]()</div>
+![screenshot-20240802-120854.png](./output/screenshot-20240802-120854.png)
 *대리 결재자 기준 표시 내용*
 </p>
 <Callout type="info">
@@ -57,7 +57,7 @@ Workflow 사용 시 편리함을 더해주는 부가 기능을 소개합니다.
     *  **Received Requests &gt; Done**  : 대리 결재 설정 기간 내 대리 결재자가 처리한 요청을 볼 수 있습니다.
 * 상세 페이지에서 승인 또는 반려할 수 있으며, Comment 입력 시에는 대리 결재 중임을 알리는 문구가 표시됩니다. 
 <p align="center">
-<div>[스크린샷 2024-08-02 오후 12.46.38.png]()</div>
+![screenshot-20240802-124638.png](./output/screenshot-20240802-124638.png)
 </p>
 
 ### 4. 대리 결재 처리된 요청 건 확인하기
@@ -65,12 +65,12 @@ Workflow 사용 시 편리함을 더해주는 부가 기능을 소개합니다.
 * 다음과 같이 요청 상세페이지 내 승인 현황에서 원 결재자 또는 대리 결재자가 처리한 것인지를 확인할 수 있습니다. 
 **원 결재자가 처리한 경우**
 <p align="center">
-<div>[스크린샷 2024-07-25 오후 3.35.33.png]()</div>
+![screenshot-20240725-153533.png](./output/screenshot-20240725-153533.png)
 *대리 결재 관련 문구 없음*
 </p>
 **대리 결재자가 처리한 경우**
 <p align="center">
-<div>[스크린샷 2024-07-25 오후 3.21.41.png]()</div>
+![screenshot-20240725-152141.png](./output/screenshot-20240725-152141.png)
 *대리 결재자가 Done by the delegate와 함께 표기됨*
 </p>
 <Callout type="info">
@@ -86,7 +86,7 @@ Slack DM을 통한 요청 알림을 사용 중이라면, 대리 결재자에게�
 
 동일한 내용으로 반복적인 결재 요청을 하거나 반려 처리된 결재 건에 대해 다음과 같이 재상신할 수 있습니다.
 <p align="center">
-<div>[image-20230824-110815.png]()</div>
+![image-20230824-110815.png](./output/image-20230824-110815.png)
 *Workflow &gt; Sent Requests &gt; Done &gt; List Details*
 </p>
 

--- a/scripts/tests/confluence_xhtml_to_markdown/testcases/692355151/expected.mdx
+++ b/scripts/tests/confluence_xhtml_to_markdown/testcases/692355151/expected.mdx
@@ -22,7 +22,7 @@ QueryPie Workflow에서 SQL Request를 작성하는 기본 방법은 동일합�
 Content Type은 “Text”만 지원합니다. “File”을 선택하면 실행 계획(Explain)기능을 사용할 수 없습니다.
 </Callout>
 <p align="center">
-<div>[image-20241029-234721.png]()</div>
+![image-20241029-234721.png](./output/image-20241029-234721.png)
 </p>
 
 1. 실행계획(Explain) 옵션 및 실행계획 수행<br/>쿼리 에디터 하단에 있는 옵션을 선택하고 `Explain` 버튼을 누릅니다.
@@ -31,14 +31,14 @@ Content Type은 “Text”만 지원합니다. “File”을 선택하면 실행
         1.  **Table**  : 테이블 형태로 결과가 표시됩니다.
         2.  **JSON**  : JSON 형태로 결과가 표시됩니다. 
 <p align="center">
-<div>[image-20241029-235845.png]()</div>
+![image-20241029-235845.png](./output/image-20241029-235845.png)
 </p>
 
 <Callout type="important">
 * 실행계획 대상이 되는 쿼리(세미콜론으로 끝나는 구문)는 100개로 제한됩니다. 
 * MySQL은 5.6 이후 부터 Explain의 결과를 JSON 포맷으로 출력할 수 있습니다. 따라서 5.6 이전 버전을 대상으로 Explain을 수행시 JSON으로 출력할 수 없습니다.
 <p align="center">
-<div>[image-20241030-001252.png]()</div>
+![image-20241030-001252.png](./output/image-20241030-001252.png)
 </p>
 </Callout>
 


### PR DESCRIPTION
## Description
이 PR은 Confluence XHTML to Markdown 변환 스크립트의 이미지 처리 기능을 개선합니다. MDX 문서와 첨부 이미지는 크기가 커서, 이번 PR 에 포함하지 않습니다.

### 주요 변경사항
1. Confluence XHTML to Markdown 변환 스크립트 개선
    - ConfluenceToMarkdown.load_attachments() 로 생성한 첨부파일 목록을 각 Parser object 의 생성자로 전달합니다. 이를 이용해, `<ac:image>` 노드를 처리할 때, 첨부파일 목록과 비교하여 링크를 생성합니다.
    - Unicode 정규화 적용: 파일명 검색 시 unicodedata.normalize('NFC', filename) 사용으로 한글 파일명 매칭 문제 해결
        - 맥에서 시스템이 생성한 파일이름은 조합형 유니코드로 생성됩니다. 완성형 유니코드로 정규화하는 과정이 필요합니다.
    - 이미지 처리 로직 개선: Attachment 클래스의 as_markdown() 메서드를 활용하여 이미지 링크 생성
    - 이미지 파일 필터링: .png 파일만 처리하도록 제한. .mov 를 제외합니다.
    - 상대 경로 개선: ./dirname/filename.png 형태로 이미지 링크 생성
2. 테스트 케이스 업데이트
    - 9개의 테스트 케이스 파일 업데이트로 변환 스크립트의 정확성 검증

## Additional notes
- 
