### PR TITLE
refactor: layout 관련 코드의 리팩토링을 먼저 수정합니다.

### DIFF
--- a/src/app/[lang]/[[...mdxPath]]/page.tsx
+++ b/src/app/[lang]/[[...mdxPath]]/page.tsx
@@ -4,12 +4,12 @@ import fs from 'fs';
 import path from 'path';
 
 export async function generateStaticParams() {
-  const locales = ['en', 'ko', 'ja']; // next.config.mjs와 동일
-  const basePath = path.resolve('src', 'content'); // content 폴더 기준
+  const locales = ['en', 'ja', 'ko']; // Same as next.config.mjs
+  const basePath = path.resolve('src', 'content'); // Content folder base path
 
   const paramsList: { lang: string; mdxPath: string[] }[] = [];
 
-  // 특정 폴더 내 .mdx 파일을 찾는 함수
+  // Function to find .mdx files in specific folders
   function findMdxFiles(dir: string): string[][] {
     const mdxFiles: string[][] = [];
     const files = fs.readdirSync(dir, { withFileTypes: true });
@@ -18,16 +18,16 @@ export async function generateStaticParams() {
       const filePath = path.join(dir, file.name);
 
       if (file.isDirectory()) {
-        // 하위 디렉토리를 재귀적으로 탐색
+        // Recursively search subdirectories
         mdxFiles.push(...findMdxFiles(filePath));
       } else if (file.isFile() && file.name.endsWith('.mdx')) {
-        // .mdx 파일만 수집
+        // Collect only .mdx files
         const relativePath = path.relative(basePath, filePath);
         const pathSegments = relativePath
-          .split(path.sep) // 경로를 분할
-          .slice(1) // locale 경로 제거
+          .split(path.sep) // Split path
+          .slice(1) // Remove locale path
           .map(
-            (segment, index, arr) => (index === arr.length - 1 ? path.parse(segment).name : segment), // 마지막 엘리먼트에서 .mdx 제거
+            (segment, index, arr) => (index === arr.length - 1 ? path.parse(segment).name : segment), // Remove .mdx from last element
           )
           .filter(segment => segment !== 'index');
 
@@ -38,7 +38,7 @@ export async function generateStaticParams() {
     return mdxFiles;
   }
 
-  // 로케일별로 mdx 파일 검색
+  // Search mdx files by locale
   for (const locale of locales) {
     const localeDir = path.join(basePath, locale);
     if (fs.existsSync(localeDir)) {
@@ -50,7 +50,7 @@ export async function generateStaticParams() {
         if (fs.existsSync(fullPath)) {
           paramsList.push({
             lang: locale,
-            mdxPath: pathSegments || [], // mdx 파일 경로 설정
+            mdxPath: pathSegments || [], // Set mdx file path
           });
         }
       }

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -49,7 +49,7 @@ export default async function RootLayout({ children, params }) {
       logo={
         <div>
           <div style={{ display: 'flex', alignItems: 'center', gap: '7px' }}>
-            <img src="/icon-32.png" alt="QueryPie 로고" width={18} height={18} />
+            <img src="/icon-32.png" alt="QueryPie Logo" width={18} height={18} />
             <div>
               <b>QueryPie</b> <span style={{ opacity: '60%' }}>Docs</span>
             </div>
@@ -73,7 +73,7 @@ export default async function RootLayout({ children, params }) {
       <body>
         <Layout
           navbar={navbar}
-          footer={<Footer>{new Date().getFullYear()} © QueryPie.</Footer>}
+          footer={<Footer>{new Date().getFullYear()} &copy; QueryPie, Inc.</Footer>}
           editLink="Edit this page on GitHub"
           docsRepositoryBase="https://github.com/chequer-io/querypie-docs/blob/main"
           feedback={{
@@ -84,8 +84,8 @@ export default async function RootLayout({ children, params }) {
           pageMap={pageMap}
           i18n={[
             { locale: 'en', name: 'English' },
-            { locale: 'ko', name: '한국어' },
             { locale: 'ja', name: '日本語' },
+            { locale: 'ko', name: '한국어' },
           ]}
         >
           {children}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,11 +12,11 @@
  */
 aside.nextra-sidebar.x\:w-64 { /* expanded */
     /* 64 is the default width of the expanded sidebar */
-    width: calc(var(--x-spacing) * 72);
+    width: calc(var(--x-spacing) * 64);
 }
 aside.nextra-sidebar.x\:w-20 { /* collapsed */
     /* 20 is the default width of the collapsed sidebar */
-    width: calc(var(--x-spacing) * 12);
+    width: calc(var(--x-spacing) * 20);
 }
 
 /* Embedded Image */

--- a/src/components/main-layout-obsoleted.tsx
+++ b/src/components/main-layout-obsoleted.tsx
@@ -8,7 +8,7 @@ interface MainLayoutProps {
   currentLang: string;
 }
 
-export default function MainLayout({ children, currentLang }: MainLayoutProps) {
+export default function MainLayoutObsoleted({ children, currentLang }: MainLayoutProps) {
   return (
     <>
       <LanguageSelector currentLang={currentLang} />

--- a/src/content/en/index.mdx
+++ b/src/content/en/index.mdx
@@ -2,7 +2,7 @@
 title: 'QueryPie Product Documentation'
 ---
 
-import MainLayout from '@/components/main-layout';
+import MainLayoutObsoleted from '@/components/main-layout-obsoleted';
 import DescriptionCards from '@/components/description-cards';
 import { 
   CircleStackIcon, 
@@ -15,7 +15,7 @@ import {
   NewspaperIcon
 } from '@heroicons/react/24/outline';
 
-<MainLayout currentLang="en">
+<MainLayoutObsoleted currentLang="en">
 
 # Welcome to QueryPie Product Documentation
 
@@ -127,5 +127,5 @@ When the validity period expires, you can extend the Community Edition license f
 * [QueryPie v10.1.0](/en/querypie-manual/10.1.0)
 * [QueryPie v10.0.0](/en/querypie-manual/10.0.0)
 * [QueryPie v9.16.0](/en/querypie/9.16.0)
-
-</MainLayout>
+  
+</MainLayoutObsoleted>

--- a/src/content/ja/index.mdx
+++ b/src/content/ja/index.mdx
@@ -2,7 +2,7 @@
 title: 'QueryPie 製品ドキュメント'
 ---
 
-import MainLayout from '@/components/main-layout';
+import MainLayoutObsoleted from '@/components/main-layout-obsoleted';
 import DescriptionCards from '@/components/description-cards';
 import { 
   CircleStackIcon, 
@@ -15,7 +15,7 @@ import {
   NewspaperIcon
 } from '@heroicons/react/24/outline';
 
-<MainLayout currentLang="ja">
+<MainLayoutObsoleted currentLang="ja">
 
 # QueryPie 製品ドキュメントへようこそ
 
@@ -123,4 +123,4 @@ Dockerベースの簡単なインストールで7-10分以内にすぐに開始�
 
 * [QueryPie v10.2.0](/ja/querypie-manual/10.2.0)
 
-</MainLayout>
+</MainLayoutObsoleted>

--- a/src/content/ko/index.mdx
+++ b/src/content/ko/index.mdx
@@ -2,7 +2,7 @@
 title: 'QueryPie 제품 문서'
 ---
 
-import MainLayout from '@/components/main-layout';
+import MainLayoutObsoleted from '@/components/main-layout-obsoleted';
 import DescriptionCards from '@/components/description-cards';
 import { 
   CircleStackIcon, 
@@ -15,7 +15,7 @@ import {
   NewspaperIcon
 } from '@heroicons/react/24/outline';
 
-<MainLayout currentLang="ko">
+<MainLayoutObsoleted currentLang="ko">
 
 # QueryPie 제품 문서에 오신 것을 환영합니다
 
@@ -130,4 +130,4 @@ Docker 기반의 간단한 설치로 7-10분 내에 바로 시작할 수 있습�
 * [QueryPie v10.0.0](/ko/querypie-manual/10.0.0)
 * [QueryPie v9.20.0](/ko/querypie/9.20.0)
 
-</MainLayout>
+</MainLayoutObsoleted>


### PR DESCRIPTION
## Description
- 여러 Layout 을 사용하는 기능을 도입하기 전, 먼저 관련 코드의 사소한 수정사항들을 반영합니다.
- `[lang]/layout.tsx`
  - 언어설정 상수값의 순서를 영어, 일본어, 한국어로 일관되게 변경
  - &copy; 를 `&copy;`로 변경
  - 한국어 문구를 영어로 변경
- `components/main-layout.tsx`은 새로운 컴포넌트로 대체할 예정입니다. 이를 위해, 이름을 미리 변경합니다.
  - MainLayout -> MainLayoutObsoleted
  - main-layout.tsx -> main-layout-obsoleted
- `globals.css`에서 좌측 Sidebar 의 폭을 기본값으로 복원합니다.
  - 전체적인 화면 레이아웃에서, 좌측 Sidebar 가 너무 넓은 것으로 보여서, 다시 기본값으로 복원합니다.
  - globals.css 에 설정값을 삭제하지 않고, 값만 변경합니다.
- `[[...mdxPath]]/page.tsx`
  - page.tsx 에서 한국어로 된 코멘트를 영어로 번경합니다. 언어설정의 순서를 영어, 일본어, 한국어로 맞춥니다.

## Additional notes
- 
