### PR TITLE
feat: Replace querypie.io, chequer-io

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository serves as the central hub for maintaining and publishing QueryPi
 ## Getting Started
 
 ### For Users
-- Visit our [live documentation site](https://docs.querypie.io)
+- Visit our [live documentation site](https://docs.querypie.com)
 - Browse through the user manual for step-by-step guides
 - Check release notes for the latest features and improvements
 

--- a/package.json
+++ b/package.json
@@ -16,13 +16,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/chequer-io/querypie-docs.git"
+    "url": "git+https://github.com/querypie/querypie-docs.git"
   },
   "author": "QueryPie",
   "bugs": {
-    "url": "https://github.com/chequer-io/querypie-docs/issues"
+    "url": "https://github.com/querypie/querypie-docs/issues"
   },
-  "homepage": "https://github.com/chequer-io/querypie-docs#readme",
+  "homepage": "https://github.com/querypie/querypie-docs#readme",
   "dependencies": {
     "@heroicons/react": "^2.2.0",
     "@next/third-parties": "^15.5.3",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -70,8 +70,6 @@ export async function middleware(request: NextRequest) {
       return new NextResponse(`User-agent: *
 Allow: /
 Sitemap: https://docs.querypie.com/sitemap.xml
-Sitemap: https://docs.querypie.io/sitemap.xml
-Sitemap: https://querypie-docs.vercel.app/sitemap.xml
 `);
     } else {
       return new NextResponse(`User-agent: *


### PR DESCRIPTION
## Description
- repository 에서 querypie.io, chequer-io 등 문자열을 찾아, querypie.com, querypie 등으로 대체합니다.

## Additional notes
- 이것으로, 현재 상태에서 https://docs.querypie.com/ 으로 릴리즈 가능한 상태가 되었습니다.
