### PR TITLE
fix: $search 문구에 backquote escape 를 적용

### DIFF
--- a/src/content/en/release-notes/1020-10212.mdx
+++ b/src/content/en/release-notes/1020-10212.mdx
@@ -77,7 +77,7 @@ April 11, 2025
 * [DAC] Added Temporary Table support in PostgreSQL
 * [DAC] Added reason input modal support in multi-agent environment
 * [DAC] Added vendor support level display in DB Connections detail page
-* [DAC] Added $search, $searchMeta stage support for MongoDB Atlas Search
+* [DAC] Added `$search`, `$searchMeta` stage support for MongoDB Atlas Search
 * [DAC] Improved to include executed queries in logs when Sensitive Data access events occur
 * [SAC] Added user-customizable RDP port functionality
 * [KAC] Added dynamic values (User Group) to kubernetesGroup item in Policy

--- a/src/content/ja/release-notes/1020-10212.mdx
+++ b/src/content/ja/release-notes/1020-10212.mdx
@@ -77,7 +77,7 @@ title: '10.2.0 ~ 10.2.12'
 * [DAC] PostgreSQLでTemporary Tableサポート
 * [DAC] マルチエージェント環境で理由入力モーダルサポート
 * [DAC] DB Connections詳細ページにベンダーサポートレベル表示
-* [DAC] MongoDB Atlas Search関連$search、$searchMeta stageサポート
+* [DAC] MongoDB Atlas Search関連`$search`、`$searchMeta` stageサポート
 * [DAC] Sensitive Dataアクセスイベント発生時ログに実行クエリ含むよう改善
 * [SAC] RDPポートユーザー任意変更機能追加
 * [KAC] Policy内kubernetesGroup項目に動的な値(User Group)追加

--- a/src/content/ko/release-notes/1020-10212.mdx
+++ b/src/content/ko/release-notes/1020-10212.mdx
@@ -77,7 +77,7 @@ title: '10.2.0 ~ 10.2.12'
 * [DAC] PostgreSQL에서 Temporary Table 지원
 * [DAC] 멀티 에이전트 환경에서 사유입력 모달 지원
 * [DAC] DB Connections 상세페이지에 벤더 지원 레벨 표시
-* [DAC] MongoDB Atlas Search 관련 $search, $searchMeta stage 지원
+* [DAC] MongoDB Atlas Search 관련 `$search`, `$searchMeta` stage 지원
 * [DAC] Sensitive Data 접근 이벤트 발생 시 로그에 수행 쿼리 포함하도록 개선
 * [SAC] RDP 포트 사용자 임의 변경 기능 추가
 * [KAC] Policy 내 kubernetesGroup 항목에 동적인 값(User Group) 추가


### PR DESCRIPTION
## Description
- MDX 파일의 본문에서 `$search`를 backquote escape 없이 사용한 경우, build 시에 경고 메시지가 발생합니다.
- backquote 를 적용하여, build warning 을 해결합니다.
```
LaTeX-incompatible input and strict mode is set to 'warn': Unicode text character "、" used in math mode [unicodeTextInMathMode]
```

## Additional notes
- 
