### PR TITLE
fix: Markdown Table 에 Nextra framework 의 Style 을 적용합니다

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,11 @@ const withNextra = nextra({
     codeblocks: false,
   },
   contentDirBasePath: '/',
+
+  // To use standard HTML elements for your tables
+  // but have them styled with components provided by useMDXComponents()
+  // Refer to this: https://nextra.site/docs/advanced/table
+  whiteListTagsStyling: ['table', 'thead', 'tbody', 'tr', 'th', 'td'],
 });
 
 // Export the final Next.js config with Nextra included


### PR DESCRIPTION
## Description
- Nextra Reference 에 따르면, next.config.ts 에서 nextra framework 를 설정할 때, Styling 을 적용할 기본 html tag 를 지정할 수 있습니다.
    - https://nextra.site/docs/advanced/table
- 위의 설정을 변경하여, 기본 Table 이 스타일 적용된 것을 확인할 수 있습니다.

## Additional notes
- 
