### PR TITLE
fix: Duplicate without user-selected canonical

### DIFF
--- a/src/app/[lang]/[[...mdxPath]]/page.tsx
+++ b/src/app/[lang]/[[...mdxPath]]/page.tsx
@@ -3,6 +3,7 @@ import { useMDXComponents as getMDXComponents } from '@/mdx-components';
 import { Metadata } from 'next';
 import fs from 'fs';
 import path from 'path';
+import { getCanonicalUrl } from '@/lib/get-canonical-url';
 
 export async function generateStaticParams() {
   const locales = ['en', 'ja', 'ko']; // Same as next.config.mjs
@@ -66,7 +67,18 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
   const params = await props.params;
   const { metadata } = await importPage(params.mdxPath, params.lang || 'en');
-  return metadata;
+  
+  // Generate canonical URL
+  const canonicalUrl = await getCanonicalUrl(params);
+  
+  // Add canonical URL to metadata, merging with existing alternates if any
+  return {
+    ...metadata,
+    alternates: {
+      ...metadata.alternates,
+      canonical: canonicalUrl,
+    },
+  };
 }
 
 const Wrapper = getMDXComponents().wrapper;

--- a/src/lib/get-canonical-url.ts
+++ b/src/lib/get-canonical-url.ts
@@ -1,0 +1,20 @@
+import { getBaseUrl } from './get-base-url';
+
+interface CanonicalUrlParams {
+  lang: string;
+  mdxPath: string[];
+}
+
+/**
+ * Generate canonical URL for a page
+ * @param params - Page parameters containing lang and mdxPath
+ * @returns Canonical URL string
+ */
+export async function getCanonicalUrl(params: CanonicalUrlParams): Promise<string> {
+  const baseUrl = await getBaseUrl();
+  const lang = params.lang || 'en';
+  const pathSegments = params.mdxPath || [];
+  const path = pathSegments.length > 0 ? `/${pathSegments.join('/')}` : '';
+  return `${baseUrl}/${lang}${path}`;
+}
+


### PR DESCRIPTION
## Description
- Google Search Console 에서 여러 url 에 대해, Duplicate without user-selected canonical 오류가 발생하였습니다.
  - 참조: https://support.google.com/webmasters/thread/225011975/duplicate-without-user-selected-canonical-error-and-wrong-canonical-url
- Google Search Console 의 문제를 해결하기 위해, alternates, alternates.canonical url 을 metadata 에 포함하여 응답합니다.
- src/lib/get-canonical-url.ts 를 구현합니다.

## Additional notes
- 
