### PR TITLE
Fix: failure of scripts/deploy/index.js when preview environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,20 @@ npm run build
 npm start
 ```
 
-## 배포
+## 배포 - Local Environment
+- `scripts/deploy/` 디렉토리로 이동합니다.
+- `npm install` 명령으로 Vercel SDK 등을 node_modules 에 설치합니다.
+- `index.js`가 필요로 하는 환경변수를 설정합니다.
+  - VERCEL_TOKEN: vercel.com 의 계정에서 생성한 Token 을 지정합니다. Scope 은 QueryPie team 을 지정합니다.
+  - VERCEL_TEAM_ID: QueryPie team 의 Team ID 를 지정합니다. Settings -> General 에서 확인할 수 있습니다.
+  - TARGET_ENV: production, staging, preview 중 하나를 지정합니다.
+  - BRANCH: branch 이름을 지정합니다.
+- `index.js`를 실행합니다.
+```shell
+TARGET_ENV=preview BRANCH=main node ./index.js
+```
+
+## 배포 - GitHub Action
 - [GitHub Actions](https://github.com/chequer-io/querypie-ai-docs/actions/workflows/deploy.yml) 에 접속합니다.
 - `Run workflow`를 눌러서 알맞게 설정한 후 실행합니다.
   - 기본값: Production으로 배포할 거면 기본값으로 두고 나가면 됩니다. 

--- a/scripts/deploy/index.js
+++ b/scripts/deploy/index.js
@@ -7,16 +7,20 @@ const vercel = new Vercel({
   bearerToken: process.env.VERCEL_TOKEN,
 });
 
+const teamId = process.env.VERCEL_TEAM_ID;
 const targetEnv = process.env.TARGET_ENV;
 const branch = process.env.BRANCH;
 
 async function createAndCheckDeployment() {
   try {
     console.log(`Creating deployment: target=[${targetEnv}], branch=[${branch}]`);
+
+    const target = targetEnv === 'preview' ? undefined : targetEnv;
     const createResponse = await vercel.deployments.createDeployment({
+      teamId: teamId,
       requestBody: {
         name: 'querypie-docs', //The project name used in the deployment URL
-        target: targetEnv, // production, preview, or staging
+        target: target, // 'production', 'staging', or undefined for 'preview'
         gitSource: {
           type: 'github',
           repo: 'querypie-docs',


### PR DESCRIPTION
## Description
- Preview environment 에 대한 createDeployment target 변경
    - Vercel.com 의 REST API Reference 에 따르면, `vercel.deployments.createDeployment({})` 의 body 에 사용되는 target 으로 `preview` 를 사용할 수 없습니다.
    - https://vercel.com/docs/rest-api/reference/endpoints/deployments/create-a-new-deployment#body-target
    - Preview environment 를 대상으로 배포할 때에는 target 값을 undefined 로 설정하여야 합니다.
    - 'production', 'staging' 등의 environment 에 대해서는 target 을 지정합니다.
- 개인 Token 을 사용할 때, 기본 Team 설정을 요구하지 않도록, teamId 를 createDeployment 에서 명시적으로 지정합니다.
    - Vercel 은 User Account 에 대해서만 Token 을 생성할 수 있습니다. User Account 의 Default Team 을 적절히 지정하지 않으면, `querypie-docs` 라는 Project 를 찾을 수 없어서, 접근 권한 오류가 발생하게 됩니다.
    - VERCEL_TEAM_ID 라는 환경변수는 `querypie-docs` git repository 의 환경변수로 추가합니다.

## Additional notes
- 로컬 개발환경에서 index.js 가 정상으로 실행되는 것을 확인하였습니다.
