### PR TITLE
feat: 첫페이지에 언어선택 기능을 강조 표시

### DIFF
--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import React from 'react';
+
+// Language data and types
+export interface LanguageOption {
+  code: string;
+  name: string;
+  flag: string;
+}
+
+export const languages: LanguageOption[] = [
+  { code: 'en', name: 'English', flag: '🇺🇸' },
+  { code: 'ja', name: '日本語', flag: '🇯🇵' },
+  { code: 'ko', name: '한국어', flag: '🇰🇷' },
+];
+
+// Utility functions
+export const getCurrentLanguage = (currentLang: string): LanguageOption => {
+  return languages.find(lang => lang.code === currentLang) || languages[0];
+};
+
+export const getCurrentPagePath = (pathname: string, currentLang: string): string => {
+  return pathname.replace(`/${currentLang}`, '') || '/';
+};
+
+export const generateLanguageSelectorHTML = (currentLang: string): string => {
+  const languageButtons = languages.map(language => {
+    const isActive = language.code === currentLang;
+    const currentPath = getCurrentPagePath(window.location.pathname, currentLang);
+    
+    return `
+      <a href="/${language.code}${currentPath}" class="language-button ${isActive ? 'active' : 'inactive'}">
+        <span>${language.flag}</span>
+        <span>${language.name}</span>
+      </a>
+    `;
+  }).join('');
+
+  return `
+    <div class="language-selector-toc">
+      <div class="language-selector-title">
+        <span>🌐</span>
+        <span>Language</span>
+      </div>
+      <div class="language-buttons">
+        ${languageButtons}
+      </div>
+    </div>
+  `;
+};
+
+// CSS styles as a string
+export const languageSelectorStyles = `
+  .language-selector-toc {
+    padding: 16px;
+    border-bottom: 1px solid #e5e7eb;
+    margin-bottom: 16px;
+  }
+
+  .language-selector-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: #374151;
+    margin-bottom: 12px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .language-buttons {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .language-button {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 12px;
+    text-decoration: none;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    transition: all 0.2s ease;
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  .language-button:hover {
+    transform: translateY(-1px);
+    text-decoration: none;
+  }
+
+  .language-button.active {
+    background: #0070f3;
+    color: white;
+  }
+
+  .language-button.active:hover {
+    background: #0051cc;
+    color: white;
+  }
+
+  .language-button.inactive {
+    background: #f8f9fa;
+    color: #495057;
+  }
+
+  .language-button.inactive:hover {
+    background: #e9ecef;
+    color: #495057;
+  }
+`;
+
+// Function to inject styles into the document
+export const injectLanguageSelectorStyles = (): void => {
+  if (typeof document !== 'undefined' && !document.querySelector('#language-selector-styles')) {
+    const style = document.createElement('style');
+    style.id = 'language-selector-styles';
+    style.textContent = languageSelectorStyles;
+    document.head.appendChild(style);
+  }
+};
+
+// Main component for TOC integration
+interface LanguageSelectorProps {
+  currentLang: string;
+}
+
+export default function LanguageSelector({ currentLang }: LanguageSelectorProps) {
+  React.useEffect(() => {
+    // Inject styles
+    injectLanguageSelectorStyles();
+
+    // Add language selector to TOC
+    const addLanguageSelector = () => {
+      const tocContainer = document.querySelector('nav.nextra-toc');
+      if (tocContainer && !tocContainer.querySelector('.language-selector-toc')) {
+        const html = generateLanguageSelectorHTML(currentLang);
+        tocContainer.insertAdjacentHTML('afterbegin', html);
+      }
+    };
+
+    addLanguageSelector();
+    const timeoutId = setTimeout(addLanguageSelector, 100);
+    return () => clearTimeout(timeoutId);
+  }, [currentLang]);
+
+  return null; // This component doesn't render anything directly
+}

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import React from 'react';
+import LanguageSelector from './LanguageSelector';
+
+interface MainLayoutProps {
+  children: React.ReactNode;
+  currentLang: string;
+}
+
+export default function MainLayout({ children, currentLang }: MainLayoutProps) {
+  return (
+    <>
+      <LanguageSelector currentLang={currentLang} />
+      {children}
+    </>
+  );
+}

--- a/src/content/en/index.mdx
+++ b/src/content/en/index.mdx
@@ -2,6 +2,10 @@
 title: 'QueryPie Documentation'
 ---
 
+import MainLayout from '@/components/MainLayout';
+
+<MainLayout currentLang="en">
+
 # Latest QueryPie Documentation
 
 * [Release Notes](release-notes)
@@ -27,3 +31,5 @@ title: 'QueryPie Documentation'
 * [QueryPie v10.1.0](/en/querypie-manual/10.1.0)
 * [QueryPie v10.0.0](/en/querypie-manual/10.0.0)
 * [QueryPie v9.16.0](/en/querypie/9.16.0)
+
+</MainLayout>

--- a/src/content/ja/index.mdx
+++ b/src/content/ja/index.mdx
@@ -2,6 +2,10 @@
 title: 'QueryPie ドキュメント'
 ---
 
+import MainLayout from '@/components/MainLayout';
+
+<MainLayout currentLang="ja">
+
 # QueryPie 最新ドキュメント
 
 * [リリースノート](release-notes)
@@ -22,3 +26,5 @@ title: 'QueryPie ドキュメント'
 # 旧リリース版ドキュメント
 
 * [QueryPie v10.2.0](/ja/querypie-manual/10.2.0)
+
+</MainLayout>

--- a/src/content/ko/index.mdx
+++ b/src/content/ko/index.mdx
@@ -2,6 +2,10 @@
 title: 'QueryPie 제품 문서'
 ---
 
+import MainLayout from '@/components/MainLayout';
+
+<MainLayout currentLang="ko">
+
 # QueryPie 제품 문서에 오신 것을 환영합니다
 
 ## QueryPie란?
@@ -59,3 +63,5 @@ Docker 기반의 간단한 설치로 7-10분 내에 바로 시작할 수 있습�
 * [QueryPie v10.1.0](/ko/querypie-manual/10.1.0)
 * [QueryPie v10.0.0](/ko/querypie-manual/10.0.0)
 * [QueryPie v9.20.0](/ko/querypie/9.20.0)
+
+</MainLayout>


### PR DESCRIPTION
## Description
- 웹사이트의 첫페이지에서 언어선택 기능을 오른쪽 상단에 크게 표시합니다. 이를 통해, 첫방문자가 원하는 언어를 쉽게 선택할 수 있도록 돕습니다.
- 오른쪽 상단에 언어선택 기능을 노출하는 MainLayout.tsx 를 정의합니다.
  - 언어 선택 기능을 LanguageSelector.tsx 로 구현합니다.
- /src/content/{ko,en,ja}/index.mdx 페이지에 MainLayout.tsx 를 적용합니다.

## Additional notes

<img width="1534" height="1147" alt="Screenshot 2025-09-09 at 7 23 57 PM" src="https://github.com/user-attachments/assets/4b4673f0-38f9-4c80-bf57-9754b808b0c4" />

