### PR TITLE
Fix: unexpected node handling

### DIFF
--- a/confluence-mdx/bin/confluence_xhtml_to_markdown.py
+++ b/confluence-mdx/bin/confluence_xhtml_to_markdown.py
@@ -1040,7 +1040,7 @@ class MultiLineParser:
             elif child.name in ['ul', 'ol']:
                 pass  # Will be processed later in this method
             else:
-                child_markdown.extend(f'<Unexpected node name={child.name}/>')
+                child_markdown.append(f'(Unexpected node name="{child.name}")')
 
         logging.debug(f'li_itself={li_itself}')
         logging.debug(f'child_markdown={child_markdown}')

--- a/confluence-mdx/tests/testcases/544381877/expected.mdx
+++ b/confluence-mdx/tests/testcases/544381877/expected.mdx
@@ -170,4 +170,4 @@ ${CA_CERT}"
 </details>
 
 * 스크립트 다운로드 이후 해당 경로에서 이하의 명령어를 수행하여 실행 권한을 부여한 뒤 사용합니다. 
-  <  U  n  e  x  p  e  c  t  e  d     n  o  d  e     n  a  m  e  =  a  c  :  s  t  r  u  c  t  u  r  e  d  -  m  a  c  r  o  /  >
+  (Unexpected node name="ac:structured-macro")

--- a/src/content/ko/administrator-manual/general/system/integrations/integrating-with-slack-dm.mdx
+++ b/src/content/ko/administrator-manual/general/system/integrations/integrating-with-slack-dm.mdx
@@ -38,7 +38,7 @@ App Manifest를 이용하여 QueryPie DM 연동 전용 Slack App을 생성합니
   ![image-20231227-065951.png](/administrator-manual/general/system/integrations/integrating-with-slack-dm/image-20231227-065951.png)
   </figure>
 4. Create app from manifest 모달에서 JSON 형식의 App Manifest를 입력합니다. <br/>미리 채워져 있는 내용들을 삭제하고 아래의 App Manifest를 붙여넣은 뒤 다음 단계로 진행합니다.<br/>:light_bulb_on: `{{..}}` 안의 값은 원하는 값으로 변경해 주세요. <br/> 
-  <  U  n  e  x  p  e  c  t  e  d     n  o  d  e     n  a  m  e  =  a  c  :  s  t  r  u  c  t  u  r  e  d  -  m  a  c  r  o  /  >5. 설정 내용을 검토하고 `Create` 버튼을 클릭하여 App 생성을 완료합니다.<br/> <br/> 
+  (Unexpected node name="ac:structured-macro")5. 설정 내용을 검토하고 `Create` 버튼을 클릭하여 App 생성을 완료합니다.<br/> <br/> 
   <figure data-layout="center" data-align="center">
   ![image-20240115-220447.png](/administrator-manual/general/system/integrations/integrating-with-slack-dm/image-20240115-220447.png)
   </figure>

--- a/src/content/ko/administrator-manual/general/user-management/provisioning/okta-provisioning-integration-guide.mdx
+++ b/src/content/ko/administrator-manual/general/user-management/provisioning/okta-provisioning-integration-guide.mdx
@@ -87,7 +87,7 @@ Okta Admin Console &gt; Applications &gt; Applications &gt; Custom SCIM App &gt;
     1. SCIM connector base URL : QueryPie에서 조회한 SCIM Endpoint 값을 삽입합니다. 
     2. Unique identifier field for users : “ **userName** ”
     3. Support provisioning action : 
-      <      U      n      e      x      p      e      c      t      e      d             n      o      d      e             n      a      m      e      =      a      c      :      t      a      s      k      -      l      i      s      t      /      >    4. Authentication Mode : “ **HTTP Header** ”
+      (Unexpected node name="ac:task-list")    4. Authentication Mode : “ **HTTP Header** ”
     5. HTTP Header &gt; Authorization : QueryPie에서 생성한 SCIM전용 access token 값을 삽입합니다. 
 3. Test Connector Configuration 버튼을 눌러 연결 테스트를 진행합니다. 
 4. “ *Connector configured successfully* ” 문구와 함께 팝업이 나타나면 `Close` 버튼을 클릭합니다. 
@@ -149,7 +149,7 @@ Okta Admin Console &gt; Applications &gt; Applications &gt; Custom SCIM App &gt;
               ![image-20240712-083117.png](/administrator-manual/general/user-management/provisioning/okta-provisioning-integration-guide/image-20240712-083117.png)
               </figure>
         4. External namespace : 해당 정보로 기입합니다. 
-          <          U          n          e          x          p          e          c          t          e          d                     n          o          d          e                     n          a          m          e          =          a          c          :          s          t          r          u          c          t          u          r          e          d          -          m          a          c          r          o          /          >        5. 이후 `Save` 또는 `Save and Add Another` 버튼을 클릭하여 저장합니다.
+          (Unexpected node name="ac:structured-macro")        5. 이후 `Save` 또는 `Save and Add Another` 버튼을 클릭하여 저장합니다.
         6. 그 다음 `Mappings` 버튼을 클릭합니다. 
           <figure data-layout="center" data-align="center">
           ![image-20240712-082549.png](/administrator-manual/general/user-management/provisioning/okta-provisioning-integration-guide/image-20240712-082549.png)

--- a/src/content/ko/administrator-manual/kubernetes/connection-management/clusters/manually-registering-kubernetes-clusters.mdx
+++ b/src/content/ko/administrator-manual/kubernetes/connection-management/clusters/manually-registering-kubernetes-clusters.mdx
@@ -170,4 +170,4 @@ ${CA_CERT}"
 </details>
 
 * 스크립트 다운로드 이후 해당 경로에서 이하의 명령어를 수행하여 실행 권한을 부여한 뒤 사용합니다. 
-  <  U  n  e  x  p  e  c  t  e  d     n  o  d  e     n  a  m  e  =  a  c  :  s  t  r  u  c  t  u  r  e  d  -  m  a  c  r  o  /  >
+  (Unexpected node name="ac:structured-macro")

--- a/src/content/ko/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-action-configuration-reference-guide.mdx
+++ b/src/content/ko/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-action-configuration-reference-guide.mdx
@@ -34,12 +34,12 @@ QueryPie KAC에서는 Yaml 형태의 Policy를 통해 k8s에 대한 접근제어
     * 그래서 `pods`에 대한 권한만 있다면 `pods`에 대한 그래프만 보이고, 만약 `pods`가 필터링 되어서 일부만 볼 수 있다면 일부만 표시됩니다. 
     * 다른 리소스들도 마찬가지로 동작합니다.
     * 추천 스펙
-      <      U      n      e      x      p      e      c      t      e      d             n      o      d      e             n      a      m      e      =      a      c      :      s      t      r      u      c      t      u      r      e      d      -      m      a      c      r      o      /      >*  **Events 파트** 
+      (Unexpected node name="ac:structured-macro")*  **Events 파트** 
     * 아래 events 항목은 `events` 리소스에 대한 권한에 의해서 보여주는데, 위의 resources 항목과 마찬가지로 namespace, name에 의해서 필터링 되어 보여집니다. 
     * 다만 `pods`에 대한 권한이 있다고 `pods` 관련 `events`가 보이는것이 아니니, 해당 화면을 보려면 명시적으로 `events` 리소스에 대한 권한을 주어야 합니다. 
     * `events` 리소스와 `pods` 리소스는 서로 분리된 리소스입니다. 따라서, `events` 리소스 권한이 있는 상태에서 `pods`에 대한 권한만을 주었다고 해서 `events` 중 `pods`에 대한 내역만 조회되지 않아 안내드립니다.
     * 추천 스펙
-      <      U      n      e      x      p      e      c      t      e      d             n      o      d      e             n      a      m      e      =      a      c      :      s      t      r      u      c      t      u      r      e      d      -      m      a      c      r      o      /      >
+      (Unexpected node name="ac:structured-macro")
 
 ### Verbs 관련 설정 가이드
 
@@ -49,13 +49,13 @@ QueryPie KAC에서는 Yaml 형태의 Policy를 통해 k8s에 대한 접근제어
     * View 권한만을 얻는 사용자의 경우는 `get`, `list`, `watch`를 모두 부여해야 합니다. 
     * `get`, `list` 만으로 kubectl의 사용은 크게 어렵지 않지만, `watch`가 없다면 lens와 같은 현황 모니터링을 지원하는 툴의 사용이 어렵습니다. 
     * 권장 스펙
-      <      U      n      e      x      p      e      c      t      e      d             n      o      d      e             n      a      m      e      =      a      c      :      s      t      r      u      c      t      u      r      e      d      -      m      a      c      r      o      /      >*  **Edit 권한** 
+      (Unexpected node name="ac:structured-macro")*  **Edit 권한** 
     * Edit 권한까지 얻는 사용자의 경우에는 View 권한(최소 `get`, `list`)도 함께 부여해주어야 합니다. kubectl에서도 특정 리소스에 대한 수정 요청을 하면 먼저 조회요청을 하기 때문입니다. 
     * lens같은 툴에서는 View 권한이 없다면 Edit 화면으로 갈 수 있는 방법이 없습니다.
     * Edit 중에서도 생성(`create`), 수정(`patch`, `update`), 삭제(`delete`, `deletecollection`) 이렇게 각 역할에 맞춰서 묶어서 주어져야 합니다. 
     * `deletecollection`은 흔하게 사용되지는 않지만, KAC에서는 `deletecollection`으로 요청이 오더라도 사용자에게 권한이 있는 리소스만을 골라서 삭제처리 하므로 유용하게 사용될 수 있습니다.
     * 권장 스펙 
-      <      U      n      e      x      p      e      c      t      e      d             n      o      d      e             n      a      m      e      =      a      c      :      s      t      r      u      c      t      u      r      e      d      -      m      a      c      r      o      /      >
+      (Unexpected node name="ac:structured-macro")
 
 ### 기타 추천 설정 가이드
 

--- a/src/content/ko/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-yaml-code-syntax-guide.mdx
+++ b/src/content/ko/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-yaml-code-syntax-guide.mdx
@@ -222,12 +222,12 @@ O
         * 해당 subjects는 Policy-wide 레벨에서 정의할 수 있어야 하며, 최소 하나가 배정되도록 정의되어야 합니다.
             * Impersonation을 위한 해당 subjects는 다른 Policy들과 하나의 Role 내에서 중첩이 가능합니다.
         * Resources에 명시된 리소스에 대한 권한 수행이 가능한 kubernetes 측 그룹(단일 또는 복수)을 정의합니다.
-          <          U          n          e          x          p          e          c          t          e          d                     n          o          d          e                     n          a          m          e          =          a          c          :          s          t          r          u          c          t          u          r          e          d          -          m          a          c          r          o          /          >        * kubernetesGroups에는 Querypie User의 Group을 예약어 형태로 입력할 수 있습니다. 이 때, User의 Group은 쌍따옴표(“) 없이 입력 입력되어야 하며, 사용자가 Policy를 볼 땐 실제 user Group의 값이 표시됩니다.
-          <          U          n          e          x          p          e          c          t          e          d                     n          o          d          e                     n          a          m          e          =          a          c          :          s          t          r          u          c          t          u          r          e          d          -          m          a          c          r          o          /          >2. `impersonation`: **[OPTIONAL]**
+          (Unexpected node name="ac:structured-macro")        * kubernetesGroups에는 Querypie User의 Group을 예약어 형태로 입력할 수 있습니다. 이 때, User의 Group은 쌍따옴표(“) 없이 입력 입력되어야 하며, 사용자가 Policy를 볼 땐 실제 user Group의 값이 표시됩니다.
+          (Unexpected node name="ac:structured-macro")2. `impersonation`: **[OPTIONAL]**
     * 사용자가 클라이언트 단에서 kubernetes 내 특정 serviceaccount 등의 권한으로 kubectl 명령에 impersonation(--as, --as-group)을 시도하는 경우, 이에 대한 호출 허용 목록을 정의합니다.
         * `users`: 쿠버네티스 내 존재하는 사용자/서비스 계정으로 "--as" 파라미터에 허용 가능한 값을 나열합니다.
         * `groups`: 쿠버네티스 내 존재하는 그룹 계정으로 "--as-group" 파라미터에 허용 가능한 값을 나열합니다.
-          <          U          n          e          x          p          e          c          t          e          d                     n          o          d          e                     n          a          m          e          =          a          c          :          s          t          r          u          c          t          u          r          e          d          -          m          a          c          r          o          /          >        * 와일드카드를 허용합니다. (`"*"`)
+          (Unexpected node name="ac:structured-macro")        * 와일드카드를 허용합니다. (`"*"`)
 
 
 ### Actions 명시 방법
@@ -248,7 +248,7 @@ O
     2. 위에 표기되지 않은 리소스 또한 정책에서 수용이 가능합니다. 
     3. 네임스페이스 하위 리소스만 지정하여 권한을 부여하더라도, Namespace에 대한 ReadOnly 권한이 함께 부여됩니다. 따라서, 리소스 호출 시 매번 네임스페이스 명시해주어야 하는 사례가 발생되지 않습니다. 특정 네임스페이스에 대한 권한 부여를 방지하고자 하는 경우, `spec:deny` 에서 네임스페이스 리소스에 대한 접근 거부를 설정할 수 있습니다. 
     4. 단일 정책 액션에서 다중으로 리소스 지정이 가능합니다. 
-      <      U      n      e      x      p      e      c      t      e      d             n      o      d      e             n      a      m      e      =      a      c      :      s      t      r      u      c      t      u      r      e      d      -      m      a      c      r      o      /      >    5. 와일드카드를 허용합니다. (`"*"`)
+      (Unexpected node name="ac:structured-macro")    5. 와일드카드를 허용합니다. (`"*"`)
 3. `namespace` : 대상 네임스페이스를 정의합니다. 
     1. 네임스페이스를 액션에서 정의하여 클러스터 내 허용 대상 네임스페이스를 리소스별로 제어할 수 있습니다. 
     2. 와일드카드와 정규표현식 모두 허용합니다.
@@ -282,9 +282,9 @@ O
 `conditions` 항목에는 `resourceTags`, `userAttributes`, `ipAddresses`를 조건으로 정의할 수 있습니다. **[OPTIONAL]**
 
 * `resourceTags` : 태그 항목에서는 리소스 태그의 키와 값으로 필터링할 수 있습니다. 
-  <  U  n  e  x  p  e  c  t  e  d     n  o  d  e     n  a  m  e  =  a  c  :  s  t  r  u  c  t  u  r  e  d  -  m  a  c  r  o  /  >* `userAttributes` : 사용자의 속성(attribute)을 조건으로 지정하고 값이 매칭되는 사용자에 한해서만 해당 정책에서 정의된 권한의 사용을 제한합니다. 
-  <  U  n  e  x  p  e  c  t  e  d     n  o  d  e     n  a  m  e  =  a  c  :  s  t  r  u  c  t  u  r  e  d  -  m  a  c  r  o  /  >* `ipAddresses` : 리소스에 대한 IP 접근 통제 조건 리스트를 단일IP, CIDR 형태으로 정의합니다. 
-  <  U  n  e  x  p  e  c  t  e  d     n  o  d  e     n  a  m  e  =  a  c  :  s  t  r  u  c  t  u  r  e  d  -  m  a  c  r  o  /  >
+  (Unexpected node name="ac:structured-macro")* `userAttributes` : 사용자의 속성(attribute)을 조건으로 지정하고 값이 매칭되는 사용자에 한해서만 해당 정책에서 정의된 권한의 사용을 제한합니다. 
+  (Unexpected node name="ac:structured-macro")* `ipAddresses` : 리소스에 대한 IP 접근 통제 조건 리스트를 단일IP, CIDR 형태으로 정의합니다. 
+  (Unexpected node name="ac:structured-macro")
 
 ### KAC Policy 예시
 

--- a/src/content/ko/administrator-manual/servers/connection-management/server-groups/managing-servers-as-groups.mdx
+++ b/src/content/ko/administrator-manual/servers/connection-management/server-groups/managing-servers-as-groups.mdx
@@ -182,7 +182,7 @@ macOS의 VNC 프로토콜 제한에 의해, VNC를 통한 자동 로그인을 �
 **Vault에서 Role을 설정할 때,**
 *  **Default extensions** 에 아래 값을 입력해야 합니다.
     * 
-      <      U      n      e      x      p      e      c      t      e      d             n      o      d      e             n      a      m      e      =      a      c      :      s      t      r      u      c      t      u      r      e      d      -      m      a      c      r      o      /      >*  **TTL / Max TTL**  설정시, 60 이상으로 설정합니다.
+      (Unexpected node name="ac:structured-macro")*  **TTL / Max TTL**  설정시, 60 이상으로 설정합니다.
     * QueryPie에서는 인증서의 TTL(Time To Live)은 60초 입니다.
 *  **Signing Algorithm** 은 ras-sha2-256 으로 설정합니다.
 </Callout>

--- a/src/content/ko/administrator-manual/web-apps/wac-quickstart/1027-wac-role-policy-guide.mdx
+++ b/src/content/ko/administrator-manual/web-apps/wac-quickstart/1027-wac-role-policy-guide.mdx
@@ -171,7 +171,7 @@ QueryPie에 정의한 웹앱 리소스명을 입력합니다.
     * `- webApp: "*Query*"` (X)
     * `- webApp: "QueryPie$"` (X)
 2. 하나의 `spec` 안에서 여러 개의 웹 앱을 나열할 수 있습니다.
-  <  U  n  e  x  p  e  c  t  e  d     n  o  d  e     n  a  m  e  =  a  c  :  s  t  r  u  c  t  u  r  e  d  -  m  a  c  r  o  /  >3. 웹 앱 이름은 다음의 조건을 만족해야 합니다.
+  (Unexpected node name="ac:structured-macro")3. 웹 앱 이름은 다음의 조건을 만족해야 합니다.
     * 글자 수 최대 120자
     * 알파벳 대소문자 (case-sensitive), 숫자 및 일부 특수기호 (`_`, `-`, `(`, `)`, `[`, `]`) 만 허용
     * 공백 허용
@@ -186,14 +186,14 @@ QueryPie에 정의한 웹앱 리소스명을 입력합니다.
 2. Base URL을 포함하여, 웹 앱에 존재하는  **모든**  하위 경로에 대해 허용 또는 거부하는 방법은 다음과 같습니다.
     * urlPaths 행을 작성하지 않습니다.
         * 예: QueryPie Web Admin 의 전체 경로에 대해 접근 허용
-          <          U          n          e          x          p          e          c          t          e          d                     n          o          d          e                     n          a          m          e          =          a          c          :          s          t          r          u          c          t          u          r          e          d          -          m          a          c          r          o          /          >    *  `urlPaths: []` 으로 작성합니다.
+          (Unexpected node name="ac:structured-macro")    *  `urlPaths: []` 으로 작성합니다.
         * 예: QueryPie Web Admin 의 전체 경로에 대해 접근 차단
-          <          U          n          e          x          p          e          c          t          e          d                     n          o          d          e                     n          a          m          e          =          a          c          :          s          t          r          u          c          t          u          r          e          d          -          m          a          c          r          o          /          >3. 특정 하위 경로 입력시, 입력한 경로와 해당 경로의 모든 하위 경로에 정책이 적용됩니다.
+          (Unexpected node name="ac:structured-macro")3. 특정 하위 경로 입력시, 입력한 경로와 해당 경로의 모든 하위 경로에 정책이 적용됩니다.
     * 하위 경로는 리스트로 나열하며, 여러 개를 입력할 수 있습니다.
         * 예: QueryPie Web Admin 의 `/general-settings/user-management` 와 `/general-settings/user-management/*`, 그리고 `/kubernetes-settings` 와 `/kubernetes-settings/*` 에 대해 접근 허용
-          <          U          n          e          x          p          e          c          t          e          d                     n          o          d          e                     n          a          m          e          =          a          c          :          s          t          r          u          c          t          u          r          e          d          -          m          a          c          r          o          /          >    * 하위 경로와 이에 포함된 세부 경로를 동시에 입력할 수 없습니다.
+          (Unexpected node name="ac:structured-macro")    * 하위 경로와 이에 포함된 세부 경로를 동시에 입력할 수 없습니다.
         * 예: QueryPie Web Admin 의 `/general-settings` 와 `/general-settings/user-management` 를  **동시에 입력 불가** 
-          <          U          n          e          x          p          e          c          t          e          d                     n          o          d          e                     n          a          m          e          =          a          c          :          s          t          r          u          c          t          u          r          e          d          -          m          a          c          r          o          /          >
+          (Unexpected node name="ac:structured-macro")
 <Callout type="info">
 urlPaths에 특정 하위 경로를 입력하려면 Web App 상세 정보에서 Path Management 활성화가 필요합니다. 등록되지 않은 하위 경로 입력 시 오류가 발생합니다.
 </Callout>
@@ -218,16 +218,16 @@ Web App의 Path Management에서 부여된 태그를 기준으로 규칙에 의�
 1. 태그는 대소문자를 구분하며, 여러 개를 입력할 수 있습니다.
     * Key가 동일한 태그를 여러 개 입력 시, OR 조건으로 동작합니다. 
         * 예: `access: admin` 또는 `access: user` 가 부여된 경로에 대해 접근 허용
-          <          U          n          e          x          p          e          c          t          e          d                     n          o          d          e                     n          a          m          e          =          a          c          :          s          t          r          u          c          t          u          r          e          d          -          m          a          c          r          o          /          >    * Key가 다른 태그를 여러 개 입력 시, AND 조건으로 동작합니다. 
+          (Unexpected node name="ac:structured-macro")    * Key가 다른 태그를 여러 개 입력 시, AND 조건으로 동작합니다. 
         * 예: `access: admin` 과 `type: general` 가 함께 부여된 경로에 대해 접근 허용
-          <          U          n          e          x          p          e          c          t          e          d                     n          o          d          e                     n          a          m          e          =          a          c          :          s          t          r          u          c          t          u          r          e          d          -          m          a          c          r          o          /          >2. `resources[].urlPaths` 와 연계되어 동작합니다.
+          (Unexpected node name="ac:structured-macro")2. `resources[].urlPaths` 와 연계되어 동작합니다.
     *  **웹앱 리소스의 대상 urlPath가 명시되지 않은 경우** 
         * 등록된 전체 하위 경로 중 urlPathTag가 있는 경로를 모두 허용합니다.
         * 예: Web App “QueryPie Web Admin” 에 대해, Path Management에 등록된 전체 하위 경로 중 `access: admin` 태그가 부여된 경로에 한하여 접근 허용
-          <          U          n          e          x          p          e          c          t          e          d                     n          o          d          e                     n          a          m          e          =          a          c          :          s          t          r          u          c          t          u          r          e          d          -          m          a          c          r          o          /          >    *  **웹앱 리소스의 대상 urlPath가 명시된 경우** 
+          (Unexpected node name="ac:structured-macro")    *  **웹앱 리소스의 대상 urlPath가 명시된 경우** 
         * 명시된 경로들 중 urlPathTag가 있는 경로만을 허용합니다.
         * 예: Web App “QueryPie Web Admin” 에 대해, `resources[].urlPaths` 에 명시된 두 경로 중 Path Management에서 `access: admin` 태그가 부여된 경로에 한하여 접근 허용
-          <          U          n          e          x          p          e          c          t          e          d                     n          o          d          e                     n          a          m          e          =          a          c          :          s          t          r          u          c          t          u          r          e          d          -          m          a          c          r          o          /          >    *  **웹앱 리소스의 대상 urlPath가 명시되었으나 범위 내에서 매칭되는 urlPathTag가 없는 경우** 
+          (Unexpected node name="ac:structured-macro")    *  **웹앱 리소스의 대상 urlPath가 명시되었으나 범위 내에서 매칭되는 urlPathTag가 없는 경우** 
         * 조건에 일치하는 urlPath가 존재하지 않으므로, 어떠한 경로도 허용하지 않습니다.
 
 #### userAttributes**[OPTIONAL]**
@@ -242,9 +242,9 @@ QueryPie 사용자의 속성(attribute)을 기준으로 규칙에 의해 리소�
 
 * Key가 동일한 속성을 여러 개 입력 시, OR 조건으로 동작합니다. 
     * 예: 부서(department)가 PM 또는 QA인 사용자에 대해 접근 허용
-      <      U      n      e      x      p      e      c      t      e      d             n      o      d      e             n      a      m      e      =      a      c      :      s      t      r      u      c      t      u      r      e      d      -      m      a      c      r      o      /      >* Key가 다른 속성을 여러 개 입력 시, AND 조건으로 동작합니다. 
+      (Unexpected node name="ac:structured-macro")* Key가 다른 속성을 여러 개 입력 시, AND 조건으로 동작합니다. 
     * 예: 부서(department)가 PM이고, 직책(title)이 관리자인 사용자에 대해 접근 허용
-      <      U      n      e      x      p      e      c      t      e      d             n      o      d      e             n      a      m      e      =      a      c      :      s      t      r      u      c      t      u      r      e      d      -      m      a      c      r      o      /      >
+      (Unexpected node name="ac:structured-macro")
 #### ipAddresses**[OPTIONAL]**
 
 리소스에 대한 IP 접근 통제 조건 리스트를 단일IP, CIDR 형태으로 정의합니다.

--- a/src/content/ko/administrator-manual/web-apps/wac-quickstart/1028-wac-rbac-guide.mdx
+++ b/src/content/ko/administrator-manual/web-apps/wac-quickstart/1028-wac-rbac-guide.mdx
@@ -202,7 +202,7 @@ QueryPie에 정의한 웹 앱 리소스 이름을 입력합니다.
     * `- webApp: "*Query*"` (X)
     * `- webApp: "QueryPie$"` (X)
 2. 하나의 `spec` 안에서 여러 개의 웹 앱을 나열할 수 있습니다.
-  <  U  n  e  x  p  e  c  t  e  d     n  o  d  e     n  a  m  e  =  a  c  :  s  t  r  u  c  t  u  r  e  d  -  m  a  c  r  o  /  >3. 웹 앱 이름은 다음의 조건을 만족해야 합니다.
+  (Unexpected node name="ac:structured-macro")3. 웹 앱 이름은 다음의 조건을 만족해야 합니다.
     * 글자 수 최대 120자
     * 알파벳 대소문자 (case-sensitive), 숫자 및 일부 특수기호 (`_`, `-`, `(`, `)`, `[`, `]`) 만 허용
     * 공백 허용
@@ -218,12 +218,12 @@ QueryPie에 정의한 웹 앱 리소스 이름을 입력합니다.
 1. Admin &gt; Web App 에 등록된 하위 경로만 등록이 가능합니다.
 2. Base URL을 포함하여, 웹 앱에 존재하는  **모든**  하위 경로에 대해 허용 또는 거부하려면 `urlPaths: ["*"]` 으로 작성합니다.
     * 예: QueryPie Web Admin 의 전체 경로에 대해 접근 차단
-      <      U      n      e      x      p      e      c      t      e      d             n      o      d      e             n      a      m      e      =      a      c      :      s      t      r      u      c      t      u      r      e      d      -      m      a      c      r      o      /      >3. 하위 경로 입력시, 입력한 경로에 대해 정책이 적용됩니다.
+      (Unexpected node name="ac:structured-macro")3. 하위 경로 입력시, 입력한 경로에 대해 정책이 적용됩니다.
     * 하위 경로는 리스트로 나열하며, 여러 개를 입력할 수 있습니다.
     * 경로의 마지막 부분에 와일드카드를 입력하여, 특정 경로 하위의 모든 경로를 지시할 수 있습니다. (상위 경로는 포함하지 않습니다)
-      <      U      n      e      x      p      e      c      t      e      d             n      o      d      e             n      a      m      e      =      a      c      :      s      t      r      u      c      t      u      r      e      d      -      m      a      c      r      o      /      >    * 입력한 경로 중에 서로 중첩되는 경로를 동시에 입력할 수 없습니다.
+      (Unexpected node name="ac:structured-macro")    * 입력한 경로 중에 서로 중첩되는 경로를 동시에 입력할 수 없습니다.
         * 예: QueryPie Web Admin 의 `/general-settings/*` 와 `/general-settings/user-management` 를  **동시에 입력 불가** 
-          <          U          n          e          x          p          e          c          t          e          d                     n          o          d          e                     n          a          m          e          =          a          c          :          s          t          r          u          c          t          u          r          e          d          -          m          a          c          r          o          /          >4. 경로의 중간 또는 경로명의 일부에 와일드카드를 입력하거나, 정규표현식을 입력할 수  **없습니다** .
+          (Unexpected node name="ac:structured-macro")4. 경로의 중간 또는 경로명의 일부에 와일드카드를 입력하거나, 정규표현식을 입력할 수  **없습니다** .
     * `"/*-settings"` (X)
     * `"/*/edit"` (X)
     * `"^/database-settings/policies/data-.*$"` (X)
@@ -236,9 +236,9 @@ QueryPie에 정의한 웹 앱 리소스 이름을 입력합니다.
 1. 태그는 대소문자를 구분하며, 여러 개를 입력할 수 있습니다.
     * Key가 동일한 태그를 여러 개 입력 시,  **OR**  조건으로 동작합니다.
         * 예: `access: admin` 또는 `access: user` 가 부여된 경로에 대해 접근 허용
-          <          U          n          e          x          p          e          c          t          e          d                     n          o          d          e                     n          a          m          e          =          a          c          :          s          t          r          u          c          t          u          r          e          d          -          m          a          c          r          o          /          >    * Key가 다른 태그를 여러 개 입력 시,  **AND**  조건으로 동작합니다.
+          (Unexpected node name="ac:structured-macro")    * Key가 다른 태그를 여러 개 입력 시,  **AND**  조건으로 동작합니다.
         * 예: `access: admin` 과 `type: general` 가 함께 부여된 경로에 대해 접근 허용
-          <          U          n          e          x          p          e          c          t          e          d                     n          o          d          e                     n          a          m          e          =          a          c          :          s          t          r          u          c          t          u          r          e          d          -          m          a          c          r          o          /          >
+          (Unexpected node name="ac:structured-macro")
 ### Conditions**[OPTIONAL]**
 
 `conditions` 은 규칙 적용 대상 리소스의 범위를 좁히기 위한 조건을 정의합니다. `userAttributes`, `ipAddresses` 두 종류의 조건 지정이 가능합니다.
@@ -259,9 +259,9 @@ QueryPie 사용자의 속성(attribute)을 기준으로 규칙에 의해 리소�
 
 * Key가 동일한 속성을 여러 개 입력 시, OR 조건으로 동작합니다.
     * 예: 부서(department)가 PM 또는 QA인 사용자에 대해 접근 허용
-      <      U      n      e      x      p      e      c      t      e      d             n      o      d      e             n      a      m      e      =      a      c      :      s      t      r      u      c      t      u      r      e      d      -      m      a      c      r      o      /      >* Key가 다른 속성을 여러 개 입력 시, AND 조건으로 동작합니다.
+      (Unexpected node name="ac:structured-macro")* Key가 다른 속성을 여러 개 입력 시, AND 조건으로 동작합니다.
     * 예: 부서(department)가 PM이고, 직책(title)이 관리자인 사용자에 대해 접근 허용
-      <      U      n      e      x      p      e      c      t      e      d             n      o      d      e             n      a      m      e      =      a      c      :      s      t      r      u      c      t      u      r      e      d      -      m      a      c      r      o      /      >
+      (Unexpected node name="ac:structured-macro")
 #### ipAddresses**[OPTIONAL]**
 
 리소스에 대한 IP 접근 통제 조건 리스트를 단일IP, CIDR 형태으로 정의합니다.

--- a/src/content/ko/user-manual/multi-agent/multi-agent-linux-installation-and-usage-guide.mdx
+++ b/src/content/ko/user-manual/multi-agent/multi-agent-linux-installation-and-usage-guide.mdx
@@ -83,8 +83,8 @@ dpkg 명령어를 기준으로 설명합니다.
 
 1. `querypie-multi-agent.deb` 을 다운로드합니다.
 2. 다음 명령어를 실행하여 파일을 설치합니다. <br/> 출력 예시
-  <  U  n  e  x  p  e  c  t  e  d     n  o  d  e     n  a  m  e  =  a  c  :  s  t  r  u  c  t  u  r  e  d  -  m  a  c  r  o  /  >  <  U  n  e  x  p  e  c  t  e  d     n  o  d  e     n  a  m  e  =  a  c  :  s  t  r  u  c  t  u  r  e  d  -  m  a  c  r  o  /  >3. 설치 여부를 확인합니다. <br/> 출력 예시
-  <  U  n  e  x  p  e  c  t  e  d     n  o  d  e     n  a  m  e  =  a  c  :  s  t  r  u  c  t  u  r  e  d  -  m  a  c  r  o  /  >  <  U  n  e  x  p  e  c  t  e  d     n  o  d  e     n  a  m  e  =  a  c  :  s  t  r  u  c  t  u  r  e  d  -  m  a  c  r  o  /  >
+  (Unexpected node name="ac:structured-macro")  (Unexpected node name="ac:structured-macro")3. 설치 여부를 확인합니다. <br/> 출력 예시
+  (Unexpected node name="ac:structured-macro")  (Unexpected node name="ac:structured-macro")
 #### Uninstall
 
 터미널에서 다음 명령어를 실행합니다.
@@ -108,8 +108,8 @@ rpm 명령어를 기준으로 설명합니다.
 
 1. `querypie-multi-agent.rpm` 을 다운로드합니다.
 2. 터미널에서 다음 명령어를 실행하여 파일을 설치합니다. <br/> 출력 예시
-  <  U  n  e  x  p  e  c  t  e  d     n  o  d  e     n  a  m  e  =  a  c  :  s  t  r  u  c  t  u  r  e  d  -  m  a  c  r  o  /  >  <  U  n  e  x  p  e  c  t  e  d     n  o  d  e     n  a  m  e  =  a  c  :  s  t  r  u  c  t  u  r  e  d  -  m  a  c  r  o  /  >3. 설치 여부를 확인합니다. <br/> 출력 예시
-  <  U  n  e  x  p  e  c  t  e  d     n  o  d  e     n  a  m  e  =  a  c  :  s  t  r  u  c  t  u  r  e  d  -  m  a  c  r  o  /  >  <  U  n  e  x  p  e  c  t  e  d     n  o  d  e     n  a  m  e  =  a  c  :  s  t  r  u  c  t  u  r  e  d  -  m  a  c  r  o  /  >
+  (Unexpected node name="ac:structured-macro")  (Unexpected node name="ac:structured-macro")3. 설치 여부를 확인합니다. <br/> 출력 예시
+  (Unexpected node name="ac:structured-macro")  (Unexpected node name="ac:structured-macro")
 #### Uninstall
 
 터미널에서 다음 명령어를 실행합니다.


### PR DESCRIPTION
## Description
- confluence_xhtml_to_markdown.py 의 버그를 수정합니다.
  - xhtml -> markdown 변환 과정에서, 변환하지 못한 xhtml node 에 대한 정보를 잘못 남긴 경우가 있습니다.
  - text string 이 한 줄 추가되어야 하는데, list of characters 가 추가되는 버그가 있었습니다. 이 버그를 수정합니다.
- testcase 의 결과를 수정합니다.
- src/content/ko/ 아래의 MDX 파일을 재생성합니다.

## Additional notes
- 
