### PR TITLE
fix: emoji와 GitHub Flavored Markdown을 사용

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,6 @@
 import nextra from 'nextra';
+import remarkEmoji from 'remark-emoji';
+import remarkGfm from 'remark-gfm';
 
 // Set up Nextra with its configuration
 const withNextra = nextra({
@@ -12,6 +14,11 @@ const withNextra = nextra({
   // but have them styled with components provided by useMDXComponents()
   // Refer to this: https://nextra.site/docs/advanced/table
   whiteListTagsStyling: ['table', 'thead', 'tbody', 'tr', 'th', 'td'],
+
+  // Add remark plugins for emoji and GitHub Flavored Markdown support
+  mdxOptions: {
+    remarkPlugins: [remarkEmoji, remarkGfm],
+  },
 });
 
 // Export the final Next.js config with Nextra included

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,9 @@
         "nextra-theme-docs": "^4.3.0",
         "pino": "^9.9.0",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "remark-emoji": "^5.0.2",
+        "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.1",
@@ -1692,6 +1694,18 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -3271,6 +3285,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -4238,6 +4261,22 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/emojilib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+      "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
+      "license": "MIT"
+    },
+    "node_modules/emoticon": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/emoticon/-/emoticon-4.1.0.tgz",
+      "integrity": "sha512-VWZfnxqwNcc51hIy/sbOdEem6D+cVtpPzEEtVAFdaas30+1dgkyaOQ4sQ6Bp0tOMqWO1v+HQfYaoodOkdhK6SQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -8279,6 +8318,21 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/node-emoji": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
+      "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.6.0",
+        "char-regex": "^1.0.2",
+        "emojilib": "^2.4.0",
+        "skin-tone": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
@@ -9273,6 +9327,22 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-emoji": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/remark-emoji/-/remark-emoji-5.0.2.tgz",
+      "integrity": "sha512-IyIqGELcyK5AVdLFafoiNww+Eaw/F+rGrNSXoKucjo95uL267zrddgxGM83GN1wFIb68pyDuAsY3m5t2Cav1pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.4",
+        "emoticon": "^4.0.1",
+        "mdast-util-find-and-replace": "^3.0.1",
+        "node-emoji": "^2.1.3",
+        "unified": "^11.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/remark-frontmatter": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-5.0.0.tgz",
@@ -9977,6 +10047,18 @@
         "is-arrayish": "^0.3.1"
       }
     },
+    "node_modules/skin-tone": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+      "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+      "license": "MIT",
+      "dependencies": {
+        "unicode-emoji-modifier-base": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/slash": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
@@ -10661,6 +10743,15 @@
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unicode-emoji-modifier-base": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+      "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/unified": {
       "version": "11.0.5",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "nextra-theme-docs": "^4.3.0",
     "pino": "^9.9.0",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "remark-emoji": "^5.0.2",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",


### PR DESCRIPTION
## Description
MDX 파일에서 emoji와 GitHub Flavored Markdown을 사용할 수 있도록 `remark-emoji`와 `remark-gfm` 플러그인을 추가합니다.

### 추가된 기능
1. Emoji 지원 (remark-emoji)
  - GitHub 스타일 emoji shortcode를 실제 이모지로 변환
  - 예시:
    - `:smile:` →  😄
    - `:heart:` → ❤️
    - `:rocket:` → 🚀
    - `:tada:` → 🎉
    - `:warning:` → ⚠️

2. GitHub Flavored Markdown 지원 (remark-gfm)
  - 테이블 렌더링
  - 작업 목록 (체크박스)
  - 취소선 텍스트
  - 자동 링크
  - 기타 GFM 확장 문법

## Additional notes
**Preview** - https://querypie-docs-git-jk-1-fix-emoji-querypie.vercel.app/ko/user-manual/multi-agent/multi-agent-seamless-ssh-usage-guide#warning%EC%8B%A4%ED%97%98%EC%A0%81-%EA%B8%B0%EB%8A%A5---qpctl-%EC%A7%81%EC%A0%91-%EC%82%AC%EC%9A%A9warning

<img width="579" height="196" alt="image" src="https://github.com/user-attachments/assets/b1aa2214-069c-425d-8c78-a9dc233b4634" />
