### PR TITLE
fix: 각 언어별 최상위 _meta.ts 수정

### DIFF
--- a/src/content/ja/_meta.ts
+++ b/src/content/ja/_meta.ts
@@ -2,9 +2,30 @@ export default {
   index: {
     display: 'hidden',
   },
+  'querypie-overview': {
+    type: 'page',
+    title: '概要',
+  },
+  'user-manual': {
+    type: 'page',
+    title: 'ユーザーガイド',
+  },
+  'administrator-manual': {
+    type: 'page',
+    title: '管理者マニュアル',
+  },
+  'release-notes': {
+    type: 'page',
+    title: 'リリースノート',
+  },
+  aiHubManual: {
+    type: 'page',
+    title: 'AI Hub マニュアル',
+    href: 'https://aihub-docs.app.querypie.com/ja',
+  },
   contactUs: {
     type: 'page',
-    title: 'Contact Us',
+    title: 'お問い合わせ',
     href: 'https://www.querypie.com/company/contact-us',
   },
 };

--- a/src/content/ko/_meta.ts
+++ b/src/content/ko/_meta.ts
@@ -4,7 +4,7 @@ export default {
   },
   'querypie-overview': {
     type: 'page',
-    title: 'Overview',
+    title: 'QueryPie Overview',
   },
   'user-manual': {
     type: 'page',
@@ -20,12 +20,12 @@ export default {
   },
   aiHubManual: {
     type: 'page',
-    title: 'AI Hub Manual',
+    title: 'AI Hub 매뉴얼',
     href: 'https://aihub-docs.app.querypie.com/ko',
   },
   contactUs: {
     type: 'page',
-    title: 'Contact Us',
+    title: '문의하기',
     href: 'https://www.querypie.com/company/contact-us',
   },
 };


### PR DESCRIPTION
## Description
- `/src/content/ko/_meta.ts` 등 각 언어별 최상위 _meta.ts 는 웹사이트의 상단 GNB 를 결정합니다.
- 3개 언어의 _meta.ts 를 업데이트하고, 문서 제목을 적절히 번역합니다.

## Additional notes
- 
