### PR TITLE
ci: Fix deploy-preview.yml

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -3,8 +3,6 @@ name: Deploy on Preview
 on:
   pull_request:
     types: [opened, synchronize]
-    branches-ignore:
-      - main
   workflow_dispatch:
     inputs:
       BRANCH:


### PR DESCRIPTION
## Description
- 잘못된 `branches-ignore` 설정을 제거합니다.
  - 이 설정값에 따르면, main branch 를 target 으로 하는 PR 을 무시하라는 의미입니다. 반대로 작동하여야 합니다.

## Additional notes
- 
