### PR TITLE
refactor: generate-sitemap 의 로깅을 간결하게 줄입니다.

### DIFF
--- a/scripts/generate-sitemap/index.js
+++ b/scripts/generate-sitemap/index.js
@@ -104,14 +104,12 @@ function generateLanguageSitemap(lang) {
     return [];
   }
 
-  console.log(`Processing language: ${lang}`);
   const mdxFiles = findMdxFiles(langDir, CONTENT_DIR);
   const urls = [];
 
   for (const file of mdxFiles) {
     const url = filePathToUrl(file, lang);
     urls.push(url);
-    console.log(`Added URL: ${url}`);
   }
 
   return urls;
@@ -139,7 +137,6 @@ function main() {
       const langDir = path.join(PUBLIC_DIR, lang);
       if (!fs.existsSync(langDir)) {
         fs.mkdirSync(langDir, { recursive: true });
-        console.log(`Created directory: ${langDir}`);
       }
       
       // Generate sitemap XML for this language
@@ -148,19 +145,18 @@ function main() {
       // Write to language-specific directory
       const outputFile = path.join(langDir, 'sitemap.xml');
       fs.writeFileSync(outputFile, xml);
-      console.log(`Sitemap generated at: ${outputFile}`);
-      console.log(`Total URLs for ${lang}: ${urls.length}`);
+      const relativePath = path.relative(process.cwd(), outputFile);
+      console.log(`${lang}: ${urls.length} URLs -> ${relativePath}`);
       totalUrls += urls.length;
     }
   }
 
   // Generate sitemap index file
-  generateSitemapIndex();
+  const indexFile = generateSitemapIndex();
+  const relativeIndexPath = path.relative(process.cwd(), indexFile);
 
-  console.log(`\nAll sitemaps generated successfully!`);
-  console.log(`Total URLs across all languages: ${totalUrls}`);
-  console.log(`Language-specific sitemaps saved to public/{language}/sitemap.xml`);
-  console.log(`Sitemap index updated at public/sitemap.xml`);
+  console.log(`\nTotal: ${totalUrls} URLs`);
+  console.log(`Sitemap index: ${relativeIndexPath}`);
 }
 
 /**
@@ -195,7 +191,7 @@ function generateSitemapIndex() {
   // Write sitemap index file
   const indexFile = path.join(PUBLIC_DIR, 'sitemap.xml');
   fs.writeFileSync(indexFile, xml);
-  console.log(`Sitemap index generated at: ${indexFile}`);
+  return indexFile;
 }
 
 // Run the script


### PR DESCRIPTION
## Description
- `npm run generate-sitemap` 실행시에 각 문서의 경로를 출력하여, 로깅 메시지가 길었습니다.
- 로깅 메시지를 간결하게 정리합니다.

## Additional notes
```
% npm run generate-sitemap

> querypie-docs@25.08.1 generate-sitemap
> node scripts/generate-sitemap/index.js

Generating language-specific sitemap.xml files...
en: 257 URLs -> public/en/sitemap.xml
ko: 257 URLs -> public/ko/sitemap.xml
ja: 257 URLs -> public/ja/sitemap.xml

Total: 771 URLs
Sitemap index: public/sitemap.xml
```
