### PR TITLE
fix: list.txt 의 탐색경로 구분자를 "/>>" 로 변경합니다.

### DIFF
--- a/docs/latest-ko-confluence/list.en.txt
+++ b/docs/latest-ko-confluence/list.en.txt
@@ -1,262 +1,263 @@
 608501837	QueryPie Docs	QueryPie Docs
 544375335	Release Notes	Release Notes
-1064830173	Release Notes > 11.0.0	11.0.0
-954335909	Release Notes > 10.3.0 ~ 10.3.4	10.3.0 ~ 10.3.4
-703463517	Release Notes > 10.2.0 ~ 10.2.12	10.2.0 ~ 10.2.12
-604995641	Release Notes > 10.1.0 ~ 10.1.11	10.1.0 ~ 10.1.11
-544375355	Release Notes > 10.0.0 ~ 10.0.2	10.0.0 ~ 10.0.2
-544375370	Release Notes > 9.20.0 ~ 9.20.2	9.20.0 ~ 9.20.2
-544375385	Release Notes > 9.19.0 	9.19.0 
-544375399	Release Notes > 9.18.0 ~ 9.18.3	9.18.0 ~ 9.18.3
-544375414	Release Notes > 9.17.0 ~ 9.17.1	9.17.0 ~ 9.17.1
-544375429	Release Notes > 9.16.0 ~ 9.16.4	9.16.0 ~ 9.16.4
-544375443	Release Notes > 9.15.0 ~ 9.15.4	9.15.0 ~ 9.15.4
-544375457	Release Notes > 9.14.0 ~ 9.14.3	9.14.0 ~ 9.14.3
-544375471	Release Notes > 9.13.0 ~ 9.13.5	9.13.0 ~ 9.13.5
-544375485	Release Notes > 9.12.0 ~ 9.12.14	9.12.0 ~ 9.12.14
-544375505	Release Notes > 9.12.0 ~ 9.12.14 > Menu Improvement Guide (9.12.0)	Menu Improvement Guide (9.12.0)
-544375587	Release Notes > 9.11.0 ~ 9.11.5	9.11.0 ~ 9.11.5
-544375607	Release Notes > 9.10.0 - 9.10.4	9.10.0 - 9.10.4
-544375624	Release Notes > 9.10.0 - 9.10.4 > External API Changes (9.10.0 Version)	External API Changes (9.10.0 Version)
-544375659	Release Notes > 9.9.0 ~ 9.9.8	9.9.0 ~ 9.9.8
-544375685	Release Notes > 9.9.0 ~ 9.9.8 > External API Changes (9.8.10 Version > 9.9.4 Version)	External API Changes (9.8.10 Version > 9.9.4 Version)
-544375741	Release Notes > 9.9.0 ~ 9.9.8 > External API Changes (9.9.4 Version > 9.9.5 Version)	External API Changes (9.9.4 Version > 9.9.5 Version)
-544375768	Release Notes > 9.8.0 ~ 9.8.12	9.8.0 ~ 9.8.12
+1171488777	Release Notes />> 11.1.0	11.1.0
+1064830173	Release Notes />> 11.0.0	11.0.0
+954335909	Release Notes />> 10.3.0 ~ 10.3.4	10.3.0 ~ 10.3.4
+703463517	Release Notes />> 10.2.0 ~ 10.2.12	10.2.0 ~ 10.2.12
+604995641	Release Notes />> 10.1.0 ~ 10.1.11	10.1.0 ~ 10.1.11
+544375355	Release Notes />> 10.0.0 ~ 10.0.2	10.0.0 ~ 10.0.2
+544375370	Release Notes />> 9.20.0 ~ 9.20.2	9.20.0 ~ 9.20.2
+544375385	Release Notes />> 9.19.0 	9.19.0 
+544375399	Release Notes />> 9.18.0 ~ 9.18.3	9.18.0 ~ 9.18.3
+544375414	Release Notes />> 9.17.0 ~ 9.17.1	9.17.0 ~ 9.17.1
+544375429	Release Notes />> 9.16.0 ~ 9.16.4	9.16.0 ~ 9.16.4
+544375443	Release Notes />> 9.15.0 ~ 9.15.4	9.15.0 ~ 9.15.4
+544375457	Release Notes />> 9.14.0 ~ 9.14.3	9.14.0 ~ 9.14.3
+544375471	Release Notes />> 9.13.0 ~ 9.13.5	9.13.0 ~ 9.13.5
+544375485	Release Notes />> 9.12.0 ~ 9.12.14	9.12.0 ~ 9.12.14
+544375505	Release Notes />> 9.12.0 ~ 9.12.14 />> Menu Improvement Guide (9.12.0)	Menu Improvement Guide (9.12.0)
+544375587	Release Notes />> 9.11.0 ~ 9.11.5	9.11.0 ~ 9.11.5
+544375607	Release Notes />> 9.10.0 - 9.10.4	9.10.0 - 9.10.4
+544375624	Release Notes />> 9.10.0 - 9.10.4 />> External API Changes (9.10.0 Version)	External API Changes (9.10.0 Version)
+544375659	Release Notes />> 9.9.0 ~ 9.9.8	9.9.0 ~ 9.9.8
+544375685	Release Notes />> 9.9.0 ~ 9.9.8 />> External API Changes (9.8.10 Version > 9.9.4 Version)	External API Changes (9.8.10 Version > 9.9.4 Version)
+544375741	Release Notes />> 9.9.0 ~ 9.9.8 />> External API Changes (9.9.4 Version > 9.9.5 Version)	External API Changes (9.9.4 Version > 9.9.5 Version)
+544375768	Release Notes />> 9.8.0 ~ 9.8.12	9.8.0 ~ 9.8.12
 544375784	QueryPie Overview	QueryPie Overview
-544112942	QueryPie Overview > Proxy Management	Proxy Management
-544377869	QueryPie Overview > Proxy Management > Enable Database Proxy	Enable Database Proxy
-544375859	QueryPie Overview > System Architecture Overview	System Architecture Overview
-544375808	QueryPie Overview > Installation and Customer Support	Installation and Customer Support
+544112942	QueryPie Overview />> Proxy Management	Proxy Management
+544377869	QueryPie Overview />> Proxy Management />> Enable Database Proxy	Enable Database Proxy
+544375859	QueryPie Overview />> System Architecture Overview	System Architecture Overview
+544375808	QueryPie Overview />> Installation and Customer Support	Installation and Customer Support
 544211126	User Manual	User Manual
-578945174	User Manual > My Dashboard	My Dashboard
-793542657	User Manual > My Dashboard > User Password Reset via Email	User Password Reset via Email
-544377922	User Manual > Workflow	Workflow
-544377968	User Manual > Workflow > Requesting DB Access	Requesting DB Access
-544378069	User Manual > Workflow > Requesting SQL	Requesting SQL
-692355151	User Manual > Workflow > Requesting SQL > Using Execution Plan (Explain) Feature	Using Execution Plan (Explain) Feature
-544378182	User Manual > Workflow > Requesting SQL Export	Requesting SQL Export
-712769539	User Manual > Workflow > Requesting Unmasking (Mask Removal Request)	Requesting Unmasking (Mask Removal Request)
-1060306945	User Manual > Workflow > Requesting Restricted Data Access	Requesting Restricted Data Access
-544378254	User Manual > Workflow > Requesting Server Access	Requesting Server Access
-878936417	User Manual > Workflow > Requesting Server Privilege	Requesting Server Privilege
-544378348	User Manual > Workflow > Requesting Access Role	Requesting Access Role
-1055358996	User Manual > Workflow > Requesting IP Registration	Requesting IP Registration
-568918170	User Manual > Workflow > Approval Additional Features (Proxy Approval, Resubmission, etc.)	Approval Additional Features (Proxy Approval, Resubmission, etc.)
-1070006273	User Manual > Workflow > Requesting DB Policy Exception	Requesting DB Policy Exception
-544380204	User Manual > Database Access Control	Database Access Control
-544380222	User Manual > Database Access Control > Connecting with Web SQL Editor	Connecting with Web SQL Editor
-544380354	User Manual > Database Access Control > Setting Default Privilege	Setting Default Privilege
-559906893	User Manual > Database Access Control > Connecting to Proxy without Agent	Connecting to Proxy without Agent
-820609510	User Manual > Database Access Control > Connecting via Google BigQuery OAuth Authentication	Connecting via Google BigQuery OAuth Authentication
-880181257	User Manual > Database Access Control > Connecting to Custom Data Source	Connecting to Custom Data Source
-544381369	User Manual > Server Access Control	Server Access Control
-544381383	User Manual > Server Access Control > Connecting to Authorized Servers	Connecting to Authorized Servers
-544381410	User Manual > Server Access Control > Using Web Terminal	Using Web Terminal
-544381477	User Manual > Server Access Control > Using Web SFTP	Using Web SFTP
-544384011	User Manual > Kubernetes Access Control	Kubernetes Access Control
-544384025	User Manual > Kubernetes Access Control > Checking Access Permission List	Checking Access Permission List
-1064829218	User Manual > Web Access Control	Web Access Control
-1073709107	User Manual > Web Access Control > Installing Root CA Certificate and Extension	Installing Root CA Certificate and Extension
-1064796396	User Manual > Web Access Control > Accessing Web Applications (Websites)	Accessing Web Applications (Websites)
-568950885	User Manual > Preferences	Preferences
-544112828	User Manual > User Agent	User Agent
-852066413	User Manual > Multi Agent	Multi Agent
-912425276	User Manual > Multi Agent > Multi Agent Linux Installation and Usage Guide	Multi Agent Linux Installation and Usage Guide
-912425288	User Manual > Multi Agent > Multi Agent Seamless SSH Usage Guide	Multi Agent Seamless SSH Usage Guide
-919240916	User Manual > Multi Agent > Multi Agent 3rd Party Tool Support List by OS	Multi Agent 3rd Party Tool Support List by OS
+578945174	User Manual />> My Dashboard	My Dashboard
+793542657	User Manual />> My Dashboard />> User Password Reset via Email	User Password Reset via Email
+544377922	User Manual />> Workflow	Workflow
+544377968	User Manual />> Workflow />> Requesting DB Access	Requesting DB Access
+544378069	User Manual />> Workflow />> Requesting SQL	Requesting SQL
+692355151	User Manual />> Workflow />> Requesting SQL />> Using Execution Plan (Explain) Feature	Using Execution Plan (Explain) Feature
+544378182	User Manual />> Workflow />> Requesting SQL Export	Requesting SQL Export
+712769539	User Manual />> Workflow />> Requesting Unmasking (Mask Removal Request)	Requesting Unmasking (Mask Removal Request)
+1060306945	User Manual />> Workflow />> Requesting Restricted Data Access	Requesting Restricted Data Access
+544378254	User Manual />> Workflow />> Requesting Server Access	Requesting Server Access
+878936417	User Manual />> Workflow />> Requesting Server Privilege	Requesting Server Privilege
+544378348	User Manual />> Workflow />> Requesting Access Role	Requesting Access Role
+1055358996	User Manual />> Workflow />> Requesting IP Registration	Requesting IP Registration
+568918170	User Manual />> Workflow />> Approval Additional Features (Proxy Approval, Resubmission, etc.)	Approval Additional Features (Proxy Approval, Resubmission, etc.)
+1070006273	User Manual />> Workflow />> Requesting DB Policy Exception	Requesting DB Policy Exception
+544380204	User Manual />> Database Access Control	Database Access Control
+544380222	User Manual />> Database Access Control />> Connecting with Web SQL Editor	Connecting with Web SQL Editor
+544380354	User Manual />> Database Access Control />> Setting Default Privilege	Setting Default Privilege
+559906893	User Manual />> Database Access Control />> Connecting to Proxy without Agent	Connecting to Proxy without Agent
+820609510	User Manual />> Database Access Control />> Connecting via Google BigQuery OAuth Authentication	Connecting via Google BigQuery OAuth Authentication
+880181257	User Manual />> Database Access Control />> Connecting to Custom Data Source	Connecting to Custom Data Source
+544381369	User Manual />> Server Access Control	Server Access Control
+544381383	User Manual />> Server Access Control />> Connecting to Authorized Servers	Connecting to Authorized Servers
+544381410	User Manual />> Server Access Control />> Using Web Terminal	Using Web Terminal
+544381477	User Manual />> Server Access Control />> Using Web SFTP	Using Web SFTP
+544384011	User Manual />> Kubernetes Access Control	Kubernetes Access Control
+544384025	User Manual />> Kubernetes Access Control />> Checking Access Permission List	Checking Access Permission List
+1064829218	User Manual />> Web Access Control	Web Access Control
+1073709107	User Manual />> Web Access Control />> Installing Root CA Certificate and Extension	Installing Root CA Certificate and Extension
+1064796396	User Manual />> Web Access Control />> Accessing Web Applications (Websites)	Accessing Web Applications (Websites)
+568950885	User Manual />> Preferences	Preferences
+544112828	User Manual />> User Agent	User Agent
+852066413	User Manual />> Multi Agent	Multi Agent
+912425276	User Manual />> Multi Agent />> Multi Agent Linux Installation and Usage Guide	Multi Agent Linux Installation and Usage Guide
+912425288	User Manual />> Multi Agent />> Multi Agent Seamless SSH Usage Guide	Multi Agent Seamless SSH Usage Guide
+919240916	User Manual />> Multi Agent />> Multi Agent 3rd Party Tool Support List by OS	Multi Agent 3rd Party Tool Support List by OS
 544178405	Administrator Manual	Administrator Manual
-544080057	Administrator Manual > General	General
-543948978	Administrator Manual > General > Company Management	Company Management
-544145591	Administrator Manual > General > Company Management > General	General
-544178422	Administrator Manual > General > Company Management > Security	Security
-544112846	Administrator Manual > General > Company Management > Allowed Zones	Allowed Zones
-544243925	Administrator Manual > General > Company Management > Channels	Channels
-543981760	Administrator Manual > General > Company Management > Alerts	Alerts
-793608206	Administrator Manual > General > Company Management > Alerts > New Request > Template Variables by Request Type	New Request > Template Variables by Request Type
-544178443	Administrator Manual > General > Company Management > Licenses	Licenses
-544375969	Administrator Manual > General > User Management	User Management
-544047331	Administrator Manual > General > User Management > Users	Users
-544376787	Administrator Manual > General > User Management > Users > User Profile	User Profile
-920944732	Administrator Manual > General > User Management > Users > Password Change Enforcement and Account Deletion Feature for qp-admin Default Account	Password Change Enforcement and Account Deletion Feature for qp-admin Default Account
-544047341	Administrator Manual > General > User Management > Groups	Groups
-543948996	Administrator Manual > General > User Management > Roles	Roles
-544376982	Administrator Manual > General > User Management > Profile Editor	Profile Editor
-953221256	Administrator Manual > General > User Management > Profile Editor > Custom Attribute	Custom Attribute
-544375984	Administrator Manual > General > User Management > Authentication	Authentication
-544376004	Administrator Manual > General > User Management > Authentication > Integrating with LDAP	Integrating with LDAP
-544376100	Administrator Manual > General > User Management > Authentication > Integrating with Okta	Integrating with Okta
-544376183	Administrator Manual > General > User Management > Authentication > Integrating with AWS SSO	Integrating with AWS SSO
-619381289	Administrator Manual > General > User Management > Authentication > Integrating with Google SAML	Integrating with Google SAML
-793575425	Administrator Manual > General > User Management > Authentication > Setting Up Multi-Factor Authentication	Setting Up Multi-Factor Authentication
-544376236	Administrator Manual > General > User Management > Provisioning	Provisioning
-544376265	Administrator Manual > General > User Management > Provisioning > Activating Provisioning	Activating Provisioning
-544376394	Administrator Manual > General > User Management > Provisioning > [Okta] Provisioning Integration Guide	[Okta] Provisioning Integration Guide
-544178462	Administrator Manual > General > Workflow Management	Workflow Management
-544047359	Administrator Manual > General > Workflow Management > All Requests	All Requests
-544378513	Administrator Manual > General > Workflow Management > Approval Rules	Approval Rules
-561414376	Administrator Manual > General > Workflow Management > Workflow Configurations	Workflow Configurations
-544112865	Administrator Manual > General > System	System
-544080097	Administrator Manual > General > System > Integrations	Integrations
-544379393	Administrator Manual > General > System > Integrations > Integrating with Syslog	Integrating with Syslog
-557940795	Administrator Manual > General > System > Integrations > Integrating with Splunk	Integrating with Splunk
-544379587	Administrator Manual > General > System > Integrations > Integrating with Secret Store	Integrating with Secret Store
-798064641	Administrator Manual > General > System > Integrations > Integrating with Email	Integrating with Email
-811401365	Administrator Manual > General > System > Integrations > Integrating Google Cloud API for OAuth 2.0	Integrating Google Cloud API for OAuth 2.0
-883654669	Administrator Manual > General > System > Integrations > Integrating with Slack DM	Integrating with Slack DM
-544378759	Administrator Manual > General > System > Integrations > Integrating with Slack DM > Slack DM - Workflow Notification Types	Slack DM - Workflow Notification Types
-544377652	Administrator Manual > General > System > API Token	API Token
-544211220	Administrator Manual > General > System > Jobs	Jobs
-544047372	Administrator Manual > Discovery	Discovery
-543949048	Administrator Manual > Discovery > Discovery Management	Discovery Management
-543981852	Administrator Manual > Discovery > Discovery Management > Dashboard	Dashboard
-544080127	Administrator Manual > Discovery > Discovery Management > Inventory	Inventory
-543949058	Administrator Manual > Discovery > Discovery Management > Discovery Jobs	Discovery Jobs
-543981865	Administrator Manual > Discovery > Discovery Management > Discovery History	Discovery History
-543949078	Administrator Manual > Discovery > Discovery Management > Scan Results	Scan Results
-544244011	Administrator Manual > Discovery > Discovery Management > Detection Profiles	Detection Profiles
-544112915	Administrator Manual > Discovery > Discovery Management > Data Patterns	Data Patterns
-544379638	Administrator Manual > Databases	Databases
-956071939	Administrator Manual > Databases > DAC General Configurations	DAC General Configurations
-921436219	Administrator Manual > Databases > DAC General Configurations > Unmasking Zones	Unmasking Zones
-544379705	Administrator Manual > Databases > Connection Management	Connection Management
-544145672	Administrator Manual > Databases > Connection Management > Cloud Providers	Cloud Providers
-544379719	Administrator Manual > Databases > Connection Management > Cloud Providers > Synchronizing DB Resources from AWS	Synchronizing DB Resources from AWS
-562167871	Administrator Manual > Databases > Connection Management > Cloud Providers > Synchronizing DB Resources from MS Azure	Synchronizing DB Resources from MS Azure
-562167809	Administrator Manual > Databases > Connection Management > Cloud Providers > Synchronizing DB Resources from Google Cloud	Synchronizing DB Resources from Google Cloud
-712507393	Administrator Manual > Databases > Connection Management > Cloud Providers > Verifying Cloud Synchronization Settings with Dry Run Feature	Verifying Cloud Synchronization Settings with Dry Run Feature
-544014712	Administrator Manual > Databases > Connection Management > DB Connections	DB Connections
-544380381	Administrator Manual > Databases > Connection Management > DB Connections > MongoDB Specific Guide	MongoDB Specific Guide
-568852692	Administrator Manual > Databases > Connection Management > DB Connections > DocumentDB Specific Guide	DocumentDB Specific Guide
-811434142	Administrator Manual > Databases > Connection Management > DB Connections > Google BigQuery OAuth Authentication Configuration	Google BigQuery OAuth Authentication Configuration
-820806182	Administrator Manual > Databases > Connection Management > DB Connections > AWS Athena Specific Guide	AWS Athena Specific Guide
-880082945	Administrator Manual > Databases > Connection Management > DB Connections > Custom Data Source Configuration and Log Verification	Custom Data Source Configuration and Log Verification
-544145691	Administrator Manual > Databases > Connection Management > SSL Configurations	SSL Configurations
-544047436	Administrator Manual > Databases > Connection Management > SSH Configurations	SSH Configurations
-544112932	Administrator Manual > Databases > Connection Management > Kerberos Configurations	Kerberos Configurations
-544380126	Administrator Manual > Databases > DB Access Control	DB Access Control
-544380140	Administrator Manual > Databases > DB Access Control > Privilege Type	Privilege Type
-544380173	Administrator Manual > Databases > DB Access Control > Access Control	Access Control
-544379868	Administrator Manual > Databases > Policies	Policies
-544379937	Administrator Manual > Databases > Policies > Data Access	Data Access
-569376769	Administrator Manual > Databases > Policies > Masking Pattern	Masking Pattern
-544379882	Administrator Manual > Databases > Policies > Data Masking	Data Masking
-544379993	Administrator Manual > Databases > Policies > Sensitive Data	Sensitive Data
-713129986	Administrator Manual > Databases > Policies > Policy Exception	Policy Exception
-571277577	Administrator Manual > Databases > Ledger Management	Ledger Management
-544380061	Administrator Manual > Databases > Ledger Management > Ledger Table Policy	Ledger Table Policy
-571277650	Administrator Manual > Databases > Ledger Management > Ledger Approval Rules	Ledger Approval Rules
-873136365	Administrator Manual > Databases > (New) Policy Management	(New) Policy Management
-878805502	Administrator Manual > Databases > (New) Policy Management > Data Paths	Data Paths
-879198569	Administrator Manual > Databases > (New) Policy Management > Data Policies	Data Policies
-1064796485	Administrator Manual > Databases > (New) Policy Management > Exception Management	Exception Management
-954139156	Administrator Manual > Databases > Monitoring	Monitoring
-954172219	Administrator Manual > Databases > Monitoring > Runnig Queries	Runnig Queries
-954204974	Administrator Manual > Databases > Monitoring > Proxy Management	Proxy Management
-544380588	Administrator Manual > Servers	Servers
-954336174	Administrator Manual > Servers > SAC General Configurations	SAC General Configurations
-544380635	Administrator Manual > Servers > Connection Management	Connection Management
-544178567	Administrator Manual > Servers > Connection Management > Cloud Providers	Cloud Providers
-544380650	Administrator Manual > Servers > Connection Management > Cloud Providers > Synchronizing Server Resources from AWS	Synchronizing Server Resources from AWS
-544380741	Administrator Manual > Servers > Connection Management > Cloud Providers > Synchronizing Server Resources from Azure	Synchronizing Server Resources from Azure
-544380708	Administrator Manual > Servers > Connection Management > Cloud Providers > Synchronizing Server Resources from GCP	Synchronizing Server Resources from GCP
-544211361	Administrator Manual > Servers > Connection Management > Servers	Servers
-544380774	Administrator Manual > Servers > Connection Management > Servers > Manually Registering Individual Servers	Manually Registering Individual Servers
-544080186	Administrator Manual > Servers > Connection Management > Server Groups	Server Groups
-544380846	Administrator Manual > Servers > Connection Management > Server Groups > Managing Servers as Groups	Managing Servers as Groups
-544211376	Administrator Manual > Servers > Connection Management > Server Agents for RDP	Server Agents for RDP
-565575990	Administrator Manual > Servers > Connection Management > Server Agents for RDP > Installing and Removing Server Agent	Installing and Removing Server Agent
-615710737	Administrator Manual > Servers > Connection Management > ProxyJump Configurations	ProxyJump Configurations
-615743551	Administrator Manual > Servers > Connection Management > ProxyJump Configurations > Creating ProxyJump	Creating ProxyJump
-613777446	Administrator Manual > Servers > Server Account Management	Server Account Management
-544380991	Administrator Manual > Servers > Server Account Management > Server Account Templates	Server Account Templates
-544380960	Administrator Manual > Servers > Server Account Management > SSH Key Configurations	SSH Key Configurations
-615743501	Administrator Manual > Servers > Server Account Management > Account Management	Account Management
-615677962	Administrator Manual > Servers > Server Account Management > Password Provisioning	Password Provisioning
-619380898	Administrator Manual > Servers > Server Account Management > Password Provisioning > Creating Password Change Job	Creating Password Change Job
-543949216	Administrator Manual > Servers > Server Access Control	Server Access Control
-544381186	Administrator Manual > Servers > Server Access Control > Access Control	Access Control
-544381282	Administrator Manual > Servers > Server Access Control > Access Control > Granting and Revoking Permissions	Granting and Revoking Permissions
-544381200	Administrator Manual > Servers > Server Access Control > Access Control > Granting and Revoking Roles	Granting and Revoking Roles
-878838349	Administrator Manual > Servers > Server Access Control > Access Control > Granting Server Privilege	Granting Server Privilege
-544381150	Administrator Manual > Servers > Server Access Control > Roles	Roles
-544381025	Administrator Manual > Servers > Server Access Control > Policies	Policies
-544381039	Administrator Manual > Servers > Server Access Control > Policies > Setting Server Access Policy	Setting Server Access Policy
-544377895	Administrator Manual > Servers > Server Access Control > Policies > Enabling Server Proxy	Enabling Server Proxy
-544381118	Administrator Manual > Servers > Server Access Control > Command Templates	Command Templates
-544244109	Administrator Manual > Servers > Server Access Control > Blocked Accounts	Blocked Accounts
-544381596	Administrator Manual > Kubernetes	Kubernetes
-954172232	Administrator Manual > Kubernetes > KAC General Configurations	KAC General Configurations
-544381637	Administrator Manual > Kubernetes > Connection Management	Connection Management
-544381651	Administrator Manual > Kubernetes > Connection Management > Cloud Providers	Cloud Providers
-544381739	Administrator Manual > Kubernetes > Connection Management > Cloud Providers > Synchronizing Kubernetes Resources from AWS	Synchronizing Kubernetes Resources from AWS
-544381839	Administrator Manual > Kubernetes > Connection Management > Clusters	Clusters
-544381877	Administrator Manual > Kubernetes > Connection Management > Clusters > Manually Registering Kubernetes Clusters	Manually Registering Kubernetes Clusters
-544383110	Administrator Manual > Kubernetes > K8s Access Control	K8s Access Control
-544383124	Administrator Manual > Kubernetes > K8s Access Control > Access Control	Access Control
-544383381	Administrator Manual > Kubernetes > K8s Access Control > Access Control > Granting and Revoking Kubernetes Roles	Granting and Revoking Kubernetes Roles
-544382741	Administrator Manual > Kubernetes > K8s Access Control > Roles	Roles
-544382963	Administrator Manual > Kubernetes > K8s Access Control > Roles > Setting Kubernetes Roles	Setting Kubernetes Roles
-544382060	Administrator Manual > Kubernetes > K8s Access Control > Policies	Policies
-544382274	Administrator Manual > Kubernetes > K8s Access Control > Policies > Setting Kubernetes Policies	Setting Kubernetes Policies
-544382364	Administrator Manual > Kubernetes > K8s Access Control > Policies > Kubernetes Policy YAML Code Syntax Guide	Kubernetes Policy YAML Code Syntax Guide
-544382445	Administrator Manual > Kubernetes > K8s Access Control > Policies > Kubernetes Policy Tips Guide	Kubernetes Policy Tips Guide
-544382522	Administrator Manual > Kubernetes > K8s Access Control > Policies > Kubernetes Policy UI Code Helper Guide	Kubernetes Policy UI Code Helper Guide
-544382659	Administrator Manual > Kubernetes > K8s Access Control > Policies > Kubernetes Policy Action Configuration Reference Guide	Kubernetes Policy Action Configuration Reference Guide
-783515900	Administrator Manual > Web Apps	Web Apps
-1064829276	Administrator Manual > Web Apps > Connection Management	Connection Management
-1070694423	Administrator Manual > Web Apps > Connection Management > Web Apps	Web Apps
-1064829246	Administrator Manual > Web Apps > Connection Management > Web App Configurations	Web App Configurations
-1070596135	Administrator Manual > Web Apps > Web App Access Control	Web App Access Control
-1070628904	Administrator Manual > Web Apps > Web App Access Control > Access Control	Access Control
-1064599910	Administrator Manual > Web Apps > Web App Access Control > Access Control > Granting and Revoking Roles	Granting and Revoking Roles
-1070628923	Administrator Manual > Web Apps > Web App Access Control > Roles	Roles
-1064829343	Administrator Manual > Web Apps > Web App Access Control > Policies	Policies
-783417593	Administrator Manual > Web Apps > WAC Quickstart	WAC Quickstart
-783745324	Administrator Manual > Web Apps > WAC Quickstart > [~10.2.7] WAC Role & Policy Guide	[~10.2.7] WAC Role & Policy Guide
-924287097	Administrator Manual > Web Apps > WAC Quickstart > [10.2.8~] WAC RBAC Guide	[10.2.8~] WAC RBAC Guide
-956235931	Administrator Manual > Web Apps > WAC Quickstart > [10.3.0 ~] WAC JIT Permission Acquisition Guide	[10.3.0 ~] WAC JIT Permission Acquisition Guide
-805962425	Administrator Manual > Web Apps > WAC Quickstart > Root CA Certificate Installation Guide	Root CA Certificate Installation Guide
-883654785	Administrator Manual > Web Apps > WAC Quickstart > Initial WAC Setup in Web App Configurations	Initial WAC Setup in Web App Configurations
-924319936	Administrator Manual > Web Apps > WAC Quickstart > WAC Troubleshooting Guide	WAC Troubleshooting Guide
-927629410	Administrator Manual > Web Apps > WAC Quickstart > WAC FAQ	WAC FAQ
-544379062	Administrator Manual > Audit	Audit
-693043522	Administrator Manual > Audit > Reports	Reports
-544384417	Administrator Manual > Audit > Reports > Reports	Reports
-544379140	Administrator Manual > Audit > Reports > Audit Log Export	Audit Log Export
-544211450	Administrator Manual > Audit > General Logs	General Logs
-544080230	Administrator Manual > Audit > General Logs > User Access History	User Access History
-544113108	Administrator Manual > Audit > General Logs > Activity Logs	Activity Logs
-544047557	Administrator Manual > Audit > General Logs > Admin Role History	Admin Role History
-705724442	Administrator Manual > Audit > General Logs > Workflow Logs	Workflow Logs
-775455036	Administrator Manual > Audit > General Logs > Reverse Tunnels	Reverse Tunnels
-811434216	Administrator Manual > Audit > General Logs > Reverse Tunnels > Communicating with Servers through Reverse Tunnel	Communicating with Servers through Reverse Tunnel
-811466988	Administrator Manual > Audit > General Logs > Reverse Tunnels > Communicating with Clusters through Reverse Tunnel	Communicating with Clusters through Reverse Tunnel
-955318273	Administrator Manual > Audit > General Logs > Reverse Tunnels > Communicating with DB through Reverse Tunnel	Communicating with DB through Reverse Tunnel
-544080248	Administrator Manual > Audit > Database Logs	Database Logs
-544113141	Administrator Manual > Audit > Database Logs > DB Access History	DB Access History
-544244149	Administrator Manual > Audit > Database Logs > Query Audit	Query Audit
-544145819	Administrator Manual > Audit > Database Logs > Running Queries	Running Queries
-544244163	Administrator Manual > Audit > Database Logs > DML Snapshots	DML Snapshots
-544014894	Administrator Manual > Audit > Database Logs > Account Lock History	Account Lock History
-544080264	Administrator Manual > Audit > Database Logs > Access Control Logs	Access Control Logs
-1070694532	Administrator Manual > Audit > Database Logs > Policy Audit Logs	Policy Audit Logs
-1164705793	Administrator Manual > Audit > Database Logs > Policy Exception logs	Policy Exception logs
-544014907	Administrator Manual > Audit > Server Logs	Server Logs
-544244182	Administrator Manual > Audit > Server Logs > Server Access History	Server Access History
-544244208	Administrator Manual > Audit > Server Logs > Command Audit	Command Audit
-544014927	Administrator Manual > Audit > Server Logs > Session Logs	Session Logs
-544014940	Administrator Manual > Audit > Server Logs > Session Monitoring	Session Monitoring
-544244234	Administrator Manual > Audit > Server Logs > Access Control Logs	Access Control Logs
-544244244	Administrator Manual > Audit > Server Logs > Server Role History	Server Role History
-543949311	Administrator Manual > Audit > Server Logs > Account Lock History	Account Lock History
-544383513	Administrator Manual > Audit > Kubernetes Logs	Kubernetes Logs
-544383587	Administrator Manual > Audit > Kubernetes Logs > Request Audit	Request Audit
-544383693	Administrator Manual > Audit > Kubernetes Logs > Pod Session Recordings	Pod Session Recordings
-544383799	Administrator Manual > Audit > Kubernetes Logs > Kubernetes Role History	Kubernetes Role History
-1064829366	Administrator Manual > Audit > Web App Logs	Web App Logs
-1064829380	Administrator Manual > Audit > Web App Logs > Web Access History	Web Access History
-1070563457	Administrator Manual > Audit > Web App Logs > Web Event Audit	Web Event Audit
-1070694561	Administrator Manual > Audit > Web App Logs > User Activity Recordings	User Activity Recordings
-1070563469	Administrator Manual > Audit > Web App Logs > Web App Role History	Web App Role History
-1070694552	Administrator Manual > Audit > Web App Logs > JIT Access Control Logs	JIT Access Control Logs
-851280543	Administrator Manual > Multi Agent Limitations	Multi Agent Limitations
+544080057	Administrator Manual />> General	General
+543948978	Administrator Manual />> General />> Company Management	Company Management
+544145591	Administrator Manual />> General />> Company Management />> General	General
+544178422	Administrator Manual />> General />> Company Management />> Security	Security
+544112846	Administrator Manual />> General />> Company Management />> Allowed Zones	Allowed Zones
+544243925	Administrator Manual />> General />> Company Management />> Channels	Channels
+543981760	Administrator Manual />> General />> Company Management />> Alerts	Alerts
+793608206	Administrator Manual />> General />> Company Management />> Alerts />> New Request > Template Variables by Request Type	New Request > Template Variables by Request Type
+544178443	Administrator Manual />> General />> Company Management />> Licenses	Licenses
+544375969	Administrator Manual />> General />> User Management	User Management
+544047331	Administrator Manual />> General />> User Management />> Users	Users
+544376787	Administrator Manual />> General />> User Management />> Users />> User Profile	User Profile
+920944732	Administrator Manual />> General />> User Management />> Users />> Password Change Enforcement and Account Deletion Feature for qp-admin Default Account	Password Change Enforcement and Account Deletion Feature for qp-admin Default Account
+544047341	Administrator Manual />> General />> User Management />> Groups	Groups
+543948996	Administrator Manual />> General />> User Management />> Roles	Roles
+544376982	Administrator Manual />> General />> User Management />> Profile Editor	Profile Editor
+953221256	Administrator Manual />> General />> User Management />> Profile Editor />> Custom Attribute	Custom Attribute
+544375984	Administrator Manual />> General />> User Management />> Authentication	Authentication
+544376004	Administrator Manual />> General />> User Management />> Authentication />> Integrating with LDAP	Integrating with LDAP
+544376100	Administrator Manual />> General />> User Management />> Authentication />> Integrating with Okta	Integrating with Okta
+544376183	Administrator Manual />> General />> User Management />> Authentication />> Integrating with AWS SSO	Integrating with AWS SSO
+619381289	Administrator Manual />> General />> User Management />> Authentication />> Integrating with Google SAML	Integrating with Google SAML
+793575425	Administrator Manual />> General />> User Management />> Authentication />> Setting Up Multi-Factor Authentication	Setting Up Multi-Factor Authentication
+544376236	Administrator Manual />> General />> User Management />> Provisioning	Provisioning
+544376265	Administrator Manual />> General />> User Management />> Provisioning />> Activating Provisioning	Activating Provisioning
+544376394	Administrator Manual />> General />> User Management />> Provisioning />> [Okta] Provisioning Integration Guide	[Okta] Provisioning Integration Guide
+544178462	Administrator Manual />> General />> Workflow Management	Workflow Management
+544047359	Administrator Manual />> General />> Workflow Management />> All Requests	All Requests
+544378513	Administrator Manual />> General />> Workflow Management />> Approval Rules	Approval Rules
+561414376	Administrator Manual />> General />> Workflow Management />> Workflow Configurations	Workflow Configurations
+544112865	Administrator Manual />> General />> System	System
+544080097	Administrator Manual />> General />> System />> Integrations	Integrations
+544379393	Administrator Manual />> General />> System />> Integrations />> Integrating with Syslog	Integrating with Syslog
+557940795	Administrator Manual />> General />> System />> Integrations />> Integrating with Splunk	Integrating with Splunk
+544379587	Administrator Manual />> General />> System />> Integrations />> Integrating with Secret Store	Integrating with Secret Store
+798064641	Administrator Manual />> General />> System />> Integrations />> Integrating with Email	Integrating with Email
+811401365	Administrator Manual />> General />> System />> Integrations />> Integrating Google Cloud API for OAuth 2.0	Integrating Google Cloud API for OAuth 2.0
+883654669	Administrator Manual />> General />> System />> Integrations />> Integrating with Slack DM	Integrating with Slack DM
+544378759	Administrator Manual />> General />> System />> Integrations />> Integrating with Slack DM />> Slack DM - Workflow Notification Types	Slack DM - Workflow Notification Types
+544377652	Administrator Manual />> General />> System />> API Token	API Token
+544211220	Administrator Manual />> General />> System />> Jobs	Jobs
+544047372	Administrator Manual />> Discovery	Discovery
+543949048	Administrator Manual />> Discovery />> Discovery Management	Discovery Management
+543981852	Administrator Manual />> Discovery />> Discovery Management />> Dashboard	Dashboard
+544080127	Administrator Manual />> Discovery />> Discovery Management />> Inventory	Inventory
+543949058	Administrator Manual />> Discovery />> Discovery Management />> Discovery Jobs	Discovery Jobs
+543981865	Administrator Manual />> Discovery />> Discovery Management />> Discovery History	Discovery History
+543949078	Administrator Manual />> Discovery />> Discovery Management />> Scan Results	Scan Results
+544244011	Administrator Manual />> Discovery />> Discovery Management />> Detection Profiles	Detection Profiles
+544112915	Administrator Manual />> Discovery />> Discovery Management />> Data Patterns	Data Patterns
+544379638	Administrator Manual />> Databases	Databases
+956071939	Administrator Manual />> Databases />> DAC General Configurations	DAC General Configurations
+921436219	Administrator Manual />> Databases />> DAC General Configurations />> Unmasking Zones	Unmasking Zones
+544379705	Administrator Manual />> Databases />> Connection Management	Connection Management
+544145672	Administrator Manual />> Databases />> Connection Management />> Cloud Providers	Cloud Providers
+544379719	Administrator Manual />> Databases />> Connection Management />> Cloud Providers />> Synchronizing DB Resources from AWS	Synchronizing DB Resources from AWS
+562167871	Administrator Manual />> Databases />> Connection Management />> Cloud Providers />> Synchronizing DB Resources from MS Azure	Synchronizing DB Resources from MS Azure
+562167809	Administrator Manual />> Databases />> Connection Management />> Cloud Providers />> Synchronizing DB Resources from Google Cloud	Synchronizing DB Resources from Google Cloud
+712507393	Administrator Manual />> Databases />> Connection Management />> Cloud Providers />> Verifying Cloud Synchronization Settings with Dry Run Feature	Verifying Cloud Synchronization Settings with Dry Run Feature
+544014712	Administrator Manual />> Databases />> Connection Management />> DB Connections	DB Connections
+544380381	Administrator Manual />> Databases />> Connection Management />> DB Connections />> MongoDB Specific Guide	MongoDB Specific Guide
+568852692	Administrator Manual />> Databases />> Connection Management />> DB Connections />> DocumentDB Specific Guide	DocumentDB Specific Guide
+811434142	Administrator Manual />> Databases />> Connection Management />> DB Connections />> Google BigQuery OAuth Authentication Configuration	Google BigQuery OAuth Authentication Configuration
+820806182	Administrator Manual />> Databases />> Connection Management />> DB Connections />> AWS Athena Specific Guide	AWS Athena Specific Guide
+880082945	Administrator Manual />> Databases />> Connection Management />> DB Connections />> Custom Data Source Configuration and Log Verification	Custom Data Source Configuration and Log Verification
+544145691	Administrator Manual />> Databases />> Connection Management />> SSL Configurations	SSL Configurations
+544047436	Administrator Manual />> Databases />> Connection Management />> SSH Configurations	SSH Configurations
+544112932	Administrator Manual />> Databases />> Connection Management />> Kerberos Configurations	Kerberos Configurations
+544380126	Administrator Manual />> Databases />> DB Access Control	DB Access Control
+544380140	Administrator Manual />> Databases />> DB Access Control />> Privilege Type	Privilege Type
+544380173	Administrator Manual />> Databases />> DB Access Control />> Access Control	Access Control
+544379868	Administrator Manual />> Databases />> Policies	Policies
+544379937	Administrator Manual />> Databases />> Policies />> Data Access	Data Access
+569376769	Administrator Manual />> Databases />> Policies />> Masking Pattern	Masking Pattern
+544379882	Administrator Manual />> Databases />> Policies />> Data Masking	Data Masking
+544379993	Administrator Manual />> Databases />> Policies />> Sensitive Data	Sensitive Data
+713129986	Administrator Manual />> Databases />> Policies />> Policy Exception	Policy Exception
+571277577	Administrator Manual />> Databases />> Ledger Management	Ledger Management
+544380061	Administrator Manual />> Databases />> Ledger Management />> Ledger Table Policy	Ledger Table Policy
+571277650	Administrator Manual />> Databases />> Ledger Management />> Ledger Approval Rules	Ledger Approval Rules
+873136365	Administrator Manual />> Databases />> (New) Policy Management	(New) Policy Management
+878805502	Administrator Manual />> Databases />> (New) Policy Management />> Data Paths	Data Paths
+879198569	Administrator Manual />> Databases />> (New) Policy Management />> Data Policies	Data Policies
+1064796485	Administrator Manual />> Databases />> (New) Policy Management />> Exception Management	Exception Management
+954139156	Administrator Manual />> Databases />> Monitoring	Monitoring
+954172219	Administrator Manual />> Databases />> Monitoring />> Runnig Queries	Runnig Queries
+954204974	Administrator Manual />> Databases />> Monitoring />> Proxy Management	Proxy Management
+544380588	Administrator Manual />> Servers	Servers
+954336174	Administrator Manual />> Servers />> SAC General Configurations	SAC General Configurations
+544380635	Administrator Manual />> Servers />> Connection Management	Connection Management
+544178567	Administrator Manual />> Servers />> Connection Management />> Cloud Providers	Cloud Providers
+544380650	Administrator Manual />> Servers />> Connection Management />> Cloud Providers />> Synchronizing Server Resources from AWS	Synchronizing Server Resources from AWS
+544380741	Administrator Manual />> Servers />> Connection Management />> Cloud Providers />> Synchronizing Server Resources from Azure	Synchronizing Server Resources from Azure
+544380708	Administrator Manual />> Servers />> Connection Management />> Cloud Providers />> Synchronizing Server Resources from GCP	Synchronizing Server Resources from GCP
+544211361	Administrator Manual />> Servers />> Connection Management />> Servers	Servers
+544380774	Administrator Manual />> Servers />> Connection Management />> Servers />> Manually Registering Individual Servers	Manually Registering Individual Servers
+544080186	Administrator Manual />> Servers />> Connection Management />> Server Groups	Server Groups
+544380846	Administrator Manual />> Servers />> Connection Management />> Server Groups />> Managing Servers as Groups	Managing Servers as Groups
+544211376	Administrator Manual />> Servers />> Connection Management />> Server Agents for RDP	Server Agents for RDP
+565575990	Administrator Manual />> Servers />> Connection Management />> Server Agents for RDP />> Installing and Removing Server Agent	Installing and Removing Server Agent
+615710737	Administrator Manual />> Servers />> Connection Management />> ProxyJump Configurations	ProxyJump Configurations
+615743551	Administrator Manual />> Servers />> Connection Management />> ProxyJump Configurations />> Creating ProxyJump	Creating ProxyJump
+613777446	Administrator Manual />> Servers />> Server Account Management	Server Account Management
+544380991	Administrator Manual />> Servers />> Server Account Management />> Server Account Templates	Server Account Templates
+544380960	Administrator Manual />> Servers />> Server Account Management />> SSH Key Configurations	SSH Key Configurations
+615743501	Administrator Manual />> Servers />> Server Account Management />> Account Management	Account Management
+615677962	Administrator Manual />> Servers />> Server Account Management />> Password Provisioning	Password Provisioning
+619380898	Administrator Manual />> Servers />> Server Account Management />> Password Provisioning />> Creating Password Change Job	Creating Password Change Job
+543949216	Administrator Manual />> Servers />> Server Access Control	Server Access Control
+544381186	Administrator Manual />> Servers />> Server Access Control />> Access Control	Access Control
+544381282	Administrator Manual />> Servers />> Server Access Control />> Access Control />> Granting and Revoking Permissions	Granting and Revoking Permissions
+544381200	Administrator Manual />> Servers />> Server Access Control />> Access Control />> Granting and Revoking Roles	Granting and Revoking Roles
+878838349	Administrator Manual />> Servers />> Server Access Control />> Access Control />> Granting Server Privilege	Granting Server Privilege
+544381150	Administrator Manual />> Servers />> Server Access Control />> Roles	Roles
+544381025	Administrator Manual />> Servers />> Server Access Control />> Policies	Policies
+544381039	Administrator Manual />> Servers />> Server Access Control />> Policies />> Setting Server Access Policy	Setting Server Access Policy
+544377895	Administrator Manual />> Servers />> Server Access Control />> Policies />> Enabling Server Proxy	Enabling Server Proxy
+544381118	Administrator Manual />> Servers />> Server Access Control />> Command Templates	Command Templates
+544244109	Administrator Manual />> Servers />> Server Access Control />> Blocked Accounts	Blocked Accounts
+544381596	Administrator Manual />> Kubernetes	Kubernetes
+954172232	Administrator Manual />> Kubernetes />> KAC General Configurations	KAC General Configurations
+544381637	Administrator Manual />> Kubernetes />> Connection Management	Connection Management
+544381651	Administrator Manual />> Kubernetes />> Connection Management />> Cloud Providers	Cloud Providers
+544381739	Administrator Manual />> Kubernetes />> Connection Management />> Cloud Providers />> Synchronizing Kubernetes Resources from AWS	Synchronizing Kubernetes Resources from AWS
+544381839	Administrator Manual />> Kubernetes />> Connection Management />> Clusters	Clusters
+544381877	Administrator Manual />> Kubernetes />> Connection Management />> Clusters />> Manually Registering Kubernetes Clusters	Manually Registering Kubernetes Clusters
+544383110	Administrator Manual />> Kubernetes />> K8s Access Control	K8s Access Control
+544383124	Administrator Manual />> Kubernetes />> K8s Access Control />> Access Control	Access Control
+544383381	Administrator Manual />> Kubernetes />> K8s Access Control />> Access Control />> Granting and Revoking Kubernetes Roles	Granting and Revoking Kubernetes Roles
+544382741	Administrator Manual />> Kubernetes />> K8s Access Control />> Roles	Roles
+544382963	Administrator Manual />> Kubernetes />> K8s Access Control />> Roles />> Setting Kubernetes Roles	Setting Kubernetes Roles
+544382060	Administrator Manual />> Kubernetes />> K8s Access Control />> Policies	Policies
+544382274	Administrator Manual />> Kubernetes />> K8s Access Control />> Policies />> Setting Kubernetes Policies	Setting Kubernetes Policies
+544382364	Administrator Manual />> Kubernetes />> K8s Access Control />> Policies />> Kubernetes Policy YAML Code Syntax Guide	Kubernetes Policy YAML Code Syntax Guide
+544382445	Administrator Manual />> Kubernetes />> K8s Access Control />> Policies />> Kubernetes Policy Tips Guide	Kubernetes Policy Tips Guide
+544382522	Administrator Manual />> Kubernetes />> K8s Access Control />> Policies />> Kubernetes Policy UI Code Helper Guide	Kubernetes Policy UI Code Helper Guide
+544382659	Administrator Manual />> Kubernetes />> K8s Access Control />> Policies />> Kubernetes Policy Action Configuration Reference Guide	Kubernetes Policy Action Configuration Reference Guide
+783515900	Administrator Manual />> Web Apps	Web Apps
+1064829276	Administrator Manual />> Web Apps />> Connection Management	Connection Management
+1070694423	Administrator Manual />> Web Apps />> Connection Management />> Web Apps	Web Apps
+1064829246	Administrator Manual />> Web Apps />> Connection Management />> Web App Configurations	Web App Configurations
+1070596135	Administrator Manual />> Web Apps />> Web App Access Control	Web App Access Control
+1070628904	Administrator Manual />> Web Apps />> Web App Access Control />> Access Control	Access Control
+1064599910	Administrator Manual />> Web Apps />> Web App Access Control />> Access Control />> Granting and Revoking Roles	Granting and Revoking Roles
+1070628923	Administrator Manual />> Web Apps />> Web App Access Control />> Roles	Roles
+1064829343	Administrator Manual />> Web Apps />> Web App Access Control />> Policies	Policies
+783417593	Administrator Manual />> Web Apps />> WAC Quickstart	WAC Quickstart
+783745324	Administrator Manual />> Web Apps />> WAC Quickstart />> [~10.2.7] WAC Role & Policy Guide	[~10.2.7] WAC Role & Policy Guide
+924287097	Administrator Manual />> Web Apps />> WAC Quickstart />> [10.2.8~] WAC RBAC Guide	[10.2.8~] WAC RBAC Guide
+956235931	Administrator Manual />> Web Apps />> WAC Quickstart />> [10.3.0 ~] WAC JIT Permission Acquisition Guide	[10.3.0 ~] WAC JIT Permission Acquisition Guide
+805962425	Administrator Manual />> Web Apps />> WAC Quickstart />> Root CA Certificate Installation Guide	Root CA Certificate Installation Guide
+883654785	Administrator Manual />> Web Apps />> WAC Quickstart />> Initial WAC Setup in Web App Configurations	Initial WAC Setup in Web App Configurations
+924319936	Administrator Manual />> Web Apps />> WAC Quickstart />> WAC Troubleshooting Guide	WAC Troubleshooting Guide
+927629410	Administrator Manual />> Web Apps />> WAC Quickstart />> WAC FAQ	WAC FAQ
+544379062	Administrator Manual />> Audit	Audit
+693043522	Administrator Manual />> Audit />> Reports	Reports
+544384417	Administrator Manual />> Audit />> Reports />> Reports	Reports
+544379140	Administrator Manual />> Audit />> Reports />> Audit Log Export	Audit Log Export
+544211450	Administrator Manual />> Audit />> General Logs	General Logs
+544080230	Administrator Manual />> Audit />> General Logs />> User Access History	User Access History
+544113108	Administrator Manual />> Audit />> General Logs />> Activity Logs	Activity Logs
+544047557	Administrator Manual />> Audit />> General Logs />> Admin Role History	Admin Role History
+705724442	Administrator Manual />> Audit />> General Logs />> Workflow Logs	Workflow Logs
+775455036	Administrator Manual />> Audit />> General Logs />> Reverse Tunnels	Reverse Tunnels
+811434216	Administrator Manual />> Audit />> General Logs />> Reverse Tunnels />> Communicating with Servers through Reverse Tunnel	Communicating with Servers through Reverse Tunnel
+811466988	Administrator Manual />> Audit />> General Logs />> Reverse Tunnels />> Communicating with Clusters through Reverse Tunnel	Communicating with Clusters through Reverse Tunnel
+955318273	Administrator Manual />> Audit />> General Logs />> Reverse Tunnels />> Communicating with DB through Reverse Tunnel	Communicating with DB through Reverse Tunnel
+544080248	Administrator Manual />> Audit />> Database Logs	Database Logs
+544113141	Administrator Manual />> Audit />> Database Logs />> DB Access History	DB Access History
+544244149	Administrator Manual />> Audit />> Database Logs />> Query Audit	Query Audit
+544145819	Administrator Manual />> Audit />> Database Logs />> Running Queries	Running Queries
+544244163	Administrator Manual />> Audit />> Database Logs />> DML Snapshots	DML Snapshots
+544014894	Administrator Manual />> Audit />> Database Logs />> Account Lock History	Account Lock History
+544080264	Administrator Manual />> Audit />> Database Logs />> Access Control Logs	Access Control Logs
+1070694532	Administrator Manual />> Audit />> Database Logs />> Policy Audit Logs	Policy Audit Logs
+1164705793	Administrator Manual />> Audit />> Database Logs />> Policy Exception logs	Policy Exception logs
+544014907	Administrator Manual />> Audit />> Server Logs	Server Logs
+544244182	Administrator Manual />> Audit />> Server Logs />> Server Access History	Server Access History
+544244208	Administrator Manual />> Audit />> Server Logs />> Command Audit	Command Audit
+544014927	Administrator Manual />> Audit />> Server Logs />> Session Logs	Session Logs
+544014940	Administrator Manual />> Audit />> Server Logs />> Session Monitoring	Session Monitoring
+544244234	Administrator Manual />> Audit />> Server Logs />> Access Control Logs	Access Control Logs
+544244244	Administrator Manual />> Audit />> Server Logs />> Server Role History	Server Role History
+543949311	Administrator Manual />> Audit />> Server Logs />> Account Lock History	Account Lock History
+544383513	Administrator Manual />> Audit />> Kubernetes Logs	Kubernetes Logs
+544383587	Administrator Manual />> Audit />> Kubernetes Logs />> Request Audit	Request Audit
+544383693	Administrator Manual />> Audit />> Kubernetes Logs />> Pod Session Recordings	Pod Session Recordings
+544383799	Administrator Manual />> Audit />> Kubernetes Logs />> Kubernetes Role History	Kubernetes Role History
+1064829366	Administrator Manual />> Audit />> Web App Logs	Web App Logs
+1064829380	Administrator Manual />> Audit />> Web App Logs />> Web Access History	Web Access History
+1070563457	Administrator Manual />> Audit />> Web App Logs />> Web Event Audit	Web Event Audit
+1070694561	Administrator Manual />> Audit />> Web App Logs />> User Activity Recordings	User Activity Recordings
+1070563469	Administrator Manual />> Audit />> Web App Logs />> Web App Role History	Web App Role History
+1070694552	Administrator Manual />> Audit />> Web App Logs />> JIT Access Control Logs	JIT Access Control Logs
+851280543	Administrator Manual />> Multi Agent Limitations	Multi Agent Limitations

--- a/docs/latest-ko-confluence/list.txt
+++ b/docs/latest-ko-confluence/list.txt
@@ -1,262 +1,263 @@
 608501837	QueryPie Docs	QueryPie Docs
 544375335	Release Notes	Release Notes
-1064830173	Release Notes > 11.0.0	11.0.0
-954335909	Release Notes > 10.3.0 ~ 10.3.4	10.3.0 ~ 10.3.4
-703463517	Release Notes > 10.2.0 ~ 10.2.12	10.2.0 ~ 10.2.12
-604995641	Release Notes > 10.1.0 ~ 10.1.11	10.1.0 ~ 10.1.11
-544375355	Release Notes > 10.0.0 ~ 10.0.2	10.0.0 ~ 10.0.2
-544375370	Release Notes > 9.20.0 ~ 9.20.2	9.20.0 ~ 9.20.2
-544375385	Release Notes > 9.19.0 	9.19.0 
-544375399	Release Notes > 9.18.0 ~ 9.18.3	9.18.0 ~ 9.18.3
-544375414	Release Notes > 9.17.0 ~ 9.17.1	9.17.0 ~ 9.17.1
-544375429	Release Notes > 9.16.0 ~ 9.16.4	9.16.0 ~ 9.16.4
-544375443	Release Notes > 9.15.0 ~ 9.15.4	9.15.0 ~ 9.15.4
-544375457	Release Notes > 9.14.0 ~ 9.14.3	9.14.0 ~ 9.14.3
-544375471	Release Notes > 9.13.0 ~ 9.13.5	9.13.0 ~ 9.13.5
-544375485	Release Notes > 9.12.0 ~ 9.12.14	9.12.0 ~ 9.12.14
-544375505	Release Notes > 9.12.0 ~ 9.12.14 > 메뉴 개선 가이드 (9.12.0)	메뉴 개선 가이드 (9.12.0)
-544375587	Release Notes > 9.11.0 ~ 9.11.5	9.11.0 ~ 9.11.5
-544375607	Release Notes > 9.10.0 - 9.10.4	9.10.0 - 9.10.4
-544375624	Release Notes > 9.10.0 - 9.10.4 > External API 변경사항 (9.10.0 버전)	External API 변경사항 (9.10.0 버전)
-544375659	Release Notes > 9.9.0 ~ 9.9.8	9.9.0 ~ 9.9.8
-544375685	Release Notes > 9.9.0 ~ 9.9.8 > External API 변경사항 (9.8.10 버전 > 9.9.4 버전)	External API 변경사항 (9.8.10 버전 > 9.9.4 버전)
-544375741	Release Notes > 9.9.0 ~ 9.9.8 > External API 변경사항 (9.9.4 버전 > 9.9.5 버전)	External API 변경사항 (9.9.4 버전 > 9.9.5 버전)
-544375768	Release Notes > 9.8.0 ~ 9.8.12	9.8.0 ~ 9.8.12
+1171488777	Release Notes />> 11.1.0	11.1.0
+1064830173	Release Notes />> 11.0.0	11.0.0
+954335909	Release Notes />> 10.3.0 ~ 10.3.4	10.3.0 ~ 10.3.4
+703463517	Release Notes />> 10.2.0 ~ 10.2.12	10.2.0 ~ 10.2.12
+604995641	Release Notes />> 10.1.0 ~ 10.1.11	10.1.0 ~ 10.1.11
+544375355	Release Notes />> 10.0.0 ~ 10.0.2	10.0.0 ~ 10.0.2
+544375370	Release Notes />> 9.20.0 ~ 9.20.2	9.20.0 ~ 9.20.2
+544375385	Release Notes />> 9.19.0 	9.19.0 
+544375399	Release Notes />> 9.18.0 ~ 9.18.3	9.18.0 ~ 9.18.3
+544375414	Release Notes />> 9.17.0 ~ 9.17.1	9.17.0 ~ 9.17.1
+544375429	Release Notes />> 9.16.0 ~ 9.16.4	9.16.0 ~ 9.16.4
+544375443	Release Notes />> 9.15.0 ~ 9.15.4	9.15.0 ~ 9.15.4
+544375457	Release Notes />> 9.14.0 ~ 9.14.3	9.14.0 ~ 9.14.3
+544375471	Release Notes />> 9.13.0 ~ 9.13.5	9.13.0 ~ 9.13.5
+544375485	Release Notes />> 9.12.0 ~ 9.12.14	9.12.0 ~ 9.12.14
+544375505	Release Notes />> 9.12.0 ~ 9.12.14 />> 메뉴 개선 가이드 (9.12.0)	메뉴 개선 가이드 (9.12.0)
+544375587	Release Notes />> 9.11.0 ~ 9.11.5	9.11.0 ~ 9.11.5
+544375607	Release Notes />> 9.10.0 - 9.10.4	9.10.0 - 9.10.4
+544375624	Release Notes />> 9.10.0 - 9.10.4 />> External API 변경사항 (9.10.0 버전)	External API 변경사항 (9.10.0 버전)
+544375659	Release Notes />> 9.9.0 ~ 9.9.8	9.9.0 ~ 9.9.8
+544375685	Release Notes />> 9.9.0 ~ 9.9.8 />> External API 변경사항 (9.8.10 버전 > 9.9.4 버전)	External API 변경사항 (9.8.10 버전 > 9.9.4 버전)
+544375741	Release Notes />> 9.9.0 ~ 9.9.8 />> External API 변경사항 (9.9.4 버전 > 9.9.5 버전)	External API 변경사항 (9.9.4 버전 > 9.9.5 버전)
+544375768	Release Notes />> 9.8.0 ~ 9.8.12	9.8.0 ~ 9.8.12
 544375784	QueryPie Overview	QueryPie Overview
-544112942	QueryPie Overview > Proxy Management	Proxy Management
-544377869	QueryPie Overview > Proxy Management > Database Proxy 사용 활성화	Database Proxy 사용 활성화
-544375859	QueryPie Overview > 시스템 구성도 개요	시스템 구성도 개요
-544375808	QueryPie Overview > Installation and Customer Support	Installation and Customer Support
+544112942	QueryPie Overview />> Proxy Management	Proxy Management
+544377869	QueryPie Overview />> Proxy Management />> Database Proxy 사용 활성화	Database Proxy 사용 활성화
+544375859	QueryPie Overview />> 시스템 구성도 개요	시스템 구성도 개요
+544375808	QueryPie Overview />> Installation and Customer Support	Installation and Customer Support
 544211126	사용자 매뉴얼	사용자 매뉴얼
-578945174	사용자 매뉴얼 > My Dashboard	My Dashboard
-793542657	사용자 매뉴얼 > My Dashboard > Email을 통한 사용자 비밀 번호 초기화	Email을 통한 사용자 비밀 번호 초기화
-544377922	사용자 매뉴얼 > Workflow	Workflow
-544377968	사용자 매뉴얼 > Workflow > DB Access Request 요청하기	DB Access Request 요청하기
-544378069	사용자 매뉴얼 > Workflow > SQL Request 요청하기	SQL Request 요청하기
-692355151	사용자 매뉴얼 > Workflow > SQL Request 요청하기 > 실행 계획(Explain) 기능 사용하기	실행 계획(Explain) 기능 사용하기
-544378182	사용자 매뉴얼 > Workflow > SQL Export Request 요청하기	SQL Export Request 요청하기
-712769539	사용자 매뉴얼 > Workflow > Unmasking Request 요청하기 (마스킹 해제 요청)	Unmasking Request 요청하기 (마스킹 해제 요청)
-1060306945	사용자 매뉴얼 > Workflow > Restricted Data Access 요청하기 (제한된 데이터 접근 요청)	Restricted Data Access 요청하기 (제한된 데이터 접근 요청)
-544378254	사용자 매뉴얼 > Workflow > Server Access Request 요청하기	Server Access Request 요청하기
-878936417	사용자 매뉴얼 > Workflow > Server Privilege Request 요청하기	Server Privilege Request 요청하기
-544378348	사용자 매뉴얼 > Workflow > Access Role Request 요청하기	Access Role Request 요청하기
-1055358996	사용자 매뉴얼 > Workflow > IP Registration Request 요청하기	IP Registration Request 요청하기
-568918170	사용자 매뉴얼 > Workflow > 결재 부가 기능 (대리 결재, 재상신 등)	결재 부가 기능 (대리 결재, 재상신 등)
-1070006273	사용자 매뉴얼 > Workflow > DB 정책 예외 요청하기 (DB Policy Exception Request)	DB 정책 예외 요청하기 (DB Policy Exception Request)
-544380204	사용자 매뉴얼 > Database Access Control	Database Access Control
-544380222	사용자 매뉴얼 > Database Access Control > 웹 SQL 에디터로 접속하기	웹 SQL 에디터로 접속하기
-544380354	사용자 매뉴얼 > Database Access Control > Default Privilege 설정하기	Default Privilege 설정하기
-559906893	사용자 매뉴얼 > Database Access Control > 에이전트 없이 프록시 접속하기	에이전트 없이 프록시 접속하기
-820609510	사용자 매뉴얼 > Database Access Control > Google BigQuery OAuth 인증을 통해 접속하기	Google BigQuery OAuth 인증을 통해 접속하기
-880181257	사용자 매뉴얼 > Database Access Control > Custom Data Source 접속하기	Custom Data Source 접속하기
-544381369	사용자 매뉴얼 > Server Access Control	Server Access Control
-544381383	사용자 매뉴얼 > Server Access Control > 권한이 있는 서버에 접속하기	권한이 있는 서버에 접속하기
-544381410	사용자 매뉴얼 > Server Access Control > 웹 터미널 사용하기	웹 터미널 사용하기
-544381477	사용자 매뉴얼 > Server Access Control > 웹 SFTP 사용하기	웹 SFTP 사용하기
-544384011	사용자 매뉴얼 > Kubernetes Access Control	Kubernetes Access Control
-544384025	사용자 매뉴얼 > Kubernetes Access Control > 접근 권한 목록 확인하기	접근 권한 목록 확인하기
-1064829218	사용자 매뉴얼 > Web Access Control	Web Access Control
-1073709107	사용자 매뉴얼 > Web Access Control > Root CA 인증서 및 Extension 설치하기	Root CA 인증서 및 Extension 설치하기
-1064796396	사용자 매뉴얼 > Web Access Control > 웹 어플리케이션 (웹 사이트) 접속하기	웹 어플리케이션 (웹 사이트) 접속하기
-568950885	사용자 매뉴얼 > Preferences	Preferences
-544112828	사용자 매뉴얼 > User Agent	User Agent
-852066413	사용자 매뉴얼 > Multi Agent	Multi Agent
-912425276	사용자 매뉴얼 > Multi Agent > Multi Agent Linux 설치 및 사용 가이드	Multi Agent Linux 설치 및 사용 가이드
-912425288	사용자 매뉴얼 > Multi Agent > Multi Agent Seamless SSH 사용 가이드	Multi Agent Seamless SSH 사용 가이드
-919240916	사용자 매뉴얼 > Multi Agent > Multi Agent OS별 3rd Party Tool 지원 목록	Multi Agent OS별 3rd Party Tool 지원 목록
+578945174	사용자 매뉴얼 />> My Dashboard	My Dashboard
+793542657	사용자 매뉴얼 />> My Dashboard />> Email을 통한 사용자 비밀 번호 초기화	Email을 통한 사용자 비밀 번호 초기화
+544377922	사용자 매뉴얼 />> Workflow	Workflow
+544377968	사용자 매뉴얼 />> Workflow />> DB Access Request 요청하기	DB Access Request 요청하기
+544378069	사용자 매뉴얼 />> Workflow />> SQL Request 요청하기	SQL Request 요청하기
+692355151	사용자 매뉴얼 />> Workflow />> SQL Request 요청하기 />> 실행 계획(Explain) 기능 사용하기	실행 계획(Explain) 기능 사용하기
+544378182	사용자 매뉴얼 />> Workflow />> SQL Export Request 요청하기	SQL Export Request 요청하기
+712769539	사용자 매뉴얼 />> Workflow />> Unmasking Request 요청하기 (마스킹 해제 요청)	Unmasking Request 요청하기 (마스킹 해제 요청)
+1060306945	사용자 매뉴얼 />> Workflow />> Restricted Data Access 요청하기 (제한된 데이터 접근 요청)	Restricted Data Access 요청하기 (제한된 데이터 접근 요청)
+544378254	사용자 매뉴얼 />> Workflow />> Server Access Request 요청하기	Server Access Request 요청하기
+878936417	사용자 매뉴얼 />> Workflow />> Server Privilege Request 요청하기	Server Privilege Request 요청하기
+544378348	사용자 매뉴얼 />> Workflow />> Access Role Request 요청하기	Access Role Request 요청하기
+1055358996	사용자 매뉴얼 />> Workflow />> IP Registration Request 요청하기	IP Registration Request 요청하기
+568918170	사용자 매뉴얼 />> Workflow />> 결재 부가 기능 (대리 결재, 재상신 등)	결재 부가 기능 (대리 결재, 재상신 등)
+1070006273	사용자 매뉴얼 />> Workflow />> DB 정책 예외 요청하기 (DB Policy Exception Request)	DB 정책 예외 요청하기 (DB Policy Exception Request)
+544380204	사용자 매뉴얼 />> Database Access Control	Database Access Control
+544380222	사용자 매뉴얼 />> Database Access Control />> 웹 SQL 에디터로 접속하기	웹 SQL 에디터로 접속하기
+544380354	사용자 매뉴얼 />> Database Access Control />> Default Privilege 설정하기	Default Privilege 설정하기
+559906893	사용자 매뉴얼 />> Database Access Control />> 에이전트 없이 프록시 접속하기	에이전트 없이 프록시 접속하기
+820609510	사용자 매뉴얼 />> Database Access Control />> Google BigQuery OAuth 인증을 통해 접속하기	Google BigQuery OAuth 인증을 통해 접속하기
+880181257	사용자 매뉴얼 />> Database Access Control />> Custom Data Source 접속하기	Custom Data Source 접속하기
+544381369	사용자 매뉴얼 />> Server Access Control	Server Access Control
+544381383	사용자 매뉴얼 />> Server Access Control />> 권한이 있는 서버에 접속하기	권한이 있는 서버에 접속하기
+544381410	사용자 매뉴얼 />> Server Access Control />> 웹 터미널 사용하기	웹 터미널 사용하기
+544381477	사용자 매뉴얼 />> Server Access Control />> 웹 SFTP 사용하기	웹 SFTP 사용하기
+544384011	사용자 매뉴얼 />> Kubernetes Access Control	Kubernetes Access Control
+544384025	사용자 매뉴얼 />> Kubernetes Access Control />> 접근 권한 목록 확인하기	접근 권한 목록 확인하기
+1064829218	사용자 매뉴얼 />> Web Access Control	Web Access Control
+1073709107	사용자 매뉴얼 />> Web Access Control />> Root CA 인증서 및 Extension 설치하기	Root CA 인증서 및 Extension 설치하기
+1064796396	사용자 매뉴얼 />> Web Access Control />> 웹 어플리케이션 (웹 사이트) 접속하기	웹 어플리케이션 (웹 사이트) 접속하기
+568950885	사용자 매뉴얼 />> Preferences	Preferences
+544112828	사용자 매뉴얼 />> User Agent	User Agent
+852066413	사용자 매뉴얼 />> Multi Agent	Multi Agent
+912425276	사용자 매뉴얼 />> Multi Agent />> Multi Agent Linux 설치 및 사용 가이드	Multi Agent Linux 설치 및 사용 가이드
+912425288	사용자 매뉴얼 />> Multi Agent />> Multi Agent Seamless SSH 사용 가이드	Multi Agent Seamless SSH 사용 가이드
+919240916	사용자 매뉴얼 />> Multi Agent />> Multi Agent OS별 3rd Party Tool 지원 목록	Multi Agent OS별 3rd Party Tool 지원 목록
 544178405	관리자 매뉴얼	관리자 매뉴얼
-544080057	관리자 매뉴얼 > General	General
-543948978	관리자 매뉴얼 > General > Company Management	Company Management
-544145591	관리자 매뉴얼 > General > Company Management > General	General
-544178422	관리자 매뉴얼 > General > Company Management > Security	Security
-544112846	관리자 매뉴얼 > General > Company Management > Allowed Zones	Allowed Zones
-544243925	관리자 매뉴얼 > General > Company Management > Channels	Channels
-543981760	관리자 매뉴얼 > General > Company Management > Alerts	Alerts
-793608206	관리자 매뉴얼 > General > Company Management > Alerts > New Request > 요청 타입별 템플릿 변수	New Request > 요청 타입별 템플릿 변수
-544178443	관리자 매뉴얼 > General > Company Management > Licenses	Licenses
-544375969	관리자 매뉴얼 > General > User Management	User Management
-544047331	관리자 매뉴얼 > General > User Management > Users	Users
-544376787	관리자 매뉴얼 > General > User Management > Users > 사용자 프로필	사용자 프로필
-920944732	관리자 매뉴얼 > General > User Management > Users > qp-admin 기본 계정에 대한 패스워드 변경 강제화 및 계정 삭제 기능	qp-admin 기본 계정에 대한 패스워드 변경 강제화 및 계정 삭제 기능
-544047341	관리자 매뉴얼 > General > User Management > Groups	Groups
-543948996	관리자 매뉴얼 > General > User Management > Roles	Roles
-544376982	관리자 매뉴얼 > General > User Management > Profile Editor	Profile Editor
-953221256	관리자 매뉴얼 > General > User Management > Profile Editor > Custom Attribute	Custom Attribute
-544375984	관리자 매뉴얼 > General > User Management > Authentication	Authentication
-544376004	관리자 매뉴얼 > General > User Management > Authentication > LDAP 연동하기	LDAP 연동하기
-544376100	관리자 매뉴얼 > General > User Management > Authentication > Okta 연동하기	Okta 연동하기
-544376183	관리자 매뉴얼 > General > User Management > Authentication > AWS SSO 연동하기	AWS SSO 연동하기
-619381289	관리자 매뉴얼 > General > User Management > Authentication > Google SAML 연동하기	Google SAML 연동하기
-793575425	관리자 매뉴얼 > General > User Management > Authentication > Multi-Factor Authentication 설정하기	Multi-Factor Authentication 설정하기
-544376236	관리자 매뉴얼 > General > User Management > Provisioning	Provisioning
-544376265	관리자 매뉴얼 > General > User Management > Provisioning > Provisioning 활성화 하기	Provisioning 활성화 하기
-544376394	관리자 매뉴얼 > General > User Management > Provisioning > [Okta] 프로비저닝 연동 가이드	[Okta] 프로비저닝 연동 가이드
-544178462	관리자 매뉴얼 > General > Workflow Management	Workflow Management
-544047359	관리자 매뉴얼 > General > Workflow Management > All Requests	All Requests
-544378513	관리자 매뉴얼 > General > Workflow Management > Approval Rules	Approval Rules
-561414376	관리자 매뉴얼 > General > Workflow Management > Workflow Configurations	Workflow Configurations
-544112865	관리자 매뉴얼 > General > System	System
-544080097	관리자 매뉴얼 > General > System > Integrations	Integrations
-544379393	관리자 매뉴얼 > General > System > Integrations > Syslog 연동	Syslog 연동
-557940795	관리자 매뉴얼 > General > System > Integrations > Splunk 연동	Splunk 연동
-544379587	관리자 매뉴얼 > General > System > Integrations > Secret Store 연동	Secret Store 연동
-798064641	관리자 매뉴얼 > General > System > Integrations > Email 연동	Email 연동
-811401365	관리자 매뉴얼 > General > System > Integrations > OAuth 2.0을 사용하기 위한 Google Cloud API 연동	OAuth 2.0을 사용하기 위한 Google Cloud API 연동
-883654669	관리자 매뉴얼 > General > System > Integrations > Slack DM 연동	Slack DM 연동
-544378759	관리자 매뉴얼 > General > System > Integrations > Slack DM 연동 > Slack DM - Workflow 알림 유형	Slack DM - Workflow 알림 유형
-544377652	관리자 매뉴얼 > General > System > API Token	API Token
-544211220	관리자 매뉴얼 > General > System > Jobs	Jobs
-544047372	관리자 매뉴얼 > Discovery	Discovery
-543949048	관리자 매뉴얼 > Discovery > Discovery Management	Discovery Management
-543981852	관리자 매뉴얼 > Discovery > Discovery Management > Dashboard	Dashboard
-544080127	관리자 매뉴얼 > Discovery > Discovery Management > Inventory	Inventory
-543949058	관리자 매뉴얼 > Discovery > Discovery Management > Discovery Jobs	Discovery Jobs
-543981865	관리자 매뉴얼 > Discovery > Discovery Management > Discovery History	Discovery History
-543949078	관리자 매뉴얼 > Discovery > Discovery Management > Scan Results	Scan Results
-544244011	관리자 매뉴얼 > Discovery > Discovery Management > Detection Profiles	Detection Profiles
-544112915	관리자 매뉴얼 > Discovery > Discovery Management > Data Patterns	Data Patterns
-544379638	관리자 매뉴얼 > Databases	Databases
-956071939	관리자 매뉴얼 > Databases > DAC General Configurations	DAC General Configurations
-921436219	관리자 매뉴얼 > Databases > DAC General Configurations > Unmasking Zones	Unmasking Zones
-544379705	관리자 매뉴얼 > Databases > Connection Management	Connection Management
-544145672	관리자 매뉴얼 > Databases > Connection Management > Cloud Providers	Cloud Providers
-544379719	관리자 매뉴얼 > Databases > Connection Management > Cloud Providers > AWS에서 DB 리소스 동기화	AWS에서 DB 리소스 동기화
-562167871	관리자 매뉴얼 > Databases > Connection Management > Cloud Providers > MS Azure에서 DB 리소스 동기화	MS Azure에서 DB 리소스 동기화
-562167809	관리자 매뉴얼 > Databases > Connection Management > Cloud Providers > Google Cloud에서 DB 리소스 동기화	Google Cloud에서 DB 리소스 동기화
-712507393	관리자 매뉴얼 > Databases > Connection Management > Cloud Providers > Dry Run 기능으로 클라우드 동기화 설정 확인하기	Dry Run 기능으로 클라우드 동기화 설정 확인하기
-544014712	관리자 매뉴얼 > Databases > Connection Management > DB Connections	DB Connections
-544380381	관리자 매뉴얼 > Databases > Connection Management > DB Connections > MongoDB 전용 가이드	MongoDB 전용 가이드
-568852692	관리자 매뉴얼 > Databases > Connection Management > DB Connections > DocumentDB 전용 가이드	DocumentDB 전용 가이드
-811434142	관리자 매뉴얼 > Databases > Connection Management > DB Connections > Google BigQuery OAuth 인증 설정	Google BigQuery OAuth 인증 설정
-820806182	관리자 매뉴얼 > Databases > Connection Management > DB Connections > AWS Athena 전용 가이드	AWS Athena 전용 가이드
-880082945	관리자 매뉴얼 > Databases > Connection Management > DB Connections > Custom Data Source 설정 및 로그 확인	Custom Data Source 설정 및 로그 확인
-544145691	관리자 매뉴얼 > Databases > Connection Management > SSL Configurations	SSL Configurations
-544047436	관리자 매뉴얼 > Databases > Connection Management > SSH Configurations	SSH Configurations
-544112932	관리자 매뉴얼 > Databases > Connection Management > Kerberos Configurations	Kerberos Configurations
-544380126	관리자 매뉴얼 > Databases > DB Access Control	DB Access Control
-544380140	관리자 매뉴얼 > Databases > DB Access Control > Privilege Type	Privilege Type
-544380173	관리자 매뉴얼 > Databases > DB Access Control > Access Control	Access Control
-544379868	관리자 매뉴얼 > Databases > Policies	Policies
-544379937	관리자 매뉴얼 > Databases > Policies > Data Access	Data Access
-569376769	관리자 매뉴얼 > Databases > Policies > Masking Pattern	Masking Pattern
-544379882	관리자 매뉴얼 > Databases > Policies > Data Masking	Data Masking
-544379993	관리자 매뉴얼 > Databases > Policies > Sensitive Data	Sensitive Data
-713129986	관리자 매뉴얼 > Databases > Policies > Policy Exception	Policy Exception
-571277577	관리자 매뉴얼 > Databases > Ledger Management	Ledger Management
-544380061	관리자 매뉴얼 > Databases > Ledger Management > Ledger Table Policy	Ledger Table Policy
-571277650	관리자 매뉴얼 > Databases > Ledger Management > Ledger Approval Rules	Ledger Approval Rules
-873136365	관리자 매뉴얼 > Databases > (New) Policy Management	(New) Policy Management
-878805502	관리자 매뉴얼 > Databases > (New) Policy Management > Data Paths	Data Paths
-879198569	관리자 매뉴얼 > Databases > (New) Policy Management > Data Policies	Data Policies
-1064796485	관리자 매뉴얼 > Databases > (New) Policy Management > Exception Management	Exception Management
-954139156	관리자 매뉴얼 > Databases > Monitoring	Monitoring
-954172219	관리자 매뉴얼 > Databases > Monitoring > Runnig Queries	Runnig Queries
-954204974	관리자 매뉴얼 > Databases > Monitoring > Proxy Management	Proxy Management
-544380588	관리자 매뉴얼 > Servers	Servers
-954336174	관리자 매뉴얼 > Servers > SAC General Configurations	SAC General Configurations
-544380635	관리자 매뉴얼 > Servers > Connection Management	Connection Management
-544178567	관리자 매뉴얼 > Servers > Connection Management > Cloud Providers	Cloud Providers
-544380650	관리자 매뉴얼 > Servers > Connection Management > Cloud Providers > AWS에서 서버 리소스 동기화	AWS에서 서버 리소스 동기화
-544380741	관리자 매뉴얼 > Servers > Connection Management > Cloud Providers > Azure에서 서버 리소스 동기화	Azure에서 서버 리소스 동기화
-544380708	관리자 매뉴얼 > Servers > Connection Management > Cloud Providers > GCP에서 서버 리소스 동기화	GCP에서 서버 리소스 동기화
-544211361	관리자 매뉴얼 > Servers > Connection Management > Servers	Servers
-544380774	관리자 매뉴얼 > Servers > Connection Management > Servers > 수동으로 개별 서버 등록하기	수동으로 개별 서버 등록하기
-544080186	관리자 매뉴얼 > Servers > Connection Management > Server Groups	Server Groups
-544380846	관리자 매뉴얼 > Servers > Connection Management > Server Groups > 서버를 그룹으로 관리하기	서버를 그룹으로 관리하기
-544211376	관리자 매뉴얼 > Servers > Connection Management > Server Agents for RDP	Server Agents for RDP
-565575990	관리자 매뉴얼 > Servers > Connection Management > Server Agents for RDP > Server Agent 설치 및 제거하기	Server Agent 설치 및 제거하기
-615710737	관리자 매뉴얼 > Servers > Connection Management > ProxyJump Configurations	ProxyJump Configurations
-615743551	관리자 매뉴얼 > Servers > Connection Management > ProxyJump Configurations > ProxyJump 생성하기	ProxyJump 생성하기
-613777446	관리자 매뉴얼 > Servers > Server Account Management	Server Account Management
-544380991	관리자 매뉴얼 > Servers > Server Account Management > Server Account Templates	Server Account Templates
-544380960	관리자 매뉴얼 > Servers > Server Account Management > SSH Key Configurations	SSH Key Configurations
-615743501	관리자 매뉴얼 > Servers > Server Account Management > Account Management	Account Management
-615677962	관리자 매뉴얼 > Servers > Server Account Management > Password Provisioning	Password Provisioning
-619380898	관리자 매뉴얼 > Servers > Server Account Management > Password Provisioning > 패스워드 변경 Job 생성하기	패스워드 변경 Job 생성하기
-543949216	관리자 매뉴얼 > Servers > Server Access Control	Server Access Control
-544381186	관리자 매뉴얼 > Servers > Server Access Control > Access Control	Access Control
-544381282	관리자 매뉴얼 > Servers > Server Access Control > Access Control > Permissions 부여 및 회수하기	Permissions 부여 및 회수하기
-544381200	관리자 매뉴얼 > Servers > Server Access Control > Access Control > Role 부여 및 회수하기	Role 부여 및 회수하기
-878838349	관리자 매뉴얼 > Servers > Server Access Control > Access Control > Server Privilege 부여하기	Server Privilege 부여하기
-544381150	관리자 매뉴얼 > Servers > Server Access Control > Roles	Roles
-544381025	관리자 매뉴얼 > Servers > Server Access Control > Policies	Policies
-544381039	관리자 매뉴얼 > Servers > Server Access Control > Policies > 서버 접근 정책 설정하기	서버 접근 정책 설정하기
-544377895	관리자 매뉴얼 > Servers > Server Access Control > Policies > Server Proxy 사용 활성화	Server Proxy 사용 활성화
-544381118	관리자 매뉴얼 > Servers > Server Access Control > Command Templates	Command Templates
-544244109	관리자 매뉴얼 > Servers > Server Access Control > Blocked Accounts	Blocked Accounts
-544381596	관리자 매뉴얼 > Kubernetes	Kubernetes
-954172232	관리자 매뉴얼 > Kubernetes > KAC General Configurations	KAC General Configurations
-544381637	관리자 매뉴얼 > Kubernetes > Connection Management	Connection Management
-544381651	관리자 매뉴얼 > Kubernetes > Connection Management > Cloud Providers	Cloud Providers
-544381739	관리자 매뉴얼 > Kubernetes > Connection Management > Cloud Providers > AWS에서 쿠버네티스 리소스 동기화	AWS에서 쿠버네티스 리소스 동기화
-544381839	관리자 매뉴얼 > Kubernetes > Connection Management > Clusters	Clusters
-544381877	관리자 매뉴얼 > Kubernetes > Connection Management > Clusters > 수동으로 쿠버네티스 클러스터 등록하기	수동으로 쿠버네티스 클러스터 등록하기
-544383110	관리자 매뉴얼 > Kubernetes > K8s Access Control	K8s Access Control
-544383124	관리자 매뉴얼 > Kubernetes > K8s Access Control > Access Control	Access Control
-544383381	관리자 매뉴얼 > Kubernetes > K8s Access Control > Access Control > 쿠버네티스 역할 부여 및 회수하기	쿠버네티스 역할 부여 및 회수하기
-544382741	관리자 매뉴얼 > Kubernetes > K8s Access Control > Roles	Roles
-544382963	관리자 매뉴얼 > Kubernetes > K8s Access Control > Roles > 쿠버네티스 역할 설정하기	쿠버네티스 역할 설정하기
-544382060	관리자 매뉴얼 > Kubernetes > K8s Access Control > Policies	Policies
-544382274	관리자 매뉴얼 > Kubernetes > K8s Access Control > Policies > 쿠버네티스 정책 설정하기	쿠버네티스 정책 설정하기
-544382364	관리자 매뉴얼 > Kubernetes > K8s Access Control > Policies > 쿠버네티스 정책 YAML Code 문법 안내	쿠버네티스 정책 YAML Code 문법 안내
-544382445	관리자 매뉴얼 > Kubernetes > K8s Access Control > Policies > 쿠버네티스 정책 Tips 안내	쿠버네티스 정책 Tips 안내
-544382522	관리자 매뉴얼 > Kubernetes > K8s Access Control > Policies > 쿠버네티스 정책 UI 코드 헬퍼 안내	쿠버네티스 정책 UI 코드 헬퍼 안내
-544382659	관리자 매뉴얼 > Kubernetes > K8s Access Control > Policies > 쿠버네티스 정책 Action 설정 참고 가이드	쿠버네티스 정책 Action 설정 참고 가이드
-783515900	관리자 매뉴얼 > Web Apps	Web Apps
-1064829276	관리자 매뉴얼 > Web Apps > Connection Management	Connection Management
-1070694423	관리자 매뉴얼 > Web Apps > Connection Management > Web Apps	Web Apps
-1064829246	관리자 매뉴얼 > Web Apps > Connection Management > Web App Configurations	Web App Configurations
-1070596135	관리자 매뉴얼 > Web Apps > Web App Access Control	Web App Access Control
-1070628904	관리자 매뉴얼 > Web Apps > Web App Access Control > Access Control	Access Control
-1064599910	관리자 매뉴얼 > Web Apps > Web App Access Control > Access Control > Role 부여 및 회수하기	Role 부여 및 회수하기
-1070628923	관리자 매뉴얼 > Web Apps > Web App Access Control > Roles	Roles
-1064829343	관리자 매뉴얼 > Web Apps > Web App Access Control > Policies	Policies
-783417593	관리자 매뉴얼 > Web Apps > WAC Quickstart	WAC Quickstart
-783745324	관리자 매뉴얼 > Web Apps > WAC Quickstart > [~10.2.7] WAC Role & Policy Guide	[~10.2.7] WAC Role & Policy Guide
-924287097	관리자 매뉴얼 > Web Apps > WAC Quickstart > [10.2.8~] WAC RBAC Guide	[10.2.8~] WAC RBAC Guide
-956235931	관리자 매뉴얼 > Web Apps > WAC Quickstart > [10.3.0 ~] WAC JIT 권한 획득 Guide	[10.3.0 ~] WAC JIT 권한 획득 Guide
-805962425	관리자 매뉴얼 > Web Apps > WAC Quickstart > Root CA 인증서 설치 가이드	Root CA 인증서 설치 가이드
-883654785	관리자 매뉴얼 > Web Apps > WAC Quickstart > Web App Configurations에서 WAC 초기 설정하기	Web App Configurations에서 WAC 초기 설정하기
-924319936	관리자 매뉴얼 > Web Apps > WAC Quickstart > WAC 트러블슈팅 가이드	WAC 트러블슈팅 가이드
-927629410	관리자 매뉴얼 > Web Apps > WAC Quickstart > WAC FAQ	WAC FAQ
-544379062	관리자 매뉴얼 > Audit	Audit
-693043522	관리자 매뉴얼 > Audit > Reports	Reports
-544384417	관리자 매뉴얼 > Audit > Reports > Reports	Reports
-544379140	관리자 매뉴얼 > Audit > Reports > Audit Log Export	Audit Log Export
-544211450	관리자 매뉴얼 > Audit > General Logs	General Logs
-544080230	관리자 매뉴얼 > Audit > General Logs > User Access History	User Access History
-544113108	관리자 매뉴얼 > Audit > General Logs > Activity Logs	Activity Logs
-544047557	관리자 매뉴얼 > Audit > General Logs > Admin Role History	Admin Role History
-705724442	관리자 매뉴얼 > Audit > General Logs > Workflow Logs	Workflow Logs
-775455036	관리자 매뉴얼 > Audit > General Logs > Reverse Tunnels	Reverse Tunnels
-811434216	관리자 매뉴얼 > Audit > General Logs > Reverse Tunnels > Reverse Tunnel을 통해 서버에 통신하기	Reverse Tunnel을 통해 서버에 통신하기
-811466988	관리자 매뉴얼 > Audit > General Logs > Reverse Tunnels > Reverse Tunnel을 통해 클러스터에 통신하기	Reverse Tunnel을 통해 클러스터에 통신하기
-955318273	관리자 매뉴얼 > Audit > General Logs > Reverse Tunnels > Reverse Tunnel을 통해 DB에 통신하기	Reverse Tunnel을 통해 DB에 통신하기
-544080248	관리자 매뉴얼 > Audit > Database Logs	Database Logs
-544113141	관리자 매뉴얼 > Audit > Database Logs > DB Access History	DB Access History
-544244149	관리자 매뉴얼 > Audit > Database Logs > Query Audit	Query Audit
-544145819	관리자 매뉴얼 > Audit > Database Logs > Running Queries	Running Queries
-544244163	관리자 매뉴얼 > Audit > Database Logs > DML Snapshots	DML Snapshots
-544014894	관리자 매뉴얼 > Audit > Database Logs > Account Lock History	Account Lock History
-544080264	관리자 매뉴얼 > Audit > Database Logs > Access Control Logs	Access Control Logs
-1070694532	관리자 매뉴얼 > Audit > Database Logs > Policy Audit Logs	Policy Audit Logs
-1164705793	관리자 매뉴얼 > Audit > Database Logs > Policy Exception logs	Policy Exception logs
-544014907	관리자 매뉴얼 > Audit > Server Logs	Server Logs
-544244182	관리자 매뉴얼 > Audit > Server Logs > Server Access History	Server Access History
-544244208	관리자 매뉴얼 > Audit > Server Logs > Command Audit	Command Audit
-544014927	관리자 매뉴얼 > Audit > Server Logs > Session Logs	Session Logs
-544014940	관리자 매뉴얼 > Audit > Server Logs > Session Monitoring	Session Monitoring
-544244234	관리자 매뉴얼 > Audit > Server Logs > Access Control Logs	Access Control Logs
-544244244	관리자 매뉴얼 > Audit > Server Logs > Server Role History	Server Role History
-543949311	관리자 매뉴얼 > Audit > Server Logs > Account Lock History	Account Lock History
-544383513	관리자 매뉴얼 > Audit > Kubernetes Logs	Kubernetes Logs
-544383587	관리자 매뉴얼 > Audit > Kubernetes Logs > Request Audit	Request Audit
-544383693	관리자 매뉴얼 > Audit > Kubernetes Logs > Pod Session Recordings	Pod Session Recordings
-544383799	관리자 매뉴얼 > Audit > Kubernetes Logs > Kubernetes Role History	Kubernetes Role History
-1064829366	관리자 매뉴얼 > Audit > Web App Logs	Web App Logs
-1064829380	관리자 매뉴얼 > Audit > Web App Logs > Web Access History	Web Access History
-1070563457	관리자 매뉴얼 > Audit > Web App Logs > Web Event Audit	Web Event Audit
-1070694561	관리자 매뉴얼 > Audit > Web App Logs > User Activity Recordings	User Activity Recordings
-1070563469	관리자 매뉴얼 > Audit > Web App Logs > Web App Role History	Web App Role History
-1070694552	관리자 매뉴얼 > Audit > Web App Logs > JIT Access Control Logs	JIT Access Control Logs
-851280543	관리자 매뉴얼 > Multi Agent 제약사항	Multi Agent 제약사항
+544080057	관리자 매뉴얼 />> General	General
+543948978	관리자 매뉴얼 />> General />> Company Management	Company Management
+544145591	관리자 매뉴얼 />> General />> Company Management />> General	General
+544178422	관리자 매뉴얼 />> General />> Company Management />> Security	Security
+544112846	관리자 매뉴얼 />> General />> Company Management />> Allowed Zones	Allowed Zones
+544243925	관리자 매뉴얼 />> General />> Company Management />> Channels	Channels
+543981760	관리자 매뉴얼 />> General />> Company Management />> Alerts	Alerts
+793608206	관리자 매뉴얼 />> General />> Company Management />> Alerts />> New Request > 요청 타입별 템플릿 변수	New Request > 요청 타입별 템플릿 변수
+544178443	관리자 매뉴얼 />> General />> Company Management />> Licenses	Licenses
+544375969	관리자 매뉴얼 />> General />> User Management	User Management
+544047331	관리자 매뉴얼 />> General />> User Management />> Users	Users
+544376787	관리자 매뉴얼 />> General />> User Management />> Users />> 사용자 프로필	사용자 프로필
+920944732	관리자 매뉴얼 />> General />> User Management />> Users />> qp-admin 기본 계정에 대한 패스워드 변경 강제화 및 계정 삭제 기능	qp-admin 기본 계정에 대한 패스워드 변경 강제화 및 계정 삭제 기능
+544047341	관리자 매뉴얼 />> General />> User Management />> Groups	Groups
+543948996	관리자 매뉴얼 />> General />> User Management />> Roles	Roles
+544376982	관리자 매뉴얼 />> General />> User Management />> Profile Editor	Profile Editor
+953221256	관리자 매뉴얼 />> General />> User Management />> Profile Editor />> Custom Attribute	Custom Attribute
+544375984	관리자 매뉴얼 />> General />> User Management />> Authentication	Authentication
+544376004	관리자 매뉴얼 />> General />> User Management />> Authentication />> LDAP 연동하기	LDAP 연동하기
+544376100	관리자 매뉴얼 />> General />> User Management />> Authentication />> Okta 연동하기	Okta 연동하기
+544376183	관리자 매뉴얼 />> General />> User Management />> Authentication />> AWS SSO 연동하기	AWS SSO 연동하기
+619381289	관리자 매뉴얼 />> General />> User Management />> Authentication />> Google SAML 연동하기	Google SAML 연동하기
+793575425	관리자 매뉴얼 />> General />> User Management />> Authentication />> Multi-Factor Authentication 설정하기	Multi-Factor Authentication 설정하기
+544376236	관리자 매뉴얼 />> General />> User Management />> Provisioning	Provisioning
+544376265	관리자 매뉴얼 />> General />> User Management />> Provisioning />> Provisioning 활성화 하기	Provisioning 활성화 하기
+544376394	관리자 매뉴얼 />> General />> User Management />> Provisioning />> [Okta] 프로비저닝 연동 가이드	[Okta] 프로비저닝 연동 가이드
+544178462	관리자 매뉴얼 />> General />> Workflow Management	Workflow Management
+544047359	관리자 매뉴얼 />> General />> Workflow Management />> All Requests	All Requests
+544378513	관리자 매뉴얼 />> General />> Workflow Management />> Approval Rules	Approval Rules
+561414376	관리자 매뉴얼 />> General />> Workflow Management />> Workflow Configurations	Workflow Configurations
+544112865	관리자 매뉴얼 />> General />> System	System
+544080097	관리자 매뉴얼 />> General />> System />> Integrations	Integrations
+544379393	관리자 매뉴얼 />> General />> System />> Integrations />> Syslog 연동	Syslog 연동
+557940795	관리자 매뉴얼 />> General />> System />> Integrations />> Splunk 연동	Splunk 연동
+544379587	관리자 매뉴얼 />> General />> System />> Integrations />> Secret Store 연동	Secret Store 연동
+798064641	관리자 매뉴얼 />> General />> System />> Integrations />> Email 연동	Email 연동
+811401365	관리자 매뉴얼 />> General />> System />> Integrations />> OAuth 2.0을 사용하기 위한 Google Cloud API 연동	OAuth 2.0을 사용하기 위한 Google Cloud API 연동
+883654669	관리자 매뉴얼 />> General />> System />> Integrations />> Slack DM 연동	Slack DM 연동
+544378759	관리자 매뉴얼 />> General />> System />> Integrations />> Slack DM 연동 />> Slack DM - Workflow 알림 유형	Slack DM - Workflow 알림 유형
+544377652	관리자 매뉴얼 />> General />> System />> API Token	API Token
+544211220	관리자 매뉴얼 />> General />> System />> Jobs	Jobs
+544047372	관리자 매뉴얼 />> Discovery	Discovery
+543949048	관리자 매뉴얼 />> Discovery />> Discovery Management	Discovery Management
+543981852	관리자 매뉴얼 />> Discovery />> Discovery Management />> Dashboard	Dashboard
+544080127	관리자 매뉴얼 />> Discovery />> Discovery Management />> Inventory	Inventory
+543949058	관리자 매뉴얼 />> Discovery />> Discovery Management />> Discovery Jobs	Discovery Jobs
+543981865	관리자 매뉴얼 />> Discovery />> Discovery Management />> Discovery History	Discovery History
+543949078	관리자 매뉴얼 />> Discovery />> Discovery Management />> Scan Results	Scan Results
+544244011	관리자 매뉴얼 />> Discovery />> Discovery Management />> Detection Profiles	Detection Profiles
+544112915	관리자 매뉴얼 />> Discovery />> Discovery Management />> Data Patterns	Data Patterns
+544379638	관리자 매뉴얼 />> Databases	Databases
+956071939	관리자 매뉴얼 />> Databases />> DAC General Configurations	DAC General Configurations
+921436219	관리자 매뉴얼 />> Databases />> DAC General Configurations />> Unmasking Zones	Unmasking Zones
+544379705	관리자 매뉴얼 />> Databases />> Connection Management	Connection Management
+544145672	관리자 매뉴얼 />> Databases />> Connection Management />> Cloud Providers	Cloud Providers
+544379719	관리자 매뉴얼 />> Databases />> Connection Management />> Cloud Providers />> AWS에서 DB 리소스 동기화	AWS에서 DB 리소스 동기화
+562167871	관리자 매뉴얼 />> Databases />> Connection Management />> Cloud Providers />> MS Azure에서 DB 리소스 동기화	MS Azure에서 DB 리소스 동기화
+562167809	관리자 매뉴얼 />> Databases />> Connection Management />> Cloud Providers />> Google Cloud에서 DB 리소스 동기화	Google Cloud에서 DB 리소스 동기화
+712507393	관리자 매뉴얼 />> Databases />> Connection Management />> Cloud Providers />> Dry Run 기능으로 클라우드 동기화 설정 확인하기	Dry Run 기능으로 클라우드 동기화 설정 확인하기
+544014712	관리자 매뉴얼 />> Databases />> Connection Management />> DB Connections	DB Connections
+544380381	관리자 매뉴얼 />> Databases />> Connection Management />> DB Connections />> MongoDB 전용 가이드	MongoDB 전용 가이드
+568852692	관리자 매뉴얼 />> Databases />> Connection Management />> DB Connections />> DocumentDB 전용 가이드	DocumentDB 전용 가이드
+811434142	관리자 매뉴얼 />> Databases />> Connection Management />> DB Connections />> Google BigQuery OAuth 인증 설정	Google BigQuery OAuth 인증 설정
+820806182	관리자 매뉴얼 />> Databases />> Connection Management />> DB Connections />> AWS Athena 전용 가이드	AWS Athena 전용 가이드
+880082945	관리자 매뉴얼 />> Databases />> Connection Management />> DB Connections />> Custom Data Source 설정 및 로그 확인	Custom Data Source 설정 및 로그 확인
+544145691	관리자 매뉴얼 />> Databases />> Connection Management />> SSL Configurations	SSL Configurations
+544047436	관리자 매뉴얼 />> Databases />> Connection Management />> SSH Configurations	SSH Configurations
+544112932	관리자 매뉴얼 />> Databases />> Connection Management />> Kerberos Configurations	Kerberos Configurations
+544380126	관리자 매뉴얼 />> Databases />> DB Access Control	DB Access Control
+544380140	관리자 매뉴얼 />> Databases />> DB Access Control />> Privilege Type	Privilege Type
+544380173	관리자 매뉴얼 />> Databases />> DB Access Control />> Access Control	Access Control
+544379868	관리자 매뉴얼 />> Databases />> Policies	Policies
+544379937	관리자 매뉴얼 />> Databases />> Policies />> Data Access	Data Access
+569376769	관리자 매뉴얼 />> Databases />> Policies />> Masking Pattern	Masking Pattern
+544379882	관리자 매뉴얼 />> Databases />> Policies />> Data Masking	Data Masking
+544379993	관리자 매뉴얼 />> Databases />> Policies />> Sensitive Data	Sensitive Data
+713129986	관리자 매뉴얼 />> Databases />> Policies />> Policy Exception	Policy Exception
+571277577	관리자 매뉴얼 />> Databases />> Ledger Management	Ledger Management
+544380061	관리자 매뉴얼 />> Databases />> Ledger Management />> Ledger Table Policy	Ledger Table Policy
+571277650	관리자 매뉴얼 />> Databases />> Ledger Management />> Ledger Approval Rules	Ledger Approval Rules
+873136365	관리자 매뉴얼 />> Databases />> (New) Policy Management	(New) Policy Management
+878805502	관리자 매뉴얼 />> Databases />> (New) Policy Management />> Data Paths	Data Paths
+879198569	관리자 매뉴얼 />> Databases />> (New) Policy Management />> Data Policies	Data Policies
+1064796485	관리자 매뉴얼 />> Databases />> (New) Policy Management />> Exception Management	Exception Management
+954139156	관리자 매뉴얼 />> Databases />> Monitoring	Monitoring
+954172219	관리자 매뉴얼 />> Databases />> Monitoring />> Runnig Queries	Runnig Queries
+954204974	관리자 매뉴얼 />> Databases />> Monitoring />> Proxy Management	Proxy Management
+544380588	관리자 매뉴얼 />> Servers	Servers
+954336174	관리자 매뉴얼 />> Servers />> SAC General Configurations	SAC General Configurations
+544380635	관리자 매뉴얼 />> Servers />> Connection Management	Connection Management
+544178567	관리자 매뉴얼 />> Servers />> Connection Management />> Cloud Providers	Cloud Providers
+544380650	관리자 매뉴얼 />> Servers />> Connection Management />> Cloud Providers />> AWS에서 서버 리소스 동기화	AWS에서 서버 리소스 동기화
+544380741	관리자 매뉴얼 />> Servers />> Connection Management />> Cloud Providers />> Azure에서 서버 리소스 동기화	Azure에서 서버 리소스 동기화
+544380708	관리자 매뉴얼 />> Servers />> Connection Management />> Cloud Providers />> GCP에서 서버 리소스 동기화	GCP에서 서버 리소스 동기화
+544211361	관리자 매뉴얼 />> Servers />> Connection Management />> Servers	Servers
+544380774	관리자 매뉴얼 />> Servers />> Connection Management />> Servers />> 수동으로 개별 서버 등록하기	수동으로 개별 서버 등록하기
+544080186	관리자 매뉴얼 />> Servers />> Connection Management />> Server Groups	Server Groups
+544380846	관리자 매뉴얼 />> Servers />> Connection Management />> Server Groups />> 서버를 그룹으로 관리하기	서버를 그룹으로 관리하기
+544211376	관리자 매뉴얼 />> Servers />> Connection Management />> Server Agents for RDP	Server Agents for RDP
+565575990	관리자 매뉴얼 />> Servers />> Connection Management />> Server Agents for RDP />> Server Agent 설치 및 제거하기	Server Agent 설치 및 제거하기
+615710737	관리자 매뉴얼 />> Servers />> Connection Management />> ProxyJump Configurations	ProxyJump Configurations
+615743551	관리자 매뉴얼 />> Servers />> Connection Management />> ProxyJump Configurations />> ProxyJump 생성하기	ProxyJump 생성하기
+613777446	관리자 매뉴얼 />> Servers />> Server Account Management	Server Account Management
+544380991	관리자 매뉴얼 />> Servers />> Server Account Management />> Server Account Templates	Server Account Templates
+544380960	관리자 매뉴얼 />> Servers />> Server Account Management />> SSH Key Configurations	SSH Key Configurations
+615743501	관리자 매뉴얼 />> Servers />> Server Account Management />> Account Management	Account Management
+615677962	관리자 매뉴얼 />> Servers />> Server Account Management />> Password Provisioning	Password Provisioning
+619380898	관리자 매뉴얼 />> Servers />> Server Account Management />> Password Provisioning />> 패스워드 변경 Job 생성하기	패스워드 변경 Job 생성하기
+543949216	관리자 매뉴얼 />> Servers />> Server Access Control	Server Access Control
+544381186	관리자 매뉴얼 />> Servers />> Server Access Control />> Access Control	Access Control
+544381282	관리자 매뉴얼 />> Servers />> Server Access Control />> Access Control />> Permissions 부여 및 회수하기	Permissions 부여 및 회수하기
+544381200	관리자 매뉴얼 />> Servers />> Server Access Control />> Access Control />> Role 부여 및 회수하기	Role 부여 및 회수하기
+878838349	관리자 매뉴얼 />> Servers />> Server Access Control />> Access Control />> Server Privilege 부여하기	Server Privilege 부여하기
+544381150	관리자 매뉴얼 />> Servers />> Server Access Control />> Roles	Roles
+544381025	관리자 매뉴얼 />> Servers />> Server Access Control />> Policies	Policies
+544381039	관리자 매뉴얼 />> Servers />> Server Access Control />> Policies />> 서버 접근 정책 설정하기	서버 접근 정책 설정하기
+544377895	관리자 매뉴얼 />> Servers />> Server Access Control />> Policies />> Server Proxy 사용 활성화	Server Proxy 사용 활성화
+544381118	관리자 매뉴얼 />> Servers />> Server Access Control />> Command Templates	Command Templates
+544244109	관리자 매뉴얼 />> Servers />> Server Access Control />> Blocked Accounts	Blocked Accounts
+544381596	관리자 매뉴얼 />> Kubernetes	Kubernetes
+954172232	관리자 매뉴얼 />> Kubernetes />> KAC General Configurations	KAC General Configurations
+544381637	관리자 매뉴얼 />> Kubernetes />> Connection Management	Connection Management
+544381651	관리자 매뉴얼 />> Kubernetes />> Connection Management />> Cloud Providers	Cloud Providers
+544381739	관리자 매뉴얼 />> Kubernetes />> Connection Management />> Cloud Providers />> AWS에서 쿠버네티스 리소스 동기화	AWS에서 쿠버네티스 리소스 동기화
+544381839	관리자 매뉴얼 />> Kubernetes />> Connection Management />> Clusters	Clusters
+544381877	관리자 매뉴얼 />> Kubernetes />> Connection Management />> Clusters />> 수동으로 쿠버네티스 클러스터 등록하기	수동으로 쿠버네티스 클러스터 등록하기
+544383110	관리자 매뉴얼 />> Kubernetes />> K8s Access Control	K8s Access Control
+544383124	관리자 매뉴얼 />> Kubernetes />> K8s Access Control />> Access Control	Access Control
+544383381	관리자 매뉴얼 />> Kubernetes />> K8s Access Control />> Access Control />> 쿠버네티스 역할 부여 및 회수하기	쿠버네티스 역할 부여 및 회수하기
+544382741	관리자 매뉴얼 />> Kubernetes />> K8s Access Control />> Roles	Roles
+544382963	관리자 매뉴얼 />> Kubernetes />> K8s Access Control />> Roles />> 쿠버네티스 역할 설정하기	쿠버네티스 역할 설정하기
+544382060	관리자 매뉴얼 />> Kubernetes />> K8s Access Control />> Policies	Policies
+544382274	관리자 매뉴얼 />> Kubernetes />> K8s Access Control />> Policies />> 쿠버네티스 정책 설정하기	쿠버네티스 정책 설정하기
+544382364	관리자 매뉴얼 />> Kubernetes />> K8s Access Control />> Policies />> 쿠버네티스 정책 YAML Code 문법 안내	쿠버네티스 정책 YAML Code 문법 안내
+544382445	관리자 매뉴얼 />> Kubernetes />> K8s Access Control />> Policies />> 쿠버네티스 정책 Tips 안내	쿠버네티스 정책 Tips 안내
+544382522	관리자 매뉴얼 />> Kubernetes />> K8s Access Control />> Policies />> 쿠버네티스 정책 UI 코드 헬퍼 안내	쿠버네티스 정책 UI 코드 헬퍼 안내
+544382659	관리자 매뉴얼 />> Kubernetes />> K8s Access Control />> Policies />> 쿠버네티스 정책 Action 설정 참고 가이드	쿠버네티스 정책 Action 설정 참고 가이드
+783515900	관리자 매뉴얼 />> Web Apps	Web Apps
+1064829276	관리자 매뉴얼 />> Web Apps />> Connection Management	Connection Management
+1070694423	관리자 매뉴얼 />> Web Apps />> Connection Management />> Web Apps	Web Apps
+1064829246	관리자 매뉴얼 />> Web Apps />> Connection Management />> Web App Configurations	Web App Configurations
+1070596135	관리자 매뉴얼 />> Web Apps />> Web App Access Control	Web App Access Control
+1070628904	관리자 매뉴얼 />> Web Apps />> Web App Access Control />> Access Control	Access Control
+1064599910	관리자 매뉴얼 />> Web Apps />> Web App Access Control />> Access Control />> Role 부여 및 회수하기	Role 부여 및 회수하기
+1070628923	관리자 매뉴얼 />> Web Apps />> Web App Access Control />> Roles	Roles
+1064829343	관리자 매뉴얼 />> Web Apps />> Web App Access Control />> Policies	Policies
+783417593	관리자 매뉴얼 />> Web Apps />> WAC Quickstart	WAC Quickstart
+783745324	관리자 매뉴얼 />> Web Apps />> WAC Quickstart />> [~10.2.7] WAC Role & Policy Guide	[~10.2.7] WAC Role & Policy Guide
+924287097	관리자 매뉴얼 />> Web Apps />> WAC Quickstart />> [10.2.8~] WAC RBAC Guide	[10.2.8~] WAC RBAC Guide
+956235931	관리자 매뉴얼 />> Web Apps />> WAC Quickstart />> [10.3.0 ~] WAC JIT 권한 획득 Guide	[10.3.0 ~] WAC JIT 권한 획득 Guide
+805962425	관리자 매뉴얼 />> Web Apps />> WAC Quickstart />> Root CA 인증서 설치 가이드	Root CA 인증서 설치 가이드
+883654785	관리자 매뉴얼 />> Web Apps />> WAC Quickstart />> Web App Configurations에서 WAC 초기 설정하기	Web App Configurations에서 WAC 초기 설정하기
+924319936	관리자 매뉴얼 />> Web Apps />> WAC Quickstart />> WAC 트러블슈팅 가이드	WAC 트러블슈팅 가이드
+927629410	관리자 매뉴얼 />> Web Apps />> WAC Quickstart />> WAC FAQ	WAC FAQ
+544379062	관리자 매뉴얼 />> Audit	Audit
+693043522	관리자 매뉴얼 />> Audit />> Reports	Reports
+544384417	관리자 매뉴얼 />> Audit />> Reports />> Reports	Reports
+544379140	관리자 매뉴얼 />> Audit />> Reports />> Audit Log Export	Audit Log Export
+544211450	관리자 매뉴얼 />> Audit />> General Logs	General Logs
+544080230	관리자 매뉴얼 />> Audit />> General Logs />> User Access History	User Access History
+544113108	관리자 매뉴얼 />> Audit />> General Logs />> Activity Logs	Activity Logs
+544047557	관리자 매뉴얼 />> Audit />> General Logs />> Admin Role History	Admin Role History
+705724442	관리자 매뉴얼 />> Audit />> General Logs />> Workflow Logs	Workflow Logs
+775455036	관리자 매뉴얼 />> Audit />> General Logs />> Reverse Tunnels	Reverse Tunnels
+811434216	관리자 매뉴얼 />> Audit />> General Logs />> Reverse Tunnels />> Reverse Tunnel을 통해 서버에 통신하기	Reverse Tunnel을 통해 서버에 통신하기
+811466988	관리자 매뉴얼 />> Audit />> General Logs />> Reverse Tunnels />> Reverse Tunnel을 통해 클러스터에 통신하기	Reverse Tunnel을 통해 클러스터에 통신하기
+955318273	관리자 매뉴얼 />> Audit />> General Logs />> Reverse Tunnels />> Reverse Tunnel을 통해 DB에 통신하기	Reverse Tunnel을 통해 DB에 통신하기
+544080248	관리자 매뉴얼 />> Audit />> Database Logs	Database Logs
+544113141	관리자 매뉴얼 />> Audit />> Database Logs />> DB Access History	DB Access History
+544244149	관리자 매뉴얼 />> Audit />> Database Logs />> Query Audit	Query Audit
+544145819	관리자 매뉴얼 />> Audit />> Database Logs />> Running Queries	Running Queries
+544244163	관리자 매뉴얼 />> Audit />> Database Logs />> DML Snapshots	DML Snapshots
+544014894	관리자 매뉴얼 />> Audit />> Database Logs />> Account Lock History	Account Lock History
+544080264	관리자 매뉴얼 />> Audit />> Database Logs />> Access Control Logs	Access Control Logs
+1070694532	관리자 매뉴얼 />> Audit />> Database Logs />> Policy Audit Logs	Policy Audit Logs
+1164705793	관리자 매뉴얼 />> Audit />> Database Logs />> Policy Exception logs	Policy Exception logs
+544014907	관리자 매뉴얼 />> Audit />> Server Logs	Server Logs
+544244182	관리자 매뉴얼 />> Audit />> Server Logs />> Server Access History	Server Access History
+544244208	관리자 매뉴얼 />> Audit />> Server Logs />> Command Audit	Command Audit
+544014927	관리자 매뉴얼 />> Audit />> Server Logs />> Session Logs	Session Logs
+544014940	관리자 매뉴얼 />> Audit />> Server Logs />> Session Monitoring	Session Monitoring
+544244234	관리자 매뉴얼 />> Audit />> Server Logs />> Access Control Logs	Access Control Logs
+544244244	관리자 매뉴얼 />> Audit />> Server Logs />> Server Role History	Server Role History
+543949311	관리자 매뉴얼 />> Audit />> Server Logs />> Account Lock History	Account Lock History
+544383513	관리자 매뉴얼 />> Audit />> Kubernetes Logs	Kubernetes Logs
+544383587	관리자 매뉴얼 />> Audit />> Kubernetes Logs />> Request Audit	Request Audit
+544383693	관리자 매뉴얼 />> Audit />> Kubernetes Logs />> Pod Session Recordings	Pod Session Recordings
+544383799	관리자 매뉴얼 />> Audit />> Kubernetes Logs />> Kubernetes Role History	Kubernetes Role History
+1064829366	관리자 매뉴얼 />> Audit />> Web App Logs	Web App Logs
+1064829380	관리자 매뉴얼 />> Audit />> Web App Logs />> Web Access History	Web Access History
+1070563457	관리자 매뉴얼 />> Audit />> Web App Logs />> Web Event Audit	Web Event Audit
+1070694561	관리자 매뉴얼 />> Audit />> Web App Logs />> User Activity Recordings	User Activity Recordings
+1070563469	관리자 매뉴얼 />> Audit />> Web App Logs />> Web App Role History	Web App Role History
+1070694552	관리자 매뉴얼 />> Audit />> Web App Logs />> JIT Access Control Logs	JIT Access Control Logs
+851280543	관리자 매뉴얼 />> Multi Agent 제약사항	Multi Agent 제약사항

--- a/scripts/generate_commands_for_xhtml2markdown.py
+++ b/scripts/generate_commands_for_xhtml2markdown.py
@@ -36,12 +36,12 @@ def process_breadcrumbs(breadcrumbs):
     Process breadcrumbs to determine the output path.
     
     Args:
-        breadcrumbs: A string containing breadcrumbs separated by ' > '
+        breadcrumbs: A string containing breadcrumbs separated by ' />> '
     
     Returns:
         A tuple containing (directory_path, filename)
     """
-    parts = breadcrumbs.split(' > ')
+    parts = breadcrumbs.split(' />> ')
     
     # Create slugified path components
     path_components = [slugify(part) for part in parts]

--- a/scripts/pages_of_confluence.py
+++ b/scripts/pages_of_confluence.py
@@ -339,7 +339,7 @@ class ConfluencePageProcessor:
                                  if ancestor.get("type") == "page" and "title" in ancestor]
                 path = ancestor_titles + [title]
 
-            return " > ".join(path)
+            return " />> ".join(path)
         except Exception as e:
             self.logger.error(f"Error building breadcrumbs for page {page_id}: {str(e)}")
             return title

--- a/scripts/xhtml2markdown.ko.sh
+++ b/scripts/xhtml2markdown.ko.sh
@@ -11,6 +11,10 @@ python scripts/confluence_xhtml_to_markdown.py docs/latest-ko-confluence/5443753
 echo 'Converted 544375335 to src/content/ko/./release-notes.mdx'
 
 mkdir -p src/content/ko/release-notes
+python scripts/confluence_xhtml_to_markdown.py docs/latest-ko-confluence/1171488777/page.xhtml src/content/ko/release-notes/1110.mdx
+echo 'Converted 1171488777 to src/content/ko/release-notes/1110.mdx'
+
+mkdir -p src/content/ko/release-notes
 python scripts/confluence_xhtml_to_markdown.py docs/latest-ko-confluence/1064830173/page.xhtml src/content/ko/release-notes/1100.mdx
 echo 'Converted 1064830173 to src/content/ko/release-notes/1100.mdx'
 
@@ -86,13 +90,13 @@ mkdir -p src/content/ko/release-notes
 python scripts/confluence_xhtml_to_markdown.py docs/latest-ko-confluence/544375659/page.xhtml src/content/ko/release-notes/990-998.mdx
 echo 'Converted 544375659 to src/content/ko/release-notes/990-998.mdx'
 
-mkdir -p src/content/ko/release-notes/990-998/external-api-changes-9810-version
-python scripts/confluence_xhtml_to_markdown.py docs/latest-ko-confluence/544375685/page.xhtml src/content/ko/release-notes/990-998/external-api-changes-9810-version/994-version.mdx
-echo 'Converted 544375685 to src/content/ko/release-notes/990-998/external-api-changes-9810-version/994-version.mdx'
+mkdir -p src/content/ko/release-notes/990-998
+python scripts/confluence_xhtml_to_markdown.py docs/latest-ko-confluence/544375685/page.xhtml src/content/ko/release-notes/990-998/external-api-changes-9810-version-994-version.mdx
+echo 'Converted 544375685 to src/content/ko/release-notes/990-998/external-api-changes-9810-version-994-version.mdx'
 
-mkdir -p src/content/ko/release-notes/990-998/external-api-changes-994-version
-python scripts/confluence_xhtml_to_markdown.py docs/latest-ko-confluence/544375741/page.xhtml src/content/ko/release-notes/990-998/external-api-changes-994-version/995-version.mdx
-echo 'Converted 544375741 to src/content/ko/release-notes/990-998/external-api-changes-994-version/995-version.mdx'
+mkdir -p src/content/ko/release-notes/990-998
+python scripts/confluence_xhtml_to_markdown.py docs/latest-ko-confluence/544375741/page.xhtml src/content/ko/release-notes/990-998/external-api-changes-994-version-995-version.mdx
+echo 'Converted 544375741 to src/content/ko/release-notes/990-998/external-api-changes-994-version-995-version.mdx'
 
 mkdir -p src/content/ko/release-notes
 python scripts/confluence_xhtml_to_markdown.py docs/latest-ko-confluence/544375768/page.xhtml src/content/ko/release-notes/980-9812.mdx
@@ -298,9 +302,9 @@ mkdir -p src/content/ko/administrator-manual/general/company-management
 python scripts/confluence_xhtml_to_markdown.py docs/latest-ko-confluence/543981760/page.xhtml src/content/ko/administrator-manual/general/company-management/alerts.mdx
 echo 'Converted 543981760 to src/content/ko/administrator-manual/general/company-management/alerts.mdx'
 
-mkdir -p src/content/ko/administrator-manual/general/company-management/alerts/new-request
-python scripts/confluence_xhtml_to_markdown.py docs/latest-ko-confluence/793608206/page.xhtml src/content/ko/administrator-manual/general/company-management/alerts/new-request/template-variables-by-request-type.mdx
-echo 'Converted 793608206 to src/content/ko/administrator-manual/general/company-management/alerts/new-request/template-variables-by-request-type.mdx'
+mkdir -p src/content/ko/administrator-manual/general/company-management/alerts
+python scripts/confluence_xhtml_to_markdown.py docs/latest-ko-confluence/793608206/page.xhtml src/content/ko/administrator-manual/general/company-management/alerts/new-request-template-variables-by-request-type.mdx
+echo 'Converted 793608206 to src/content/ko/administrator-manual/general/company-management/alerts/new-request-template-variables-by-request-type.mdx'
 
 mkdir -p src/content/ko/administrator-manual/general/company-management
 python scripts/confluence_xhtml_to_markdown.py docs/latest-ko-confluence/544178443/page.xhtml src/content/ko/administrator-manual/general/company-management/licenses.mdx


### PR DESCRIPTION
## Description
- 기존에는 ` > `를 구분자로 사용하였는데, 문서 제목에 ` > ` 문구를 사용하는 경우와 충돌이 발생합니다.
- 제목에 사용하지 않을 듯한 문구, ` />> `를 구분자로 사용하여, 탐색경로를 표현합니다.
- 이 변경에 따라 list.txt, list.en.txt, xhtml2markdown.ko.sh 등 파일을 함께 변경합니다.
- 11.1.0 Release Note 가 추가된 것을 반영합니다.

## Additional notes
- 
