### PR TITLE
Reverse Proxy: Proxy 대상 호스트를 변경합니다.

### DIFF
--- a/src/lib/proxy.ts
+++ b/src/lib/proxy.ts
@@ -3,7 +3,7 @@ import {proxyLogger} from './logger';
 import {LRUCache} from './lru-cache';
 
 // Configure target base URL
-const TARGET_BASE_URL = 'https://docs.querypie.com';
+const TARGET_BASE_URL = 'https://querypie-docs-v10-v9.scrollhelp.site';
 
 // Configure your target path mappings here
 const TARGET_PATH_MAPPINGS: Record<string, string> = {
@@ -24,11 +24,8 @@ const TARGET_PATH_MAPPINGS: Record<string, string> = {
 const EXCLUDED_REQUEST_HEADERS = ['host', 'x-forwarded-host', 'x-forwarded-proto'];
 const EXCLUDED_RESPONSE_HEADERS = ['content-encoding', 'content-length', 'transfer-encoding'];
 
-
-
-// Create cache instance for pathname matching results
+// Create a cache instance for pathname matching results
 const pathnameMatchCache = new LRUCache<string, { targetBaseUrl: string; remainingPath: string } | null>(10);
-
 // Cache statistics
 let cacheHits = 0;
 let cacheMisses = 0;


### PR DESCRIPTION
## Description
- `docs.querypie.com` 주소는 Vercel Hosting Site 가 이름을 대체할 예정입니다. 기존 Scroll View Site 의 이름과 동일한 이름을 사용하면, Reverse Proxy 대상이 무한 재귀하게 되는 문제가 발생합니다.
- 문제를 해결하기 위해, `querypie-docs-v10-v9.scrollhelp.site` 라는 새로운 Scroll View Site 를 생성하였습니다. 이 웹사이트는 `docs.querypie.com`과 별개로 배포, 서비스 제공됩니다.
- proxy.ts 의 TARGET_BASE_URL 를 변경합니다.

## Additional notes
- localhost:3000 에서 정상적으로 작동하는 것을 확인하였습니다.
