### PR TITLE
feat: confluence-mdx/tests 에 skeleton 테스트 타겟 추가

### DIFF
--- a/confluence-mdx/tests/Makefile
+++ b/confluence-mdx/tests/Makefile
@@ -5,6 +5,8 @@
 VENV = source ../../venv/bin/activate
 # Converter script now lives under confluence-mdx/bin/
 SCRIPT = ../bin/confluence_xhtml_to_markdown.py
+# Skeleton converter script
+SKELETON_SCRIPT = ../bin/mdx_to_skeleton.py
 # Testcases live under this directory
 TEST_DIR = testcases
 DIFF = diff -u
@@ -103,20 +105,65 @@ debug-one:
 		echo "  No page.xhtml found for test case $(TEST_ID)"; \
 	fi
 
+# Run skeleton tests
+.PHONY: test-skeleton
+test-skeleton:
+	@echo "Running skeleton tests..."
+	@for test_case in $$(find $(TEST_DIR) -type d -depth 1); do \
+		test_id=$$(basename $$test_case); \
+		if [ -f "$(TEST_DIR)/$$test_id/output.mdx" ]; then \
+			echo "Testing case: $$test_id (Skeleton)"; \
+			echo "  Converting output.mdx to output.skel.mdx"; \
+			$(VENV) && \
+			python $(SKELETON_SCRIPT) $(TEST_DIR)/$$test_id/output.mdx; \
+			if [ -f "$(TEST_DIR)/$$test_id/expected.skel.mdx" ]; then \
+				$(DIFF) $(TEST_DIR)/$$test_id/expected.skel.mdx $(TEST_DIR)/$$test_id/output.skel.mdx || echo "Test $$test_id (Skeleton) failed"; \
+			else \
+				echo "  Warning: expected.skel.mdx not found for test case $$test_id"; \
+			fi; \
+		else \
+			echo "  Skipping $$test_id: output.mdx not found"; \
+		fi; \
+	done
+
+# Run a specific skeleton test
+.PHONY: test-skeleton-one
+test-skeleton-one:
+	@if [ -z "$(TEST_ID)" ]; then \
+		echo "Usage: make test-skeleton-one TEST_ID=<test_id>"; \
+		exit 1; \
+	fi
+	@echo "Testing case: $(TEST_ID) (Skeleton)"
+	@if [ -f "$(TEST_DIR)/$(TEST_ID)/output.mdx" ]; then \
+		echo "  Converting output.mdx to output.skel.mdx"; \
+		$(VENV) && \
+		python $(SKELETON_SCRIPT) $(TEST_DIR)/$(TEST_ID)/output.mdx; \
+		if [ -f "$(TEST_DIR)/$(TEST_ID)/expected.skel.mdx" ]; then \
+			$(DIFF) $(TEST_DIR)/$(TEST_ID)/expected.skel.mdx $(TEST_DIR)/$(TEST_ID)/output.skel.mdx || echo "Test $(TEST_ID) (Skeleton) failed"; \
+		else \
+			echo "  Warning: expected.skel.mdx not found for test case $(TEST_ID)"; \
+		fi; \
+	else \
+		echo "  No output.mdx found for test case $(TEST_ID)"; \
+	fi
+
 # Clean output files
 .PHONY: clean
 clean:
 	@echo "Cleaning output files..."
 	@find $(TEST_DIR) -name "output.mdx" -type f -delete
+	@find $(TEST_DIR) -name "output.skel.mdx" -type f -delete
 
 # Help
 .PHONY: help
 help:
 	@echo "Available targets:"
-	@echo "  all            - Run all tests (default)"
-	@echo "  test           - Run all tests (XHTML only)"
-	@echo "  test-one       - Run a specific test for XHTML, e.g., make test-one TEST_ID=568918170"
-	@echo "  debug          - Run all tests with debug log level (XHTML only)"
-	@echo "  debug-one      - Run a specific test with debug log level for XHTML, e.g., make debug-one TEST_ID=568918170"
-	@echo "  clean          - Remove all output files"
-	@echo "  help           - Show this help message"
+	@echo "  all                - Run all tests (default)"
+	@echo "  test               - Run all tests (XHTML only)"
+	@echo "  test-one           - Run a specific test for XHTML, e.g., make test-one TEST_ID=568918170"
+	@echo "  test-skeleton      - Run all skeleton tests (converts output.mdx to output.skel.mdx and compares with expected.skel.mdx)"
+	@echo "  test-skeleton-one  - Run a specific skeleton test, e.g., make test-skeleton-one TEST_ID=568918170"
+	@echo "  debug              - Run all tests with debug log level (XHTML only)"
+	@echo "  debug-one          - Run a specific test with debug log level for XHTML, e.g., make debug-one TEST_ID=568918170"
+	@echo "  clean              - Remove all output files (output.mdx and output.skel.mdx)"
+	@echo "  help               - Show this help message"

--- a/confluence-mdx/tests/testcases/.gitignore
+++ b/confluence-mdx/tests/testcases/.gitignore
@@ -1,1 +1,2 @@
 */output.mdx
+*/output.skel.mdx

--- a/confluence-mdx/tests/testcases/544112828/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544112828/expected.skel.mdx
@@ -1,0 +1,298 @@
+---
+title: '_TEXT_'
+---
+
+import { Callout } from 'nextra/components'
+
+# _TEXT_
+
+### _TEXT_
+
+_TEXT_, _TEXT_, _TEXT_, _TEXT_/_TEXT_, _TEXT_, _TEXT_.
+
+
+### _TEXT_
+
+1. _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+2. _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+<Callout type="info">
+_TEXT_, _TEXT_, _TEXT_.
+</Callout>
+
+3. _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![__TEXT__](___TEXT___TEXT___)
+<figcaption>
+_TEXT_
+</figcaption>
+</figure>
+
+4. _TEXT_. _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+
+### _TEXT_
+
+1. _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![__TEXT__](___TEXT___TEXT___)
+</figure>
+
+2. _TEXT_, _TEXT_, `___TEXT___TEXT___TEXT___` _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+3. _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+4. _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![__TEXT__](___TEXT___TEXT___)
+<figcaption>
+_TEXT_- _TEXT_
+</figcaption>
+</figure>
+
+### _TEXT_
+
+_TEXT_. _TEXT_.<br/>_TEXT_`___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+2. _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![__TEXT__](___TEXT___TEXT___)
+<figcaption>
+_TEXT_
+</figcaption>
+</figure>
+
+
+### _TEXT_
+
+_TEXT_.
+
+#### _TEXT_. _TEXT_
+
+* _TEXT_`___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_.
+* _TEXT_, _TEXT____TEXT___TEXT___TEXT___ _TEXT_. 
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+<Callout type="info">
+_TEXT_, _TEXT_.
+</Callout>
+
+#### <br/>_TEXT_. _TEXT_
+
+* _TEXT_, _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+* _TEXT_, _TEXT_. 
+* _TEXT_, `___TEXT___TEXT___TEXT___` _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+#### _TEXT_. _TEXT_
+
+_TEXT_. _TEXT_. _TEXT_.
+
+_TEXT_) _TEXT_, . _TEXT_.
+```
+___TEXT___TEXT___TEXT___
+```
+
+_TEXT_) _TEXT_.
+```
+___TEXT___TEXT___TEXT___
+```
+
+_TEXT_) _TEXT_, `___TEXT___TEXT___TEXT___` _TEXT_.
+```
+___TEXT___TEXT___TEXT___
+```
+
+<Callout type="info">
+_TEXT_, _TEXT_, _TEXT_. _TEXT_, _TEXT_.
+```
+___TEXT___TEXT___TEXT___
+```
+</Callout>
+
+_TEXT_) _TEXT_. _TEXT____TEXT___TEXT___TEXT___ _TEXT_.
+```
+___TEXT___TEXT___TEXT___
+```
+
+
+### _TEXT_
+
+<figure data-layout="center" data-align="center">
+![__TEXT__](___TEXT___TEXT___)
+</figure>
+
+* _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
+* _TEXT_(_TEXT_, _TEXT_, _TEXT_) _TEXT_.
+* _TEXT_, _TEXT_.
+* _TEXT_.
+
+#### _TEXT_. _TEXT_
+
+_TEXT_`___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+<Callout type="info">
+_TEXT_, _TEXT_.
+</Callout>
+
+
+#### _TEXT_. _TEXT_
+
+_TEXT_. _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+#### _TEXT_. _TEXT_
+
+_TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+*  **__TEXT__**  : _TEXT_.
+    * _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
+    * _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_. 
+
+
+<figure data-layout="center" data-align="center">
+![__TEXT__](___TEXT___TEXT___)
+<figcaption>
+_TEXT_
+</figcaption>
+</figure>
+
+*  **__TEXT__**  : _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
+*  **__TEXT__**  : _TEXT_. _TEXT_.
+*  **__TEXT__**  : _TEXT_.
+
+_TEXT_) _TEXT_, _TEXT_"`___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___`"_TEXT_.
+```
+___TEXT___TEXT___TEXT___
+```
+
+_TEXT_) _TEXT_.
+```
+___TEXT___TEXT___TEXT___
+```
+
+_TEXT_) _TEXT_.
+
+* _TEXT_: [__TEXT__](___TEXT___TEXT___)
+* _TEXT_: [__TEXT__](___TEXT___TEXT___)
+
+_TEXT_) `___TEXT___TEXT___TEXT___` _TEXT_
+```
+___TEXT___TEXT___TEXT___
+```
+
+
+### _TEXT_
+
+_TEXT_.
+#### _TEXT_
+
+_TEXT_`___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+
+#### (_TEXT_) _TEXT_
+
+_TEXT_. `___TEXT___TEXT___TEXT___` _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+

--- a/confluence-mdx/tests/testcases/544113141/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544113141/expected.skel.mdx
@@ -1,0 +1,87 @@
+---
+title: '_TEXT_'
+---
+
+# _TEXT_
+
+### _TEXT_
+
+_TEXT_.
+
+### _TEXT_
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+1. _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_.
+2. _TEXT_.
+3. _TEXT_.
+    1.  **__TEXT__**  : _TEXT_
+    2.  **__TEXT__**  : _TEXT_
+    3.  **__TEXT__**  : _TEXT_
+4. _TEXT_/_TEXT_.
+  <figure data-layout="center" data-align="center">
+  ![__TEXT__](___TEXT___TEXT___)
+  </figure>
+    1.  **__TEXT__**  : _TEXT_
+    2.  **__TEXT__** : _TEXT_
+    3.  **__TEXT__** : _TEXT_/ _TEXT_
+    4.  **__TEXT__** : _TEXT_/_TEXT_
+    5.  **__TEXT__**  : _TEXT_
+5. _TEXT_.
+6. _TEXT_:
+    1.  **__TEXT__**  : _TEXT_
+    2.  **__TEXT__**  : _TEXT_
+    3.  **__TEXT__**  : _TEXT_/ _TEXT_
+    4.  **__TEXT__**  : _TEXT_/_TEXT_
+        1. : _TEXT___TEXT_: _TEXT_
+        2. : _TEXT___TEXT_: _TEXT_
+    5.  **__TEXT__**  : _TEXT_
+    6.  **__TEXT__**  : _TEXT_
+    7.  **__TEXT__**  : _TEXT_
+    8.  **__TEXT__**  : _TEXT_
+    9.  **__TEXT__**  : _TEXT_
+    10.  **__TEXT__**   **__TEXT__**  : _TEXT_
+    11.  **__TEXT__**  : _TEXT_
+    12.  **__TEXT__**  : _TEXT_
+    13.  **__TEXT__**  : _TEXT_
+    14.  **__TEXT__**  : _TEXT_
+    15.  **__TEXT__**  : _TEXT_
+    16.  **__TEXT__**   **__TEXT__**  : _TEXT_(_TEXT_)
+    17.  **__TEXT__**  : _TEXT_
+    18.  **__TEXT__**   **__TEXT__**  : _TEXT_
+
+### _TEXT_
+
+_TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+* _TEXT_:
+    1.  **__TEXT__**  : _TEXT_/_TEXT_
+        1. : _TEXT___TEXT_: _TEXT_
+        2. : _TEXT___TEXT_: _TEXT_
+    2.  **__TEXT__**  : _TEXT_
+    3.  **__TEXT__**  : _TEXT_
+    4.  **__TEXT__** : _TEXT_/ _TEXT_
+    5.  **__TEXT__**   **__TEXT__**  : _TEXT_
+    6.  **__TEXT__**  : _TEXT_
+    7.  **__TEXT__**   **__TEXT__** : _TEXT_
+    8.  **__TEXT__**  : _TEXT_
+    9.  **__TEXT__**   **__TEXT__**  : _TEXT_(_TEXT_)
+    10.  **__TEXT__**  : _TEXT_
+    11.  **__TEXT__**  : _TEXT_
+    12.  **__TEXT__**  : _TEXT_
+    13.  **__TEXT__**  : _TEXT_
+    14.  **__TEXT__**  : _TEXT_
+    15.  **__TEXT__**  : _TEXT_
+    16.  **__TEXT__**  : _TEXT_

--- a/confluence-mdx/tests/testcases/544145591/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544145591/expected.skel.mdx
@@ -1,0 +1,248 @@
+---
+title: '_TEXT_'
+---
+
+# _TEXT_
+
+### _TEXT_
+
+_TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+### _TEXT_
+
+*  **__TEXT__**  : _TEXT_.
+*  **__TEXT__**  : _TEXT_
+*  **__TEXT__**  : _TEXT_.
+*  **__TEXT__**  : _TEXT_.
+*  **__TEXT__**  : _TEXT_. (_TEXT_: _TEXT_) 
+*  **__TEXT__** : _TEXT_. _TEXT_.
+*  **__TEXT__**  : _TEXT_. 
+
+
+### _TEXT_
+
+_TEXT_, _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+
+### _TEXT_
+
+_TEXT_.
+
+<figure data-layout="center" data-align="center">
+![__TEXT__](___TEXT___TEXT___)
+</figure>
+
+### _TEXT_
+
+_TEXT_.
+
+_TEXT_. _TEXT_(_TEXT_)_TEXT_.
+
+* _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_, _TEXT_(_TEXT_)_TEXT_. 
+
+### _TEXT_
+
+_TEXT_, _TEXT_, _TEXT_, _TEXT_. _TEXT_.
+
+* _TEXT_.
+    * _TEXT_: _TEXT_, _TEXT_. (_TEXT_: _TEXT_, _TEXT_)
+    * _TEXT_: _TEXT_, _TEXT_, _TEXT_, _TEXT_, _TEXT_. (_TEXT_: _TEXT_, _TEXT_)
+* _TEXT_.
+
+### _TEXT_
+
+_TEXT_.
+
+* _TEXT_.
+* _TEXT_.
+* _TEXT_. (_TEXT_, _TEXT_.)
+
+### _TEXT_
+
+_TEXT_.
+
+* _TEXT_(_TEXT_)_TEXT_.
+* _TEXT_.
+    * _TEXT_: _TEXT_
+    * _TEXT_: _TEXT_
+* _TEXT_. _TEXT_, _TEXT_, _TEXT_.
+
+### _TEXT_
+
+_TEXT_-_TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+_TEXT_, _TEXT_(_TEXT_: _TEXT_, _TEXT_)_TEXT_. _TEXT_.
+
+* _TEXT_: 
+    * _TEXT_.
+      <figure data-layout="center" data-align="center">
+      ![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_<br/>](___TEXT___TEXT___)
+      <figcaption>
+      _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_<br/>
+      </figcaption>
+      </figure>
+    * _TEXT_(_TEXT_).
+* _TEXT_
+    * _TEXT_. _TEXT_(_TEXT_: _TEXT_)_TEXT_.
+        * _TEXT_: _TEXT_, _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_(_TEXT_: _TEXT_).
+    * _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_, '_TEXT_' _TEXT_'_TEXT_(_TEXT_-_TEXT_)' _TEXT_.
+        * _TEXT_, _TEXT_(_TEXT_: _TEXT_)_TEXT_, _TEXT_.
+        * _TEXT_: _TEXT_'_TEXT_(_TEXT_)' _TEXT_, _TEXT_. _TEXT_, _TEXT_.
+    * _TEXT____TEXT___TEXT___TEXT___ _TEXT_(_TEXT_-_TEXT_)_TEXT_.
+* _TEXT_
+    * _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_.
+    * _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_'_TEXT_' _TEXT_'_TEXT_(_TEXT_-_TEXT_)' _TEXT_.
+    * _TEXT_'_TEXT_(_TEXT_-_TEXT_)' _TEXT_, _TEXT_.
+        * _TEXT_: _TEXT_.
+        * _TEXT_, _TEXT_, _TEXT_.
+    * _TEXT____TEXT___TEXT___TEXT___ _TEXT_(_TEXT_-_TEXT_)_TEXT_. 
+* _TEXT_
+    * _TEXT_(_TEXT_, _TEXT_), _TEXT_. _TEXT_.
+        * _TEXT_: 
+          <figure data-layout="center" data-align="center">
+          ![__TEXT__](___TEXT___TEXT___)
+          </figure>
+* _TEXT_
+    * _TEXT_, _TEXT_.
+        * _TEXT_:
+          <figure data-layout="center" data-align="center">
+          ![__TEXT__](___TEXT___TEXT___)
+          </figure>
+
+### _TEXT_(_TEXT_)
+
+_TEXT_.
+
+<figure data-layout="center" data-align="center">
+![__TEXT__](___TEXT___TEXT___)
+</figure>
+
+_TEXT_(_TEXT_)_TEXT_.
+
+* _TEXT_`___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___`_TEXT_.
+* _TEXT_`___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_.
+*  **__TEXT__**  `___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_.
+
+### _TEXT_(_TEXT_)
+
+_TEXT_.
+
+<figure data-layout="center" data-align="center">
+![__TEXT__](___TEXT___TEXT___)
+</figure>
+
+
+_TEXT_, _TEXT_, _TEXT_(_TEXT_)_TEXT_. _TEXT_.
+
+*  **__TEXT__**  : _TEXT_~_TEXT_, _TEXT_, _TEXT_
+    * _TEXT_) _TEXT_, _TEXT_. 
+*  **__TEXT__** : _TEXT_, _TEXT_(_TEXT_~ _TEXT_, _TEXT_)
+
+### _TEXT_
+
+_TEXT_.
+
+<figure data-layout="center" data-align="center">
+![__TEXT__](___TEXT___TEXT___)
+</figure>
+
+_TEXT_, _TEXT_, _TEXT_, `___TEXT___TEXT___TEXT___` _TEXT_. _TEXT_.
+
+* _TEXT_
+    * _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_.
+    * _TEXT_, `___TEXT___TEXT___TEXT___` _TEXT_, _TEXT_.
+* _TEXT_
+    * _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_.
+    * _TEXT_, _TEXT_, _TEXT_, `___TEXT___TEXT___TEXT___` _TEXT_
+
+### _TEXT_
+
+_TEXT_.
+
+<figure data-layout="center" data-align="center">
+![__TEXT__](___TEXT___TEXT___)
+</figure>
+
+_TEXT_(_TEXT_) _TEXT_.
+
+* _TEXT_(_TEXT_)_TEXT_:
+    * _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_:
+        * _TEXT_(_TEXT_(_TEXT_), _TEXT_(_TEXT_), _TEXT_(_TEXT_), _TEXT_(_TEXT_))_TEXT_.
+        * _TEXT_. _TEXT_.
+    * _TEXT_:
+        * _TEXT_(_TEXT_) _TEXT_.
+    * _TEXT_:
+        * _TEXT_(_TEXT_), _TEXT_(_TEXT_), _TEXT_(_TEXT_) _TEXT_.
+        * _TEXT_, _TEXT_(_TEXT_: "_TEXT_")_TEXT_.
+* _TEXT_(_TEXT_)_TEXT_(_TEXT_):
+    * _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_:
+        * _TEXT_.
+    * _TEXT_:
+        * _TEXT_, _TEXT_.
+        * _TEXT_.
+
+### _TEXT_
+
+_TEXT_(_TEXT_)_TEXT_“_TEXT_” _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![__TEXT__](___TEXT___TEXT___)
+<figcaption>
+_TEXT_
+</figcaption>
+</figure>
+
+`___TEXT___TEXT___TEXT___` _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![__TEXT__](___TEXT___TEXT___)
+</figure>
+
+*  **__TEXT__**  : _TEXT_.
+*  **__TEXT__**  : _TEXT_.
+    *  **__TEXT__**  : _TEXT_.
+    *  **__TEXT__** : _TEXT_.
+*   **__TEXT__**  : _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_.
+*  **__TEXT__**  : _TEXT_(_TEXT_)_TEXT_.
+
+#### _TEXT_
+
+* _TEXT_“_TEXT_-_TEXT_” _TEXT_, _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
+    * _TEXT_: _TEXT_.
+    * _TEXT_: _TEXT_-_TEXT_.
+    * _TEXT_: _TEXT_. 
+* _TEXT_/_TEXT_, _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
+    * _TEXT_: _TEXT_.
+    * _TEXT_: _TEXT_/_TEXT_.
+    * _TEXT_: _TEXT_.
+
+### _TEXT_/ _TEXT_
+
+_TEXT_“_TEXT_” _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![__TEXT__](___TEXT___TEXT___)
+</figure>
+
+_TEXT_“_TEXT_” _TEXT_“_TEXT_” _TEXT_.

--- a/confluence-mdx/tests/testcases/544178405/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544178405/expected.skel.mdx
@@ -1,0 +1,211 @@
+---
+title: '_TEXT_'
+---
+
+# _TEXT_
+
+### _TEXT_.
+
+_TEXT_, _TEXT_, _TEXT_. _TEXT_.
+
+_TEXT_. _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_. _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![__TEXT__](___TEXT___TEXT___)
+<figcaption>
+_TEXT_
+</figcaption>
+</figure>
+
+
+### _TEXT_?
+
+_TEXT_, _TEXT_, _TEXT_. _TEXT_, _TEXT_, _TEXT_.
+
+<table data-table-width="760" data-layout="default" local-id="96d34ea4-8772-49af-9ba2-14ea36b1f3e1">
+<colgroup>
+<col/>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+</th>
+<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+**__TEXT__**
+</th>
+<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+**__TEXT__**
+</th>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<th>
+**__TEXT__**
+</th>
+<td>
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_/_TEXT_) 
+    * _TEXT_, _TEXT_, _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<th>
+**__TEXT__**
+</th>
+<td>
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_/_TEXT_) 
+    * _TEXT_, _TEXT_, _TEXT_
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_/_TEXT_-_TEXT_) 
+    * _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<th>
+**__TEXT__**
+</th>
+<td>
+* _TEXT_
+    * [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_)
+    * [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_)
+    * [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_-_TEXT_)
+* _TEXT_
+    * [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_)
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_/_TEXT_) 
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<th>
+**__TEXT__**
+</th>
+<td>
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_/_TEXT_)
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<th>
+**__TEXT__**
+</th>
+<td>
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_/_TEXT_-_TEXT_)
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<th>
+**__TEXT__**
+</th>
+<td>
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_/_TEXT_)
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_/_TEXT_)
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<th>
+**__TEXT__**
+</th>
+<td>
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_/_TEXT_)
+</td>
+</tr>
+</tbody>
+</table>
+
+
+### _TEXT_, _TEXT_. _TEXT_?
+
+_TEXT_. _TEXT_. _TEXT_/_TEXT_. _TEXT_.
+
+<table data-table-width="760" data-layout="default" local-id="1c770267-da7f-48dc-b1e3-817744eeec38">
+<colgroup>
+<col/>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+</th>
+<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+**__TEXT__**
+</th>
+<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+**__TEXT__**
+</th>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<th>
+**__TEXT__**
+</th>
+<td>
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_)
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_)
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_)
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_)
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<th>
+**__TEXT__**
+</th>
+<td>
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_)
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_)
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<th>
+**__TEXT__**
+</th>
+<td>
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_)
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_)
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<th>
+**__TEXT__**
+</th>
+<td>
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_)
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_)
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_)
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_)
+</td>
+</tr>
+</tbody>
+</table>
+
+
+

--- a/confluence-mdx/tests/testcases/544211126/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544211126/expected.skel.mdx
@@ -1,0 +1,123 @@
+---
+title: '_TEXT_'
+---
+
+# _TEXT_
+
+### _TEXT_.
+
+_TEXT_(_TEXT_, _TEXT_, _TEXT_)_TEXT_, _TEXT_.
+
+
+### _TEXT_?
+
+_TEXT_. _TEXT_.
+
+<table data-table-width="760" data-layout="default" local-id="c53b8e8a-3f68-476f-aa0a-03f2f0eb700f">
+<colgroup>
+<col/>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+</th>
+<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+**__TEXT__**
+</th>
+<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+**__TEXT__**
+</th>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+**__TEXT__**
+</th>
+<td>
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_-_TEXT_#_TEXT_-_TEXT_%_TEXT_%_TEXT_%_TEXT_-%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_) 
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+**__TEXT__**
+</th>
+<td>
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_-_TEXT_#%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_-%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_) 
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+**__TEXT__**
+</th>
+<td>
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_)
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_)
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_)
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_-_TEXT_-_TEXT_)
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_-_TEXT_)
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_)
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_)
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_)
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_)
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_-_TEXT_)
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+**__TEXT__**
+</th>
+<td>
+* _TEXT_
+    * [__TEXT__](_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_-_TEXT_-_TEXT_)
+    * [__TEXT__](_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_)
+    * [__TEXT__](_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_-_TEXT_-_TEXT_)
+* _TEXT_
+    * [__TEXT__](_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_-_TEXT_) 
+    * [__TEXT__](_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_)
+    * [__TEXT__](_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_)
+* _TEXT_
+    * [__TEXT__](_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_-_TEXT_)
+* _TEXT_
+    * [__TEXT__](_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_-_TEXT_-_TEXT_-_TEXT_)
+    * [__TEXT__](_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_-_TEXT_)
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+**__TEXT__**
+</th>
+<td>
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_-_TEXT_)
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+**__TEXT__**
+</th>
+<td>
+* [__TEXT__](_TEXT_-_TEXT_/_TEXT_)
+</td>
+</tr>
+</tbody>
+</table>
+
+

--- a/confluence-mdx/tests/testcases/544375741/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544375741/expected.skel.mdx
@@ -1,0 +1,152 @@
+---
+title: '_TEXT_'
+---
+
+# _TEXT_(_TEXT_. _TEXT_. _TEXT_> _TEXT_. _TEXT_. _TEXT_)
+
+---
+
+## API Docs Json File
+
+: _TEXT_
+: _TEXT_
+---
+
+## _TEXT_. _TEXT_
+
+#### (_TEXT_) _TEXT_
+
+##### _TEXT_
+
+* _TEXT_
+
+##### _TEXT_
+
+<table data-table-width="760" data-layout="default" local-id="729f4860-908e-453e-a2ce-586ef92bde21">
+<colgroup>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+</tr>
+<tr>
+<td>
+
+</td>
+<td>
+* _TEXT_
+</td>
+</tr>
+</tbody>
+</table>
+
+*  **__TEXT__**  _TEXT_**__TEXT__** _TEXT_.
+---
+
+## 2. Approval API
+
+#### (GET) List
+
+##### Request
+
+* 변경점 없음
+
+##### Response
+
+<table data-table-width="760" data-layout="default" local-id="d1aedf57-9c7c-4ffd-abf3-d1381144dd7d">
+<colgroup>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**변경 전**
+</th>
+<th>
+**변경 후**
+</th>
+</tr>
+<tr>
+<td>
+
+</td>
+<td>
+* id
+</td>
+</tr>
+</tbody>
+</table>
+
+*  **id**  가  **추가** 되었습니다.
+---
+
+## _TEXT_. _TEXT_
+
+#### (_TEXT_) _TEXT_
+
+`___TEXT___TEXT___TEXT___`
+
+##### _TEXT_
+
+* _TEXT_
+* /_TEXT_/_TEXT_**__TEXT__**  _TEXT_.
+
+##### _TEXT_
+
+* /_TEXT_/_TEXT_**__TEXT__**  _TEXT_.
+---
+
+## 4. Notification Channels API
+
+#### (GET) List
+
+`/api/external/notification-channels`
+
+##### Request
+
+* Query Parameter
+
+<table data-table-width="760" data-layout="default" local-id="a8579e9b-bf3a-44ef-8dbe-bef487c68840">
+<colgroup>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**변경 전**
+</th>
+<th>
+**변경 후**
+</th>
+</tr>
+<tr>
+<td>
+* dataFlowRequest.filterKey
+* dataFlowRequest.filterValue
+* dataFlowRequest.sortKey
+* dataFlowRequest.sortType
+</td>
+<td>
+* filterKey
+* filterValue
+* sortKey
+* sortType
+</td>
+</tr>
+</tbody>
+</table>
+
+*  **이름** 이  **변경** 되었습니다.
+
+##### Response
+
+* 변경점 없음

--- a/confluence-mdx/tests/testcases/544377869/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544377869/expected.skel.mdx
@@ -1,0 +1,54 @@
+---
+title: '_TEXT_'
+---
+
+import { Callout } from 'nextra/components'
+
+# _TEXT_
+
+### _TEXT_
+
+_TEXT_. _TEXT_, _TEXT_/_TEXT_. _TEXT_, _TEXT_, _TEXT_. _TEXT_, _TEXT_, _TEXT_, _TEXT_, _TEXT_, _TEXT_, _TEXT_, _TEXT_.
+
+
+### _TEXT_
+
+_TEXT_. _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+1. _TEXT_.
+2. _TEXT_.
+3. _TEXT_.
+4. `___TEXT___TEXT___TEXT___` _TEXT_.
+5. _TEXT_.
+    1.  **__TEXT__** : _TEXT_/ _TEXT_. _TEXT_.
+    _TEXT_.  **__TEXT__**  : _TEXT_/ _TEXT_. _TEXT_. <br/> ※ _TEXT_/ _TEXT_, _TEXT_.
+6.  **__TEXT__**  : _TEXT_.
+
+_TEXT_. _TEXT_, _TEXT_.
+
+
+### _TEXT_
+
+<Callout type="info">
+_TEXT_. _TEXT_. _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_. _TEXT_. _TEXT_. _TEXT_[__TEXT__](../../_TEXT_-_TEXT_/_TEXT_/_TEXT_/_TEXT_-_TEXT_) _TEXT_.
+</Callout>
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+1. _TEXT_.
+2. _TEXT_.
+3. _TEXT_, _TEXT_`___TEXT___TEXT___TEXT___`_TEXT_.
+
+

--- a/confluence-mdx/tests/testcases/544379140/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544379140/expected.skel.mdx
@@ -1,0 +1,181 @@
+---
+title: '_TEXT_'
+---
+
+import { Callout } from 'nextra/components'
+
+# _TEXT_
+
+### _TEXT_
+
+_TEXT_. _TEXT_. _TEXT_. _TEXT_, _TEXT_.
+
+<Callout type="important">
+_TEXT_, _TEXT_‘_TEXT_’ _TEXT_. _TEXT_. _TEXT_.
+</Callout>
+
+<Callout type="important">
+**__TEXT__**
+1. _TEXT_[__TEXT__]
+2. _TEXT_[__TEXT__]
+3. _TEXT_[__TEXT__]
+4. _TEXT_[__TEXT__]
+5. _TEXT_[__TEXT__]
+6. _TEXT_[__TEXT__]
+7. _TEXT_[__TEXT__]
+8. _TEXT_[__TEXT__]
+9. _TEXT_[__TEXT__]
+10. _TEXT_[__TEXT__]
+11. _TEXT_[__TEXT__]
+12. _TEXT_[__TEXT__]
+13. _TEXT_[__TEXT__]
+14. _TEXT_[__TEXT__]
+15. _TEXT_[__TEXT__]
+16. _TEXT_[__TEXT__]
+17. _TEXT_[__TEXT__]
+18. _TEXT_[__TEXT__]
+19. _TEXT_[__TEXT__]
+20. _TEXT_[__TEXT__]
+21. _TEXT_[__TEXT__]
+22. _TEXT_[__TEXT__] **__TEXT__** 
+23. _TEXT_[__TEXT__] **__TEXT__** 
+24. _TEXT_[__TEXT__] **__TEXT__** 
+25. _TEXT_[__TEXT__] **__TEXT__** 
+26. _TEXT_[__TEXT__] **__TEXT__**
+27. _TEXT_[__TEXT__] **__TEXT__**
+28. _TEXT_[__TEXT__] **__TEXT__**
+29. _TEXT_[__TEXT__] **__TEXT__**
+30. _TEXT_[__TEXT__] **__TEXT__** 
+31. _TEXT_[__TEXT__] **__TEXT__** 
+32. _TEXT_[__TEXT__] **__TEXT__** 
+</Callout>
+
+
+### _TEXT_
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+1. _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_.
+2. _TEXT_.
+3. _TEXT_.
+    *  **__TEXT__**  : _TEXT_.
+    *  **__TEXT__**  : _TEXT_, _TEXT_. (_TEXT_, _TEXT_.)
+    *  **__TEXT__**  : _TEXT_. _TEXT_.
+
+### _TEXT_
+
+_TEXT_. (_TEXT_) _TEXT_→ (_TEXT_) _TEXT_→ (_TEXT_) _TEXT_→ (_TEXT_) _TEXT_
+
+_TEXT_‘_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_. _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+1.  **__TEXT__** : _TEXT_.
+2.  **__TEXT__** : _TEXT_. 
+    1. _TEXT_.
+    2. _TEXT_.
+3.  **__TEXT__** : _TEXT_. (_TEXT_. _TEXT_. _TEXT_, _TEXT_. _TEXT_**__TEXT__** _TEXT_.) 
+4.  **__TEXT__**  : _TEXT_, _TEXT_.
+    1. _TEXT_- _TEXT_, _TEXT_. _TEXT_.
+    2. _TEXT_- _TEXT_, _TEXT_.
+5.  **__TEXT__**  : _TEXT_.
+6.  **__TEXT__** : _TEXT_. _TEXT_. _TEXT_. _TEXT_. 
+7.  **__TEXT__**  : _TEXT_. 
+    1. _TEXT_‘ **__TEXT__** ’_TEXT_.
+8.  **__TEXT__** : _TEXT_. 
+    1. _TEXT_.
+    2. _TEXT_‘_TEXT_’_TEXT_.
+9. `___TEXT___TEXT___TEXT___` _TEXT_: _TEXT_. 
+
+<Callout type="info">
+**__TEXT__**
+_TEXT_, _TEXT_.
+</Callout>
+
+<Callout type="important">
+**__TEXT__**
+
+(_TEXT_) _TEXT_'_TEXT_'_TEXT_.<br/>
+
+(_TEXT_) _TEXT_.
+
+- _TEXT_
+
+_TEXT_: `___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___`<br/>_TEXT_: `___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___`_TEXT_``
+
+- _TEXT_
+
+_TEXT_: `___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___`<br/>_TEXT_: `___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___`
+
+- _TEXT_
+
+_TEXT_: `___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___`<br/>_TEXT_: `___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___`
+
+- _TEXT_
+
+_TEXT_: `___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___`
+
+
+(_TEXT_) _TEXT_.
+
+- _TEXT_: `___TEXT___TEXT___TEXT___` _TEXT_.
+
+- _TEXT_: `___TEXT___TEXT___TEXT___` _TEXT_.
+
+- _TEXT_: _TEXT_(`___TEXT___TEXT___TEXT___`)_TEXT_.
+
+
+(_TEXT_) _TEXT_
+
+- _TEXT_: `___TEXT___TEXT___TEXT___`
+
+- _TEXT_: `___TEXT___TEXT___TEXT___`
+
+- _TEXT_: `___TEXT___TEXT___TEXT___`
+
+- _TEXT_: `___TEXT___TEXT___TEXT___`
+</Callout>
+
+
+<Callout type="important">
+**__TEXT__**
+
+_TEXT_‘_TEXT_’ _TEXT_. _TEXT_.
+
+1. _TEXT_(_TEXT_, _TEXT_)_TEXT_.
+2. _TEXT_. 
+3. _TEXT_.
+</Callout>
+
+
+### _TEXT_
+
+_TEXT_. _TEXT_.
+
+_TEXT_.
+
+1. _TEXT_: _TEXT_.
+2. _TEXT_: _TEXT_, _TEXT_.
+
+<Callout type="important">
+**__TEXT__**
+
+_TEXT_‘*__TEXT__*. _TEXT_*. _TEXT_’_TEXT_.
+
+_TEXT_‘_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_‘_TEXT_’_TEXT_.
+</Callout>
+
+
+### _TEXT_
+
+_TEXT_, _TEXT_. _TEXT_. _TEXT_, _TEXT_.

--- a/confluence-mdx/tests/testcases/544381877/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544381877/expected.skel.mdx
@@ -1,0 +1,81 @@
+---
+title: '_TEXT_'
+---
+
+# _TEXT_
+
+### _TEXT_
+
+_TEXT_.
+
+
+### _TEXT_
+
+_TEXT_.
+
+<figure data-layout="center" data-align="center">
+![__TEXT__](___TEXT___TEXT___)
+</figure>
+
+1. _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_.
+2. _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
+3.  **__TEXT__**  : _TEXT_
+    1.  **__TEXT__**  : _TEXT_. (_TEXT_) 
+        * _TEXT_. 
+    2.  **__TEXT__**  : _TEXT_. (_TEXT_) 
+        * _TEXT_. 
+    3.  **__TEXT__**  : _TEXT_. 
+    4. 
+    5.  **__TEXT__**  : _TEXT_. _TEXT_.
+        1.  **__TEXT__**  : _TEXT_. 
+        2.  **__TEXT__**  : _TEXT_.
+        3.  **__TEXT__**  : _TEXT_. _TEXT_. _TEXT_.
+            * : _TEXT___TEXT___TEXT__**  : _TEXT_. 
+            * : _TEXT___TEXT___TEXT__**  : _TEXT_, _TEXT_. 
+    6.  **__TEXT__**  : _TEXT_. 
+        1.  **__TEXT__**  : _TEXT_, _TEXT_`___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___`_TEXT_, 
+            1. _TEXT_. 
+            2. _TEXT_. 
+        2.  **__TEXT__**  : _TEXT_. _TEXT_. 
+            1. _TEXT_: 
+                1. `___TEXT___TEXT___TEXT___` 
+                2. `___TEXT___TEXT___TEXT___` 
+                3. `___TEXT___TEXT___TEXT___` 
+                4. `___TEXT___TEXT___TEXT___`
+                5. `___TEXT___TEXT___TEXT___`
+                6. `___TEXT___TEXT___TEXT___`
+                7. `___TEXT___TEXT___TEXT___`
+                8. `___TEXT___TEXT___TEXT___`
+            2. ✅ _TEXT_: _TEXT_. 
+        3.  **__TEXT__**  : _TEXT_, _TEXT_`___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___`_TEXT_: 
+            1. _TEXT_`___TEXT___TEXT___TEXT___`_TEXT_. 
+            2. _TEXT_:
+                1. `___TEXT___TEXT___TEXT___`
+                2. `___TEXT___TEXT___TEXT___`
+4.  **__TEXT__**  : _TEXT_. (_TEXT_, _TEXT_.) `___TEXT___TEXT___TEXT___` _TEXT_-_TEXT_. 
+    1.  **__TEXT__**  : _TEXT_. 
+        1. _TEXT_, _TEXT_. 
+        2. _TEXT_. 
+    2.  **__TEXT__**  : _TEXT_.
+5. _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_. 
+
+
+### _TEXT_
+
+<figure data-layout="center" data-align="center">
+![__TEXT__](___TEXT___TEXT___)
+</figure>
+
+* _TEXT_.
+* _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_“_TEXT_”_TEXT_. 
+<details>
+<summary>_TEXT___TEXT___TEXT_. _TEXT_</summary>
+```
+___TEXT___TEXT___TEXT___
+```
+</details>
+
+* _TEXT_. 
+  ```
+___TEXT___TEXT___TEXT___
+```

--- a/confluence-mdx/tests/testcases/544384417/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544384417/expected.skel.mdx
@@ -1,0 +1,853 @@
+---
+title: '_TEXT_'
+---
+
+import { Callout } from 'nextra/components'
+
+# _TEXT_
+
+<Callout type="important">
+_TEXT_. _TEXT_. _TEXT_.
+</Callout>
+
+### _TEXT_
+
+_TEXT_.
+
+_TEXT_, _TEXT_, _TEXT_/_TEXT_, _TEXT_/_TEXT_/_TEXT_.
+
+<Callout type="info">
+_TEXT_. _TEXT_. _TEXT_.
+</Callout>
+
+### _TEXT_
+
+_TEXT_. _TEXT_. _TEXT_.
+
+<table data-table-width="958" data-layout="center" local-id="cfcbf091-3775-4454-bff4-924bf43e88f4">
+<a id="table-1"></a>
+<colgroup>
+<col/>
+<col/>
+<col/>
+<col/>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+</tr>
+<tr>
+<td rowspan="12">
+_TEXT_
+</td>
+<td rowspan="5">
+_TEXT_
+</td>
+<td>
+_TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+* _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_<br/>_TEXT_/_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_**__TEXT__**<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_**__TEXT__**<br/>_TEXT_/_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td rowspan="3">
+_TEXT_
+</td>
+<td>
+_TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_<br/>_TEXT_/_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td rowspan="2">
+_TEXT_
+</td>
+<td>
+_TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td rowspan="2">
+_TEXT_
+</td>
+<td>
+_TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_**__TEXT__**<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td rowspan="8">
+_TEXT_
+</td>
+<td rowspan="2">
+_TEXT_**__TEXT__**
+</td>
+<td>
+_TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_<br/>_TEXT_/_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td rowspan="2">
+_TEXT_
+</td>
+<td>
+_TEXT_- _TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_<br/>_TEXT_/_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td rowspan="2">
+_TEXT_& _TEXT_
+</td>
+<td>
+_TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+* _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td rowspan="2">
+_TEXT_- _TEXT_**__TEXT__**
+</td>
+<td>
+_TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_**__TEXT__**
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td rowspan="20">
+_TEXT_
+</td>
+<td rowspan="2">
+_TEXT_<br/>**__TEXT__**
+</td>
+<td>
+_TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_<br/>_TEXT_/_TEXT_/_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td rowspan="2">
+_TEXT_**__TEXT__**
+</td>
+<td>
+_TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_<br/>_TEXT_/_TEXT_/_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td rowspan="2">
+_TEXT_& _TEXT_**__TEXT__**
+</td>
+<td>
+_TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td rowspan="7">
+_TEXT_
+</td>
+<td>
+_TEXT_/_TEXT_**__TEXT__**<br/>_TEXT_/_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+*__TEXT__* **__TEXT__**<br/> *__TEXT__*
+</td>
+<td>
+*__TEXT__*
+</td>
+<td>
+*__TEXT__*
+</td>
+<td>
+*__TEXT__*
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_-_TEXT_**__TEXT__**<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_**__TEXT__**<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_& _TEXT_**__TEXT__**<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_/_TEXT_<br/>_TEXT_/_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td rowspan="6">
+_TEXT_
+</td>
+<td>
+_TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+* _TEXT_
+* _TEXT_
+* _TEXT_
+* _TEXT_
+
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+* _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_/_TEXT_<br/>_TEXT_/_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+* _TEXT_
+
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_- _TEXT_<br/>**__TEXT__**
+</td>
+<td>
+_TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+</tbody>
+</table>
+
+### _TEXT_
+
+_TEXT____TEXT___TEXT___TEXT___ _TEXT_.
+
+<Callout type="info">
+_TEXT_.
+</Callout>
+
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+
+1.  **__TEXT__**  : _TEXT_.
+2.  **__TEXT__**  : _TEXT_.
+3.  **__TEXT__**  : _TEXT_.
+4.  **__TEXT__**  : _TEXT_, _TEXT_.
+    1. _TEXT_
+    2. _TEXT_
+    3. _TEXT_
+5.  **__TEXT__**  : _TEXT_.
+6.  **__TEXT__**  : _TEXT_, _TEXT_.
+    1. _TEXT_: _TEXT_(_TEXT_)
+    2. _TEXT_: _TEXT_
+    3. _TEXT_: _TEXT_
+    4. _TEXT_: _TEXT_
+    5. _TEXT_: _TEXT_
+7.  **__TEXT__**  : _TEXT_.
+8.  **__TEXT__**  : _TEXT_.
+9.  **__TEXT__**  : _TEXT_. (_TEXT_)
+10.  **__TEXT__**  : _TEXT_. _TEXT_.
+    1. _TEXT_: _TEXT_
+    2. _TEXT_: _TEXT_
+    3. _TEXT_: _TEXT_
+11.  **__TEXT__**  : _TEXT_, _TEXT_.
+    1. _TEXT_, _TEXT_.
+    2. _TEXT_.
+    3. _TEXT_, _TEXT_. _TEXT_.
+
+### _TEXT_
+
+_TEXT_, _TEXT_.
+
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+
+1.  **__TEXT__**  : _TEXT_, _TEXT_.
+    1. _TEXT_, _TEXT_.
+2.  **__TEXT__**  : _TEXT_. (_TEXT_, _TEXT_, _TEXT_) 
+    1. _TEXT_.
+3.  **__TEXT__**  : _TEXT_. (_TEXT_, _TEXT_, _TEXT_, _TEXT_)
+4.  **__TEXT__**  : _TEXT_.
+5.  **__TEXT__**  : _TEXT_.
+6.  **__TEXT__**  : _TEXT_. (_TEXT_)
+7.  **__TEXT__**  : _TEXT_.
+8.  **__TEXT__**  : _TEXT_.
+9.  **__TEXT__**  : _TEXT_. 
+    1. _TEXT_. : _TEXT_
+    2. _TEXT_: _TEXT_
+    3. _TEXT_: _TEXT_(_TEXT_)_TEXT_
+    4. _TEXT_: _TEXT_(_TEXT_, _TEXT_)
+    5. _TEXT_: _TEXT_
+        * _TEXT_, _TEXT_.
+        * _TEXT_.
+        * _TEXT_, _TEXT_. _TEXT_.
+10.  **__TEXT__**  : _TEXT_.
+    1. _TEXT_: _TEXT_
+    2. _TEXT_: _TEXT_(_TEXT_, _TEXT_)
+    3. _TEXT_. : _TEXT_(_TEXT_)
+    4. _TEXT_: _TEXT_
+
+### _TEXT_
+
+_TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
+
+_TEXT_, _TEXT_, _TEXT_, _TEXT_. `___TEXT___TEXT___TEXT___` _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+1.  **__TEXT__**  : _TEXT_.
+2.  **__TEXT__**  : _TEXT_. (_TEXT_, _TEXT_, _TEXT_)
+3.  **__TEXT__**  : _TEXT_.
+    1. _TEXT_: _TEXT_.
+    2. _TEXT_: _TEXT_.
+    3. _TEXT_: _TEXT_.
+    4. _TEXT_: _TEXT_.
+    5. _TEXT_: _TEXT_.
+4.  **__TEXT__**  : _TEXT_
+    1. `___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_, _TEXT_.
+    2. _TEXT_.
+    3. _TEXT_: _TEXT_.
+        1.  `___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_.
+5.  **__TEXT__**  : _TEXT_
+    1. `___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_, _TEXT_.
+6.  **__TEXT__**  : _TEXT_
+    1. _TEXT_, _TEXT_.
+    2. _TEXT_: _TEXT_
+    3. _TEXT_: _TEXT_
+7.  **__TEXT__**  : _TEXT_
+    1. _TEXT_.
+    2. _TEXT_
+
+_TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
+
+`___TEXT___TEXT___TEXT___` _TEXT_.
+
+### _TEXT_**__TEXT__**
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_- _TEXT_
+</figcaption>
+</figure>
+
+_TEXT_: _TEXT_: `___TEXT___TEXT___TEXT___` _TEXT_, _TEXT_.
+
+_TEXT_.
+
+*  **__TEXT__**  - _TEXT_
+*  **__TEXT__**  - _TEXT_
+*  **__TEXT__**  - _TEXT_
+    * _TEXT_, _TEXT_, _TEXT_
+*  **__TEXT__**  - _TEXT_
+*  **__TEXT__**  - _TEXT_
+    * _TEXT_, _TEXT_, _TEXT_, _TEXT_
+
+### _TEXT_
+
+_TEXT_.
+
+1.  **__TEXT__**  : _TEXT_.
+    1. _TEXT_: _TEXT_
+        * _TEXT_: _TEXT_
+        * _TEXT_: _TEXT_- _TEXT_
+        * _TEXT____TEXT___TEXT___TEXT___ _TEXT_/_TEXT_: _TEXT_(_TEXT_)
+2.  **__TEXT__**  : _TEXT_.
+    1. _TEXT_: `___TEXT___TEXT___TEXT___` _TEXT_
+        * _TEXT_: _TEXT_
+        * _TEXT_: _TEXT_- _TEXT_
+        * _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___`
+    2. _TEXT_, _TEXT_.
+        * _TEXT_.
+        * _TEXT_.
+    3. _TEXT_. _TEXT_.
+3.  **__TEXT__** _TEXT_.
+    1. _TEXT_: _TEXT_, _TEXT_, _TEXT_, _TEXT_
+4.  **__TEXT__**  : _TEXT_.
+    1. _TEXT_.
+    2. _TEXT_. _TEXT_, _TEXT_.
+5.  **__TEXT__**  : _TEXT_.
+    1. _TEXT_: _TEXT_, _TEXT_
+6.  **__TEXT__**  : _TEXT_(_TEXT_)_TEXT_.
+    1. _TEXT_: _TEXT_, _TEXT_
+7.  **__TEXT__**  : _TEXT_.
+    1. _TEXT_.
+8.  **__TEXT__**  : _TEXT_.
+    1. _TEXT_.
+    2. _TEXT_. (_TEXT_)
+    3. _TEXT_.
+    4. _TEXT_.

--- a/confluence-mdx/tests/testcases/568918170/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/568918170/expected.skel.mdx
@@ -1,0 +1,127 @@
+---
+title: '_TEXT_'
+---
+
+import { Callout } from 'nextra/components'
+
+# _TEXT_(_TEXT_, _TEXT_)
+
+### _TEXT_
+
+_TEXT_.
+
+
+### _TEXT_
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+1. _TEXT____TEXT___TEXT___TEXT___ _TEXT_. 
+    1. _TEXT_(_TEXT_/_TEXT_) _TEXT_. 
+    2. _TEXT_**__TEXT__**  _TEXT_`___TEXT___TEXT___TEXT___`_TEXT_. 
+2. _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_. 
+3. _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_. 
+4. _TEXT_**__TEXT__** _TEXT_.
+
+
+
+### _TEXT_
+
+_TEXT_. _TEXT_.
+
+#### _TEXT_. _TEXT_
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+*  **__TEXT__**  : _TEXT_
+*  **__TEXT__**  : _TEXT_
+*  **__TEXT__**  : _TEXT_
+*  **__TEXT__**  : _TEXT_
+*  **__TEXT__**  : `___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_.
+
+#### _TEXT_. _TEXT_
+
+_TEXT_.
+<figure data-layout="center" data-align="center">
+![__TEXT__](___TEXT___TEXT___)
+<figcaption>
+_TEXT_
+</figcaption>
+</figure>
+<figure data-layout="center" data-align="center">
+![__TEXT__](___TEXT___TEXT___)
+<figcaption>
+_TEXT_
+</figcaption>
+</figure>
+<Callout type="info">
+_TEXT_. _TEXT_.
+</Callout>
+
+#### _TEXT_. _TEXT_
+
+* _TEXT_, _TEXT_. 
+    *  **__TEXT__**  : _TEXT_(_TEXT_
+    *  **__TEXT__**  : _TEXT_.
+* _TEXT_, _TEXT_. 
+
+<figure data-layout="center" data-align="center">
+![__TEXT__](___TEXT___TEXT___)
+</figure>
+
+#### _TEXT_. _TEXT_
+
+* _TEXT_. 
+**__TEXT__**
+<figure data-layout="center" data-align="center">
+![__TEXT__](___TEXT___TEXT___)
+<figcaption>
+_TEXT_
+</figcaption>
+</figure>
+**__TEXT__**
+<figure data-layout="center" data-align="center">
+![__TEXT__](___TEXT___TEXT___)
+<figcaption>
+_TEXT_
+</figcaption>
+</figure>
+<Callout type="info">
+_TEXT_, _TEXT_. _TEXT_[__TEXT__](../../_TEXT_-_TEXT_/_TEXT_/_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_-_TEXT_-_TEXT_) _TEXT_.
+</Callout>
+
+#### _TEXT_. _TEXT_
+
+* _TEXT____TEXT___TEXT___TEXT___ _TEXT_, _TEXT_. _TEXT_. 
+
+
+### _TEXT_
+
+_TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+<figcaption>
+_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+</figcaption>
+</figure>
+
+1. _TEXT____TEXT___TEXT___TEXT___ _TEXT_. 
+
+<Callout type="info">
+_TEXT_(_TEXT_, _TEXT_, _TEXT_, _TEXT_)_TEXT_*__TEXT__* _TEXT_, _TEXT_.
+</Callout>
+
+1. _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_. 
+2. _TEXT_. 
+3. `___TEXT___TEXT___TEXT___` _TEXT_.
+4. _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_.

--- a/confluence-mdx/tests/testcases/692355151/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/692355151/expected.skel.mdx
@@ -1,0 +1,92 @@
+---
+title: '_TEXT_'
+---
+
+import { Callout } from 'nextra/components'
+
+# _TEXT_(_TEXT_) _TEXT_
+
+<Callout type="info">
+_TEXT_. _TEXT_. _TEXT_. (_TEXT_. _TEXT_. _TEXT_.)
+_TEXT_. _TEXT_. _TEXT_. _TEXT_.
+</Callout>
+
+### _TEXT_
+
+_TEXT_(_TEXT_)_TEXT_. _TEXT_.
+
+<Callout type="info">
+_TEXT_?<br/>_TEXT_. _TEXT_.
+</Callout>
+
+### _TEXT_(_TEXT_) _TEXT_
+
+_TEXT_. (_TEXT_: [__TEXT__](.))
+
+_TEXT_. _TEXT_<br/>_TEXT_. 
+
+<Callout type="important">
+_TEXT_“_TEXT_”_TEXT_. “_TEXT_”_TEXT_(_TEXT_)_TEXT_.
+</Callout>
+
+<figure data-layout="center" data-align="center">
+![__TEXT__](___TEXT___TEXT___)
+</figure>
+
+_TEXT_. _TEXT_(_TEXT_) _TEXT_<br/>_TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
+    1.  **__TEXT__**  : _TEXT_. (_TEXT_. _TEXT_.) 
+    2. _TEXT_
+        1.  **__TEXT__**  : _TEXT_.
+        2.  **__TEXT__**  : _TEXT_. 
+
+<figure data-layout="center" data-align="center">
+![__TEXT__](___TEXT___TEXT___)
+</figure>
+
+<Callout type="important">
+* _TEXT_(_TEXT_)_TEXT_. 
+* _TEXT_. _TEXT_. _TEXT_. _TEXT_.
+<figure data-layout="center" data-align="center">
+![__TEXT__](___TEXT___TEXT___)
+</figure>
+</Callout>
+
+1. _TEXT_(_TEXT_) _TEXT_
+    _TEXT_. _TEXT_<br/>_TEXT_. _TEXT_.<br/> <br/>  
+      <figure data-layout="center" data-align="center">
+      ![__TEXT__](___TEXT___TEXT___)
+      </figure>
+    _TEXT_. _TEXT_<br/>_TEXT_. `___TEXT___TEXT___TEXT___` _TEXT_.<br/> <br/>  <br/> <br/>  <br/>_TEXT_(_TEXT_)_TEXT_.
+      <figure data-layout="center" data-align="center">
+      ![`___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+      <figcaption>
+      `___TEXT___TEXT___TEXT___`_TEXT_.
+      </figcaption>
+      </figure>
+      <figure data-layout="center" data-align="center">
+      ![__TEXT__](___TEXT___TEXT___)
+      <figcaption>
+      _TEXT_.
+      </figcaption>
+      </figure>
+
+### _TEXT_
+
+_TEXT_. _TEXT_(_TEXT_)_TEXT_(_TEXT_)_TEXT_<br/>_TEXT_(_TEXT_)_TEXT_.
+  <figure data-layout="center" data-align="center">
+  ![__TEXT__](___TEXT___TEXT___)
+  </figure>
+
+<Callout type="important">
+_TEXT_(_TEXT_) _TEXT_. _TEXT_, _TEXT_.
+</Callout>
+
+_TEXT_. _TEXT_(_TEXT_)_TEXT_<br/>_TEXT_. 
+
+|  **__TEXT__**  |  **__TEXT__**                         |
+| -------------------- | ------------------------------------------- |
+| _TEXT_| _TEXT_, _TEXT_, _TEXT_, _TEXT_, _TEXT_|
+
+<Callout type="important">
+_TEXT___TEXT_, _TEXT_(_TEXT_) _TEXT_.
+</Callout>

--- a/confluence-mdx/tests/testcases/793608206/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/793608206/expected.skel.mdx
@@ -1,0 +1,1540 @@
+---
+title: '_TEXT_'
+---
+
+# _TEXT_> _TEXT_
+
+_TEXT_, _TEXT_.
+
+### _TEXT_
+
+_TEXT_.
+
+_TEXT_.
+
+<table data-table-width="811" data-layout="center" local-id="c749b9ca-9033-4c2b-b8fa-3880ad5a8736">
+<colgroup>
+<col/>
+<col/>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+* _TEXT_: _TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+* _TEXT_: _TEXT_(_TEXT_), _TEXT_(_TEXT_), _TEXT_(_TEXT_)
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+* _TEXT_: _TEXT_.
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+* _TEXT_: _TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+* _TEXT_: [__TEXT__](_TEXT_: _TEXT_@_TEXT_. _TEXT_)
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+* _TEXT_
+* _TEXT_
+* _TEXT_
+* _TEXT_
+* _TEXT_
+* _TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+* _TEXT_: _TEXT_://`___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___`
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+* _TEXT_: _TEXT_-_TEXT_-_TEXT_-_TEXT_-_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+* _TEXT_: _TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+* _TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+</tbody>
+</table>
+
+### _TEXT_
+
+<table data-table-width="808" data-layout="center" local-id="ee62ec7d-c9f6-4e28-b56e-747b6443c26d">
+<colgroup>
+<col/>
+<col/>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+_TEXT_. _TEXT_. _TEXT_- _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+* _TEXT_:
+    * _TEXT_: _TEXT_/_TEXT_
+    * _TEXT_: _TEXT_-_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+</tbody>
+</table>
+
+### _TEXT_
+
+<table data-table-width="814" data-layout="center" local-id="65178aed-8861-4dee-943a-42d33ce617bf">
+<colgroup>
+<col/>
+<col/>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+* _TEXT_(_TEXT_, _TEXT_)
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+* _TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+_TEXT_. _TEXT_. _TEXT_- _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_/_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+_TEXT_. _TEXT_. _TEXT_- _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+</tbody>
+</table>
+
+### _TEXT_
+
+<table data-table-width="816" data-layout="center" local-id="a7dabd97-8ea6-4502-b876-197d927dd1dc">
+<colgroup>
+<col/>
+<col/>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+* _TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+* _TEXT_, _TEXT_
+* _TEXT_, _TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_/_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+</tbody>
+</table>
+
+### _TEXT_
+
+<table data-table-width="816" data-layout="center" local-id="212dceed-34bd-42c0-9cab-7b11a24950af">
+<colgroup>
+<col/>
+<col/>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+* _TEXT_: [__TEXT__]
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+* _TEXT_: 
+    * _TEXT_
+    * _TEXT_-_TEXT_-_TEXT_: _TEXT_: _TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+</tbody>
+</table>
+
+### _TEXT_
+
+<table data-table-width="816" data-layout="center" local-id="8d66df32-3ad9-473e-9876-a4c7fe8775e1">
+<colgroup>
+<col/>
+<col/>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+* _TEXT_: [__TEXT__]
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+* _TEXT_: 
+    * _TEXT_
+    * _TEXT_-_TEXT_-_TEXT_: _TEXT_: _TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+</tbody>
+</table>
+
+### _TEXT_
+
+<table data-table-width="816" data-layout="center" local-id="8fdf1d5c-786c-4147-8e56-bfd6d8dcdb0f">
+<colgroup>
+<col/>
+<col/>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+* _TEXT_: [__TEXT__]
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+* _TEXT_: 
+    * _TEXT_
+    * _TEXT_-_TEXT_-_TEXT_: _TEXT_: _TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+</tbody>
+</table>
+
+### _TEXT_
+
+<table data-table-width="820" data-layout="center" local-id="a4480e83-0193-4c46-ba7c-53a665a6ad03">
+<colgroup>
+<col/>
+<col/>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+* _TEXT_: 
+    * _TEXT_
+    * _TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+* _TEXT_: 
+    * _TEXT_
+    * _TEXT_-_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+_TEXT_. _TEXT_. _TEXT_- _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_(_TEXT_) _TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+</tbody>
+</table>
+
+### _TEXT_
+
+<table data-table-width="820" data-layout="center" local-id="1ac8db57-f53b-4306-9a63-eabe504365d4">
+<colgroup>
+<col/>
+<col/>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+* _TEXT_: 
+    * _TEXT_
+    * _TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+* _TEXT_: 
+    * _TEXT_
+    * _TEXT_-_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+_TEXT_. _TEXT_. _TEXT_- _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_(_TEXT_) _TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+</tbody>
+</table>
+
+### _TEXT_
+
+<table data-table-width="816" data-layout="center" local-id="e44f2beb-29c0-417c-b961-8a1b7946b510">
+<colgroup>
+<col/>
+<col/>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+<th>
+**__TEXT__**
+</th>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+* _TEXT_, _TEXT_, _TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+_TEXT_. _TEXT_. _TEXT_- _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`___TEXT___TEXT___TEXT___`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+</tbody>
+</table>
+
+### _TEXT_-_TEXT_-_TEXT_
+
+|  **__TEXT__**                 |  **__TEXT__**                      |  **__TEXT__**                        |  **__TEXT__**  |
+| ------------------------ | ---------------------------- | ------------------------------ | ----------- |
+| _TEXT_| `___TEXT___TEXT___TEXT___` | _TEXT_| _TEXT_. _TEXT_. _TEXT_|
+| _TEXT_| `___TEXT___TEXT___TEXT___`             | _TEXT_| _TEXT_. _TEXT_. _TEXT_|
+| _TEXT_| `___TEXT___TEXT___TEXT___`         | _TEXT_(_TEXT_) _TEXT_| _TEXT_. _TEXT_. _TEXT_|
+
+### _TEXT_
+
+|  **__TEXT__**                 |  **__TEXT__**                      |  **__TEXT__**  |  **__TEXT__**  |
+| ------------------------ | ---------------------------- | -------- | ----------- |
+| _TEXT_| `___TEXT___TEXT___TEXT___` | _TEXT_| _TEXT_. _TEXT_. _TEXT_|
+| _TEXT_| `___TEXT___TEXT___TEXT___`            | _TEXT_| _TEXT_. _TEXT_. _TEXT_|

--- a/confluence-mdx/tests/testcases/880181257/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/880181257/expected.skel.mdx
@@ -1,0 +1,75 @@
+---
+title: '_TEXT_'
+---
+
+import { Callout } from 'nextra/components'
+
+# _TEXT_
+
+#### _TEXT_
+
+1. _TEXT_.
+_TEXT_. _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_. <br/> 
+  <figure data-layout="center" data-align="center">
+  ![__TEXT__](___TEXT___TEXT___)
+  </figure>
+3. _TEXT_.
+4. _TEXT_'_TEXT_'_TEXT_.
+5. _TEXT_“-”_TEXT_. 
+_TEXT_. _TEXT_. <br/> 
+  <figure data-layout="center" data-align="center">
+  ![__TEXT__](___TEXT___TEXT___)
+  </figure>
+7. _TEXT_`___TEXT___TEXT___TEXT___`_TEXT_. 
+8. _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_.
+
+<Callout type="important">
+**__TEXT__**
+* _TEXT_. 
+* _TEXT_: "_TEXT_(_TEXT_. _TEXT_., _TEXT_, _TEXT_, _TEXT_). _TEXT_."
+* _TEXT_.
+</Callout>
+
+#### <br/>_TEXT_
+
+1.  **__TEXT__** 
+    * _TEXT_.
+    * _TEXT_. <br/> 
+      <figure data-layout="center" data-align="center">
+      ![__TEXT__](___TEXT___TEXT___)
+      </figure>
+2.  **__TEXT__** 
+    * _TEXT_.
+    * _TEXT_. <br/> 
+      <figure data-layout="center" data-align="center">
+      ![__TEXT__](___TEXT___TEXT___)
+      </figure>
+    * _TEXT_/_TEXT_, _TEXT_.
+    * _TEXT_"-"_TEXT_.
+3.  **__TEXT__** 
+    * _TEXT_.
+    *  **__TEXT__**  
+    * _TEXT_.
+      <figure data-layout="center" data-align="center">
+      ![__TEXT__](___TEXT___TEXT___)
+      </figure>
+
+<Callout type="important">
+**__TEXT__**
+* _TEXT_.
+</Callout>
+
+#### _TEXT_
+
+1.  **__TEXT__** 
+    * _TEXT_. 
+    * _TEXT_. <br/> 
+      <figure data-layout="center" data-align="center">
+      ![__TEXT__](___TEXT___TEXT___)
+      </figure>
+2.  **__TEXT__** 
+    * _TEXT_.
+    * _TEXT_.  <br/> "_TEXT_. _TEXT_."
+      <figure data-layout="center" data-align="center">
+      ![__TEXT__](___TEXT___TEXT___)
+      </figure>

--- a/confluence-mdx/tests/testcases/883654669/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/883654669/expected.skel.mdx
@@ -1,0 +1,144 @@
+---
+title: '_TEXT_'
+---
+
+import { Callout } from 'nextra/components'
+
+# _TEXT_
+
+### _TEXT_
+
+_TEXT_, _TEXT_.
+
+<Callout type="info">
+_TEXT_**__TEXT__** _TEXT_.
+_TEXT_. _TEXT_. _TEXT_[__TEXT__](___TEXT___TEXT___)_TEXT_.
+</Callout>
+
+#### _TEXT_
+
+* _TEXT_(_TEXT_)
+* _TEXT_
+
+### _TEXT_(_TEXT_)
+
+_TEXT_.
+
+
+_TEXT_. [__TEXT__](___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_.<br/> <br/> 
+  <figure data-layout="center" data-align="center">
+  ![__TEXT__](___TEXT___TEXT___)
+  </figure>
+_TEXT_. _TEXT_, _TEXT_. `___TEXT___TEXT___TEXT___` _TEXT_.<br/> <br/> 
+  <figure data-layout="center" data-align="center">
+  ![__TEXT__](___TEXT___TEXT___)
+  </figure>
+_TEXT_. _TEXT_.<br/> <br/> 
+  <figure data-layout="center" data-align="center">
+  ![__TEXT__](___TEXT___TEXT___)
+  </figure>
+_TEXT_. _TEXT_. <br/>_TEXT_.<br/>: _TEXT___TEXT___TEXT_: `___TEXT___TEXT___TEXT___` _TEXT_. <br/> 
+  ```
+___TEXT___TEXT___TEXT___
+```
+_TEXT_. _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.<br/> <br/> 
+  <figure data-layout="center" data-align="center">
+  ![__TEXT__](___TEXT___TEXT___)
+  </figure>
+
+### _TEXT_
+
+1. _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_. 
+_TEXT_. _TEXT_, `___TEXT___TEXT___TEXT___`_TEXT_. <br/> 
+  <figure data-layout="center" data-align="center">
+  ![__TEXT__](___TEXT___TEXT___)
+  </figure>
+3. _TEXT_.
+  <figure data-layout="center" data-align="center">
+  ![__TEXT__](___TEXT___TEXT___)
+  </figure>
+
+### _TEXT_
+
+_TEXT____TEXT___TEXT___TEXT___ _TEXT_& _TEXT_,  **__TEXT__**  _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![__TEXT__](___TEXT___TEXT___)
+</figure>
+
+
+### _TEXT_-_TEXT_
+
+<Callout type="info">
+_TEXT_, _TEXT_(_TEXT_-)_TEXT_.
+* _TEXT_(_TEXT_)_TEXT_/_TEXT_
+* _TEXT_(_TEXT_)_TEXT_, _TEXT_/_TEXT_
+</Callout>
+
+_TEXT_-_TEXT_.
+
+_TEXT_. _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_.<br/> <br/> 
+  <figure data-layout="center" data-align="center">
+  ![__TEXT__](___TEXT___TEXT___)
+  </figure>
+_TEXT_. _TEXT_-_TEXT_, _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.<br/> <br/> 
+  <figure data-layout="center" data-align="center">
+  ![__TEXT__](___TEXT___TEXT___)
+  </figure>
+3. _TEXT_-_TEXT_, _TEXT_. _TEXT_-_TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
+
+### _TEXT_
+
+_TEXT_. _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_.<br/> <br/> 
+  <figure data-layout="center" data-align="center">
+  ![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+  <figcaption>
+  _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+  </figcaption>
+  </figure>
+2. _TEXT_.
+3. _TEXT_. _TEXT_/_TEXT_.
+    *  **__TEXT__**  : _TEXT_
+    *  **__TEXT__**  : _TEXT_<br/> <br/> 
+      <figure data-layout="center" data-align="center">
+      ![__TEXT__](___TEXT___TEXT___)
+      <figcaption>
+      _TEXT_(_TEXT_) / _TEXT_(_TEXT_)
+      </figcaption>
+      </figure>
+4. `___TEXT___TEXT___TEXT___` _TEXT_.
+
+### _TEXT_
+
+_TEXT_. _TEXT_, _TEXT_.<br/> <br/> 
+  <figure data-layout="center" data-align="center">
+  ![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+  <figcaption>
+  _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+  </figcaption>
+  </figure>
+_TEXT_. `___TEXT___TEXT___TEXT___` _TEXT_.<br/>
+  <figure data-layout="center" data-align="center">
+  ![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+  <figcaption>
+  _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+  </figcaption>
+  </figure>
+
+
+### _TEXT_
+
+_TEXT_, _TEXT_.
+
+_TEXT_. _TEXT____TEXT___TEXT___TEXT___ _TEXT_, _TEXT_. _TEXT_, _TEXT_. <br/> 
+  <figure data-layout="center" data-align="center">
+  ![__TEXT__](___TEXT___TEXT___)
+  </figure>
+_TEXT_. _TEXT_.<br/> **__TEXT__**  _TEXT_, _TEXT_.<br/> <br/> 
+  <figure data-layout="center" data-align="center">
+  ![__TEXT__](___TEXT___TEXT___)
+  </figure>
+_TEXT_. _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_, _TEXT_.<br/>
+  <figure data-layout="center" data-align="center">
+  ![__TEXT__](___TEXT___TEXT___)
+  </figure>

--- a/confluence-mdx/tests/testcases/lists/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/lists/expected.skel.mdx
@@ -1,0 +1,47 @@
+#### _TEXT_
+
+* _TEXT_
+    * _TEXT_
+    * _TEXT_
+        * _TEXT_
+        * _TEXT_
+        * _TEXT_
+* _TEXT_
+    * _TEXT_
+        * _TEXT_
+        * _TEXT_
+    * _TEXT_
+* _TEXT_
+    * _TEXT_
+    * _TEXT_
+* _TEXT_
+
+#### _TEXT_
+
+1. _TEXT_
+    1. _TEXT_
+    2. _TEXT_
+        1. _TEXT_
+        2. _TEXT_
+            1. _TEXT_
+            2. _TEXT_
+        3. _TEXT_
+    3. _TEXT_
+2. _TEXT_
+3. _TEXT_
+
+#### _TEXT_
+
+1. _TEXT_
+2. _TEXT_
+    * _TEXT_
+        1. _TEXT_
+        2. _TEXT_
+            * _TEXT_
+            * _TEXT_
+            * _TEXT_
+        3. _TEXT_
+    * _TEXT_
+    * _TEXT_
+3. _TEXT_
+4. _TEXT_

--- a/confluence-mdx/tests/testcases/panels/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/panels/expected.skel.mdx
@@ -1,0 +1,35 @@
+import { Callout } from 'nextra/components'
+
+<Callout type="info">
+_TEXT_.
+</Callout>
+---
+
+<Callout type="important">
+This is a note panel.
+</Callout>
+---
+
+<Callout type="error">
+_TEXT_.
+</Callout>
+---
+
+<Callout type="default">
+This is a success panel.
+</Callout>
+---
+
+<Callout type="important">
+_TEXT_.
+</Callout>
+---
+
+<Callout type="info" emoji="🌈">
+This is a custom panel.
+</Callout>
+---
+
+_TEXT_.
+
+

--- a/confluence-mdx/tests/update-expected-skel-mdx.sh
+++ b/confluence-mdx/tests/update-expected-skel-mdx.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Update expected.mdx files from the latest output.mdx for each testcase.
+# Run this script from confluence-mdx/tests directory.
+
+set -o nounset -o errtrace -o pipefail
+
+script_dir="$(dirname "${BASH_SOURCE[0]}")"
+pushd "$script_dir" || exit 1
+
+for testcase in testcases/[0-9]* testcases/lists testcases/panels; do
+  pushd $testcase
+  (set -x; cp output.skel.mdx expected.skel.mdx)
+  popd
+done


### PR DESCRIPTION
## Description
- test-skeleton 타겟: 모든 테스트 케이스에 대해 skeleton 테스트 실행
  - 각 테스트 케이스의 output.mdx를 output.skel.mdx로 변환
  - expected.skel.mdx가 있으면 diff 비교
  - expected.skel.mdx가 없으면 경고 메시지 출력
- test-skeleton-one 타겟: 특정 테스트 케이스에 대해 skeleton 테스트 실행
  - 사용법: make test-skeleton-one TEST_ID=<test_id>
- clean 타겟 업데이트: output.skel.mdx 파일도 삭제하도록 수정
- help 타겟 업데이트: 새로운 타겟들에 대한 설명 추가

### 사용 예시:
- 모든 skeleton 테스트 실행: `make test-skeleton`
- 특정 테스트 케이스만 실행: `make test-skeleton-one TEST_ID=544112828`

## Additional notes
- 
