### PR TITLE
feat: Accept-Language 헤더에 따라 기본 언어를 선택

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -37,13 +37,4 @@ export default withNextra({
     };
     return config;
   },
-  async redirects() {
-    return [
-      {
-        source: '/',
-        destination: '/en/',
-        permanent: false,
-      },
-    ];
-  },
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,11 +3,66 @@ import {NextRequest, NextResponse} from 'next/server';
 import {handleProxyRequest, shouldProxy} from './lib/proxy';
 import {middlewareLogger} from './lib/logger';
 
+// Supported languages
+const supportedLanguages = ['en', 'ko', 'ja'];
+const defaultLanguage = 'en';
+
+// Language detection function
+function detectUserLanguage(request: NextRequest): string {
+  // Check Accept-Language header
+  const acceptLanguage = request.headers.get('accept-language');
+  if (acceptLanguage) {
+    // Parse Accept-Language header (e.g., "ko-KR,ko;q=0.9,en;q=0.8")
+    const languages = acceptLanguage
+      .split(',')
+      .map(lang => {
+        const [code, qValue] = lang.trim().split(';q=');
+        return {
+          code: code.split('-')[0], // Extract language code (ko from ko-KR)
+          quality: qValue ? parseFloat(qValue) : 1.0
+        };
+      })
+      .sort((a, b) => b.quality - a.quality);
+
+    // Find the first supported language
+    for (const lang of languages) {
+      if (supportedLanguages.includes(lang.code)) {
+        middlewareLogger.debug('Language detected from Accept-Language header', { 
+          lang: lang.code, 
+          quality: lang.quality,
+          acceptLanguage 
+        });
+        return lang.code;
+      }
+    }
+  }
+
+  // Default fallback
+  middlewareLogger.debug('Using default language', { lang: defaultLanguage });
+  return defaultLanguage;
+}
+
 export async function middleware(request: NextRequest) {
   middlewareLogger.debug('Middleware request', {
     pathname: request.nextUrl.pathname,
     method: request.method
   });
+
+  // Handle root path redirect with dynamic language detection
+  if (request.nextUrl.pathname === '/') {
+    const detectedLanguage = detectUserLanguage(request);
+    const redirectUrl = new URL(`/${detectedLanguage}/`, request.url);
+    
+    middlewareLogger.info('Root redirect with dynamic language detection', {
+      from: '/',
+      to: `/${detectedLanguage}/`,
+      detectedLanguage,
+      userAgent: request.headers.get('user-agent'),
+      acceptLanguage: request.headers.get('accept-language'),
+    });
+
+    return NextResponse.redirect(redirectUrl);
+  }
 
   if (request.nextUrl.pathname === '/robots.txt') {
     middlewareLogger.debug('Handling robots.txt request');


### PR DESCRIPTION
## Description
- `/` 에 이용자가 접속하는 경우, accept-language 헤더값에 따라, redirect 합니다.
  - `middleware.ts` 에서 언어 선택 기능을 구현합니다.
  - 기본 언어는 `en`입니다.
- `next.config.ts`에서 설정된 static redirect 를 제거합니다.

## Additional notes
- chrome://settings/languages 에서 선호 언어를 다르게 설정한 Profile 을 생성하고, 기능 작동을 검증하였습니다.
