### PR TITLE
feat: hidden chars 를 포함하여 링크의 문서 제목을 찾아냅니다.

### DIFF
--- a/scripts/tests/confluence_xhtml_to_markdown/testcases/544178405/expected.mdx
+++ b/scripts/tests/confluence_xhtml_to_markdown/testcases/544178405/expected.mdx
@@ -87,7 +87,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 **관리자 역할 할당하기**
 </th>
 <td>
-* [Roles](administrator-manual/web-apps/web-app-access-control/roles)
+* [Roles](administrator-manual/general/user-management/roles)
 </td>
 </tr>
 <tr>
@@ -156,9 +156,9 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 **Databased Access Control 설정하기**
 </th>
 <td>
-* [Connection Management](administrator-manual/web-apps/connection-management)
+* [Connection Management](administrator-manual/databases/connection-management)
 * [DB Access Control](administrator-manual/databases/db-access-control)
-* [Policies](administrator-manual/web-apps/web-app-access-control/policies)
+* [Policies](administrator-manual/databases/policies)
 * [Ledger Management](administrator-manual/databases/ledger-management)
 </td>
 </tr>
@@ -170,8 +170,8 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 **Server Access Control 설정하기**
 </th>
 <td>
-* [Connection Management](administrator-manual/web-apps/connection-management)
-* [Server Access Control ](administrator-manual/servers/server-access-control)
+* [Connection Management](administrator-manual/servers/connection-management)
+* [Server Access Control ](user-manual/server-access-control)
 </td>
 </tr>
 <tr>
@@ -182,7 +182,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 **Kubernetes Access Control 설정하기**
 </th>
 <td>
-* [Connection Management](administrator-manual/web-apps/connection-management)
+* [Connection Management](administrator-manual/kubernetes/connection-management)
 * [K8s Access Control ](administrator-manual/kubernetes/k8s-access-control)
 </td>
 </tr>


### PR DESCRIPTION
## Description
Confluence XHTML to Markdown 변환 스크립트의 코드 구조를 개선하고 `clean_text()` 함수의 적용 범위를 명확히 하여 더 안정적인 문서 변환을 지원합니다.

### 주요 변경사항
- 전역 변수 구조 개선: PAGES_DICT를 PAGES_BY_TITLE로 이름 변경하고 PAGES_BY_ID를 추가하여 페이지 정보를 제목과 ID로 각각 인덱싱합니다. PAGES_BY_TITLE 은  `relative_path_to_titled_page()`가 사용하지만, PAGES_BY_ID 는 아직 사용되지 않습니다.
- `relative_path_to_titled_page()` 함수 추출: 페이지 간 상대 경로 계산 로직을 별도 함수로 분리하여 코드 재사용성을 향상시키고 링크 처리 로직의 중복을 제거합니다.
- `clean_text()` 함수 적용 범위 최적화: HTML 콘텐츠 전체에 전역적으로 적용하던 것을 NavigableString 노드와 첨부 파일명 정규화에만 적용하도록 변경하여 불필요한 텍스트 정리 작업을 제거합니다.
- `load_pages_yaml()` 함수 리팩토링: 함수 시그니처를 변경하고 중복 제목 검증 로직을 추가하여 더 안정적인 페이지 로딩을 지원합니다.
- 테스트 케이스 업데이트: 링크 경로가 올바르게 계산되는지 검증하는 테스트 케이스를 실제 문서 구조에 맞는 상대 경로로 업데이트합니다.

## Additional notes
- 
