### PR TITLE
refactor: pages_of_confluence.py 기능 추가

### DIFF
--- a/docs/korean-titles-translations.txt
+++ b/docs/korean-titles-translations.txt
@@ -55,11 +55,6 @@ Multi Agent 제약사항 | Multi Agent Limitations
 
 # User Management
 Email을 통한 사용자 비밀 번호 초기화 | User Password Reset via Email
-
-# WAC Quickstart
-Root CA 인증서 설치 가이드 | Root CA Certificate Installation Guide
-
-# User Management
 사용자 프로필 | User Profile
 qp-admin 기본 계정에 대한 패스워드 변경 강제화 및 계정 삭제 기능 | Password Change Enforcement and Account Deletion Feature for qp-admin Default Account
 LDAP 연동하기 | Integrating with LDAP
@@ -69,6 +64,10 @@ Google SAML 연동하기 | Integrating with Google SAML
 Multi-Factor Authentication 설정하기 | Setting Up Multi-Factor Authentication
 Provisioning 활성화 하기 | Activating Provisioning
 [Okta] 프로비저닝 연동 가이드 | [Okta] Provisioning Integration Guide
+
+# Company Management
+요청 타입별 템플릿 변수 | Template Variables by Request Type
+New Request > 요청 타입별 템플릿 변수 | New Request > Template Variables by Request Type
 
 # System Integrations
 Syslog 연동 | Integrating with Syslog
@@ -89,9 +88,6 @@ DocumentDB 전용 가이드 | DocumentDB Specific Guide
 Google BigQuery OAuth 인증 설정 | Google BigQuery OAuth Authentication Configuration
 AWS Athena 전용 가이드 | AWS Athena Specific Guide
 Custom Data Source 설정 및 로그 확인 | Custom Data Source Configuration and Log Verification
-
-# Company Management
-요청 타입별 템플릿 변수 | Template Variables by Request Type
 
 # Server Connection Management
 AWS에서 서버 리소스 동기화 | Synchronizing Server Resources from AWS
@@ -130,6 +126,9 @@ Web App Configurations에서 WAC 초기 설정하기 | Initial WAC Setup in Web 
 WAC 트러블슈팅 가이드 | WAC Troubleshooting Guide
 [10.3.0 ~] WAC JIT 권한 획득 Guide | [10.3.0 ~] WAC JIT Permission Acquisition Guide
 Role 부여 및 회수하기 | Granting and Revoking Roles
+
+# WAC Quickstart
+Root CA 인증서 설치 가이드 | Root CA Certificate Installation Guide
 
 # Reverse Tunnels
 Reverse Tunnel을 통해 서버에 통신하기 | Communicating with Servers through Reverse Tunnel


### PR DESCRIPTION
## Description
- pages_of_confluence.py 가 `output_dir/list.txt`, `output_dir/list.en.txt` 를 직접 생성하도록, 기능을 추가합니다.
- korean-titles-translations.txt 를 참조하여, `output_dir/list.en.txt` 를 생성합니다.
  - korean-titles-translations.txt 는 문서 제목을 한국어 - 영어로 번역한 데이터를 갖고 있습니다.
  - translate_titles.py 를 이용하지 않고, pages_of_confluence.py 에서 직접 list.en.txt 를 생성합니다.

## Additional notes
- `./scripts/pages_of_confluence.py --local` 실행을 성공합니다. list.txt, list.en.txt 가 동일하게 생성됩니다.
