### PR TITLE
CSS: Sidebar 의 폭을 조정합니다.

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,8 +3,20 @@
 /* Custom CSS for QueryPie AI Hub Docs */
 
 /* 사이드바 폭 테스트 - 하나씩 확인 */
-.nextra-sidebar {
-  width: 300px !important;
+
+/* sidebar component 는 isExpanded 라는 내부 상태에 따라,
+ * 'x:w-64' 또는 'x:w-20' 이라는 class 를 갖게 됩니다:
+ * Refer to https://github.com/shuding/nextra/blob/main/packages/nextra-theme-docs/src/components/sidebar.tsx#L434
+ *
+ * 'x:w-<num>' 패턴의 class 이름은 tailwindcss framework 에서 비롯하였습니다: Refer to https://tailwindcss.com/docs/width
+ */
+aside.nextra-sidebar.x\:w-64 { /* expanded */
+    /* 64 is the default width of the expanded sidebar */
+    width: calc(var(--x-spacing) * 72);
+}
+aside.nextra-sidebar.x\:w-20 { /* collapsed */
+    /* 20 is the default width of the collapsed sidebar */
+    width: calc(var(--x-spacing) * 12);
 }
 
 /* Custom styles for QueryPie branding */


### PR DESCRIPTION
## Description
- 펼쳐졌을 때에 더 넓게, 접혔을 때 더 좁게, Sidebar 의 폭을 조정합니다.
- Sidebar 에 노출되는 문서 제목의 길이가 긴 경우가 종종 있습니다. 이에 따라 펼쳐진 폭을 늘입니다.
- 접힌 경우의 기본값 폭이 상당히 넓은 편입니다. 본문에 충분한 공간을 주기 위해, 접힌 경우의 폭을 줄입니다.

## Additional notes
- 
