### PR TITLE
feat: link to Confluence for legacy version documentation

### DIFF
--- a/src/content/en/index.mdx
+++ b/src/content/en/index.mdx
@@ -121,11 +121,11 @@ When the validity period expires, you can extend the Community Edition license f
 
 ## Previous Version Documentation
 
-* [QueryPie v11.0.0](/en/querypie-manual/11.0.0)
-* [QueryPie v10.3.0](/en/querypie-manual/10.3.0)
-* [QueryPie v10.2.0](/en/querypie-manual/10.2.0)
-* [QueryPie v10.1.0](/en/querypie-manual/10.1.0)
-* [QueryPie v10.0.0](/en/querypie-manual/10.0.0)
-* [QueryPie v9.16.0](/en/querypie/9.16.0)
+* [QueryPie v11.0.0](https://querypie.atlassian.net/wiki/spaces/QM/pages/1129677677/)
+* [QueryPie v10.3.0](https://querypie.atlassian.net/wiki/spaces/QM/pages/968950182/)
+* [QueryPie v10.2.0](https://querypie.atlassian.net/wiki/spaces/QM/pages/736756862/)
+* [QueryPie v10.1.0](https://querypie.atlassian.net/wiki/spaces/QM/pages/633799987/)
+* [QueryPie v10.0.0](https://querypie.atlassian.net/wiki/spaces/QM/pages/580224801/)
+* [QueryPie v9.16.0](https://querypie.atlassian.net/wiki/spaces/QS1/pages/369951121/)
   
 </MainLayoutObsoleted>

--- a/src/content/ja/index.mdx
+++ b/src/content/ja/index.mdx
@@ -121,6 +121,6 @@ Dockerベースの簡単なインストールで7-10分以内にすぐに開始�
 
 ## 旧バージョンドキュメント
 
-* [QueryPie v10.2.0](/ja/querypie-manual/10.2.0)
+* [QueryPie v10.2.0](https://querypie.atlassian.net/wiki/spaces/QM/pages/834863167/)
 
 </MainLayoutObsoleted>

--- a/src/content/ko/index.mdx
+++ b/src/content/ko/index.mdx
@@ -120,11 +120,11 @@ Docker 기반의 간단한 설치로 7-10분 내에 바로 시작할 수 있습�
 
 ## 이전 버전 문서
 
-* [QueryPie v11.2.0](/ko/querypie-manual/11.2.0)
-* [QueryPie v11.1.0](/ko/querypie-manual/11.1.0)
-* [QueryPie v11.0.0](/ko/querypie-manual/11.0.0)
-* [QueryPie v10.3.0](/ko/querypie-manual/10.3.0)
-* [QueryPie v10.2.0](/ko/querypie-manual/10.2.0)
-* [QueryPie v10.1.0](/ko/querypie-manual/10.1.0)
-* [QueryPie v10.0.0](/ko/querypie-manual/10.0.0)
-* [QueryPie v9.20.0](/ko/querypie/9.20.0)
+* [QueryPie v11.2.0](https://querypie.atlassian.net/wiki/spaces/QM/pages/1291125198/)
+* [QueryPie v11.1.0](https://querypie.atlassian.net/wiki/spaces/QM/pages/1171325037/)
+* [QueryPie v11.0.0](https://querypie.atlassian.net/wiki/spaces/QM/pages/1071939590/)
+* [QueryPie v10.3.0](https://querypie.atlassian.net/wiki/spaces/QM/pages/959545600/)
+* [QueryPie v10.2.0](https://querypie.atlassian.net/wiki/spaces/QM/pages/736428087/)
+* [QueryPie v10.1.0](https://querypie.atlassian.net/wiki/spaces/QM/pages/634519553/)
+* [QueryPie v10.0.0](https://querypie.atlassian.net/wiki/spaces/QM/pages/579010917/)
+* [QueryPie v9.20.0](https://querypie.atlassian.net/wiki/spaces/QS1/pages/524944097/)


### PR DESCRIPTION
## Description
- docs.querypie.com 의 첫페이지에 링크된 구버전 제품 매뉴얼의 링크를 querypie.atlassian.net 의 Confluence Page 링크로 연결합니다.

## Additional notes
- 
