### PR TITLE
feat: Use redirect for legacy version documentation

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -40,6 +40,91 @@ export default withNextra({
     // Enable IP address extraction
     trustProxy: true,
   },
+  // Configure redirects for Previous Version Documentation
+  async redirects() {
+    return [
+      // Korean (ko) redirects
+      {
+        source: '/ko/querypie-manual/11.2.0/:path*',
+        destination: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1291125198/',
+        permanent: true,
+      },
+      {
+        source: '/ko/querypie-manual/11.1.0/:path*',
+        destination: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1171325037/',
+        permanent: true,
+      },
+      {
+        source: '/ko/querypie-manual/11.0.0/:path*',
+        destination: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1071939590/',
+        permanent: true,
+      },
+      {
+        source: '/ko/querypie-manual/10.3.0/:path*',
+        destination: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/959545600/',
+        permanent: true,
+      },
+      {
+        source: '/ko/querypie-manual/10.2.0/:path*',
+        destination: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/736428087/',
+        permanent: true,
+      },
+      {
+        source: '/ko/querypie-manual/10.1.0/:path*',
+        destination: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/634519553/',
+        permanent: true,
+      },
+      {
+        source: '/ko/querypie-manual/10.0.0/:path*',
+        destination: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/579010917/',
+        permanent: true,
+      },
+      {
+        source: '/ko/querypie/9.20.0/:path*',
+        destination: 'https://querypie.atlassian.net/wiki/spaces/QS1/pages/524944097/',
+        permanent: true,
+      },
+      
+      // English (en) redirects
+      {
+        source: '/en/querypie-manual/11.0.0/:path*',
+        destination: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1129677677/',
+        permanent: true,
+      },
+      {
+        source: '/en/querypie-manual/10.3.0/:path*',
+        destination: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/968950182/',
+        permanent: true,
+      },
+      {
+        source: '/en/querypie-manual/10.2.0/:path*',
+        destination: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/736756862/',
+        permanent: true,
+      },
+      {
+        source: '/en/querypie-manual/10.1.0/:path*',
+        destination: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/633799987/',
+        permanent: true,
+      },
+      {
+        source: '/en/querypie-manual/10.0.0/:path*',
+        destination: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/580224801/',
+        permanent: true,
+      },
+      {
+        source: '/en/querypie/9.16.0/:path*',
+        destination: 'https://querypie.atlassian.net/wiki/spaces/QS1/pages/369951121/',
+        permanent: true,
+      },
+      
+      // Japanese (ja) redirects
+      {
+        source: '/ja/querypie-manual/10.2.0/:path*',
+        destination: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/834863167/',
+        permanent: true,
+      },
+    ];
+  },
   // Configure webpack to use memory cache to avoid large string serialization warnings
   webpack: (config, { dev, isServer }) => {
     // Use memory cache for better performance and to avoid serialization warnings


### PR DESCRIPTION
## Description
- next.config.ts 의 redirect 설정을 통해, 구버전 문서를 Confluence Space 로 연결합니다.
- 이를 통해 reverse proxy 방식으로 scroll site 에 연결하는 기능을 더이상 사용하지 않게 됩니다. reverse proxy 기능을 코드에서 제외하는 것은 후속 PR 에서 진행합니다.

## Additional notes
- 
