### PR TITLE
fix: Table Rendering 오류 수정을 시도합니다.

### DIFF
--- a/scripts/confluence_xhtml_to_markdown.py
+++ b/scripts/confluence_xhtml_to_markdown.py
@@ -409,7 +409,9 @@ def get_html_attributes(node):
         # TODO(JK): Do not include style attribute of Tag for now.
         # Or, npm run build fails.
         # MDX requires style property in JSX format, style={{ name: value, ...}}.
-        if attr_name == 'style':
+        # TODO(JK): Do not include class attribute of Tag for now.
+        # class="numberingColumn" might be the cause of broken table rendering.
+        if attr_name in ['style', 'class']:
             continue
 
         if isinstance(attr_value, list):

--- a/scripts/tests/confluence_xhtml_to_markdown/testcases/544178405/expected.mdx
+++ b/scripts/tests/confluence_xhtml_to_markdown/testcases/544178405/expected.mdx
@@ -28,7 +28,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </colgroup>
 <tbody>
 <tr>
-<th class="numberingColumn">
+<th>
 </th>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
 **설정 순서**
@@ -38,7 +38,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </th>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 1
 </td>
 <th>
@@ -50,7 +50,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 2
 </td>
 <th>
@@ -64,7 +64,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 3
 </td>
 <th>
@@ -81,7 +81,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 4
 </td>
 <th>
@@ -92,7 +92,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 5
 </td>
 <th>
@@ -103,7 +103,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 6
 </td>
 <th>
@@ -115,7 +115,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 7
 </td>
 <th>
@@ -141,7 +141,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </colgroup>
 <tbody>
 <tr>
-<th class="numberingColumn">
+<th>
 </th>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
 **설정 순서**
@@ -151,7 +151,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </th>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 1
 </td>
 <th>
@@ -165,7 +165,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 2
 </td>
 <th>
@@ -177,7 +177,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 3
 </td>
 <th>
@@ -189,7 +189,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 4
 </td>
 <th>
@@ -203,7 +203,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 5
 </td>
 <th>

--- a/scripts/tests/confluence_xhtml_to_markdown/testcases/544211126/expected.mdx
+++ b/scripts/tests/confluence_xhtml_to_markdown/testcases/544211126/expected.mdx
@@ -19,7 +19,7 @@ title: '사용자 매뉴얼'
 </colgroup>
 <tbody>
 <tr>
-<th class="numberingColumn">
+<th>
 </th>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
 **사용 순서**
@@ -29,7 +29,7 @@ title: '사용자 매뉴얼'
 </th>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 1
 </td>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
@@ -40,7 +40,7 @@ title: '사용자 매뉴얼'
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 2
 </td>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
@@ -51,7 +51,7 @@ title: '사용자 매뉴얼'
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 3
 </td>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
@@ -71,7 +71,7 @@ title: '사용자 매뉴얼'
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 4
 </td>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
@@ -94,7 +94,7 @@ title: '사용자 매뉴얼'
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 5
 </td>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
@@ -105,7 +105,7 @@ title: '사용자 매뉴얼'
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 6
 </td>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">

--- a/src/content/ko/administrator-manual.mdx
+++ b/src/content/ko/administrator-manual.mdx
@@ -28,7 +28,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </colgroup>
 <tbody>
 <tr>
-<th class="numberingColumn">
+<th>
 </th>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
 **설정 순서**
@@ -38,7 +38,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </th>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 1
 </td>
 <th>
@@ -50,7 +50,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 2
 </td>
 <th>
@@ -64,7 +64,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 3
 </td>
 <th>
@@ -81,7 +81,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 4
 </td>
 <th>
@@ -92,7 +92,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 5
 </td>
 <th>
@@ -103,7 +103,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 6
 </td>
 <th>
@@ -115,7 +115,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 7
 </td>
 <th>
@@ -141,7 +141,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </colgroup>
 <tbody>
 <tr>
-<th class="numberingColumn">
+<th>
 </th>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
 **설정 순서**
@@ -151,7 +151,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </th>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 1
 </td>
 <th>
@@ -165,7 +165,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 2
 </td>
 <th>
@@ -177,7 +177,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 3
 </td>
 <th>
@@ -189,7 +189,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 4
 </td>
 <th>
@@ -203,7 +203,7 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 5
 </td>
 <th>

--- a/src/content/ko/administrator-manual/databases.mdx
+++ b/src/content/ko/administrator-manual/databases.mdx
@@ -28,7 +28,7 @@ QueryPie DAC(Database Access Controller)을 처음 사용하는 관리자라면 
 </colgroup>
 <tbody>
 <tr>
-<th class="numberingColumn">
+<th>
 </th>
 <th>
 **설정 순서**
@@ -38,7 +38,7 @@ QueryPie DAC(Database Access Controller)을 처음 사용하는 관리자라면 
 </th>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 1
 </td>
 <th>
@@ -50,7 +50,7 @@ QueryPie DAC(Database Access Controller)을 처음 사용하는 관리자라면 
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 2
 </td>
 <th>
@@ -63,7 +63,7 @@ QueryPie DAC(Database Access Controller)을 처음 사용하는 관리자라면 
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 3
 </td>
 <th>
@@ -77,7 +77,7 @@ QueryPie DAC(Database Access Controller)을 처음 사용하는 관리자라면 
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 4
 </td>
 <th>
@@ -89,7 +89,7 @@ QueryPie DAC(Database Access Controller)을 처음 사용하는 관리자라면 
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 5
 </td>
 <th>
@@ -100,7 +100,7 @@ QueryPie DAC(Database Access Controller)을 처음 사용하는 관리자라면 
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 6
 </td>
 <th>

--- a/src/content/ko/administrator-manual/kubernetes.mdx
+++ b/src/content/ko/administrator-manual/kubernetes.mdx
@@ -29,7 +29,7 @@ QueryPie KAC(Kubernetes Access Controller)을 처음 사용하는 관리자라�
 </colgroup>
 <tbody>
 <tr>
-<th class="numberingColumn">
+<th>
 </th>
 <th>
 **설정 순서**
@@ -39,7 +39,7 @@ QueryPie KAC(Kubernetes Access Controller)을 처음 사용하는 관리자라�
 </th>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 1
 </td>
 <th>
@@ -51,7 +51,7 @@ QueryPie KAC(Kubernetes Access Controller)을 처음 사용하는 관리자라�
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 2
 </td>
 <th>
@@ -63,7 +63,7 @@ QueryPie KAC(Kubernetes Access Controller)을 처음 사용하는 관리자라�
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 3
 </td>
 <th>
@@ -75,7 +75,7 @@ QueryPie KAC(Kubernetes Access Controller)을 처음 사용하는 관리자라�
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 4
 </td>
 <th>
@@ -86,7 +86,7 @@ QueryPie KAC(Kubernetes Access Controller)을 처음 사용하는 관리자라�
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 5
 </td>
 <th>
@@ -97,7 +97,7 @@ QueryPie KAC(Kubernetes Access Controller)을 처음 사용하는 관리자라�
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 6
 </td>
 <th>
@@ -108,7 +108,7 @@ QueryPie KAC(Kubernetes Access Controller)을 처음 사용하는 관리자라�
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 7
 </td>
 <th>

--- a/src/content/ko/administrator-manual/servers.mdx
+++ b/src/content/ko/administrator-manual/servers.mdx
@@ -29,7 +29,7 @@ SAC(System Access Controller)을 처음 사용하는 관리자라면 원활한 �
 </colgroup>
 <tbody>
 <tr>
-<th class="numberingColumn">
+<th>
 </th>
 <th>
 **설정 순서**
@@ -39,7 +39,7 @@ SAC(System Access Controller)을 처음 사용하는 관리자라면 원활한 �
 </th>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 1
 </td>
 <th>
@@ -53,7 +53,7 @@ SAC(System Access Controller)을 처음 사용하는 관리자라면 원활한 �
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 2
 </td>
 <th>
@@ -65,7 +65,7 @@ SAC(System Access Controller)을 처음 사용하는 관리자라면 원활한 �
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 3
 </td>
 <th>
@@ -76,7 +76,7 @@ SAC(System Access Controller)을 처음 사용하는 관리자라면 원활한 �
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 4
 </td>
 <th>
@@ -88,7 +88,7 @@ SAC(System Access Controller)을 처음 사용하는 관리자라면 원활한 �
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 5
 </td>
 <th>
@@ -100,7 +100,7 @@ SAC(System Access Controller)을 처음 사용하는 관리자라면 원활한 �
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 6
 </td>
 <th>
@@ -111,7 +111,7 @@ SAC(System Access Controller)을 처음 사용하는 관리자라면 원활한 �
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 7
 </td>
 <th>

--- a/src/content/ko/user-manual.mdx
+++ b/src/content/ko/user-manual.mdx
@@ -19,7 +19,7 @@ title: '사용자 매뉴얼'
 </colgroup>
 <tbody>
 <tr>
-<th class="numberingColumn">
+<th>
 </th>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
 **사용 순서**
@@ -29,7 +29,7 @@ title: '사용자 매뉴얼'
 </th>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 1
 </td>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
@@ -40,7 +40,7 @@ title: '사용자 매뉴얼'
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 2
 </td>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
@@ -51,7 +51,7 @@ title: '사용자 매뉴얼'
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 3
 </td>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
@@ -71,7 +71,7 @@ title: '사용자 매뉴얼'
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 4
 </td>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
@@ -94,7 +94,7 @@ title: '사용자 매뉴얼'
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 5
 </td>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
@@ -105,7 +105,7 @@ title: '사용자 매뉴얼'
 </td>
 </tr>
 <tr>
-<td class="numberingColumn">
+<td>
 6
 </td>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">


### PR DESCRIPTION
## Description
- 특정 페이지의 Table 에서, Server Side Rendering 과 Client Side Rendering 의 결과가 다른 현상이 발생합니다.
  - 테이블의 첫번째 컬럼이 번호를 붙이는 컬럼인 경우, Reload 또는 최초 웹페이지 열기 때에는, 가로폭이 좁게 찌그러집니다.
  - Sidebar 메뉴를 통해 다른 페이지로 이동하였다가 돌아오는 경우, 정상적인 폭으로 렌더링됩니다.
- 문제 원인 추정
  - `<td class="numberingClass">` 와 같이, Confluence XHTML 에서만 유효한 class 속성이 Markdown 에 전달된 것이 원인일 것으로 추정해 봅니다.
- 변경사항
  - `def get_html_attributes(node)`를 변경합니다. `style` 속성에 더해, `class` 속성을 Markdown 에 전달하지 않습니다.
- Update MDX files in src/content/
- Update expected.mdx of testcases

## Additional notes
- Preview Deployment 를 배포합니다.
  - https://github.com/chequer-io/querypie-docs/actions/runs/17403723994
  - https://querypie-docs-git-jk-2-fix-table-rendering-querypie.vercel.app/ko/administrator-manual
- Preview Deployment 에서 문제가 해결되는 것을 확인하였습니다.
