### PR TITLE
fix: <ac:image> 의 width 를 사용하지 않습니다.

### DIFF
--- a/confluence-mdx/bin/confluence_xhtml_to_markdown.py
+++ b/confluence-mdx/bin/confluence_xhtml_to_markdown.py
@@ -156,14 +156,12 @@ HIDDEN_CHARACTERS = {
     '\u3164': ''  # Hangul Filler
 }
 
-
 def confluence_url():
     if GLOBAL_PAGE_V1:
         page_id = GLOBAL_PAGE_V1.get('id')
         return f'https://querypie.atlassian.net/wiki/spaces/QM/pages/{page_id}/'
     else:
         return 'https://querypie.atlassian.net/wiki/spaces/QM/overview'
-
 
 def clean_text(text: Optional[str]) -> Optional[str]:
     """Clean text by removing hidden characters"""
@@ -176,7 +174,6 @@ def clean_text(text: Optional[str]) -> Optional[str]:
     for hidden_char, replacement in HIDDEN_CHARACTERS.items():
         cleaned_text = cleaned_text.replace(hidden_char, replacement)
     return cleaned_text
-
 
 def load_pages_yaml(yaml_path: str, pages_by_title: PagesDict, pages_by_id: PagesDict):
     """
@@ -1693,7 +1690,6 @@ def generate_meta_from_children(input_dir: str, output_file_path: str, pages_by_
                         return int(item.get('childPosition', 0))
                     except Exception:
                         return 0
-
                 ordered = sorted(results, key=_pos)
 
                 # Determine where _meta.ts and child mdx files should live

--- a/confluence-mdx/bin/confluence_xhtml_to_markdown.py
+++ b/confluence-mdx/bin/confluence_xhtml_to_markdown.py
@@ -126,11 +126,9 @@ class Attachment:
             rehype_attr.append('class="mx-auto block"')
 
         if self.filename.endswith('.png'):
-            if rehype_attr:
-                attr_str = ' '.join(rehype_attr)
-                return f'![{caption}]({self.output_dir}/{self.filename}){{{attr_str}}}'
-            else:
-                return f'![{caption}]({self.output_dir}/{self.filename})'
+            # TODO(JK): For now, do not use rehype-attr for images.
+            # Otherwise, `npm run build` fails with 'Could not parse expression with acorn'
+            return f'![{caption}]({self.output_dir}/{self.filename})'
         else:
             return f'[{caption}]({self.output_dir}/{self.filename})'
 
@@ -158,12 +156,14 @@ HIDDEN_CHARACTERS = {
     '\u3164': ''  # Hangul Filler
 }
 
+
 def confluence_url():
     if GLOBAL_PAGE_V1:
         page_id = GLOBAL_PAGE_V1.get('id')
         return f'https://querypie.atlassian.net/wiki/spaces/QM/pages/{page_id}/'
     else:
         return 'https://querypie.atlassian.net/wiki/spaces/QM/overview'
+
 
 def clean_text(text: Optional[str]) -> Optional[str]:
     """Clean text by removing hidden characters"""
@@ -176,6 +176,7 @@ def clean_text(text: Optional[str]) -> Optional[str]:
     for hidden_char, replacement in HIDDEN_CHARACTERS.items():
         cleaned_text = cleaned_text.replace(hidden_char, replacement)
     return cleaned_text
+
 
 def load_pages_yaml(yaml_path: str, pages_by_title: PagesDict, pages_by_id: PagesDict):
     """
@@ -1692,6 +1693,7 @@ def generate_meta_from_children(input_dir: str, output_file_path: str, pages_by_
                         return int(item.get('childPosition', 0))
                     except Exception:
                         return 0
+
                 ordered = sorted(results, key=_pos)
 
                 # Determine where _meta.ts and child mdx files should live

--- a/confluence-mdx/tests/testcases/544112828/expected.mdx
+++ b/confluence-mdx/tests/testcases/544112828/expected.mdx
@@ -16,7 +16,7 @@ QueryPie Agent를 설치하면, DataGrip, DBeaver와 같은 SQL Client, iTerm/Se
 1. QueryPie 로그인 후 우측 상단 프로필을 클릭하여 `Agent Download` 버튼을 클릭합니다.
 
 <figure data-layout="center" data-align="center">
-![QueryPie Web &gt; 프로필 메뉴](/544112828/output/screenshot-20240804-173002.png){width=760 class="mx-auto block"}
+![QueryPie Web &gt; 프로필 메뉴](/544112828/output/screenshot-20240804-173002.png)
 <figcaption>
 QueryPie Web &gt; 프로필 메뉴
 </figcaption>
@@ -25,7 +25,7 @@ QueryPie Web &gt; 프로필 메뉴
 2. QueryPie Agent Downloads 팝업창이 실행되면 Step 1에서 사용 중인 PC 운영체제에 맞는 설치 파일을 다운로드한 후 Step 3에 있는 QueryPie URL을 복사해 둡니다.
 
 <figure data-layout="center" data-align="center">
-![QueryPie Web &gt; Agent Downloads 팝업창](/544112828/output/image-20240723-154847.png){width=760 class="mx-auto block"}
+![QueryPie Web &gt; Agent Downloads 팝업창](/544112828/output/image-20240723-154847.png)
 <figcaption>
 QueryPie Web &gt; Agent Downloads 팝업창
 </figcaption>
@@ -38,7 +38,7 @@ QueryPie Agent는 Mac, Windows, Linux OS를 지원합니다.
 3. 다운로드받은 QueryPie Agent 설치 프로그램을 실행하여 설치를 완료합니다.
 
 <figure data-layout="center" data-align="center">
-![Mac OS 설치 프로그램](/544112828/output/screenshot-20240804-174002.png){width=760 class="mx-auto block"}
+![Mac OS 설치 프로그램](/544112828/output/screenshot-20240804-174002.png)
 <figcaption>
 Mac OS 설치 프로그램
 </figcaption>
@@ -47,7 +47,7 @@ Mac OS 설치 프로그램
 4. 설치 완료된 QueryPie Agent를 실행합니다. QueryPie Host 입력란에 미리 복사해뒀던 QueryPie URL을 입력하고 `Next` 버튼을 클릭하면 로그인 화면으로 진입하게 됩니다.
 
 <figure data-layout="center" data-align="center">
-![Agent &gt; QueryPie Host 입력](/544112828/output/agent-03.png){width=760 class="mx-auto block"}
+![Agent &gt; QueryPie Host 입력](/544112828/output/agent-03.png)
 <figcaption>
 Agent &gt; QueryPie Host 입력
 </figcaption>
@@ -59,13 +59,13 @@ Agent &gt; QueryPie Host 입력
 1. Agent 앱 내 로그인 화면에서 `Login` 버튼을 클릭합니다.
 
 <figure data-layout="center" data-align="center">
-![screenshot-20240804-173713.png](/544112828/output/screenshot-20240804-173713.png){width=760 class="mx-auto block"}
+![screenshot-20240804-173713.png](/544112828/output/screenshot-20240804-173713.png)
 </figure>
 
 2. 웹 브라우저가 열리면, 로그인 페이지에서 인증정보를 입력하고, `Continue` 버튼을 클릭합니다.
 
 <figure data-layout="center" data-align="center">
-![QueryPie Web &gt; Agent Login Page](/544112828/output/screenshot-20240729-171236.png){width=760 class="mx-auto block"}
+![QueryPie Web &gt; Agent Login Page](/544112828/output/screenshot-20240729-171236.png)
 <figcaption>
 QueryPie Web &gt; Agent Login Page
 </figcaption>
@@ -74,7 +74,7 @@ QueryPie Web &gt; Agent Login Page
 3. 로그인을 성공하면 아래와 같이 로그인 성공 화면이 표시되며 이후 Agent로 돌아갑니다.
 
 <figure data-layout="center" data-align="center">
-![QueryPie Web &gt; Agent Login Success Page](/544112828/output/screenshot-20240729-171314.png){width=764 class="mx-auto block"}
+![QueryPie Web &gt; Agent Login Success Page](/544112828/output/screenshot-20240729-171314.png)
 <figcaption>
 QueryPie Web &gt; Agent Login Success Page
 </figcaption>
@@ -83,7 +83,7 @@ QueryPie Web &gt; Agent Login Success Page
 4. Agent 열기를 명시적으로 수행하여 인증정보를 Agent로 전달합니다.
 
 <figure data-layout="center" data-align="center">
-![Chrome - Agent App 열기 모달](/544112828/output/screenshot-20240804-174209.png){width=760 class="mx-auto block"}
+![Chrome - Agent App 열기 모달](/544112828/output/screenshot-20240804-174209.png)
 <figcaption>
 Chrome - Agent App 열기 모달
 </figcaption>
@@ -94,7 +94,7 @@ Chrome - Agent App 열기 모달
 1. 로그인이 정상적으로 완료되면 Agent 앱 내 Databases 탭에서 권한 있는 커넥션들의 접속 정보를 확인할 수 있습니다.<br/>접속할 커넥션에 할당된 `Port` 를 클릭하면, 해당 커넥션의 `Proxy Credentials` 정보를 확인할 수 있습니다.
 
 <figure data-layout="center" data-align="center">
-![Agent &gt; DB Connection Information](/544112828/output/screenshot-20240730-151001.png){width=764 class="mx-auto block"}
+![Agent &gt; DB Connection Information](/544112828/output/screenshot-20240730-151001.png)
 <figcaption>
 Agent &gt; DB Connection Information
 </figcaption>
@@ -103,7 +103,7 @@ Agent &gt; DB Connection Information
 2. 위의 접속 정보를 3rd Party 클라이언트에 입력하면 DB 커넥션 접속이 가능합니다.
 
 <figure data-layout="center" data-align="center">
-![3rd Party Client를 이용한 DB 커넥션 접속](/544112828/output/agent-07.png){width=764 class="mx-auto block"}
+![3rd Party Client를 이용한 DB 커넥션 접속](/544112828/output/agent-07.png)
 <figcaption>
 3rd Party Client를 이용한 DB 커넥션 접속
 </figcaption>
@@ -120,7 +120,7 @@ Agent &gt; DB Connection Information
 * Default 역할 선택시, Workflow &gt; Server Access Request 요청에 의해 할당받은 서버 권한을 사용합니다. 
 
 <figure data-layout="center" data-align="center">
-![Agent &gt; Server &gt; Select a Role](/544112828/output/screenshot-20240730-162653.png){width=764 class="mx-auto block"}
+![Agent &gt; Server &gt; Select a Role](/544112828/output/screenshot-20240730-162653.png)
 <figcaption>
 Agent &gt; Server &gt; Select a Role
 </figcaption>
@@ -135,7 +135,7 @@ Agent &gt; Server &gt; Select a Role
 * 접속할 서버를 우클릭 후 Open Connection with 메뉴를 선택하여, 사용하려는 터미널 툴을 선택합니다.
 
 <figure data-layout="center" data-align="center">
-![Agent &gt; Server &gt; Open Connection with](/544112828/output/screenshot-20240730-161729.png){width=760 class="mx-auto block"}
+![Agent &gt; Server &gt; Open Connection with](/544112828/output/screenshot-20240730-161729.png)
 <figcaption>
 Agent &gt; Server &gt; Open Connection with
 </figcaption>
@@ -145,7 +145,7 @@ Agent &gt; Server &gt; Open Connection with
 * 사용하려는 계정을 선택하고 필요시 비밀번호를 입력한 뒤, `OK` 버튼을 클릭하여 세션을 엽니다.
 
 <figure data-layout="center" data-align="center">
-![Agent &gt; Server &gt; Open New Session](/544112828/output/screenshot-20240730-162532.png){width=746 class="mx-auto block"}
+![Agent &gt; Server &gt; Open New Session](/544112828/output/screenshot-20240730-162532.png)
 <figcaption>
 Agent &gt; Server &gt; Open New Session
 </figcaption>
@@ -190,7 +190,7 @@ $ ssh deploy@{{Server Name}}
 ### 에이전트를 통한 쿠버네티스 접속
 
 <figure data-layout="center" data-align="center">
-![kubernetes-agent-access-flow.png](/544112828/output/kubernetes-agent-access-flow.png){width=764 class="mx-auto block"}
+![kubernetes-agent-access-flow.png](/544112828/output/kubernetes-agent-access-flow.png)
 </figure>
 
 * 권한을 부여 받은 사용자는 에이전트 실행 시 현재 정책에 따른 `kubeconfig` 파일이 자동으로 수신됩니다.
@@ -203,7 +203,7 @@ $ ssh deploy@{{Server Name}}
 사용자 프로필 영역 하단의 `Role` 버튼을 클릭하면 역할 선택 모달이 열립니다. 원하는 역할을 고르고 `OK` 버튼을 클릭하세요.
 
 <figure data-layout="center" data-align="center">
-![Agent &gt; Kubernetes &gt; Select a Role](/544112828/output/screenshot-20240730-152705.png){width=760 class="mx-auto block"}
+![Agent &gt; Kubernetes &gt; Select a Role](/544112828/output/screenshot-20240730-152705.png)
 <figcaption>
 Agent &gt; Kubernetes &gt; Select a Role
 </figcaption>
@@ -219,7 +219,7 @@ Agent &gt; Kubernetes &gt; Select a Role
 선택된 역할에 따라 접근 가능한 리소스가 표시됩니다. 각 클러스터 우측의 `🔍` 버튼을 누르면 Policy Information 팝업창이 나타나며 이곳에서 해당 클러스터에 적용된 정책 목록을 자세히 확인할 수 있습니다.
 
 <figure data-layout="center" data-align="center">
-![Agent &gt; Policy Information](/544112828/output/screenshot-20240730-161141.png){width=760 class="mx-auto block"}
+![Agent &gt; Policy Information](/544112828/output/screenshot-20240730-161141.png)
 <figcaption>
 Agent &gt; Policy Information
 </figcaption>
@@ -230,7 +230,7 @@ Agent &gt; Policy Information
 Agent 설정 메뉴에서 `KubeConfig Path` 버튼을 클릭하여 Kubeconfig 경로 설정 모달을 엽니다.
 
 <figure data-layout="center" data-align="center">
-![Agent &gt; Settings &gt; Configure Kubeconfig Path](/544112828/output/screenshot-20240730-154623.png){width=764 class="mx-auto block"}
+![Agent &gt; Settings &gt; Configure Kubeconfig Path](/544112828/output/screenshot-20240730-154623.png)
 <figcaption>
 Agent &gt; Settings &gt; Configure Kubeconfig Path
 </figcaption>
@@ -242,7 +242,7 @@ Agent &gt; Settings &gt; Configure Kubeconfig Path
 
 
 <figure data-layout="center" data-align="center">
-![경로 지정 팝업](/544112828/output/screenshot-20240730-163530.png){width=760 class="mx-auto block"}
+![경로 지정 팝업](/544112828/output/screenshot-20240730-163530.png)
 <figcaption>
 경로 지정 팝업
 </figcaption>
@@ -281,7 +281,7 @@ export KUBECONFIG="${KUBECONFIG}:${HOME}/.kube/querypie-kubeconfig"
 프로필 영역 우측 `⚙️` 버튼을 클릭하여 설정 메뉴를 엽니다. `Reset All Settings` 버튼을 클릭합니다.
 
 <figure data-layout="center" data-align="center">
-![Agent &gt; Settings](/544112828/output/screenshot-20240730-153518.png){width=361 class="mx-auto block"}
+![Agent &gt; Settings](/544112828/output/screenshot-20240730-153518.png)
 <figcaption>
 Agent &gt; Settings
 </figcaption>
@@ -293,7 +293,7 @@ Agent &gt; Settings
 메뉴 막대에서 QueryPie Agent 아이콘을 클릭하여 앱 메뉴를 엽니다. `Reset All Settings` 버튼을 클릭합니다.
 
 <figure data-layout="center" data-align="center">
-![Agent &gt; App menu](/544112828/output/screenshot-20240730-153524.png){width=363 class="mx-auto block"}
+![Agent &gt; App menu](/544112828/output/screenshot-20240730-153524.png)
 <figcaption>
 Agent &gt; App menu
 </figcaption>

--- a/confluence-mdx/tests/testcases/544113141/expected.mdx
+++ b/confluence-mdx/tests/testcases/544113141/expected.mdx
@@ -11,7 +11,7 @@ title: 'DB Access History'
 ### DB Access History 조회하기
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; Audit &gt; Databases &gt; DB Access History](/544113141/output/image-20240730-070842.png){width=760 class="mx-auto block"}
+![Administrator &gt; Audit &gt; Databases &gt; DB Access History](/544113141/output/image-20240730-070842.png)
 <figcaption>
 Administrator &gt; Audit &gt; Databases &gt; DB Access History
 </figcaption>
@@ -25,7 +25,7 @@ Administrator &gt; Audit &gt; Databases &gt; DB Access History
     3.  **Client IP**  : 사용자 IP
 4. 검색 필드 우측 필터 버튼을 클릭하여 AND/OR 조건으로 이하의 필터링이 가능합니다.
   <figure data-layout="center" data-align="center">
-  ![image-20240730-064139.png](/544113141/output/image-20240730-064139.png){width=736 class="mx-auto block"}
+  ![image-20240730-064139.png](/544113141/output/image-20240730-064139.png)
   </figure>
     1.  **Connection Name**  : 접속한 DB 커넥션명
     2.  **Database Type** : 데이터베이스 유형
@@ -60,7 +60,7 @@ Administrator &gt; Audit &gt; Databases &gt; DB Access History
 각 행을 클릭하면 세부 정보 조회가 가능합니다.
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; Audit &gt; Databases &gt; DB Access History &gt; DB Access History Details](/544113141/output/image-20240730-065045.png){width=760 class="mx-auto block"}
+![Administrator &gt; Audit &gt; Databases &gt; DB Access History &gt; DB Access History Details](/544113141/output/image-20240730-065045.png)
 <figcaption>
 Administrator &gt; Audit &gt; Databases &gt; DB Access History &gt; DB Access History Details
 </figcaption>

--- a/confluence-mdx/tests/testcases/544145591/expected.mdx
+++ b/confluence-mdx/tests/testcases/544145591/expected.mdx
@@ -9,7 +9,7 @@ title: 'General'
 General 페이지에서는 QueryPie 전체의 기본 설정을 변경할 수 있습니다.
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; General &gt; Company Management &gt; General](/544145591/output/image-20250822-103044.png){width=760 class="mx-auto block"}
+![Administrator &gt; General &gt; Company Management &gt; General](/544145591/output/image-20250822-103044.png)
 <figcaption>
 Administrator &gt; General &gt; Company Management &gt; General
 </figcaption>
@@ -31,7 +31,7 @@ Administrator &gt; General &gt; Company Management &gt; General
 System Properties 페이지에서는 QueryPie 시스템 컴포넌트들의 설정값을 확인하고, 파일로 저장할 수 있습니다.
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; General &gt; Company Management &gt; General &gt; System Properties](/544145591/output/image-20240805-014838.png){width=760 class="mx-auto block"}
+![Administrator &gt; General &gt; Company Management &gt; General &gt; System Properties](/544145591/output/image-20240805-014838.png)
 <figcaption>
 Administrator &gt; General &gt; Company Management &gt; General &gt; System Properties
 </figcaption>
@@ -43,7 +43,7 @@ Administrator &gt; General &gt; Company Management &gt; General &gt; System Prop
 Workflow Configurations에서는 결재 상신 및 승인 관련 설정을 변경합니다.
 
 <figure data-layout="center" data-align="center">
-![Screenshot-2025-08-25-at-5.36.19-PM.png](/544145591/output/Screenshot-2025-08-25-at-5.36.19-PM.png){width=543 class="mx-auto block"}
+![Screenshot-2025-08-25-at-5.36.19-PM.png](/544145591/output/Screenshot-2025-08-25-at-5.36.19-PM.png)
 </figure>
 
 ### 최대 승인 기간 설정
@@ -86,7 +86,7 @@ Allow users to submit requests in Urgent mode 토글로 활성화합니다.
 Use User Attribute-Based Approval 토글을 활성화합니다.
 
 <figure data-layout="center" data-align="center">
-![Admin &gt; General &gt; Company Management &gt; General &gt; Workflow Configurations](/544145591/output/Screenshot-2025-06-16-at-10.14.55-AM.png){width=664 class="mx-auto block"}
+![Admin &gt; General &gt; Company Management &gt; General &gt; Workflow Configurations](/544145591/output/Screenshot-2025-06-16-at-10.14.55-AM.png)
 <figcaption>
 Admin &gt; General &gt; Company Management &gt; General &gt; Workflow Configurations
 </figcaption>
@@ -97,7 +97,7 @@ Admin &gt; General &gt; Company Management &gt; General &gt; Workflow Configurat
 * 중요: 
     * 선택된 Attribute의 값으로는 승인자의 QueryPie Login ID가 입력되어 있어야 합니다.
       <figure data-layout="center" data-align="center">
-      ![Admin &gt; General &gt; Users &gt; Detail page &gt; Profile 탭<br/>](/544145591/output/Screenshot-2025-06-12-at-1.33.58-PM.png){width=712 class="mx-auto block"}
+      ![Admin &gt; General &gt; Users &gt; Detail page &gt; Profile 탭<br/>](/544145591/output/Screenshot-2025-06-12-at-1.33.58-PM.png)
       <figcaption>
       Admin &gt; General &gt; Users &gt; Detail page &gt; Profile 탭<br/>
       </figcaption>
@@ -121,13 +121,13 @@ Admin &gt; General &gt; Company Management &gt; General &gt; Workflow Configurat
     * 만약 상신자 User Profile에 해당 Attribute 값이 비어 있는 경우(즉, 승인자의 Login ID가 지정되지 않은 경우), 워크플로우 상신 시 다음과 같은 내용의 알림 모달이 표시되며 요청 제출이 중단됩니다. 상신자는 관리자에게 문의하여 프로필의 Attribute 값을 설정해야 합니다.
         * 에러 메시지 예시: 
           <figure data-layout="center" data-align="center">
-          ![image-20250508-022114.png](/544145591/output/image-20250508-022114.png){width=688 class="mx-auto block"}
+          ![image-20250508-022114.png](/544145591/output/image-20250508-022114.png)
           </figure>
 * Attribute 값은 있지만 해당 사용자가 비활성화된 경우
     * 만약 상신자 User Profile에 해당 Attribute 값으로 지정된 승인자가 비활성화된 경우, 워크플로우 상신 시 Approver란에 지정된 승인자가 표기되지 않으며 아래와 같은 내용의 알림 모달이 표시되며 요청 제출이 중단됩니다.
         * 에러 메세지 예시:
           <figure data-layout="center" data-align="center">
-          ![Screenshot-2025-06-16-at-10.30.14-AM.png](/544145591/output/Screenshot-2025-06-16-at-10.30.14-AM.png){width=615 class="mx-auto block"}
+          ![Screenshot-2025-06-16-at-10.30.14-AM.png](/544145591/output/Screenshot-2025-06-16-at-10.30.14-AM.png)
           </figure>
 
 ### Attribute 기반 워크플로우 메뉴 숨김 기능 (Use User Attribute to Hide Workflow Menu)
@@ -135,7 +135,7 @@ Admin &gt; General &gt; Company Management &gt; General &gt; Workflow Configurat
 Use User Attribute to Hide Workflow Menu 토글을 활성화합니다.
 
 <figure data-layout="center" data-align="center">
-![Screenshot-2025-06-26-at-6.35.32-PM.png](/544145591/output/Screenshot-2025-06-26-at-6.35.32-PM.png){width=670 class="mx-auto block"}
+![Screenshot-2025-06-26-at-6.35.32-PM.png](/544145591/output/Screenshot-2025-06-26-at-6.35.32-PM.png)
 </figure>
 
 특정 사용자 속성(User Attribute)을 기준으로 사용자 대시보드에서 Workflow 메뉴를 보이지 않도록 설정하는 기능입니다.
@@ -149,7 +149,7 @@ Use User Attribute to Hide Workflow Menu 토글을 활성화합니다.
 토글을 켜면 Workflow에서 상신된 SQL 요청 실행시 쓰로틀링을 적용합니다.
 
 <figure data-layout="center" data-align="center">
-![Screenshot-2025-05-09-at-3.18.32-PM.png](/544145591/output/Screenshot-2025-05-09-at-3.18.32-PM.png){width=604 class="mx-auto block"}
+![Screenshot-2025-05-09-at-3.18.32-PM.png](/544145591/output/Screenshot-2025-05-09-at-3.18.32-PM.png)
 </figure>
 
 
@@ -164,7 +164,7 @@ Use User Attribute to Hide Workflow Menu 토글을 활성화합니다.
 Redirect to custom page for SQL Requests 토글을 활성화합니다.
 
 <figure data-layout="center" data-align="center">
-![Screenshot-2025-05-09-at-8.33.07-PM.png](/544145591/output/Screenshot-2025-05-09-at-8.33.07-PM.png){width=516 class="mx-auto block"}
+![Screenshot-2025-05-09-at-8.33.07-PM.png](/544145591/output/Screenshot-2025-05-09-at-8.33.07-PM.png)
 </figure>
 
 이 옵션을 통해 User Agent에서 Ledger 테이블 대상으로 INSERT, UPDATE, DELETE 쿼리 실행으로 인해 워크플로 승인 요청이 발생할 경우, `Send Request` 버튼 클릭 시 사용자를 사전에 정의된 커스텀 URL 페이지로 리디렉션할지 여부를 결정합니다. 이를 통해 고객사는 자체 운영 중인 외부 워크플로 시스템과의 연동을 강화할 수 있습니다.
@@ -181,7 +181,7 @@ Redirect to custom page for SQL Requests 토글을 활성화합니다.
 Select Request Types Allowed for Users 토글을 활성화합니다.
 
 <figure data-layout="center" data-align="center">
-![Screenshot-2025-05-09-at-8.40.28-PM.png](/544145591/output/Screenshot-2025-05-09-at-8.40.28-PM.png){width=352 class="mx-auto block"}
+![Screenshot-2025-05-09-at-8.40.28-PM.png](/544145591/output/Screenshot-2025-05-09-at-8.40.28-PM.png)
 </figure>
 
 이 옵션을 통해 관리자가 사용자가 접근하고 요청할 수 있는 워크플로우의 요청(Request) 타입을 선택적으로 제어할 수 있도록 합니다.
@@ -207,7 +207,7 @@ Select Request Types Allowed for Users 토글을 활성화합니다.
 Workflow를 통해 DB Access Request 를 상신할 경우 요청하는 권한에 따라 결재선 (Approval Rule)을 특정할 수 있도록 하려면 “Use DB Privilege Type Based Approval” 토글을 활성화합니다.
 
 <figure data-layout="center" data-align="center">
-![Use DB Privilege Type Based Approval](/544145591/output/image-20250822-111454.png){width=507 class="mx-auto block"}
+![Use DB Privilege Type Based Approval](/544145591/output/image-20250822-111454.png)
 <figcaption>
 Use DB Privilege Type Based Approval
 </figcaption>
@@ -216,7 +216,7 @@ Use DB Privilege Type Based Approval
 `+Routing Rule` 버튼을 누르면 privilege 에 대한 조건을 지정하여 결재선에 대한 라우팅을 지정할 수 있습니다.
 
 <figure data-layout="center" data-align="center">
-![image-20250822-112026.png](/544145591/output/image-20250822-112026.png){width=432 class="mx-auto block"}
+![image-20250822-112026.png](/544145591/output/image-20250822-112026.png)
 </figure>
 
 *  **Routing Rule Name**  : 식별하기 쉬운 라우팅 규칙의 이름을 입력합니다.
@@ -242,7 +242,7 @@ Use DB Privilege Type Based Approval
 Workflow의 SQL Request를 통해 수행할 쿼리를 상신할 때 실행 계획 결과를 첨부하는 “Attach Explain Results” 기능을 활성 또는 비활성화 할 수 있도록 옵션을 제공합니다.
 
 <figure data-layout="center" data-align="center">
-![image-20250825-002423.png](/544145591/output/image-20250825-002423.png){width=425 class="mx-auto block"}
+![image-20250825-002423.png](/544145591/output/image-20250825-002423.png)
 </figure>
 
 관리자가 이 옵션을 활성화 하더라도 Workflow의 SQL Request 양식에서 “Attach Explain Results” 는 Off로 되어 있으므로 사용자가 필요시 명시적으로 “Attatch Explain Results” 토글 스위치를 On으로 변경해야 실행계획 결과가 첨부됩니다.

--- a/confluence-mdx/tests/testcases/544178405/expected.mdx
+++ b/confluence-mdx/tests/testcases/544178405/expected.mdx
@@ -11,7 +11,7 @@ QueryPie의 관리자는 QueryPie Web 또는 API를 통하여 리소스 및 권�
 관리자 페이지를 진입하기 위해서는 먼저 QueryPie 로그인을 진행합니다. 로그인이 정상적으로 완료되었다면 사용자 대시보드 이동하게 되며 만약 QueryPie 관리자 역할을 할당받은 사용자일 경우 우측 상단에 `Go to Admin Page` 버튼이 표시됩니다. 이 버튼을 클릭하여 관리자 페이지를 새 탭으로 열 수 있습니다.
 
 <figure data-layout="center" data-align="center">
-![GNB 내 관리자 페이지 진입점](/544178405/output/screenshot-20240801-145006.png){width=762 class="mx-auto block"}
+![GNB 내 관리자 페이지 진입점](/544178405/output/screenshot-20240801-145006.png)
 <figcaption>
 GNB 내 관리자 페이지 진입점
 </figcaption>

--- a/confluence-mdx/tests/testcases/544377869/expected.mdx
+++ b/confluence-mdx/tests/testcases/544377869/expected.mdx
@@ -16,7 +16,7 @@ import { Callout } from 'nextra/components'
 기본적으로는 Proxy 사용 옵션이 비활성화되어 있습니다. 접속을 허용할 커넥션에서 Proxy 사용 여부를 활성화합니다.
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; Databases &gt; Connection Management &gt; DB Connections &gt; Connection Details &gt; Proxy Usage](/544377869/output/image-20240725-070857.png){width=760 class="mx-auto block"}
+![Administrator &gt; Databases &gt; Connection Management &gt; DB Connections &gt; Connection Details &gt; Proxy Usage](/544377869/output/image-20240725-070857.png)
 <figcaption>
 Administrator &gt; Databases &gt; Connection Management &gt; DB Connections &gt; Connection Details &gt; Proxy Usage
 </figcaption>
@@ -41,7 +41,7 @@ Proxy Usage 옵션을 활성화하면 Proxy 로 접속할 수 있는 Port 가 �
 </Callout>
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; Databases &gt; Connection Management &gt; DB Connections &gt; Proxy Management](/544377869/output/image-20240725-071030.png){width=760 class="mx-auto block"}
+![Administrator &gt; Databases &gt; Connection Management &gt; DB Connections &gt; Proxy Management](/544377869/output/image-20240725-071030.png)
 <figcaption>
 Administrator &gt; Databases &gt; Connection Management &gt; DB Connections &gt; Proxy Management
 </figcaption>

--- a/confluence-mdx/tests/testcases/544379140/expected.mdx
+++ b/confluence-mdx/tests/testcases/544379140/expected.mdx
@@ -54,7 +54,7 @@ Audit Log Export 기능 추가에 따라, 각 로그 화면에서 제공되던 �
 ### Audit Log Export 목록 조회하기
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; Audit &gt; General &gt; Audit Log Export](/544379140/output/image-20240714-063656.png){width=760 class="mx-auto block"}
+![Administrator &gt; Audit &gt; General &gt; Audit Log Export](/544379140/output/image-20240714-063656.png)
 <figcaption>
 Administrator &gt; Audit &gt; General &gt; Audit Log Export
 </figcaption>
@@ -74,7 +74,7 @@ Administrator &gt; Audit &gt; General &gt; Audit Log Export
 감사 로그 추출을 시작하기 위해서는 ‘Audit &gt; General &gt; Audit Log Export’ 메뉴 접근 후, 우측 상단의 `Create Task` 버튼을 클릭해야 합니다. 해당 버튼 클릭시 아래와 같은 화면이 나타납니다.
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; Audit &gt; General &gt; Audit Log Export &gt; Create New Task](/544379140/output/screenshot-20250116-131805.png){width=612 class="mx-auto block"}
+![Administrator &gt; Audit &gt; General &gt; Audit Log Export &gt; Create New Task](/544379140/output/screenshot-20250116-131805.png)
 <figcaption>
 Administrator &gt; Audit &gt; General &gt; Audit Log Export &gt; Create New Task
 </figcaption>

--- a/confluence-mdx/tests/testcases/544381877/expected.mdx
+++ b/confluence-mdx/tests/testcases/544381877/expected.mdx
@@ -14,7 +14,7 @@ QueryPie에서는 접근 제어를 적용할 온프레미스 등에 위치한 �
 개별 서버를 수동으로 등록하기 위해서는 서버의 기본적인 정보 입력이 필요합니다.
 
 <figure data-layout="center" data-align="center">
-![image-20240721-054859.png](/544381877/output/image-20240721-054859.png){width=760 class="mx-auto block"}
+![image-20240721-054859.png](/544381877/output/image-20240721-054859.png)
 </figure>
 
 1. Administrator &gt; Kubernetes &gt; Connection Management &gt; Clusters 메뉴로 이동합니다.
@@ -63,7 +63,7 @@ QueryPie에서는 접근 제어를 적용할 온프레미스 등에 위치한 �
 ### 쿠버네티스 클러스터 연동용 스크립트 이용 안내
 
 <figure data-layout="center" data-align="center">
-![image-20240511-033842.png](/544381877/output/image-20240511-033842.png){width=760 class="mx-auto block"}
+![image-20240511-033842.png](/544381877/output/image-20240511-033842.png)
 </figure>
 
 * 관리자는 사전에 해당 대상 쿠버네티스 클러스터에 접속이 가능하여야 합니다.

--- a/confluence-mdx/tests/testcases/544384417/expected.mdx
+++ b/confluence-mdx/tests/testcases/544384417/expected.mdx
@@ -685,7 +685,7 @@ Audit 메뉴에서 Reports &gt; Reports 메뉴로 진입하면 보고서 생성 
 
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; Audit &gt; Reports &gt; Reports](/544384417/output/screenshot-20241223-112238.png){width=760 class="mx-auto block"}
+![Administrator &gt; Audit &gt; Reports &gt; Reports](/544384417/output/screenshot-20241223-112238.png)
 <figcaption>
 Administrator &gt; Audit &gt; Reports &gt; Reports
 </figcaption>
@@ -724,7 +724,7 @@ Administrator &gt; Audit &gt; Reports &gt; Reports
 
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; Audit &gt; Reports &gt; Reports &gt; Report Detail](/544384417/output/screenshot-20241223-112524.png){width=760 class="mx-auto block"}
+![Administrator &gt; Audit &gt; Reports &gt; Reports &gt; Report Detail](/544384417/output/screenshot-20241223-112524.png)
 <figcaption>
 Administrator &gt; Audit &gt; Reports &gt; Reports &gt; Report Detail
 </figcaption>
@@ -763,7 +763,7 @@ Administrator &gt; Audit &gt; Reports &gt; Reports &gt; Report Detail
 태스크 이름, 보고서 유형, 스케줄링 관련 내용을 입력하고, 섹션 단위로 보고서 출력 항목 및 적용할 필터를 지정할 수 있습니다. `+ Add Section` 버튼을 클릭하여 섹션을 추가할 수 있습니다.
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; Audit &gt; Reports &gt; Reports &gt; Create](/544384417/output/screenshot-20241209-104337.png){width=760 class="mx-auto block"}
+![Administrator &gt; Audit &gt; Reports &gt; Reports &gt; Create](/544384417/output/screenshot-20241209-104337.png)
 <figcaption>
 Administrator &gt; Audit &gt; Reports &gt; Reports &gt; Create
 </figcaption>
@@ -799,7 +799,7 @@ Administrator &gt; Audit &gt; Reports &gt; Reports &gt; Create
 ### 보고서 복제하기**[10.2.2]**
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; Audit &gt; Reports &gt; Reports - Duplicate Task](/544384417/output/screenshot-20241223-104529.png){width=589 class="mx-auto block"}
+![Administrator &gt; Audit &gt; Reports &gt; Reports - Duplicate Task](/544384417/output/screenshot-20241223-104529.png)
 <figcaption>
 Administrator &gt; Audit &gt; Reports &gt; Reports - Duplicate Task
 </figcaption>

--- a/confluence-mdx/tests/testcases/568918170/expected.mdx
+++ b/confluence-mdx/tests/testcases/568918170/expected.mdx
@@ -14,7 +14,7 @@ Workflow 사용 시 편리함을 더해주는 부가 기능을 소개합니다.
 ### 참조된 요청 확인 처리하기
 
 <figure data-layout="center" data-align="center">
-![Workflow &gt; Reviews &gt; All Reviews &gt; Review Details](/568918170/output/screenshot-20240802-114129.png){width=760 class="mx-auto block"}
+![Workflow &gt; Reviews &gt; All Reviews &gt; Review Details](/568918170/output/screenshot-20240802-114129.png)
 <figcaption>
 Workflow &gt; Reviews &gt; All Reviews &gt; Review Details
 </figcaption>
@@ -36,7 +36,7 @@ Workflow &gt; Reviews &gt; All Reviews &gt; Review Details
 #### 1. 대리 결재 사용 설정하기
 
 <figure data-layout="center" data-align="center">
-![User &gt; 상단 메뉴바에서 프로필 클릭 &gt; Preferences](/568918170/output/screenshot-20240802-120401.png){width=760 class="mx-auto block"}
+![User &gt; 상단 메뉴바에서 프로필 클릭 &gt; Preferences](/568918170/output/screenshot-20240802-120401.png)
 <figcaption>
 User &gt; 상단 메뉴바에서 프로필 클릭 &gt; Preferences
 </figcaption>
@@ -52,13 +52,13 @@ User &gt; 상단 메뉴바에서 프로필 클릭 &gt; Preferences
 
 대리 결재 설정 기간에는 원 결재자와 대리 결재자의 접속 시 상단 메뉴바에 다음과 같이 표시됩니다.
 <figure data-layout="center" data-align="center">
-![원 결재자 기준 표시 내용](/568918170/output/screenshot-20240802-120741.png){width=594 class="mx-auto block"}
+![원 결재자 기준 표시 내용](/568918170/output/screenshot-20240802-120741.png)
 <figcaption>
 원 결재자 기준 표시 내용
 </figcaption>
 </figure>
 <figure data-layout="center" data-align="center">
-![대리 결재자 기준 표시 내용](/568918170/output/screenshot-20240802-120854.png){width=594 class="mx-auto block"}
+![대리 결재자 기준 표시 내용](/568918170/output/screenshot-20240802-120854.png)
 <figcaption>
 대리 결재자 기준 표시 내용
 </figcaption>
@@ -75,7 +75,7 @@ User &gt; 상단 메뉴바에서 프로필 클릭 &gt; Preferences
 * 상세 페이지에서 승인 또는 반려할 수 있으며, Comment 입력 시에는 대리 결재 중임을 알리는 문구가 표시됩니다. 
 
 <figure data-layout="center" data-align="center">
-![screenshot-20240802-124638.png](/568918170/output/screenshot-20240802-124638.png){width=760 class="mx-auto block"}
+![screenshot-20240802-124638.png](/568918170/output/screenshot-20240802-124638.png)
 </figure>
 
 #### 4. 대리 결재 처리된 요청 건 확인하기
@@ -83,14 +83,14 @@ User &gt; 상단 메뉴바에서 프로필 클릭 &gt; Preferences
 * 다음과 같이 요청 상세페이지 내 승인 현황에서 원 결재자 또는 대리 결재자가 처리한 것인지를 확인할 수 있습니다. 
 **원 결재자가 처리한 경우**
 <figure data-layout="center" data-align="center">
-![대리 결재 관련 문구 없음](/568918170/output/screenshot-20240725-153533.png){width=363 class="mx-auto block"}
+![대리 결재 관련 문구 없음](/568918170/output/screenshot-20240725-153533.png)
 <figcaption>
 대리 결재 관련 문구 없음
 </figcaption>
 </figure>
 **대리 결재자가 처리한 경우**
 <figure data-layout="center" data-align="center">
-![대리 결재자가 Done by the delegate와 함께 표기됨](/568918170/output/screenshot-20240725-152141.png){width=363 class="mx-auto block"}
+![대리 결재자가 Done by the delegate와 함께 표기됨](/568918170/output/screenshot-20240725-152141.png)
 <figcaption>
 대리 결재자가 Done by the delegate와 함께 표기됨
 </figcaption>
@@ -109,7 +109,7 @@ Slack DM을 통한 요청 알림을 사용 중이라면, 대리 결재자에게�
 동일한 내용으로 반복적인 결재 요청을 하거나 반려 처리된 결재 건에 대해 다음과 같이 재상신할 수 있습니다.
 
 <figure data-layout="center" data-align="center">
-![Workflow &gt; Sent Requests &gt; Done &gt; List Details](/568918170/output/image-20230824-110815.png){width=768 class="mx-auto block"}
+![Workflow &gt; Sent Requests &gt; Done &gt; List Details](/568918170/output/image-20230824-110815.png)
 <figcaption>
 Workflow &gt; Sent Requests &gt; Done &gt; List Details
 </figcaption>

--- a/confluence-mdx/tests/testcases/692355151/expected.mdx
+++ b/confluence-mdx/tests/testcases/692355151/expected.mdx
@@ -30,7 +30,7 @@ Content Type은 “Text”만 지원합니다. “File”을 선택하면 실행
 </Callout>
 
 <figure data-layout="center" data-align="center">
-![image-20241029-234721.png](/692355151/output/image-20241029-234721.png){width=760 class="mx-auto block"}
+![image-20241029-234721.png](/692355151/output/image-20241029-234721.png)
 </figure>
 
 1. 실행계획(Explain) 옵션 및 실행계획 수행<br/>쿼리 에디터 하단에 있는 옵션을 선택하고 `Explain` 버튼을 누릅니다.
@@ -40,31 +40,31 @@ Content Type은 “Text”만 지원합니다. “File”을 선택하면 실행
         2.  **JSON**  : JSON 형태로 결과가 표시됩니다. 
 
 <figure data-layout="center" data-align="center">
-![image-20241029-235845.png](/692355151/output/image-20241029-235845.png){width=682 class="mx-auto block"}
+![image-20241029-235845.png](/692355151/output/image-20241029-235845.png)
 </figure>
 
 <Callout type="important">
 * 실행계획 대상이 되는 쿼리(세미콜론으로 끝나는 구문)는 100개로 제한됩니다. 
 * MySQL은 5.6 이후 부터 Explain의 결과를 JSON 포맷으로 출력할 수 있습니다. 따라서 5.6 이전 버전을 대상으로 Explain을 수행시 JSON으로 출력할 수 없습니다.
 <figure data-layout="center" data-align="center">
-![image-20241030-001252.png](/692355151/output/image-20241030-001252.png){width=682 class="mx-auto block"}
+![image-20241030-001252.png](/692355151/output/image-20241030-001252.png)
 </figure>
 </Callout>
 
 1. 실행계획(Explain) 결과 확인
     1. Table 형태의 결과 확인<br/>아래 그림과 같은 결과가 표시됩니다. 각 필드의 의미는 MySQL reference 문서를 참고 바랍니다.<br/> <br/>  
       <figure data-layout="center" data-align="center">
-      ![image-20241030-002325.png](/692355151/output/image-20241030-002325.png){width=712 class="mx-auto block"}
+      ![image-20241030-002325.png](/692355151/output/image-20241030-002325.png)
       </figure>
     2. JSON 형태의 결과 확인<br/>JSON 을 선택하고 Explain 버튼을 누르면 아래 그림과 같은 결과가 표시됩니다. `{JSON}` 을 클릭하면 전체 JSON 내용을 확인 할 수 있습니다.<br/> <br/>  <br/> <br/>  <br/>내보내기(Export)를 할 때 관리자 설정에 따라 암호 입력을 요구하는 팝업이 출력될 수 있습니다.
       <figure data-layout="center" data-align="center">
-      ![`{JSON}`을 클릭하면 전체 내용을 볼수 있습니다.](/692355151/output/image-20241030-003040.png){width=712 class="mx-auto block"}
+      ![`{JSON}`을 클릭하면 전체 내용을 볼수 있습니다.](/692355151/output/image-20241030-003040.png)
       <figcaption>
       `{JSON}`을 클릭하면 전체 내용을 볼수 있습니다.
       </figcaption>
       </figure>
       <figure data-layout="center" data-align="center">
-      ![JSON 결과의 복사와 내보내기가 가능합니다.](/692355151/output/image-20241030-003129.png){width=560 class="mx-auto block"}
+      ![JSON 결과의 복사와 내보내기가 가능합니다.](/692355151/output/image-20241030-003129.png)
       <figcaption>
       JSON 결과의 복사와 내보내기가 가능합니다.
       </figcaption>
@@ -74,7 +74,7 @@ Content Type은 “Text”만 지원합니다. “File”을 선택하면 실행
 
 1. 결재자(Approver)의 실행계획(Explain)결과 확인<br/>결재자는 Explain Results 탭에서 첨부된 실행계획(Explain)결과를 확인하고 승인의 참고자료로 활용할 수 있습니다.
   <figure data-layout="center" data-align="center">
-  ![image-20241030-004258.png](/692355151/output/image-20241030-004258.png){width=736 class="mx-auto block"}
+  ![image-20241030-004258.png](/692355151/output/image-20241030-004258.png)
   </figure>
 
 <Callout type="important">

--- a/confluence-mdx/tests/testcases/880181257/expected.mdx
+++ b/confluence-mdx/tests/testcases/880181257/expected.mdx
@@ -11,14 +11,14 @@ import { Callout } from 'nextra/components'
 1. 사용자 화면 상단 Workflow 메뉴로 이동합니다.
 2. 좌측 상단 `Submit Request` 버튼 클릭후 DB Access Request 항목을 선택합니다. <br/> 
   <figure data-layout="center" data-align="center">
-  ![Screenshot-2025-03-06-at-1.19.24-PM.png](/880181257/output/Screenshot-2025-03-06-at-1.19.24-PM.png){width=712 class="mx-auto block"}
+  ![Screenshot-2025-03-06-at-1.19.24-PM.png](/880181257/output/Screenshot-2025-03-06-at-1.19.24-PM.png)
   </figure>
 3. Approval Rule을 상황에 맞게 설정하고 Title도 작성합니다.
 4. DB Connection 목록에서 Type이 'Custom Data Source'인 항목을 선택합니다.
 5. 다른 벤더들과 다르게 Privilege를 선택할 수 없기 때문에 “-”로 표기됩니다. 
 6. Expiration Date과 Reason for Request 항목도 상황에 맞게 설정 및 작성합니다. <br/> 
   <figure data-layout="center" data-align="center">
-  ![Screenshot-2025-03-06-at-1.22.28-PM.png](/880181257/output/Screenshot-2025-03-06-at-1.22.28-PM.png){width=712 class="mx-auto block"}
+  ![Screenshot-2025-03-06-at-1.22.28-PM.png](/880181257/output/Screenshot-2025-03-06-at-1.22.28-PM.png)
   </figure>
 7. 작성을 완료했다면 하단 `Submit`버튼을 클릭하여 신청을 완료합니다. 
 8. 관리자의 승인을 받았다면 좌측 Workflow &gt; Sent Request &gt; Done 메뉴에서 확인할 수 있습니다.
@@ -36,13 +36,13 @@ import { Callout } from 'nextra/components'
     * QueryPie Agent를 실행합니다.
     * Database 항목에서 Custom Data Source를 확인할 수 있습니다. <br/> 
       <figure data-layout="center" data-align="center">
-      ![Screenshot-2025-03-06-at-2.05.26-PM.png](/880181257/output/Screenshot-2025-03-06-at-2.05.26-PM.png){width=400 class="mx-auto block"}
+      ![Screenshot-2025-03-06-at-2.05.26-PM.png](/880181257/output/Screenshot-2025-03-06-at-2.05.26-PM.png)
       </figure>
 2.  **Connection Guide 확인** 
     * Agent에서 Custom Data Source 커넥션 행을 클릭하면 Port 정보를 담은 행이 보입니다.
     * 위 행을 우클릭을 한뒤 Connection Guide를 클릭하면 접속 정보를 확인할 수 있습니다. <br/> 
       <figure data-layout="center" data-align="center">
-      ![Screenshot-2025-03-06-at-2.08.11-PM.png](/880181257/output/Screenshot-2025-03-06-at-2.08.11-PM.png){width=712 class="mx-auto block"}
+      ![Screenshot-2025-03-06-at-2.08.11-PM.png](/880181257/output/Screenshot-2025-03-06-at-2.08.11-PM.png)
       </figure>
     * UID/PW는 수정할 수 없는 db username, db password로 표시됩니다.
     * Privileges는 "-"로 표시됩니다.
@@ -51,7 +51,7 @@ import { Callout } from 'nextra/components'
     *  **Host와 Port는 Connection Guide에 명시되어있는 정보를 입력해야합니다.**  
     * 벤더에 따라 추가 정보를 입력합니다.
       <figure data-layout="center" data-align="center">
-      ![Screenshot-2025-03-06-at-2.18.26-PM.png](/880181257/output/Screenshot-2025-03-06-at-2.18.26-PM.png){width=712 class="mx-auto block"}
+      ![Screenshot-2025-03-06-at-2.18.26-PM.png](/880181257/output/Screenshot-2025-03-06-at-2.18.26-PM.png)
       </figure>
 
 <Callout type="important">
@@ -65,11 +65,11 @@ import { Callout } from 'nextra/components'
     * 사용자 화면 상단 Databases를 클릭합니다. 
     * 좌측 커넥션 목록에서 QueryPie Connections를 클릭하면 접근 권한이 있는 Custom Data Source가 표시됩니다. <br/> 
       <figure data-layout="center" data-align="center">
-      ![Screenshot-2025-03-06-at-2.22.22-PM.png](/880181257/output/Screenshot-2025-03-06-at-2.22.22-PM.png){width=712 class="mx-auto block"}
+      ![Screenshot-2025-03-06-at-2.22.22-PM.png](/880181257/output/Screenshot-2025-03-06-at-2.22.22-PM.png)
       </figure>
 2.  **접속 불가 안내** 
     * Custom Data Source 선택 시 Connect 버튼이 비활성화됩니다.
     * 아래와 같은 툴팁이 표시되며 웹으로는 접속이 불가합니다.  <br/> "Access is only possible through a proxy and cannot be accessed through the web. Please open the QueryPie Agent to connect to the Custom Data Source."
       <figure data-layout="center" data-align="center">
-      ![Screenshot-2025-03-06-at-2.23.37-PM.png](/880181257/output/Screenshot-2025-03-06-at-2.23.37-PM.png){width=712 class="mx-auto block"}
+      ![Screenshot-2025-03-06-at-2.23.37-PM.png](/880181257/output/Screenshot-2025-03-06-at-2.23.37-PM.png)
       </figure>


### PR DESCRIPTION
## Description
- rehype-attr 의 구문을 활용하여 width, class 속성을 적용하는 경우, MDX 컴파일 오류가 발생합니다.
  - `Could not parse expression with acorn`
- 문제를 해결하는 과정이 간단하지 않아, 먼저 rehype-attr 구문을 적용하지 않도록, 코드를 변경합니다.

## Additional notes
- 
