### PR TITLE
feat: Replace querypie.io with querypie.com

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -27,7 +27,7 @@ npm start
 - Vercel Project
   - https://vercel.com/querypie/querypie-docs
 - Production Deployment
-  - [ ] https://docs.querypie.com
+  - [x] https://docs.querypie.com
   - [x] https://docs.querypie.io
   - [x] https://querypie-docs.vercel.app
 - Staging Deployment

--- a/scripts/generate-sitemap/index.js
+++ b/scripts/generate-sitemap/index.js
@@ -13,7 +13,7 @@ const fs = require('fs');
 const path = require('path');
 
 // Configuration
-const BASE_URL = 'https://docs.querypie.io';
+const BASE_URL = 'https://docs.querypie.com';
 const CONTENT_DIR = path.join(process.cwd(), 'src', 'content');
 const PUBLIC_DIR = path.join(process.cwd(), 'public');
 const LANGUAGES = ['en', 'ko', 'ja'];

--- a/src/lib/proxy.ts
+++ b/src/lib/proxy.ts
@@ -139,7 +139,7 @@ function rewriteUrlsInHtml(htmlContent: string, proxyOrigin: string): string {
  * Rewrite URLs in sitemap XML content to use proxy URLs
  */
 function rewriteUrlsInSitemap(xmlContent: string, proxyOrigin: string): string {
-  // Replace docs.querypie.io with proxy origin
+  // Replace querypie-docs-v10-v9.scrollhelp.site with proxy origin
   const rewrittenXml = xmlContent.replace(/https:\/\/querypie-docs-v10-v9\.scrollhelp\.site/g, proxyOrigin);
 
   const originalCount = (xmlContent.match(/https:\/\/querypie-docs-v10-v9\.scrollhelp\.site/g) || []).length;


### PR DESCRIPTION
## Description
- 소스코드 중, docs.querypie.io 를 하드코딩한 경우를 찾아, docs.querypie.com 으로 변경합니다.
- #191 에서 누락된 파일을 찾아, 수정합니다.

## Additional notes
- 
