### PR TITLE
ci: PR 생성, commit 추가 때 Preview 배포 실행

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -2,7 +2,7 @@ name: Deploy on Preview
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, synchronize]
     branches-ignore:
       - main
   workflow_dispatch:


### PR DESCRIPTION
## Description
- PR 생성 때, 수작업으로 Preview 를 실행하지 않고, Preview 배포를 자동으로 수행합니다.
- opened, synchronize, 2개 type 에 대해 자동 배포합니다.
  - reopened, ready_for_review 의 경우, 코드 변경이 없기에, Preview 배포를 수행하지 않습니다. 코드 변경이 발생한 경우에만, 배포합니다.

## Additional notes
pull_request 의 type 유형의 의미는 다음과 같습니다.
- opened: 새 PR 이 생성되었을 때
- reopened: 닫힌 PR 이 다시 열렸을 때
- synchronize: PR 의 branch 에 변경사항이 발생한 때
    - PR 의 title/description 변경은 `edited` 입니다.
- ready_for_review: draft PR 을 리뷰 준비된 상태로 변경한 때
