### PR TITLE
feat: mdx_to_skeleton.py 를 개선합니다.

### DIFF
--- a/confluence-mdx/tests/testcases/544112828/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544112828/expected.skel.mdx
@@ -8,102 +8,102 @@ import { Callout } from 'nextra/components'
 
 ### _TEXT_
 
-_TEXT_, _TEXT_, _TEXT_, _TEXT_/_TEXT_, _TEXT_, _TEXT_.
+_TEXT_.
 
 
 ### _TEXT_
 
-1. _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
+1. _TEXT_.
 
 <figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+![_TEXT_](/544112828/output/screenshot-20240804-173002.png)
 <figcaption>
-_TEXT____TEXT___TEXT___TEXT___ _TEXT_
+_TEXT_
 </figcaption>
 </figure>
 
 2. _TEXT_.
 
 <figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
-<figcaption>
-_TEXT____TEXT___TEXT___TEXT___ _TEXT_
-</figcaption>
-</figure>
-
-<Callout type="info">
-_TEXT_, _TEXT_, _TEXT_.
-</Callout>
-
-3. _TEXT_.
-
-<figure data-layout="center" data-align="center">
-![__TEXT__](___TEXT___TEXT___)
+![_TEXT_](/544112828/output/image-20240723-154847.png)
 <figcaption>
 _TEXT_
 </figcaption>
 </figure>
 
-4. _TEXT_. _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
+<Callout type="info">
+_TEXT_.
+</Callout>
+
+3. _TEXT_.
 
 <figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+![_TEXT_](/544112828/output/screenshot-20240804-174002.png)
 <figcaption>
-_TEXT____TEXT___TEXT___TEXT___ _TEXT_
+_TEXT_
+</figcaption>
+</figure>
+
+4. _TEXT_. _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT_](/544112828/output/agent-03.png)
+<figcaption>
+_TEXT_
 </figcaption>
 </figure>
 
 
 ### _TEXT_
 
-1. _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
+1. _TEXT_.
 
 <figure data-layout="center" data-align="center">
-![__TEXT__](___TEXT___TEXT___)
+![_TEXT_](/544112828/output/screenshot-20240804-173713.png)
 </figure>
 
-2. _TEXT_, _TEXT_, `___TEXT___TEXT___TEXT___` _TEXT_.
+2. _TEXT_.
 
 <figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+![_TEXT_](/544112828/output/screenshot-20240729-171236.png)
 <figcaption>
-_TEXT____TEXT___TEXT___TEXT___ _TEXT_
+_TEXT_
 </figcaption>
 </figure>
 
 3. _TEXT_.
 
 <figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+![_TEXT_](/544112828/output/screenshot-20240729-171314.png)
 <figcaption>
-_TEXT____TEXT___TEXT___TEXT___ _TEXT_
+_TEXT_
 </figcaption>
 </figure>
 
 4. _TEXT_.
 
 <figure data-layout="center" data-align="center">
-![__TEXT__](___TEXT___TEXT___)
+![_TEXT_](/544112828/output/screenshot-20240804-174209.png)
 <figcaption>
-_TEXT_- _TEXT_
+_TEXT_
 </figcaption>
 </figure>
 
 ### _TEXT_
 
-_TEXT_. _TEXT_.<br/>_TEXT_`___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_.
+_TEXT_. _TEXT_.<br/>_TEXT_.
 
 <figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+![_TEXT_](/544112828/output/screenshot-20240730-151001.png)
 <figcaption>
-_TEXT____TEXT___TEXT___TEXT___ _TEXT_
+_TEXT_
 </figcaption>
 </figure>
 
 2. _TEXT_.
 
 <figure data-layout="center" data-align="center">
-![__TEXT__](___TEXT___TEXT___)
+![_TEXT_](/544112828/output/agent-07.png)
 <figcaption>
 _TEXT_
 </figcaption>
@@ -116,38 +116,38 @@ _TEXT_.
 
 #### _TEXT_. _TEXT_
 
-* _TEXT_`___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_.
-* _TEXT_, _TEXT____TEXT___TEXT___TEXT___ _TEXT_. 
+* _TEXT_.
+* _TEXT_. 
 
 <figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+![_TEXT_](/544112828/output/screenshot-20240730-162653.png)
 <figcaption>
-_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+_TEXT_
 </figcaption>
 </figure>
 
 <Callout type="info">
-_TEXT_, _TEXT_.
+_TEXT_.
 </Callout>
 
 #### <br/>_TEXT_. _TEXT_
 
-* _TEXT_, _TEXT_.
+* _TEXT_.
 
 <figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+![_TEXT_](/544112828/output/screenshot-20240730-161729.png)
 <figcaption>
-_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+_TEXT_
 </figcaption>
 </figure>
 
-* _TEXT_, _TEXT_. 
-* _TEXT_, `___TEXT___TEXT___TEXT___` _TEXT_.
+* _TEXT_. 
+* _TEXT_.
 
 <figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+![_TEXT_](/544112828/output/screenshot-20240730-162532.png)
 <figcaption>
-_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+_TEXT_
 </figcaption>
 </figure>
 
@@ -155,117 +155,117 @@ _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
 
 _TEXT_. _TEXT_. _TEXT_.
 
-_TEXT_) _TEXT_, . _TEXT_.
+_TEXT_. _TEXT_.
 ```
-___TEXT___TEXT___TEXT___
-```
-
-_TEXT_) _TEXT_.
-```
-___TEXT___TEXT___TEXT___
+_TEXT_
 ```
 
-_TEXT_) _TEXT_, `___TEXT___TEXT___TEXT___` _TEXT_.
+_TEXT_.
 ```
-___TEXT___TEXT___TEXT___
+_TEXT_
+```
+
+_TEXT_.
+```
+_TEXT_
 ```
 
 <Callout type="info">
-_TEXT_, _TEXT_, _TEXT_. _TEXT_, _TEXT_.
+_TEXT_. _TEXT_.
 ```
-___TEXT___TEXT___TEXT___
+_TEXT_
 ```
 </Callout>
 
-_TEXT_) _TEXT_. _TEXT____TEXT___TEXT___TEXT___ _TEXT_.
+_TEXT_. _TEXT_.
 ```
-___TEXT___TEXT___TEXT___
+_TEXT_
 ```
 
 
 ### _TEXT_
 
 <figure data-layout="center" data-align="center">
-![__TEXT__](___TEXT___TEXT___)
+![_TEXT_](/544112828/output/kubernetes-agent-access-flow.png)
 </figure>
 
-* _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
-* _TEXT_(_TEXT_, _TEXT_, _TEXT_) _TEXT_.
-* _TEXT_, _TEXT_.
+* _TEXT_.
+* _TEXT_.
+* _TEXT_.
 * _TEXT_.
 
 #### _TEXT_. _TEXT_
 
-_TEXT_`___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_.
+_TEXT_.
 
 <figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
-<figcaption>
-_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
-</figcaption>
-</figure>
-
-<Callout type="info">
-_TEXT_, _TEXT_.
-</Callout>
-
-
-#### _TEXT_. _TEXT_
-
-_TEXT_. _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
-
-<figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
-<figcaption>
-_TEXT____TEXT___TEXT___TEXT___ _TEXT_
-</figcaption>
-</figure>
-
-#### _TEXT_. _TEXT_
-
-_TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
-
-<figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
-<figcaption>
-_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
-</figcaption>
-</figure>
-
-*  **__TEXT__**  : _TEXT_.
-    * _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
-    * _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_. 
-
-
-<figure data-layout="center" data-align="center">
-![__TEXT__](___TEXT___TEXT___)
+![_TEXT_](/544112828/output/screenshot-20240730-152705.png)
 <figcaption>
 _TEXT_
 </figcaption>
 </figure>
 
-*  **__TEXT__**  : _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
-*  **__TEXT__**  : _TEXT_. _TEXT_.
-*  **__TEXT__**  : _TEXT_.
+<Callout type="info">
+_TEXT_.
+</Callout>
 
-_TEXT_) _TEXT_, _TEXT_"`___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___`"_TEXT_.
+
+#### _TEXT_. _TEXT_
+
+_TEXT_. _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT_](/544112828/output/screenshot-20240730-161141.png)
+<figcaption>
+_TEXT_
+</figcaption>
+</figure>
+
+#### _TEXT_. _TEXT_
+
+_TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT_](/544112828/output/screenshot-20240730-154623.png)
+<figcaption>
+_TEXT_
+</figcaption>
+</figure>
+
+*  _TEXT_.
+    * _TEXT_.
+    * _TEXT_. 
+
+
+<figure data-layout="center" data-align="center">
+![_TEXT_](/544112828/output/screenshot-20240730-163530.png)
+<figcaption>
+_TEXT_
+</figcaption>
+</figure>
+
+*  _TEXT_.
+*  _TEXT_. _TEXT_.
+*  _TEXT_.
+
+_TEXT_.
 ```
-___TEXT___TEXT___TEXT___
+_TEXT_
 ```
 
-_TEXT_) _TEXT_.
+_TEXT_.
 ```
-___TEXT___TEXT___TEXT___
+_TEXT_
 ```
 
-_TEXT_) _TEXT_.
+_TEXT_.
 
-* _TEXT_: [__TEXT__](___TEXT___TEXT___)
-* _TEXT_: [__TEXT__](___TEXT___TEXT___)
+* _TEXT_
+* _TEXT_
 
-_TEXT_) `___TEXT___TEXT___TEXT___` _TEXT_
+_TEXT_
 ```
-___TEXT___TEXT___TEXT___
+_TEXT_
 ```
 
 
@@ -274,24 +274,24 @@ ___TEXT___TEXT___TEXT___
 _TEXT_.
 #### _TEXT_
 
-_TEXT_`___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_.
+_TEXT_.
 
 <figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+![_TEXT_](/544112828/output/screenshot-20240730-153518.png)
 <figcaption>
-_TEXT____TEXT___TEXT___TEXT___ _TEXT_
+_TEXT_
 </figcaption>
 </figure>
 
 
-#### (_TEXT_) _TEXT_
+#### _TEXT_
 
-_TEXT_. `___TEXT___TEXT___TEXT___` _TEXT_.
+_TEXT_. _TEXT_.
 
 <figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+![_TEXT_](/544112828/output/screenshot-20240730-153524.png)
 <figcaption>
-_TEXT____TEXT___TEXT___TEXT___ _TEXT_
+_TEXT_
 </figcaption>
 </figure>
 

--- a/confluence-mdx/tests/testcases/544113141/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544113141/expected.skel.mdx
@@ -11,77 +11,77 @@ _TEXT_.
 ### _TEXT_
 
 <figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+![_TEXT_](/544113141/output/image-20240730-070842.png)
 <figcaption>
-_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+_TEXT_
 </figcaption>
 </figure>
 
-1. _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_.
+1. _TEXT_.
 2. _TEXT_.
 3. _TEXT_.
-    1.  **__TEXT__**  : _TEXT_
-    2.  **__TEXT__**  : _TEXT_
-    3.  **__TEXT__**  : _TEXT_
-4. _TEXT_/_TEXT_.
+    1.  _TEXT_
+    2.  _TEXT_
+    3.  _TEXT_
+4. _TEXT_.
   <figure data-layout="center" data-align="center">
-  ![__TEXT__](___TEXT___TEXT___)
+  ![_TEXT_](/544113141/output/image-20240730-064139.png)
   </figure>
-    1.  **__TEXT__**  : _TEXT_
-    2.  **__TEXT__** : _TEXT_
-    3.  **__TEXT__** : _TEXT_/ _TEXT_
-    4.  **__TEXT__** : _TEXT_/_TEXT_
-    5.  **__TEXT__**  : _TEXT_
+    1.  _TEXT_
+    2.  _TEXT_
+    3.  _TEXT_
+    4.  _TEXT_
+    5.  _TEXT_
 5. _TEXT_.
-6. _TEXT_:
-    1.  **__TEXT__**  : _TEXT_
-    2.  **__TEXT__**  : _TEXT_
-    3.  **__TEXT__**  : _TEXT_/ _TEXT_
-    4.  **__TEXT__**  : _TEXT_/_TEXT_
-        1. : _TEXT___TEXT_: _TEXT_
-        2. : _TEXT___TEXT_: _TEXT_
-    5.  **__TEXT__**  : _TEXT_
-    6.  **__TEXT__**  : _TEXT_
-    7.  **__TEXT__**  : _TEXT_
-    8.  **__TEXT__**  : _TEXT_
-    9.  **__TEXT__**  : _TEXT_
-    10.  **__TEXT__**   **__TEXT__**  : _TEXT_
-    11.  **__TEXT__**  : _TEXT_
-    12.  **__TEXT__**  : _TEXT_
-    13.  **__TEXT__**  : _TEXT_
-    14.  **__TEXT__**  : _TEXT_
-    15.  **__TEXT__**  : _TEXT_
-    16.  **__TEXT__**   **__TEXT__**  : _TEXT_(_TEXT_)
-    17.  **__TEXT__**  : _TEXT_
-    18.  **__TEXT__**   **__TEXT__**  : _TEXT_
+6. _TEXT_
+    1.  _TEXT_
+    2.  _TEXT_
+    3.  _TEXT_
+    4.  _TEXT_
+        1. _TEXT_
+        2. _TEXT_
+    5.  _TEXT_
+    6.  _TEXT_
+    7.  _TEXT_
+    8.  _TEXT_
+    9.  _TEXT_
+    10.  _TEXT_
+    11.  _TEXT_
+    12.  _TEXT_
+    13.  _TEXT_
+    14.  _TEXT_
+    15.  _TEXT_
+    16.  _TEXT_
+    17.  _TEXT_
+    18.  _TEXT_
 
 ### _TEXT_
 
 _TEXT_.
 
 <figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+![_TEXT_](/544113141/output/image-20240730-065045.png)
 <figcaption>
-_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+_TEXT_
 </figcaption>
 </figure>
 
-* _TEXT_:
-    1.  **__TEXT__**  : _TEXT_/_TEXT_
-        1. : _TEXT___TEXT_: _TEXT_
-        2. : _TEXT___TEXT_: _TEXT_
-    2.  **__TEXT__**  : _TEXT_
-    3.  **__TEXT__**  : _TEXT_
-    4.  **__TEXT__** : _TEXT_/ _TEXT_
-    5.  **__TEXT__**   **__TEXT__**  : _TEXT_
-    6.  **__TEXT__**  : _TEXT_
-    7.  **__TEXT__**   **__TEXT__** : _TEXT_
-    8.  **__TEXT__**  : _TEXT_
-    9.  **__TEXT__**   **__TEXT__**  : _TEXT_(_TEXT_)
-    10.  **__TEXT__**  : _TEXT_
-    11.  **__TEXT__**  : _TEXT_
-    12.  **__TEXT__**  : _TEXT_
-    13.  **__TEXT__**  : _TEXT_
-    14.  **__TEXT__**  : _TEXT_
-    15.  **__TEXT__**  : _TEXT_
-    16.  **__TEXT__**  : _TEXT_
+* _TEXT_
+    1.  _TEXT_
+        1. _TEXT_
+        2. _TEXT_
+    2.  _TEXT_
+    3.  _TEXT_
+    4.  _TEXT_
+    5.  _TEXT_
+    6.  _TEXT_
+    7.  _TEXT_
+    8.  _TEXT_
+    9.  _TEXT_
+    10.  _TEXT_
+    11.  _TEXT_
+    12.  _TEXT_
+    13.  _TEXT_
+    14.  _TEXT_
+    15.  _TEXT_
+    16.  _TEXT_

--- a/confluence-mdx/tests/testcases/544145591/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544145591/expected.skel.mdx
@@ -9,240 +9,240 @@ title: '_TEXT_'
 _TEXT_.
 
 <figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
-<figcaption>
-_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
-</figcaption>
-</figure>
-
-### _TEXT_
-
-*  **__TEXT__**  : _TEXT_.
-*  **__TEXT__**  : _TEXT_
-*  **__TEXT__**  : _TEXT_.
-*  **__TEXT__**  : _TEXT_.
-*  **__TEXT__**  : _TEXT_. (_TEXT_: _TEXT_) 
-*  **__TEXT__** : _TEXT_. _TEXT_.
-*  **__TEXT__**  : _TEXT_. 
-
-
-### _TEXT_
-
-_TEXT_, _TEXT_.
-
-<figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
-<figcaption>
-_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
-</figcaption>
-</figure>
-
-
-### _TEXT_
-
-_TEXT_.
-
-<figure data-layout="center" data-align="center">
-![__TEXT__](___TEXT___TEXT___)
-</figure>
-
-### _TEXT_
-
-_TEXT_.
-
-_TEXT_. _TEXT_(_TEXT_)_TEXT_.
-
-* _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_, _TEXT_(_TEXT_)_TEXT_. 
-
-### _TEXT_
-
-_TEXT_, _TEXT_, _TEXT_, _TEXT_. _TEXT_.
-
-* _TEXT_.
-    * _TEXT_: _TEXT_, _TEXT_. (_TEXT_: _TEXT_, _TEXT_)
-    * _TEXT_: _TEXT_, _TEXT_, _TEXT_, _TEXT_, _TEXT_. (_TEXT_: _TEXT_, _TEXT_)
-* _TEXT_.
-
-### _TEXT_
-
-_TEXT_.
-
-* _TEXT_.
-* _TEXT_.
-* _TEXT_. (_TEXT_, _TEXT_.)
-
-### _TEXT_
-
-_TEXT_.
-
-* _TEXT_(_TEXT_)_TEXT_.
-* _TEXT_.
-    * _TEXT_: _TEXT_
-    * _TEXT_: _TEXT_
-* _TEXT_. _TEXT_, _TEXT_, _TEXT_.
-
-### _TEXT_
-
-_TEXT_-_TEXT_.
-
-<figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
-<figcaption>
-_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
-</figcaption>
-</figure>
-
-_TEXT_, _TEXT_(_TEXT_: _TEXT_, _TEXT_)_TEXT_. _TEXT_.
-
-* _TEXT_: 
-    * _TEXT_.
-      <figure data-layout="center" data-align="center">
-      ![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_<br/>](___TEXT___TEXT___)
-      <figcaption>
-      _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_<br/>
-      </figcaption>
-      </figure>
-    * _TEXT_(_TEXT_).
-* _TEXT_
-    * _TEXT_. _TEXT_(_TEXT_: _TEXT_)_TEXT_.
-        * _TEXT_: _TEXT_, _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_(_TEXT_: _TEXT_).
-    * _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_, '_TEXT_' _TEXT_'_TEXT_(_TEXT_-_TEXT_)' _TEXT_.
-        * _TEXT_, _TEXT_(_TEXT_: _TEXT_)_TEXT_, _TEXT_.
-        * _TEXT_: _TEXT_'_TEXT_(_TEXT_)' _TEXT_, _TEXT_. _TEXT_, _TEXT_.
-    * _TEXT____TEXT___TEXT___TEXT___ _TEXT_(_TEXT_-_TEXT_)_TEXT_.
-* _TEXT_
-    * _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_.
-    * _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_'_TEXT_' _TEXT_'_TEXT_(_TEXT_-_TEXT_)' _TEXT_.
-    * _TEXT_'_TEXT_(_TEXT_-_TEXT_)' _TEXT_, _TEXT_.
-        * _TEXT_: _TEXT_.
-        * _TEXT_, _TEXT_, _TEXT_.
-    * _TEXT____TEXT___TEXT___TEXT___ _TEXT_(_TEXT_-_TEXT_)_TEXT_. 
-* _TEXT_
-    * _TEXT_(_TEXT_, _TEXT_), _TEXT_. _TEXT_.
-        * _TEXT_: 
-          <figure data-layout="center" data-align="center">
-          ![__TEXT__](___TEXT___TEXT___)
-          </figure>
-* _TEXT_
-    * _TEXT_, _TEXT_.
-        * _TEXT_:
-          <figure data-layout="center" data-align="center">
-          ![__TEXT__](___TEXT___TEXT___)
-          </figure>
-
-### _TEXT_(_TEXT_)
-
-_TEXT_.
-
-<figure data-layout="center" data-align="center">
-![__TEXT__](___TEXT___TEXT___)
-</figure>
-
-_TEXT_(_TEXT_)_TEXT_.
-
-* _TEXT_`___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___`_TEXT_.
-* _TEXT_`___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_.
-*  **__TEXT__**  `___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_.
-
-### _TEXT_(_TEXT_)
-
-_TEXT_.
-
-<figure data-layout="center" data-align="center">
-![__TEXT__](___TEXT___TEXT___)
-</figure>
-
-
-_TEXT_, _TEXT_, _TEXT_(_TEXT_)_TEXT_. _TEXT_.
-
-*  **__TEXT__**  : _TEXT_~_TEXT_, _TEXT_, _TEXT_
-    * _TEXT_) _TEXT_, _TEXT_. 
-*  **__TEXT__** : _TEXT_, _TEXT_(_TEXT_~ _TEXT_, _TEXT_)
-
-### _TEXT_
-
-_TEXT_.
-
-<figure data-layout="center" data-align="center">
-![__TEXT__](___TEXT___TEXT___)
-</figure>
-
-_TEXT_, _TEXT_, _TEXT_, `___TEXT___TEXT___TEXT___` _TEXT_. _TEXT_.
-
-* _TEXT_
-    * _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_.
-    * _TEXT_, `___TEXT___TEXT___TEXT___` _TEXT_, _TEXT_.
-* _TEXT_
-    * _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_.
-    * _TEXT_, _TEXT_, _TEXT_, `___TEXT___TEXT___TEXT___` _TEXT_
-
-### _TEXT_
-
-_TEXT_.
-
-<figure data-layout="center" data-align="center">
-![__TEXT__](___TEXT___TEXT___)
-</figure>
-
-_TEXT_(_TEXT_) _TEXT_.
-
-* _TEXT_(_TEXT_)_TEXT_:
-    * _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_:
-        * _TEXT_(_TEXT_(_TEXT_), _TEXT_(_TEXT_), _TEXT_(_TEXT_), _TEXT_(_TEXT_))_TEXT_.
-        * _TEXT_. _TEXT_.
-    * _TEXT_:
-        * _TEXT_(_TEXT_) _TEXT_.
-    * _TEXT_:
-        * _TEXT_(_TEXT_), _TEXT_(_TEXT_), _TEXT_(_TEXT_) _TEXT_.
-        * _TEXT_, _TEXT_(_TEXT_: "_TEXT_")_TEXT_.
-* _TEXT_(_TEXT_)_TEXT_(_TEXT_):
-    * _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_:
-        * _TEXT_.
-    * _TEXT_:
-        * _TEXT_, _TEXT_.
-        * _TEXT_.
-
-### _TEXT_
-
-_TEXT_(_TEXT_)_TEXT_“_TEXT_” _TEXT_.
-
-<figure data-layout="center" data-align="center">
-![__TEXT__](___TEXT___TEXT___)
+![_TEXT_](/544145591/output/image-20250822-103044.png)
 <figcaption>
 _TEXT_
 </figcaption>
 </figure>
 
-`___TEXT___TEXT___TEXT___` _TEXT_.
+### _TEXT_
+
+*  _TEXT_.
+*  _TEXT_
+*  _TEXT_.
+*  _TEXT_.
+*  _TEXT_. _TEXT_
+*  _TEXT_. _TEXT_.
+*  _TEXT_. 
+
+
+### _TEXT_
+
+_TEXT_.
 
 <figure data-layout="center" data-align="center">
-![__TEXT__](___TEXT___TEXT___)
+![_TEXT_](/544145591/output/image-20240805-014838.png)
+<figcaption>
+_TEXT_
+</figcaption>
 </figure>
 
-*  **__TEXT__**  : _TEXT_.
-*  **__TEXT__**  : _TEXT_.
-    *  **__TEXT__**  : _TEXT_.
-    *  **__TEXT__** : _TEXT_.
-*   **__TEXT__**  : _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_.
-*  **__TEXT__**  : _TEXT_(_TEXT_)_TEXT_.
+
+### _TEXT_
+
+_TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT_](/544145591/output/Screenshot-2025-08-25-at-5.36.19-PM.png)
+</figure>
+
+### _TEXT_
+
+_TEXT_.
+
+_TEXT_. _TEXT_.
+
+* _TEXT_. 
+
+### _TEXT_
+
+_TEXT_. _TEXT_.
+
+* _TEXT_.
+    * _TEXT_. _TEXT_
+    * _TEXT_. _TEXT_
+* _TEXT_.
+
+### _TEXT_
+
+_TEXT_.
+
+* _TEXT_.
+* _TEXT_.
+* _TEXT_. _TEXT_.)
+
+### _TEXT_
+
+_TEXT_.
+
+* _TEXT_.
+* _TEXT_.
+    * _TEXT_
+    * _TEXT_
+* _TEXT_. _TEXT_.
+
+### _TEXT_
+
+_TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT_](/544145591/output/Screenshot-2025-06-16-at-10.14.55-AM.png)
+<figcaption>
+_TEXT_
+</figcaption>
+</figure>
+
+_TEXT_. _TEXT_.
+
+* _TEXT_
+    * _TEXT_.
+      <figure data-layout="center" data-align="center">
+      ! _TEXT_<br/>_TEXT_. _TEXT_. _TEXT_. _TEXT_
+      <figcaption>
+      _TEXT_<br/>
+      </figcaption>
+      </figure>
+    * _TEXT_.
+* _TEXT_
+    * _TEXT_. _TEXT_.
+        * _TEXT_.
+    * _TEXT_.
+        * _TEXT_.
+        * _TEXT_. _TEXT_.
+    * _TEXT_.
+* _TEXT_
+    * _TEXT_.
+    * _TEXT_.
+    * _TEXT_.
+        * _TEXT_.
+        * _TEXT_.
+    * _TEXT_. 
+* _TEXT_
+    * _TEXT_. _TEXT_.
+        * _TEXT_
+          <figure data-layout="center" data-align="center">
+          ![_TEXT_](/544145591/output/image-20250508-022114.png)
+          </figure>
+* _TEXT_
+    * _TEXT_.
+        * _TEXT_
+          <figure data-layout="center" data-align="center">
+          ![_TEXT_](/544145591/output/Screenshot-2025-06-16-at-10.30.14-AM.png)
+          </figure>
+
+### _TEXT_
+
+_TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT_](/544145591/output/Screenshot-2025-06-26-at-6.35.32-PM.png)
+</figure>
+
+_TEXT_.
+
+* _TEXT_.
+* _TEXT_.
+*  _TEXT_.
+
+### _TEXT_
+
+_TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT_](/544145591/output/Screenshot-2025-05-09-at-3.18.32-PM.png)
+</figure>
+
+
+_TEXT_. _TEXT_.
+
+*  _TEXT_
+    * _TEXT_. 
+*  _TEXT_
+
+### _TEXT_
+
+_TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT_](/544145591/output/Screenshot-2025-05-09-at-8.33.07-PM.png)
+</figure>
+
+_TEXT_. _TEXT_.
+
+* _TEXT_
+    * _TEXT_.
+    * _TEXT_.
+* _TEXT_
+    * _TEXT_.
+    * _TEXT_
+
+### _TEXT_
+
+_TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT_](/544145591/output/Screenshot-2025-05-09-at-8.40.28-PM.png)
+</figure>
+
+_TEXT_.
+
+* _TEXT_
+    * _TEXT_
+        * _TEXT_.
+        * _TEXT_. _TEXT_.
+    * _TEXT_
+        * _TEXT_.
+    * _TEXT_
+        * _TEXT_.
+        * _TEXT_.
+* _TEXT_
+    * _TEXT_
+        * _TEXT_.
+    * _TEXT_
+        * _TEXT_.
+        * _TEXT_.
+
+### _TEXT_
+
+_TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT_](/544145591/output/image-20250822-111454.png)
+<figcaption>
+_TEXT_
+</figcaption>
+</figure>
+
+_TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT_](/544145591/output/image-20250822-112026.png)
+</figure>
+
+*  _TEXT_.
+*  _TEXT_.
+    *  _TEXT_.
+    *  _TEXT_.
+*   _TEXT_.
+*  _TEXT_.
 
 #### _TEXT_
 
-* _TEXT_“_TEXT_-_TEXT_” _TEXT_, _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
-    * _TEXT_: _TEXT_.
-    * _TEXT_: _TEXT_-_TEXT_.
-    * _TEXT_: _TEXT_. 
-* _TEXT_/_TEXT_, _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
-    * _TEXT_: _TEXT_.
-    * _TEXT_: _TEXT_/_TEXT_.
-    * _TEXT_: _TEXT_.
+* _TEXT_.
+    * _TEXT_.
+    * _TEXT_.
+    * _TEXT_. 
+* _TEXT_.
+    * _TEXT_.
+    * _TEXT_.
+    * _TEXT_.
 
-### _TEXT_/ _TEXT_
+### _TEXT_
 
-_TEXT_“_TEXT_” _TEXT_.
+_TEXT_.
 
 <figure data-layout="center" data-align="center">
-![__TEXT__](___TEXT___TEXT___)
+![_TEXT_](/544145591/output/image-20250825-002423.png)
 </figure>
 
-_TEXT_“_TEXT_” _TEXT_“_TEXT_” _TEXT_.
+_TEXT_.

--- a/confluence-mdx/tests/testcases/544178405/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544178405/expected.skel.mdx
@@ -6,12 +6,12 @@ title: '_TEXT_'
 
 ### _TEXT_.
 
-_TEXT_, _TEXT_, _TEXT_. _TEXT_.
+_TEXT_. _TEXT_.
 
-_TEXT_. _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_. _TEXT_.
+_TEXT_. _TEXT_. _TEXT_.
 
 <figure data-layout="center" data-align="center">
-![__TEXT__](___TEXT___TEXT___)
+![_TEXT_](/544178405/output/screenshot-20240801-145006.png)
 <figcaption>
 _TEXT_
 </figcaption>
@@ -20,7 +20,7 @@ _TEXT_
 
 ### _TEXT_?
 
-_TEXT_, _TEXT_, _TEXT_. _TEXT_, _TEXT_, _TEXT_.
+_TEXT_. _TEXT_.
 
 <table data-table-width="760" data-layout="default" local-id="96d34ea4-8772-49af-9ba2-14ea36b1f3e1">
 <colgroup>
@@ -33,10 +33,10 @@ _TEXT_, _TEXT_, _TEXT_. _TEXT_, _TEXT_, _TEXT_.
 <th>
 </th>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
-**__TEXT__**
+_TEXT_
 </th>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
-**__TEXT__**
+_TEXT_
 </th>
 </tr>
 <tr>
@@ -44,24 +44,10 @@ _TEXT_, _TEXT_, _TEXT_. _TEXT_, _TEXT_, _TEXT_.
 _TEXT_
 </td>
 <th>
-**__TEXT__**
-</th>
-<td>
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_/_TEXT_) 
-    * _TEXT_, _TEXT_, _TEXT_
-</td>
-</tr>
-<tr>
-<td>
 _TEXT_
-</td>
-<th>
-**__TEXT__**
 </th>
 <td>
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_/_TEXT_) 
-    * _TEXT_, _TEXT_, _TEXT_
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_/_TEXT_-_TEXT_) 
+* _TEXT_
     * _TEXT_
 </td>
 </tr>
@@ -70,16 +56,13 @@ _TEXT_
 _TEXT_
 </td>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <td>
 * _TEXT_
-    * [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_)
-    * [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_)
-    * [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_-_TEXT_)
+    * _TEXT_
 * _TEXT_
-    * [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_)
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_/_TEXT_) 
+    * _TEXT_
 </td>
 </tr>
 <tr>
@@ -87,10 +70,16 @@ _TEXT_
 _TEXT_
 </td>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <td>
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_/_TEXT_)
+* _TEXT_
+    * _TEXT_
+    * _TEXT_
+    * _TEXT_
+* _TEXT_
+    * _TEXT_
+* _TEXT_
 </td>
 </tr>
 <tr>
@@ -98,10 +87,10 @@ _TEXT_
 _TEXT_
 </td>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <td>
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_/_TEXT_-_TEXT_)
+* _TEXT_
 </td>
 </tr>
 <tr>
@@ -109,11 +98,10 @@ _TEXT_
 _TEXT_
 </td>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <td>
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_/_TEXT_)
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_/_TEXT_)
+* _TEXT_
 </td>
 </tr>
 <tr>
@@ -121,19 +109,31 @@ _TEXT_
 _TEXT_
 </td>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <td>
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_/_TEXT_)
+* _TEXT_
+* _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<th>
+_TEXT_
+</th>
+<td>
+* _TEXT_
 </td>
 </tr>
 </tbody>
 </table>
 
 
-### _TEXT_, _TEXT_. _TEXT_?
+### _TEXT_. _TEXT_?
 
-_TEXT_. _TEXT_. _TEXT_/_TEXT_. _TEXT_.
+_TEXT_. _TEXT_. _TEXT_. _TEXT_.
 
 <table data-table-width="760" data-layout="default" local-id="1c770267-da7f-48dc-b1e3-817744eeec38">
 <colgroup>
@@ -146,10 +146,10 @@ _TEXT_. _TEXT_. _TEXT_/_TEXT_. _TEXT_.
 <th>
 </th>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
-**__TEXT__**
+_TEXT_
 </th>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
-**__TEXT__**
+_TEXT_
 </th>
 </tr>
 <tr>
@@ -157,13 +157,13 @@ _TEXT_. _TEXT_. _TEXT_/_TEXT_. _TEXT_.
 _TEXT_
 </td>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <td>
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_)
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_)
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_)
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_)
+* _TEXT_
+* _TEXT_
+* _TEXT_
+* _TEXT_
 </td>
 </tr>
 <tr>
@@ -171,11 +171,11 @@ _TEXT_
 _TEXT_
 </td>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <td>
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_)
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_)
+* _TEXT_
+* _TEXT_
 </td>
 </tr>
 <tr>
@@ -183,11 +183,11 @@ _TEXT_
 _TEXT_
 </td>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <td>
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_)
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_)
+* _TEXT_
+* _TEXT_
 </td>
 </tr>
 <tr>
@@ -195,13 +195,13 @@ _TEXT_
 _TEXT_
 </td>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <td>
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_)
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_)
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_)
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_)
+* _TEXT_
+* _TEXT_
+* _TEXT_
+* _TEXT_
 </td>
 </tr>
 </tbody>

--- a/confluence-mdx/tests/testcases/544211126/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544211126/expected.skel.mdx
@@ -6,7 +6,7 @@ title: '_TEXT_'
 
 ### _TEXT_.
 
-_TEXT_(_TEXT_, _TEXT_, _TEXT_)_TEXT_, _TEXT_.
+_TEXT_.
 
 
 ### _TEXT_?
@@ -24,10 +24,10 @@ _TEXT_. _TEXT_.
 <th>
 </th>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
-**__TEXT__**
+_TEXT_
 </th>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
-**__TEXT__**
+_TEXT_
 </th>
 </tr>
 <tr>
@@ -35,64 +35,10 @@ _TEXT_. _TEXT_.
 _TEXT_
 </td>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
-**__TEXT__**
-</th>
-<td>
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_-_TEXT_#_TEXT_-_TEXT_%_TEXT_%_TEXT_%_TEXT_-%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_) 
-</td>
-</tr>
-<tr>
-<td>
 _TEXT_
-</td>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
-**__TEXT__**
-</th>
-<td>
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_-_TEXT_#%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_-%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_%_TEXT_) 
-</td>
-</tr>
-<tr>
-<td>
-_TEXT_
-</td>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
-**__TEXT__**
-</th>
-<td>
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_)
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_)
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_)
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_-_TEXT_-_TEXT_)
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_-_TEXT_)
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_)
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_)
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_)
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_)
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_-_TEXT_)
-</td>
-</tr>
-<tr>
-<td>
-_TEXT_
-</td>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
-**__TEXT__**
 </th>
 <td>
 * _TEXT_
-    * [__TEXT__](_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_-_TEXT_-_TEXT_)
-    * [__TEXT__](_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_)
-    * [__TEXT__](_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_-_TEXT_-_TEXT_)
-* _TEXT_
-    * [__TEXT__](_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_-_TEXT_) 
-    * [__TEXT__](_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_)
-    * [__TEXT__](_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_)
-* _TEXT_
-    * [__TEXT__](_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_-_TEXT_)
-* _TEXT_
-    * [__TEXT__](_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_-_TEXT_-_TEXT_-_TEXT_)
-    * [__TEXT__](_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_-_TEXT_)
 </td>
 </tr>
 <tr>
@@ -100,10 +46,10 @@ _TEXT_
 _TEXT_
 </td>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
-**__TEXT__**
+_TEXT_
 </th>
 <td>
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_-_TEXT_)
+* _TEXT_
 </td>
 </tr>
 <tr>
@@ -111,10 +57,64 @@ _TEXT_
 _TEXT_
 </td>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
-**__TEXT__**
+_TEXT_
 </th>
 <td>
-* [__TEXT__](_TEXT_-_TEXT_/_TEXT_)
+* _TEXT_
+* _TEXT_
+* _TEXT_
+* _TEXT_
+* _TEXT_
+* _TEXT_
+* _TEXT_
+* _TEXT_
+* _TEXT_
+* _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+_TEXT_
+</th>
+<td>
+* _TEXT_
+    * _TEXT_
+    * _TEXT_
+    * _TEXT_
+* _TEXT_
+    * _TEXT_
+    * _TEXT_
+    * _TEXT_
+* _TEXT_
+    * _TEXT_
+* _TEXT_
+    * _TEXT_
+    * _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+_TEXT_
+</th>
+<td>
+* _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+_TEXT_
+</th>
+<td>
+* _TEXT_
 </td>
 </tr>
 </tbody>

--- a/confluence-mdx/tests/testcases/544375741/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544375741/expected.skel.mdx
@@ -2,7 +2,7 @@
 title: '_TEXT_'
 ---
 
-# _TEXT_(_TEXT_. _TEXT_. _TEXT_> _TEXT_. _TEXT_. _TEXT_)
+# _TEXT_. _TEXT_. _TEXT_. _TEXT_. _TEXT_
 
 ---
 
@@ -14,7 +14,7 @@ title: '_TEXT_'
 
 ## _TEXT_. _TEXT_
 
-#### (_TEXT_) _TEXT_
+#### _TEXT_
 
 ##### _TEXT_
 
@@ -30,10 +30,10 @@ title: '_TEXT_'
 <tbody>
 <tr>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 </tr>
 <tr>
@@ -47,7 +47,7 @@ title: '_TEXT_'
 </tbody>
 </table>
 
-*  **__TEXT__**  _TEXT_**__TEXT__** _TEXT_.
+*  _TEXT_.
 ---
 
 ## 2. Approval API
@@ -90,18 +90,18 @@ title: '_TEXT_'
 
 ## _TEXT_. _TEXT_
 
-#### (_TEXT_) _TEXT_
+#### _TEXT_
 
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 
 ##### _TEXT_
 
 * _TEXT_
-* /_TEXT_/_TEXT_**__TEXT__**  _TEXT_.
+* _TEXT_.
 
 ##### _TEXT_
 
-* /_TEXT_/_TEXT_**__TEXT__**  _TEXT_.
+* _TEXT_.
 ---
 
 ## 4. Notification Channels API

--- a/confluence-mdx/tests/testcases/544377869/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544377869/expected.skel.mdx
@@ -8,7 +8,7 @@ import { Callout } from 'nextra/components'
 
 ### _TEXT_
 
-_TEXT_. _TEXT_, _TEXT_/_TEXT_. _TEXT_, _TEXT_, _TEXT_. _TEXT_, _TEXT_, _TEXT_, _TEXT_, _TEXT_, _TEXT_, _TEXT_, _TEXT_.
+_TEXT_. _TEXT_. _TEXT_. _TEXT_.
 
 
 ### _TEXT_
@@ -16,39 +16,39 @@ _TEXT_. _TEXT_, _TEXT_/_TEXT_. _TEXT_, _TEXT_, _TEXT_. _TEXT_, _TEXT_, _TEXT_, _
 _TEXT_. _TEXT_.
 
 <figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+![_TEXT_](/544377869/output/image-20240725-070857.png)
 <figcaption>
-_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+_TEXT_
 </figcaption>
 </figure>
 
 1. _TEXT_.
 2. _TEXT_.
 3. _TEXT_.
-4. `___TEXT___TEXT___TEXT___` _TEXT_.
+4. _TEXT_.
 5. _TEXT_.
-    1.  **__TEXT__** : _TEXT_/ _TEXT_. _TEXT_.
-    _TEXT_.  **__TEXT__**  : _TEXT_/ _TEXT_. _TEXT_. <br/> ※ _TEXT_/ _TEXT_, _TEXT_.
-6.  **__TEXT__**  : _TEXT_.
+    1.  _TEXT_. _TEXT_.
+    _TEXT_. _TEXT_. _TEXT_. <br/> _TEXT_.
+6.  _TEXT_.
 
-_TEXT_. _TEXT_, _TEXT_.
+_TEXT_. _TEXT_.
 
 
 ### _TEXT_
 
 <Callout type="info">
-_TEXT_. _TEXT_. _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_. _TEXT_. _TEXT_. _TEXT_[__TEXT__](../../_TEXT_-_TEXT_/_TEXT_/_TEXT_/_TEXT_-_TEXT_) _TEXT_.
+_TEXT_. _TEXT_. _TEXT_. _TEXT_. _TEXT_. _TEXT_../.. _TEXT_.
 </Callout>
 
 <figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+![_TEXT_](/544377869/output/image-20240725-071030.png)
 <figcaption>
-_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+_TEXT_
 </figcaption>
 </figure>
 
 1. _TEXT_.
 2. _TEXT_.
-3. _TEXT_, _TEXT_`___TEXT___TEXT___TEXT___`_TEXT_.
+3. _TEXT_.
 
 

--- a/confluence-mdx/tests/testcases/544379140/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544379140/expected.skel.mdx
@@ -8,151 +8,151 @@ import { Callout } from 'nextra/components'
 
 ### _TEXT_
 
-_TEXT_. _TEXT_. _TEXT_. _TEXT_, _TEXT_.
+_TEXT_. _TEXT_. _TEXT_. _TEXT_.
 
 <Callout type="important">
-_TEXT_, _TEXT_‘_TEXT_’ _TEXT_. _TEXT_. _TEXT_.
+_TEXT_. _TEXT_. _TEXT_.
 </Callout>
 
 <Callout type="important">
-**__TEXT__**
-1. _TEXT_[__TEXT__]
-2. _TEXT_[__TEXT__]
-3. _TEXT_[__TEXT__]
-4. _TEXT_[__TEXT__]
-5. _TEXT_[__TEXT__]
-6. _TEXT_[__TEXT__]
-7. _TEXT_[__TEXT__]
-8. _TEXT_[__TEXT__]
-9. _TEXT_[__TEXT__]
-10. _TEXT_[__TEXT__]
-11. _TEXT_[__TEXT__]
-12. _TEXT_[__TEXT__]
-13. _TEXT_[__TEXT__]
-14. _TEXT_[__TEXT__]
-15. _TEXT_[__TEXT__]
-16. _TEXT_[__TEXT__]
-17. _TEXT_[__TEXT__]
-18. _TEXT_[__TEXT__]
-19. _TEXT_[__TEXT__]
-20. _TEXT_[__TEXT__]
-21. _TEXT_[__TEXT__]
-22. _TEXT_[__TEXT__] **__TEXT__** 
-23. _TEXT_[__TEXT__] **__TEXT__** 
-24. _TEXT_[__TEXT__] **__TEXT__** 
-25. _TEXT_[__TEXT__] **__TEXT__** 
-26. _TEXT_[__TEXT__] **__TEXT__**
-27. _TEXT_[__TEXT__] **__TEXT__**
-28. _TEXT_[__TEXT__] **__TEXT__**
-29. _TEXT_[__TEXT__] **__TEXT__**
-30. _TEXT_[__TEXT__] **__TEXT__** 
-31. _TEXT_[__TEXT__] **__TEXT__** 
-32. _TEXT_[__TEXT__] **__TEXT__** 
+_TEXT_
+1. _TEXT_
+2. _TEXT_
+3. _TEXT_
+4. _TEXT_
+5. _TEXT_
+6. _TEXT_
+7. _TEXT_
+8. _TEXT_
+9. _TEXT_
+10. _TEXT_
+11. _TEXT_
+12. _TEXT_
+13. _TEXT_
+14. _TEXT_
+15. _TEXT_
+16. _TEXT_
+17. _TEXT_
+18. _TEXT_
+19. _TEXT_
+20. _TEXT_
+21. _TEXT_
+22. _TEXT_
+23. _TEXT_
+24. _TEXT_
+25. _TEXT_
+26. _TEXT_
+27. _TEXT_
+28. _TEXT_
+29. _TEXT_
+30. _TEXT_
+31. _TEXT_
+32. _TEXT_
 </Callout>
 
 
 ### _TEXT_
 
 <figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+![_TEXT_](/544379140/output/image-20240714-063656.png)
 <figcaption>
-_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+_TEXT_
 </figcaption>
 </figure>
 
-1. _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_.
+1. _TEXT_.
 2. _TEXT_.
 3. _TEXT_.
-    *  **__TEXT__**  : _TEXT_.
-    *  **__TEXT__**  : _TEXT_, _TEXT_. (_TEXT_, _TEXT_.)
-    *  **__TEXT__**  : _TEXT_. _TEXT_.
+    *  _TEXT_.
+    *  _TEXT_. _TEXT_.)
+    *  _TEXT_. _TEXT_.
 
 ### _TEXT_
 
-_TEXT_. (_TEXT_) _TEXT_→ (_TEXT_) _TEXT_→ (_TEXT_) _TEXT_→ (_TEXT_) _TEXT_
+_TEXT_. _TEXT_
 
-_TEXT_‘_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_. _TEXT_.
+_TEXT_. _TEXT_.
 
 <figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+![_TEXT_](/544379140/output/screenshot-20250116-131805.png)
 <figcaption>
-_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+_TEXT_
 </figcaption>
 </figure>
 
-1.  **__TEXT__** : _TEXT_.
-2.  **__TEXT__** : _TEXT_. 
+1.  _TEXT_.
+2.  _TEXT_. 
     1. _TEXT_.
     2. _TEXT_.
-3.  **__TEXT__** : _TEXT_. (_TEXT_. _TEXT_. _TEXT_, _TEXT_. _TEXT_**__TEXT__** _TEXT_.) 
-4.  **__TEXT__**  : _TEXT_, _TEXT_.
-    1. _TEXT_- _TEXT_, _TEXT_. _TEXT_.
-    2. _TEXT_- _TEXT_, _TEXT_.
-5.  **__TEXT__**  : _TEXT_.
-6.  **__TEXT__** : _TEXT_. _TEXT_. _TEXT_. _TEXT_. 
-7.  **__TEXT__**  : _TEXT_. 
-    1. _TEXT_‘ **__TEXT__** ’_TEXT_.
-8.  **__TEXT__** : _TEXT_. 
+3.  _TEXT_. _TEXT_. _TEXT_. _TEXT_. _TEXT_.) 
+4.  _TEXT_.
+    1. _TEXT_. _TEXT_.
+    2. _TEXT_.
+5.  _TEXT_.
+6.  _TEXT_. _TEXT_. _TEXT_. _TEXT_. 
+7.  _TEXT_. 
     1. _TEXT_.
-    2. _TEXT_‘_TEXT_’_TEXT_.
-9. `___TEXT___TEXT___TEXT___` _TEXT_: _TEXT_. 
+8.  _TEXT_. 
+    1. _TEXT_.
+    2. _TEXT_.
+9. _TEXT_. 
 
 <Callout type="info">
-**__TEXT__**
-_TEXT_, _TEXT_.
+_TEXT_
+_TEXT_.
 </Callout>
 
 <Callout type="important">
-**__TEXT__**
+_TEXT_
 
-(_TEXT_) _TEXT_'_TEXT_'_TEXT_.<br/>
+_TEXT_.<br/>
 
-(_TEXT_) _TEXT_.
-
-- _TEXT_
-
-_TEXT_: `___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___`<br/>_TEXT_: `___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___`_TEXT_``
+_TEXT_.
 
 - _TEXT_
 
-_TEXT_: `___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___`<br/>_TEXT_: `___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___`
+_TEXT_<br/>_TEXT_
 
 - _TEXT_
 
-_TEXT_: `___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___`<br/>_TEXT_: `___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___`
+_TEXT_<br/>_TEXT_
 
 - _TEXT_
 
-_TEXT_: `___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___`
+_TEXT_<br/>_TEXT_
+
+- _TEXT_
+
+_TEXT_
 
 
-(_TEXT_) _TEXT_.
+_TEXT_.
 
-- _TEXT_: `___TEXT___TEXT___TEXT___` _TEXT_.
+- _TEXT_.
 
-- _TEXT_: `___TEXT___TEXT___TEXT___` _TEXT_.
+- _TEXT_.
 
-- _TEXT_: _TEXT_(`___TEXT___TEXT___TEXT___`)_TEXT_.
+- _TEXT_.
 
 
-(_TEXT_) _TEXT_
+_TEXT_
 
-- _TEXT_: `___TEXT___TEXT___TEXT___`
+- _TEXT_
 
-- _TEXT_: `___TEXT___TEXT___TEXT___`
+- _TEXT_
 
-- _TEXT_: `___TEXT___TEXT___TEXT___`
+- _TEXT_
 
-- _TEXT_: `___TEXT___TEXT___TEXT___`
+- _TEXT_
 </Callout>
 
 
 <Callout type="important">
-**__TEXT__**
+_TEXT_
 
-_TEXT_‘_TEXT_’ _TEXT_. _TEXT_.
+_TEXT_. _TEXT_.
 
-1. _TEXT_(_TEXT_, _TEXT_)_TEXT_.
+1. _TEXT_.
 2. _TEXT_. 
 3. _TEXT_.
 </Callout>
@@ -164,18 +164,18 @@ _TEXT_. _TEXT_.
 
 _TEXT_.
 
-1. _TEXT_: _TEXT_.
-2. _TEXT_: _TEXT_, _TEXT_.
+1. _TEXT_.
+2. _TEXT_.
 
 <Callout type="important">
-**__TEXT__**
+_TEXT_
 
-_TEXT_‘*__TEXT__*. _TEXT_*. _TEXT_’_TEXT_.
+_TEXT_. _TEXT_. _TEXT_.
 
-_TEXT_‘_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_‘_TEXT_’_TEXT_.
+_TEXT_.
 </Callout>
 
 
 ### _TEXT_
 
-_TEXT_, _TEXT_. _TEXT_. _TEXT_, _TEXT_.
+_TEXT_. _TEXT_. _TEXT_.

--- a/confluence-mdx/tests/testcases/544381877/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544381877/expected.skel.mdx
@@ -14,68 +14,68 @@ _TEXT_.
 _TEXT_.
 
 <figure data-layout="center" data-align="center">
-![__TEXT__](___TEXT___TEXT___)
+![_TEXT_](/544381877/output/image-20240721-054859.png)
 </figure>
 
-1. _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_.
-2. _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
-3.  **__TEXT__**  : _TEXT_
-    1.  **__TEXT__**  : _TEXT_. (_TEXT_) 
+1. _TEXT_.
+2. _TEXT_.
+3.  _TEXT_
+    1.  _TEXT_. _TEXT_
         * _TEXT_. 
-    2.  **__TEXT__**  : _TEXT_. (_TEXT_) 
+    2.  _TEXT_. _TEXT_
         * _TEXT_. 
-    3.  **__TEXT__**  : _TEXT_. 
+    3.  _TEXT_. 
     4. 
-    5.  **__TEXT__**  : _TEXT_. _TEXT_.
-        1.  **__TEXT__**  : _TEXT_. 
-        2.  **__TEXT__**  : _TEXT_.
-        3.  **__TEXT__**  : _TEXT_. _TEXT_. _TEXT_.
-            * : _TEXT___TEXT___TEXT__**  : _TEXT_. 
-            * : _TEXT___TEXT___TEXT__**  : _TEXT_, _TEXT_. 
-    6.  **__TEXT__**  : _TEXT_. 
-        1.  **__TEXT__**  : _TEXT_, _TEXT_`___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___`_TEXT_, 
+    5.  _TEXT_. _TEXT_.
+        1.  _TEXT_. 
+        2.  _TEXT_.
+        3.  _TEXT_. _TEXT_. _TEXT_.
+            * _TEXT_. 
+            * _TEXT_. 
+    6.  _TEXT_. 
+        1.  _TEXT_
             1. _TEXT_. 
             2. _TEXT_. 
-        2.  **__TEXT__**  : _TEXT_. _TEXT_. 
-            1. _TEXT_: 
-                1. `___TEXT___TEXT___TEXT___` 
-                2. `___TEXT___TEXT___TEXT___` 
-                3. `___TEXT___TEXT___TEXT___` 
-                4. `___TEXT___TEXT___TEXT___`
-                5. `___TEXT___TEXT___TEXT___`
-                6. `___TEXT___TEXT___TEXT___`
-                7. `___TEXT___TEXT___TEXT___`
-                8. `___TEXT___TEXT___TEXT___`
-            2. ✅ _TEXT_: _TEXT_. 
-        3.  **__TEXT__**  : _TEXT_, _TEXT_`___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___`_TEXT_: 
-            1. _TEXT_`___TEXT___TEXT___TEXT___`_TEXT_. 
-            2. _TEXT_:
-                1. `___TEXT___TEXT___TEXT___`
-                2. `___TEXT___TEXT___TEXT___`
-4.  **__TEXT__**  : _TEXT_. (_TEXT_, _TEXT_.) `___TEXT___TEXT___TEXT___` _TEXT_-_TEXT_. 
-    1.  **__TEXT__**  : _TEXT_. 
-        1. _TEXT_, _TEXT_. 
+        2.  _TEXT_. _TEXT_. 
+            1. _TEXT_
+                1. _TEXT_
+                2. _TEXT_
+                3. _TEXT_
+                4. _TEXT_
+                5. _TEXT_
+                6. _TEXT_
+                7. _TEXT_
+                8. _TEXT_
+            2. _TEXT_. 
+        3.  _TEXT_
+            1. _TEXT_. 
+            2. _TEXT_
+                1. _TEXT_
+                2. _TEXT_
+4.  _TEXT_. _TEXT_. _TEXT_. 
+    1.  _TEXT_. 
+        1. _TEXT_. 
         2. _TEXT_. 
-    2.  **__TEXT__**  : _TEXT_.
-5. _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_. 
+    2.  _TEXT_.
+5. _TEXT_. 
 
 
 ### _TEXT_
 
 <figure data-layout="center" data-align="center">
-![__TEXT__](___TEXT___TEXT___)
+![_TEXT_](/544381877/output/image-20240511-033842.png)
 </figure>
 
 * _TEXT_.
-* _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_“_TEXT_”_TEXT_. 
+* _TEXT_. 
 <details>
-<summary>_TEXT___TEXT___TEXT_. _TEXT_</summary>
+<summary>_TEXT_. _TEXT_</summary>
 ```
-___TEXT___TEXT___TEXT___
+_TEXT_
 ```
 </details>
 
 * _TEXT_. 
   ```
-___TEXT___TEXT___TEXT___
+_TEXT_
 ```

--- a/confluence-mdx/tests/testcases/544384417/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544384417/expected.skel.mdx
@@ -14,7 +14,7 @@ _TEXT_. _TEXT_. _TEXT_.
 
 _TEXT_.
 
-_TEXT_, _TEXT_, _TEXT_/_TEXT_, _TEXT_/_TEXT_/_TEXT_.
+_TEXT_.
 
 <Callout type="info">
 _TEXT_. _TEXT_. _TEXT_.
@@ -37,22 +37,22 @@ _TEXT_. _TEXT_. _TEXT_.
 <tbody>
 <tr>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 </tr>
 <tr>
@@ -91,7 +91,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_<br/>_TEXT_/_TEXT_
+_TEXT_<br/>_TEXT_
 </td>
 <td>
 _TEXT_
@@ -105,7 +105,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_**__TEXT__**<br/>_TEXT_
+_TEXT_<br/>_TEXT_
 </td>
 <td>
 _TEXT_
@@ -119,7 +119,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_**__TEXT__**<br/>_TEXT_/_TEXT_
+_TEXT_<br/>_TEXT_
 </td>
 <td>
 _TEXT_
@@ -150,37 +150,6 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_<br/>_TEXT_/_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
--
-</td>
-</tr>
-<tr>
-<td>
-_TEXT_<br/>_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
--
-</td>
-</tr>
-<tr>
-<td rowspan="2">
-_TEXT_
-</td>
-<td>
 _TEXT_<br/>_TEXT_
 </td>
 <td>
@@ -226,7 +195,38 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_**__TEXT__**<br/>_TEXT_
+_TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td rowspan="2">
+_TEXT_
+</td>
+<td>
+_TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+-
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_<br/>_TEXT_
 </td>
 <td>
 _TEXT_
@@ -243,7 +243,7 @@ _TEXT_
 _TEXT_
 </td>
 <td rowspan="2">
-_TEXT_**__TEXT__**
+_TEXT_
 </td>
 <td>
 _TEXT_<br/>_TEXT_
@@ -260,7 +260,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_<br/>_TEXT_/_TEXT_
+_TEXT_<br/>_TEXT_
 </td>
 <td>
 _TEXT_
@@ -277,7 +277,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_- _TEXT_<br/>_TEXT_
+_TEXT_<br/>_TEXT_
 </td>
 <td>
 _TEXT_
@@ -291,7 +291,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_<br/>_TEXT_/_TEXT_
+_TEXT_<br/>_TEXT_
 </td>
 <td>
 _TEXT_
@@ -305,7 +305,7 @@ _TEXT_
 </tr>
 <tr>
 <td rowspan="2">
-_TEXT_& _TEXT_
+_TEXT_
 </td>
 <td>
 _TEXT_<br/>_TEXT_
@@ -336,7 +336,7 @@ _TEXT_
 </tr>
 <tr>
 <td rowspan="2">
-_TEXT_- _TEXT_**__TEXT__**
+_TEXT_
 </td>
 <td>
 _TEXT_<br/>_TEXT_
@@ -353,7 +353,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_**__TEXT__**
+_TEXT_
 _TEXT_
 </td>
 <td>
@@ -371,7 +371,7 @@ _TEXT_
 _TEXT_
 </td>
 <td rowspan="2">
-_TEXT_<br/>**__TEXT__**
+_TEXT_<br/>_TEXT_
 </td>
 <td>
 _TEXT_<br/>_TEXT_
@@ -388,7 +388,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_<br/>_TEXT_/_TEXT_/_TEXT_
+_TEXT_<br/>_TEXT_
 </td>
 <td>
 _TEXT_
@@ -402,7 +402,7 @@ _TEXT_
 </tr>
 <tr>
 <td rowspan="2">
-_TEXT_**__TEXT__**
+_TEXT_
 </td>
 <td>
 _TEXT_<br/>_TEXT_
@@ -419,7 +419,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_<br/>_TEXT_/_TEXT_/_TEXT_
+_TEXT_<br/>_TEXT_
 </td>
 <td>
 _TEXT_
@@ -433,7 +433,7 @@ _TEXT_
 </tr>
 <tr>
 <td rowspan="2">
-_TEXT_& _TEXT_**__TEXT__**
+_TEXT_
 </td>
 <td>
 _TEXT_<br/>_TEXT_
@@ -467,7 +467,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_/_TEXT_**__TEXT__**<br/>_TEXT_/_TEXT_
+_TEXT_<br/>_TEXT_
 </td>
 <td>
 _TEXT_
@@ -495,21 +495,21 @@ _TEXT_
 </tr>
 <tr>
 <td>
-*__TEXT__* **__TEXT__**<br/> *__TEXT__*
+_TEXT_<br/> _TEXT_
 </td>
 <td>
-*__TEXT__*
+_TEXT_
 </td>
 <td>
-*__TEXT__*
+_TEXT_
 </td>
 <td>
-*__TEXT__*
+_TEXT_
 </td>
 </tr>
 <tr>
 <td>
-_TEXT_-_TEXT_**__TEXT__**<br/>_TEXT_
+_TEXT_<br/>_TEXT_
 </td>
 <td>
 _TEXT_
@@ -523,7 +523,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_**__TEXT__**<br/>_TEXT_
+_TEXT_<br/>_TEXT_
 </td>
 <td>
 _TEXT_
@@ -537,7 +537,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_& _TEXT_**__TEXT__**<br/>_TEXT_
+_TEXT_<br/>_TEXT_
 </td>
 <td>
 _TEXT_
@@ -551,7 +551,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_/_TEXT_<br/>_TEXT_/_TEXT_
+_TEXT_<br/>_TEXT_
 </td>
 <td>
 _TEXT_
@@ -628,7 +628,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_/_TEXT_<br/>_TEXT_/_TEXT_
+_TEXT_<br/>_TEXT_
 </td>
 <td>
 _TEXT_
@@ -657,7 +657,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_- _TEXT_<br/>**__TEXT__**
+_TEXT_<br/>_TEXT_
 </td>
 <td>
 _TEXT_<br/>_TEXT_
@@ -677,7 +677,7 @@ _TEXT_
 
 ### _TEXT_
 
-_TEXT____TEXT___TEXT___TEXT___ _TEXT_.
+_TEXT_.
 
 <Callout type="info">
 _TEXT_.
@@ -685,169 +685,169 @@ _TEXT_.
 
 
 <figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+![_TEXT_](/544384417/output/screenshot-20241223-112238.png)
 <figcaption>
-_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+_TEXT_
 </figcaption>
 </figure>
 
 
-1.  **__TEXT__**  : _TEXT_.
-2.  **__TEXT__**  : _TEXT_.
-3.  **__TEXT__**  : _TEXT_.
-4.  **__TEXT__**  : _TEXT_, _TEXT_.
+1.  _TEXT_.
+2.  _TEXT_.
+3.  _TEXT_.
+4.  _TEXT_.
     1. _TEXT_
     2. _TEXT_
     3. _TEXT_
-5.  **__TEXT__**  : _TEXT_.
-6.  **__TEXT__**  : _TEXT_, _TEXT_.
-    1. _TEXT_: _TEXT_(_TEXT_)
-    2. _TEXT_: _TEXT_
-    3. _TEXT_: _TEXT_
-    4. _TEXT_: _TEXT_
-    5. _TEXT_: _TEXT_
-7.  **__TEXT__**  : _TEXT_.
-8.  **__TEXT__**  : _TEXT_.
-9.  **__TEXT__**  : _TEXT_. (_TEXT_)
-10.  **__TEXT__**  : _TEXT_. _TEXT_.
-    1. _TEXT_: _TEXT_
-    2. _TEXT_: _TEXT_
-    3. _TEXT_: _TEXT_
-11.  **__TEXT__**  : _TEXT_, _TEXT_.
-    1. _TEXT_, _TEXT_.
-    2. _TEXT_.
-    3. _TEXT_, _TEXT_. _TEXT_.
-
-### _TEXT_
-
-_TEXT_, _TEXT_.
-
-
-<figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
-<figcaption>
-_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
-</figcaption>
-</figure>
-
-
-1.  **__TEXT__**  : _TEXT_, _TEXT_.
-    1. _TEXT_, _TEXT_.
-2.  **__TEXT__**  : _TEXT_. (_TEXT_, _TEXT_, _TEXT_) 
+5.  _TEXT_.
+6.  _TEXT_.
+    1. _TEXT_
+    2. _TEXT_
+    3. _TEXT_
+    4. _TEXT_
+    5. _TEXT_
+7.  _TEXT_.
+8.  _TEXT_.
+9.  _TEXT_. _TEXT_
+10.  _TEXT_. _TEXT_.
+    1. _TEXT_
+    2. _TEXT_
+    3. _TEXT_
+11.  _TEXT_.
     1. _TEXT_.
-3.  **__TEXT__**  : _TEXT_. (_TEXT_, _TEXT_, _TEXT_, _TEXT_)
-4.  **__TEXT__**  : _TEXT_.
-5.  **__TEXT__**  : _TEXT_.
-6.  **__TEXT__**  : _TEXT_. (_TEXT_)
-7.  **__TEXT__**  : _TEXT_.
-8.  **__TEXT__**  : _TEXT_.
-9.  **__TEXT__**  : _TEXT_. 
-    1. _TEXT_. : _TEXT_
-    2. _TEXT_: _TEXT_
-    3. _TEXT_: _TEXT_(_TEXT_)_TEXT_
-    4. _TEXT_: _TEXT_(_TEXT_, _TEXT_)
-    5. _TEXT_: _TEXT_
-        * _TEXT_, _TEXT_.
-        * _TEXT_.
-        * _TEXT_, _TEXT_. _TEXT_.
-10.  **__TEXT__**  : _TEXT_.
-    1. _TEXT_: _TEXT_
-    2. _TEXT_: _TEXT_(_TEXT_, _TEXT_)
-    3. _TEXT_. : _TEXT_(_TEXT_)
-    4. _TEXT_: _TEXT_
+    2. _TEXT_.
+    3. _TEXT_. _TEXT_.
 
 ### _TEXT_
 
-_TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
+_TEXT_.
 
-_TEXT_, _TEXT_, _TEXT_, _TEXT_. `___TEXT___TEXT___TEXT___` _TEXT_.
 
 <figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+![_TEXT_](/544384417/output/screenshot-20241223-112524.png)
 <figcaption>
-_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+_TEXT_
 </figcaption>
 </figure>
 
-1.  **__TEXT__**  : _TEXT_.
-2.  **__TEXT__**  : _TEXT_. (_TEXT_, _TEXT_, _TEXT_)
-3.  **__TEXT__**  : _TEXT_.
-    1. _TEXT_: _TEXT_.
-    2. _TEXT_: _TEXT_.
-    3. _TEXT_: _TEXT_.
-    4. _TEXT_: _TEXT_.
-    5. _TEXT_: _TEXT_.
-4.  **__TEXT__**  : _TEXT_
-    1. `___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_, _TEXT_.
+
+1.  _TEXT_.
+    1. _TEXT_.
+2.  _TEXT_. _TEXT_
+    1. _TEXT_.
+3.  _TEXT_. _TEXT_
+4.  _TEXT_.
+5.  _TEXT_.
+6.  _TEXT_. _TEXT_
+7.  _TEXT_.
+8.  _TEXT_.
+9.  _TEXT_. 
+    1. _TEXT_. _TEXT_
+    2. _TEXT_
+    3. _TEXT_
+    4. _TEXT_
+    5. _TEXT_
+        * _TEXT_.
+        * _TEXT_.
+        * _TEXT_. _TEXT_.
+10.  _TEXT_.
+    1. _TEXT_
+    2. _TEXT_
+    3. _TEXT_. _TEXT_
+    4. _TEXT_
+
+### _TEXT_
+
+_TEXT_.
+
+_TEXT_. _TEXT_.
+
+<figure data-layout="center" data-align="center">
+![_TEXT_](/544384417/output/screenshot-20241209-104337.png)
+<figcaption>
+_TEXT_
+</figcaption>
+</figure>
+
+1.  _TEXT_.
+2.  _TEXT_. _TEXT_
+3.  _TEXT_.
+    1. _TEXT_.
     2. _TEXT_.
-    3. _TEXT_: _TEXT_.
-        1.  `___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_.
-5.  **__TEXT__**  : _TEXT_
-    1. `___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_, _TEXT_.
-6.  **__TEXT__**  : _TEXT_
-    1. _TEXT_, _TEXT_.
-    2. _TEXT_: _TEXT_
-    3. _TEXT_: _TEXT_
-7.  **__TEXT__**  : _TEXT_
+    3. _TEXT_.
+    4. _TEXT_.
+    5. _TEXT_.
+4.  _TEXT_
+    1. _TEXT_.
+    2. _TEXT_.
+    3. _TEXT_.
+        1.  _TEXT_.
+5.  _TEXT_
+    1. _TEXT_.
+6.  _TEXT_
+    1. _TEXT_.
+    2. _TEXT_
+    3. _TEXT_
+7.  _TEXT_
     1. _TEXT_.
     2. _TEXT_
 
-_TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
-
-`___TEXT___TEXT___TEXT___` _TEXT_.
-
-### _TEXT_**__TEXT__**
-
-<figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
-<figcaption>
-_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_- _TEXT_
-</figcaption>
-</figure>
-
-_TEXT_: _TEXT_: `___TEXT___TEXT___TEXT___` _TEXT_, _TEXT_.
+_TEXT_.
 
 _TEXT_.
 
-*  **__TEXT__**  - _TEXT_
-*  **__TEXT__**  - _TEXT_
-*  **__TEXT__**  - _TEXT_
-    * _TEXT_, _TEXT_, _TEXT_
-*  **__TEXT__**  - _TEXT_
-*  **__TEXT__**  - _TEXT_
-    * _TEXT_, _TEXT_, _TEXT_, _TEXT_
+### _TEXT_
+
+<figure data-layout="center" data-align="center">
+![_TEXT_](/544384417/output/screenshot-20241223-104529.png)
+<figcaption>
+_TEXT_
+</figcaption>
+</figure>
+
+_TEXT_.
+
+_TEXT_.
+
+*  _TEXT_
+*  _TEXT_
+*  _TEXT_
+    * _TEXT_
+*  _TEXT_
+*  _TEXT_
+    * _TEXT_
 
 ### _TEXT_
 
 _TEXT_.
 
-1.  **__TEXT__**  : _TEXT_.
-    1. _TEXT_: _TEXT_
-        * _TEXT_: _TEXT_
-        * _TEXT_: _TEXT_- _TEXT_
-        * _TEXT____TEXT___TEXT___TEXT___ _TEXT_/_TEXT_: _TEXT_(_TEXT_)
-2.  **__TEXT__**  : _TEXT_.
-    1. _TEXT_: `___TEXT___TEXT___TEXT___` _TEXT_
-        * _TEXT_: _TEXT_
-        * _TEXT_: _TEXT_- _TEXT_
-        * _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___`
-    2. _TEXT_, _TEXT_.
+1.  _TEXT_.
+    1. _TEXT_
+        * _TEXT_
+        * _TEXT_
+        * _TEXT_
+2.  _TEXT_.
+    1. _TEXT_
+        * _TEXT_
+        * _TEXT_
+        * _TEXT_
+    2. _TEXT_.
         * _TEXT_.
         * _TEXT_.
     3. _TEXT_. _TEXT_.
-3.  **__TEXT__** _TEXT_.
-    1. _TEXT_: _TEXT_, _TEXT_, _TEXT_, _TEXT_
-4.  **__TEXT__**  : _TEXT_.
+3.  _TEXT_.
+    1. _TEXT_
+4.  _TEXT_.
     1. _TEXT_.
-    2. _TEXT_. _TEXT_, _TEXT_.
-5.  **__TEXT__**  : _TEXT_.
-    1. _TEXT_: _TEXT_, _TEXT_
-6.  **__TEXT__**  : _TEXT_(_TEXT_)_TEXT_.
-    1. _TEXT_: _TEXT_, _TEXT_
-7.  **__TEXT__**  : _TEXT_.
+    2. _TEXT_. _TEXT_.
+5.  _TEXT_.
+    1. _TEXT_
+6.  _TEXT_.
+    1. _TEXT_
+7.  _TEXT_.
     1. _TEXT_.
-8.  **__TEXT__**  : _TEXT_.
+8.  _TEXT_.
     1. _TEXT_.
-    2. _TEXT_. (_TEXT_)
+    2. _TEXT_. _TEXT_
     3. _TEXT_.
     4. _TEXT_.

--- a/confluence-mdx/tests/testcases/568918170/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/568918170/expected.skel.mdx
@@ -4,7 +4,7 @@ title: '_TEXT_'
 
 import { Callout } from 'nextra/components'
 
-# _TEXT_(_TEXT_, _TEXT_)
+# _TEXT_
 
 ### _TEXT_
 
@@ -14,18 +14,18 @@ _TEXT_.
 ### _TEXT_
 
 <figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+![_TEXT_](/568918170/output/screenshot-20240802-114129.png)
 <figcaption>
-_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+_TEXT_
 </figcaption>
 </figure>
 
-1. _TEXT____TEXT___TEXT___TEXT___ _TEXT_. 
-    1. _TEXT_(_TEXT_/_TEXT_) _TEXT_. 
-    2. _TEXT_**__TEXT__**  _TEXT_`___TEXT___TEXT___TEXT___`_TEXT_. 
-2. _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_. 
-3. _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_. 
-4. _TEXT_**__TEXT__** _TEXT_.
+1. _TEXT_. 
+    1. _TEXT_. 
+    2. _TEXT_. 
+2. _TEXT_. 
+3. _TEXT_. 
+4. _TEXT_.
 
 
 
@@ -36,29 +36,29 @@ _TEXT_. _TEXT_.
 #### _TEXT_. _TEXT_
 
 <figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+![_TEXT_](/568918170/output/screenshot-20240802-120401.png)
 <figcaption>
-_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+_TEXT_
 </figcaption>
 </figure>
 
-*  **__TEXT__**  : _TEXT_
-*  **__TEXT__**  : _TEXT_
-*  **__TEXT__**  : _TEXT_
-*  **__TEXT__**  : _TEXT_
-*  **__TEXT__**  : `___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_.
+*  _TEXT_
+*  _TEXT_
+*  _TEXT_
+*  _TEXT_
+*  _TEXT_.
 
 #### _TEXT_. _TEXT_
 
 _TEXT_.
 <figure data-layout="center" data-align="center">
-![__TEXT__](___TEXT___TEXT___)
+![_TEXT_](/568918170/output/screenshot-20240802-120741.png)
 <figcaption>
 _TEXT_
 </figcaption>
 </figure>
 <figure data-layout="center" data-align="center">
-![__TEXT__](___TEXT___TEXT___)
+![_TEXT_](/568918170/output/screenshot-20240802-120854.png)
 <figcaption>
 _TEXT_
 </figcaption>
@@ -69,39 +69,39 @@ _TEXT_. _TEXT_.
 
 #### _TEXT_. _TEXT_
 
-* _TEXT_, _TEXT_. 
-    *  **__TEXT__**  : _TEXT_(_TEXT_
-    *  **__TEXT__**  : _TEXT_.
-* _TEXT_, _TEXT_. 
+* _TEXT_. 
+    *  _TEXT_
+    *  _TEXT_.
+* _TEXT_. 
 
 <figure data-layout="center" data-align="center">
-![__TEXT__](___TEXT___TEXT___)
+![_TEXT_](/568918170/output/screenshot-20240802-124638.png)
 </figure>
 
 #### _TEXT_. _TEXT_
 
 * _TEXT_. 
-**__TEXT__**
+_TEXT_
 <figure data-layout="center" data-align="center">
-![__TEXT__](___TEXT___TEXT___)
+![_TEXT_](/568918170/output/screenshot-20240725-153533.png)
 <figcaption>
 _TEXT_
 </figcaption>
 </figure>
-**__TEXT__**
+_TEXT_
 <figure data-layout="center" data-align="center">
-![__TEXT__](___TEXT___TEXT___)
+![_TEXT_](/568918170/output/screenshot-20240725-152141.png)
 <figcaption>
 _TEXT_
 </figcaption>
 </figure>
 <Callout type="info">
-_TEXT_, _TEXT_. _TEXT_[__TEXT__](../../_TEXT_-_TEXT_/_TEXT_/_TEXT_/_TEXT_/_TEXT_-_TEXT_-_TEXT_-_TEXT_/_TEXT_-_TEXT_-_TEXT_-_TEXT_-_TEXT_) _TEXT_.
+_TEXT_. _TEXT_../.. _TEXT_.
 </Callout>
 
 #### _TEXT_. _TEXT_
 
-* _TEXT____TEXT___TEXT___TEXT___ _TEXT_, _TEXT_. _TEXT_. 
+* _TEXT_. _TEXT_. 
 
 
 ### _TEXT_
@@ -109,19 +109,19 @@ _TEXT_, _TEXT_. _TEXT_[__TEXT__](../../_TEXT_-_TEXT_/_TEXT_/_TEXT_/_TEXT_/_TEXT_
 _TEXT_.
 
 <figure data-layout="center" data-align="center">
-![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+![_TEXT_](/568918170/output/image-20230824-110815.png)
 <figcaption>
-_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+_TEXT_
 </figcaption>
 </figure>
 
-1. _TEXT____TEXT___TEXT___TEXT___ _TEXT_. 
+1. _TEXT_. 
 
 <Callout type="info">
-_TEXT_(_TEXT_, _TEXT_, _TEXT_, _TEXT_)_TEXT_*__TEXT__* _TEXT_, _TEXT_.
+_TEXT_.
 </Callout>
 
-1. _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_. 
+1. _TEXT_. 
 2. _TEXT_. 
-3. `___TEXT___TEXT___TEXT___` _TEXT_.
-4. _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_.
+3. _TEXT_.
+4. _TEXT_.

--- a/confluence-mdx/tests/testcases/692355151/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/692355151/expected.skel.mdx
@@ -4,67 +4,67 @@ title: '_TEXT_'
 
 import { Callout } from 'nextra/components'
 
-# _TEXT_(_TEXT_) _TEXT_
+# _TEXT_
 
 <Callout type="info">
-_TEXT_. _TEXT_. _TEXT_. (_TEXT_. _TEXT_. _TEXT_.)
+_TEXT_. _TEXT_. _TEXT_. _TEXT_. _TEXT_. _TEXT_.)
 _TEXT_. _TEXT_. _TEXT_. _TEXT_.
 </Callout>
 
 ### _TEXT_
 
-_TEXT_(_TEXT_)_TEXT_. _TEXT_.
+_TEXT_. _TEXT_.
 
 <Callout type="info">
 _TEXT_?<br/>_TEXT_. _TEXT_.
 </Callout>
 
-### _TEXT_(_TEXT_) _TEXT_
+### _TEXT_
 
-_TEXT_. (_TEXT_: [__TEXT__](.))
+_TEXT_. _TEXT_.))
 
 _TEXT_. _TEXT_<br/>_TEXT_. 
 
 <Callout type="important">
-_TEXT_“_TEXT_”_TEXT_. “_TEXT_”_TEXT_(_TEXT_)_TEXT_.
+_TEXT_. _TEXT_.
 </Callout>
 
 <figure data-layout="center" data-align="center">
-![__TEXT__](___TEXT___TEXT___)
+![_TEXT_](/692355151/output/image-20241029-234721.png)
 </figure>
 
-_TEXT_. _TEXT_(_TEXT_) _TEXT_<br/>_TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
-    1.  **__TEXT__**  : _TEXT_. (_TEXT_. _TEXT_.) 
+_TEXT_. _TEXT_<br/>_TEXT_.
+    1.  _TEXT_. _TEXT_. _TEXT_.) 
     2. _TEXT_
-        1.  **__TEXT__**  : _TEXT_.
-        2.  **__TEXT__**  : _TEXT_. 
+        1.  _TEXT_.
+        2.  _TEXT_. 
 
 <figure data-layout="center" data-align="center">
-![__TEXT__](___TEXT___TEXT___)
+![_TEXT_](/692355151/output/image-20241029-235845.png)
 </figure>
 
 <Callout type="important">
-* _TEXT_(_TEXT_)_TEXT_. 
+* _TEXT_. 
 * _TEXT_. _TEXT_. _TEXT_. _TEXT_.
 <figure data-layout="center" data-align="center">
-![__TEXT__](___TEXT___TEXT___)
+![_TEXT_](/692355151/output/image-20241030-001252.png)
 </figure>
 </Callout>
 
-1. _TEXT_(_TEXT_) _TEXT_
+1. _TEXT_
     _TEXT_. _TEXT_<br/>_TEXT_. _TEXT_.<br/> <br/>  
       <figure data-layout="center" data-align="center">
-      ![__TEXT__](___TEXT___TEXT___)
+      ![_TEXT_](/692355151/output/image-20241030-002325.png)
       </figure>
-    _TEXT_. _TEXT_<br/>_TEXT_. `___TEXT___TEXT___TEXT___` _TEXT_.<br/> <br/>  <br/> <br/>  <br/>_TEXT_(_TEXT_)_TEXT_.
+    _TEXT_. _TEXT_<br/>_TEXT_. _TEXT_.<br/> <br/>  <br/> <br/>  <br/>_TEXT_.
       <figure data-layout="center" data-align="center">
-      ![`___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+      ![_TEXT_](/692355151/output/image-20241030-003040.png)
       <figcaption>
-      `___TEXT___TEXT___TEXT___`_TEXT_.
+      _TEXT_.
       </figcaption>
       </figure>
       <figure data-layout="center" data-align="center">
-      ![__TEXT__](___TEXT___TEXT___)
+      ![_TEXT_](/692355151/output/image-20241030-003129.png)
       <figcaption>
       _TEXT_.
       </figcaption>
@@ -72,21 +72,21 @@ _TEXT_. _TEXT_(_TEXT_) _TEXT_<br/>_TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
 
 ### _TEXT_
 
-_TEXT_. _TEXT_(_TEXT_)_TEXT_(_TEXT_)_TEXT_<br/>_TEXT_(_TEXT_)_TEXT_.
+_TEXT_. _TEXT_<br/>_TEXT_.
   <figure data-layout="center" data-align="center">
-  ![__TEXT__](___TEXT___TEXT___)
+  ![_TEXT_](/692355151/output/image-20241030-004258.png)
   </figure>
 
 <Callout type="important">
-_TEXT_(_TEXT_) _TEXT_. _TEXT_, _TEXT_.
+_TEXT_. _TEXT_.
 </Callout>
 
-_TEXT_. _TEXT_(_TEXT_)_TEXT_<br/>_TEXT_. 
+_TEXT_. _TEXT_<br/>_TEXT_. 
 
-|  **__TEXT__**  |  **__TEXT__**                         |
+_TEXT_
 | -------------------- | ------------------------------------------- |
-| _TEXT_| _TEXT_, _TEXT_, _TEXT_, _TEXT_, _TEXT_|
+_TEXT_
 
 <Callout type="important">
-_TEXT___TEXT_, _TEXT_(_TEXT_) _TEXT_.
+_TEXT_.
 </Callout>

--- a/confluence-mdx/tests/testcases/793608206/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/793608206/expected.skel.mdx
@@ -2,9 +2,9 @@
 title: '_TEXT_'
 ---
 
-# _TEXT_> _TEXT_
+# _TEXT_
 
-_TEXT_, _TEXT_.
+_TEXT_.
 
 ### _TEXT_
 
@@ -22,16 +22,16 @@ _TEXT_.
 <tbody>
 <tr>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 </tr>
 <tr>
@@ -39,11 +39,11 @@ _TEXT_.
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
-* _TEXT_: _TEXT_
+* _TEXT_
 </td>
 <td>
 -
@@ -54,11 +54,11 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
-* _TEXT_: _TEXT_(_TEXT_), _TEXT_(_TEXT_), _TEXT_(_TEXT_)
+* _TEXT_
 </td>
 <td>
 -
@@ -69,11 +69,11 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
-* _TEXT_: _TEXT_.
+* _TEXT_.
 </td>
 <td>
 -
@@ -84,11 +84,11 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
-* _TEXT_: _TEXT_
+* _TEXT_
 </td>
 <td>
 -
@@ -99,11 +99,11 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
-* _TEXT_: [__TEXT__](_TEXT_: _TEXT_@_TEXT_. _TEXT_)
+* _TEXT_. _TEXT_
 </td>
 <td>
 -
@@ -114,7 +114,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -134,11 +134,11 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
-* _TEXT_: _TEXT_://`___TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___`
+* _TEXT_
 </td>
 <td>
 -
@@ -149,11 +149,11 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
-* _TEXT_: _TEXT_-_TEXT_-_TEXT_-_TEXT_-_TEXT_
+* _TEXT_
 </td>
 <td>
 -
@@ -164,11 +164,11 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
-* _TEXT_: _TEXT_
+* _TEXT_
 </td>
 <td>
 -
@@ -179,7 +179,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -204,16 +204,16 @@ _TEXT_. _TEXT_. _TEXT_
 <tbody>
 <tr>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 </tr>
 <tr>
@@ -221,27 +221,13 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
 </td>
 <td>
 _TEXT_. _TEXT_. _TEXT_
-_TEXT_. _TEXT_. _TEXT_- _TEXT_
-</td>
-</tr>
-<tr>
-<td>
-_TEXT_
-</td>
-<td>
-`___TEXT___TEXT___TEXT___`
-</td>
-<td>
-_TEXT_
-</td>
-<td>
 _TEXT_. _TEXT_. _TEXT_
 </td>
 </tr>
@@ -250,7 +236,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -264,13 +250,27 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
-* _TEXT_:
-    * _TEXT_: _TEXT_/_TEXT_
-    * _TEXT_: _TEXT_-_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+* _TEXT_
+    * _TEXT_
+    * _TEXT_
 </td>
 <td>
 _TEXT_. _TEXT_. _TEXT_
@@ -291,16 +291,16 @@ _TEXT_. _TEXT_. _TEXT_
 <tbody>
 <tr>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 </tr>
 <tr>
@@ -308,22 +308,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
-</td>
-<td>
 _TEXT_
-* _TEXT_(_TEXT_, _TEXT_)
-</td>
-<td>
-_TEXT_. _TEXT_. _TEXT_
-</td>
-</tr>
-<tr>
-<td>
-_TEXT_
-</td>
-<td>
-`___TEXT___TEXT___TEXT___`
 </td>
 <td>
 _TEXT_
@@ -338,7 +323,22 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
+</td>
+<td>
+_TEXT_
+* _TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -352,7 +352,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -366,7 +366,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -380,7 +380,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -394,7 +394,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -408,7 +408,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -422,27 +422,13 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
 </td>
 <td>
 _TEXT_. _TEXT_. _TEXT_
-_TEXT_. _TEXT_. _TEXT_- _TEXT_
-</td>
-</tr>
-<tr>
-<td>
-_TEXT_
-</td>
-<td>
-`___TEXT___TEXT___TEXT___`
-</td>
-<td>
-_TEXT_
-</td>
-<td>
 _TEXT_. _TEXT_. _TEXT_
 </td>
 </tr>
@@ -451,22 +437,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
-</td>
-<td>
-_TEXT_/_TEXT_
-</td>
-<td>
-_TEXT_. _TEXT_. _TEXT_
-_TEXT_. _TEXT_. _TEXT_- _TEXT_
-</td>
-</tr>
-<tr>
-<td>
 _TEXT_
-</td>
-<td>
-`___TEXT___TEXT___TEXT___`
 </td>
 <td>
 _TEXT_
@@ -480,7 +451,36 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -504,16 +504,16 @@ _TEXT_. _TEXT_. _TEXT_
 <tbody>
 <tr>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 </tr>
 <tr>
@@ -521,7 +521,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -535,7 +535,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -549,7 +549,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -563,7 +563,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -577,7 +577,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -591,7 +591,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -606,12 +606,12 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
-* _TEXT_, _TEXT_
-* _TEXT_, _TEXT_
+* _TEXT_
+* _TEXT_
 </td>
 <td>
 _TEXT_. _TEXT_. _TEXT_
@@ -622,21 +622,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
-</td>
-<td>
 _TEXT_
-</td>
-<td>
-_TEXT_. _TEXT_. _TEXT_
-</td>
-</tr>
-<tr>
-<td>
-_TEXT_
-</td>
-<td>
-`___TEXT___TEXT___TEXT___`
 </td>
 <td>
 _TEXT_
@@ -650,21 +636,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
-</td>
-<td>
-_TEXT_/_TEXT_
-</td>
-<td>
-_TEXT_. _TEXT_. _TEXT_
-</td>
-</tr>
-<tr>
-<td>
 _TEXT_
-</td>
-<td>
-`___TEXT___TEXT___TEXT___`
 </td>
 <td>
 _TEXT_
@@ -678,7 +650,35 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -702,16 +702,16 @@ _TEXT_. _TEXT_. _TEXT_
 <tbody>
 <tr>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 </tr>
 <tr>
@@ -719,7 +719,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -733,7 +733,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -747,7 +747,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -761,7 +761,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -775,7 +775,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -789,11 +789,11 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
-* _TEXT_: [__TEXT__]
+* _TEXT_
 </td>
 <td>
 _TEXT_. _TEXT_. _TEXT_
@@ -804,13 +804,13 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
-* _TEXT_: 
+* _TEXT_
     * _TEXT_
-    * _TEXT_-_TEXT_-_TEXT_: _TEXT_: _TEXT_
+    * _TEXT_
 </td>
 <td>
 _TEXT_. _TEXT_. _TEXT_
@@ -821,7 +821,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -845,16 +845,16 @@ _TEXT_. _TEXT_. _TEXT_
 <tbody>
 <tr>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 </tr>
 <tr>
@@ -862,7 +862,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -876,7 +876,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -890,7 +890,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -904,7 +904,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -918,7 +918,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -932,11 +932,11 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
-* _TEXT_: [__TEXT__]
+* _TEXT_
 </td>
 <td>
 _TEXT_. _TEXT_. _TEXT_
@@ -947,13 +947,13 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
-* _TEXT_: 
+* _TEXT_
     * _TEXT_
-    * _TEXT_-_TEXT_-_TEXT_: _TEXT_: _TEXT_
+    * _TEXT_
 </td>
 <td>
 _TEXT_. _TEXT_. _TEXT_
@@ -964,7 +964,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -988,16 +988,16 @@ _TEXT_. _TEXT_. _TEXT_
 <tbody>
 <tr>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 </tr>
 <tr>
@@ -1005,7 +1005,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -1019,7 +1019,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -1033,7 +1033,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -1047,7 +1047,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -1061,7 +1061,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -1075,7 +1075,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -1089,11 +1089,11 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
-* _TEXT_: [__TEXT__]
+* _TEXT_
 </td>
 <td>
 _TEXT_. _TEXT_. _TEXT_
@@ -1104,13 +1104,13 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
-* _TEXT_: 
+* _TEXT_
     * _TEXT_
-    * _TEXT_-_TEXT_-_TEXT_: _TEXT_: _TEXT_
+    * _TEXT_
 </td>
 <td>
 _TEXT_. _TEXT_. _TEXT_
@@ -1121,7 +1121,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -1145,16 +1145,16 @@ _TEXT_. _TEXT_. _TEXT_
 <tbody>
 <tr>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 </tr>
 <tr>
@@ -1162,7 +1162,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -1176,11 +1176,11 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
-* _TEXT_: 
+* _TEXT_
     * _TEXT_
     * _TEXT_
 </td>
@@ -1193,13 +1193,13 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
-* _TEXT_: 
+* _TEXT_
     * _TEXT_
-    * _TEXT_-_TEXT_
+    * _TEXT_
 </td>
 <td>
 _TEXT_. _TEXT_. _TEXT_
@@ -1210,27 +1210,13 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
 </td>
 <td>
 _TEXT_. _TEXT_. _TEXT_
-_TEXT_. _TEXT_. _TEXT_- _TEXT_
-</td>
-</tr>
-<tr>
-<td>
-_TEXT_
-</td>
-<td>
-`___TEXT___TEXT___TEXT___`
-</td>
-<td>
-_TEXT_
-</td>
-<td>
 _TEXT_. _TEXT_. _TEXT_
 </td>
 </tr>
@@ -1239,7 +1225,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -1253,7 +1239,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -1267,10 +1253,24 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
-_TEXT_(_TEXT_) _TEXT_
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
 </td>
 <td>
 _TEXT_. _TEXT_. _TEXT_
@@ -1291,16 +1291,16 @@ _TEXT_. _TEXT_. _TEXT_
 <tbody>
 <tr>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 </tr>
 <tr>
@@ -1308,7 +1308,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -1322,11 +1322,11 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
-* _TEXT_: 
+* _TEXT_
     * _TEXT_
     * _TEXT_
 </td>
@@ -1339,13 +1339,13 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
-* _TEXT_: 
+* _TEXT_
     * _TEXT_
-    * _TEXT_-_TEXT_
+    * _TEXT_
 </td>
 <td>
 _TEXT_. _TEXT_. _TEXT_
@@ -1356,27 +1356,13 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
 </td>
 <td>
 _TEXT_. _TEXT_. _TEXT_
-_TEXT_. _TEXT_. _TEXT_- _TEXT_
-</td>
-</tr>
-<tr>
-<td>
-_TEXT_
-</td>
-<td>
-`___TEXT___TEXT___TEXT___`
-</td>
-<td>
-_TEXT_
-</td>
-<td>
 _TEXT_. _TEXT_. _TEXT_
 </td>
 </tr>
@@ -1385,7 +1371,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -1399,7 +1385,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -1413,10 +1399,24 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
-_TEXT_(_TEXT_) _TEXT_
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
 </td>
 <td>
 _TEXT_. _TEXT_. _TEXT_
@@ -1437,16 +1437,16 @@ _TEXT_. _TEXT_. _TEXT_
 <tbody>
 <tr>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 <th>
-**__TEXT__**
+_TEXT_
 </th>
 </tr>
 <tr>
@@ -1454,11 +1454,11 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
 </td>
 <td>
 _TEXT_
-* _TEXT_, _TEXT_, _TEXT_
+* _TEXT_
 </td>
 <td>
 _TEXT_. _TEXT_. _TEXT_
@@ -1469,36 +1469,7 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
-</td>
-<td>
 _TEXT_
-</td>
-<td>
-_TEXT_. _TEXT_. _TEXT_
-</td>
-</tr>
-<tr>
-<td>
-_TEXT_
-</td>
-<td>
-`___TEXT___TEXT___TEXT___`
-</td>
-<td>
-_TEXT_
-</td>
-<td>
-_TEXT_. _TEXT_. _TEXT_
-_TEXT_. _TEXT_. _TEXT_- _TEXT_
-</td>
-</tr>
-<tr>
-<td>
-_TEXT_
-</td>
-<td>
-`___TEXT___TEXT___TEXT___`
 </td>
 <td>
 _TEXT_
@@ -1512,7 +1483,36 @@ _TEXT_. _TEXT_. _TEXT_
 _TEXT_
 </td>
 <td>
-`___TEXT___TEXT___TEXT___`
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_. _TEXT_. _TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
 </td>
 <td>
 _TEXT_
@@ -1524,17 +1524,17 @@ _TEXT_. _TEXT_. _TEXT_
 </tbody>
 </table>
 
-### _TEXT_-_TEXT_-_TEXT_
+### _TEXT_
 
-|  **__TEXT__**                 |  **__TEXT__**                      |  **__TEXT__**                        |  **__TEXT__**  |
+_TEXT_
 | ------------------------ | ---------------------------- | ------------------------------ | ----------- |
-| _TEXT_| `___TEXT___TEXT___TEXT___` | _TEXT_| _TEXT_. _TEXT_. _TEXT_|
-| _TEXT_| `___TEXT___TEXT___TEXT___`             | _TEXT_| _TEXT_. _TEXT_. _TEXT_|
-| _TEXT_| `___TEXT___TEXT___TEXT___`         | _TEXT_(_TEXT_) _TEXT_| _TEXT_. _TEXT_. _TEXT_|
+_TEXT_. _TEXT_. _TEXT_
+_TEXT_. _TEXT_. _TEXT_
+_TEXT_. _TEXT_. _TEXT_
 
 ### _TEXT_
 
-|  **__TEXT__**                 |  **__TEXT__**                      |  **__TEXT__**  |  **__TEXT__**  |
+_TEXT_
 | ------------------------ | ---------------------------- | -------- | ----------- |
-| _TEXT_| `___TEXT___TEXT___TEXT___` | _TEXT_| _TEXT_. _TEXT_. _TEXT_|
-| _TEXT_| `___TEXT___TEXT___TEXT___`            | _TEXT_| _TEXT_. _TEXT_. _TEXT_|
+_TEXT_. _TEXT_. _TEXT_
+_TEXT_. _TEXT_. _TEXT_

--- a/confluence-mdx/tests/testcases/880181257/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/880181257/expected.skel.mdx
@@ -9,67 +9,67 @@ import { Callout } from 'nextra/components'
 #### _TEXT_
 
 1. _TEXT_.
-_TEXT_. _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_. <br/> 
-  <figure data-layout="center" data-align="center">
-  ![__TEXT__](___TEXT___TEXT___)
-  </figure>
-3. _TEXT_.
-4. _TEXT_'_TEXT_'_TEXT_.
-5. _TEXT_“-”_TEXT_. 
 _TEXT_. _TEXT_. <br/> 
   <figure data-layout="center" data-align="center">
-  ![__TEXT__](___TEXT___TEXT___)
+  ![_TEXT_](/880181257/output/Screenshot-2025-03-06-at-1.19.24-PM.png)
   </figure>
-7. _TEXT_`___TEXT___TEXT___TEXT___`_TEXT_. 
-8. _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_.
+3. _TEXT_.
+4. _TEXT_.
+5. _TEXT_. 
+_TEXT_. _TEXT_. <br/> 
+  <figure data-layout="center" data-align="center">
+  ![_TEXT_](/880181257/output/Screenshot-2025-03-06-at-1.22.28-PM.png)
+  </figure>
+7. _TEXT_. 
+8. _TEXT_.
 
 <Callout type="important">
-**__TEXT__**
+_TEXT_
 * _TEXT_. 
-* _TEXT_: "_TEXT_(_TEXT_. _TEXT_., _TEXT_, _TEXT_, _TEXT_). _TEXT_."
+* _TEXT_. _TEXT_. _TEXT_. _TEXT_."
 * _TEXT_.
 </Callout>
 
 #### <br/>_TEXT_
 
-1.  **__TEXT__** 
+1.  _TEXT_
     * _TEXT_.
-    * _TEXT_. <br/> 
+    _TEXT_. <br/> 
       <figure data-layout="center" data-align="center">
-      ![__TEXT__](___TEXT___TEXT___)
+      ![_TEXT_](/880181257/output/Screenshot-2025-03-06-at-2.05.26-PM.png)
       </figure>
-2.  **__TEXT__** 
+2.  _TEXT_
     * _TEXT_.
-    * _TEXT_. <br/> 
+    _TEXT_. <br/> 
       <figure data-layout="center" data-align="center">
-      ![__TEXT__](___TEXT___TEXT___)
+      ![_TEXT_](/880181257/output/Screenshot-2025-03-06-at-2.08.11-PM.png)
       </figure>
-    * _TEXT_/_TEXT_, _TEXT_.
-    * _TEXT_"-"_TEXT_.
-3.  **__TEXT__** 
     * _TEXT_.
-    *  **__TEXT__**  
+    * _TEXT_.
+3.  _TEXT_
+    * _TEXT_.
+    *  _TEXT_
     * _TEXT_.
       <figure data-layout="center" data-align="center">
-      ![__TEXT__](___TEXT___TEXT___)
+      ![_TEXT_](/880181257/output/Screenshot-2025-03-06-at-2.18.26-PM.png)
       </figure>
 
 <Callout type="important">
-**__TEXT__**
+_TEXT_
 * _TEXT_.
 </Callout>
 
 #### _TEXT_
 
-1.  **__TEXT__** 
+1.  _TEXT_
     * _TEXT_. 
-    * _TEXT_. <br/> 
+    _TEXT_. <br/> 
       <figure data-layout="center" data-align="center">
-      ![__TEXT__](___TEXT___TEXT___)
+      ![_TEXT_](/880181257/output/Screenshot-2025-03-06-at-2.22.22-PM.png)
       </figure>
-2.  **__TEXT__** 
+2.  _TEXT_
     * _TEXT_.
-    * _TEXT_.  <br/> "_TEXT_. _TEXT_."
+    _TEXT_.  <br/> _TEXT_. _TEXT_."
       <figure data-layout="center" data-align="center">
-      ![__TEXT__](___TEXT___TEXT___)
+      ![_TEXT_](/880181257/output/Screenshot-2025-03-06-at-2.23.37-PM.png)
       </figure>

--- a/confluence-mdx/tests/testcases/883654669/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/883654669/expected.skel.mdx
@@ -8,137 +8,137 @@ import { Callout } from 'nextra/components'
 
 ### _TEXT_
 
-_TEXT_, _TEXT_.
+_TEXT_.
 
 <Callout type="info">
-_TEXT_**__TEXT__** _TEXT_.
-_TEXT_. _TEXT_. _TEXT_[__TEXT__](___TEXT___TEXT___)_TEXT_.
+_TEXT_.
+_TEXT_. _TEXT_. _TEXT_.
 </Callout>
 
 #### _TEXT_
 
-* _TEXT_(_TEXT_)
+* _TEXT_
 * _TEXT_
 
-### _TEXT_(_TEXT_)
+### _TEXT_
 
 _TEXT_.
 
 
-_TEXT_. [__TEXT__](___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_.<br/> <br/> 
+_TEXT_. _TEXT_.<br/> <br/> 
   <figure data-layout="center" data-align="center">
-  ![__TEXT__](___TEXT___TEXT___)
+  ![_TEXT_](/883654669/output/image-20231227-065658.png)
   </figure>
-_TEXT_. _TEXT_, _TEXT_. `___TEXT___TEXT___TEXT___` _TEXT_.<br/> <br/> 
+_TEXT_. _TEXT_. _TEXT_.<br/> <br/> 
   <figure data-layout="center" data-align="center">
-  ![__TEXT__](___TEXT___TEXT___)
+  ![_TEXT_](/883654669/output/screenshot-20250218-131725.png)
   </figure>
 _TEXT_. _TEXT_.<br/> <br/> 
   <figure data-layout="center" data-align="center">
-  ![__TEXT__](___TEXT___TEXT___)
+  ![_TEXT_](/883654669/output/image-20231227-065951.png)
   </figure>
-_TEXT_. _TEXT_. <br/>_TEXT_.<br/>: _TEXT___TEXT___TEXT_: `___TEXT___TEXT___TEXT___` _TEXT_. <br/> 
+_TEXT_. _TEXT_. <br/>_TEXT_.<br/>_TEXT_. <br/> 
   ```
-___TEXT___TEXT___TEXT___
+_TEXT_
 ```
-_TEXT_. _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.<br/> <br/> 
+_TEXT_. _TEXT_.<br/> <br/> 
   <figure data-layout="center" data-align="center">
-  ![__TEXT__](___TEXT___TEXT___)
+  ![_TEXT_](/883654669/output/image-20240115-220447.png)
   </figure>
 
 ### _TEXT_
 
-1. _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_. 
-_TEXT_. _TEXT_, `___TEXT___TEXT___TEXT___`_TEXT_. <br/> 
+1. _TEXT_. 
+_TEXT_. _TEXT_. <br/> 
   <figure data-layout="center" data-align="center">
-  ![__TEXT__](___TEXT___TEXT___)
+  ![_TEXT_](/883654669/output/image-20240115-221520.png)
   </figure>
 3. _TEXT_.
   <figure data-layout="center" data-align="center">
-  ![__TEXT__](___TEXT___TEXT___)
+  ![_TEXT_](/883654669/output/image-20240115-221618.png)
   </figure>
 
 ### _TEXT_
 
-_TEXT____TEXT___TEXT___TEXT___ _TEXT_& _TEXT_,  **__TEXT__**  _TEXT_.
+_TEXT_.
 
 <figure data-layout="center" data-align="center">
-![__TEXT__](___TEXT___TEXT___)
+![_TEXT_](/883654669/output/image-20240418-022640.png)
 </figure>
 
 
-### _TEXT_-_TEXT_
+### _TEXT_
 
 <Callout type="info">
-_TEXT_, _TEXT_(_TEXT_-)_TEXT_.
-* _TEXT_(_TEXT_)_TEXT_/_TEXT_
-* _TEXT_(_TEXT_)_TEXT_, _TEXT_/_TEXT_
+_TEXT_.
+* _TEXT_
+* _TEXT_
 </Callout>
 
-_TEXT_-_TEXT_.
+_TEXT_.
 
-_TEXT_. _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_.<br/> <br/> 
+_TEXT_. _TEXT_.<br/> <br/> 
   <figure data-layout="center" data-align="center">
-  ![__TEXT__](___TEXT___TEXT___)
+  ![_TEXT_](/883654669/output/screenshot-20250218-140951.png)
   </figure>
-_TEXT_. _TEXT_-_TEXT_, _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.<br/> <br/> 
+_TEXT_. _TEXT_.<br/> <br/> 
   <figure data-layout="center" data-align="center">
-  ![__TEXT__](___TEXT___TEXT___)
+  ![_TEXT_](/883654669/output/screenshot-20250218-141555.png)
   </figure>
-3. _TEXT_-_TEXT_, _TEXT_. _TEXT_-_TEXT_`___TEXT___TEXT___TEXT___` _TEXT_.
+3. _TEXT_. _TEXT_.
 
 ### _TEXT_
 
-_TEXT_. _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___` _TEXT_.<br/> <br/> 
+_TEXT_. _TEXT_.<br/> <br/> 
   <figure data-layout="center" data-align="center">
-  ![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+  ![_TEXT_](/883654669/output/screenshot-20250310-113509.png)
   <figcaption>
-  _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+  _TEXT_
   </figcaption>
   </figure>
 2. _TEXT_.
-3. _TEXT_. _TEXT_/_TEXT_.
-    *  **__TEXT__**  : _TEXT_
-    *  **__TEXT__**  : _TEXT_<br/> <br/> 
+3. _TEXT_. _TEXT_.
+    *  _TEXT_
+    _TEXT_<br/> <br/> 
       <figure data-layout="center" data-align="center">
-      ![__TEXT__](___TEXT___TEXT___)
+      ![_TEXT_](/883654669/output/image-20231003-054240.png)
       <figcaption>
-      _TEXT_(_TEXT_) / _TEXT_(_TEXT_)
+      _TEXT_
       </figcaption>
       </figure>
-4. `___TEXT___TEXT___TEXT___` _TEXT_.
+4. _TEXT_.
 
 ### _TEXT_
 
-_TEXT_. _TEXT_, _TEXT_.<br/> <br/> 
+_TEXT_. _TEXT_.<br/> <br/> 
   <figure data-layout="center" data-align="center">
-  ![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+  ![_TEXT_](/883654669/output/screenshot-20250310-113950.png)
   <figcaption>
-  _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+  _TEXT_
   </figcaption>
   </figure>
-_TEXT_. `___TEXT___TEXT___TEXT___` _TEXT_.<br/>
+_TEXT_. _TEXT_.<br/>
   <figure data-layout="center" data-align="center">
-  ![_TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___)
+  ![_TEXT_](/883654669/output/screenshot-20250218-152840.png)
   <figcaption>
-  _TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT____TEXT____TEXT___TEXT___TEXT___ _TEXT_
+  _TEXT_
   </figcaption>
   </figure>
 
 
 ### _TEXT_
 
-_TEXT_, _TEXT_.
+_TEXT_.
 
-_TEXT_. _TEXT____TEXT___TEXT___TEXT___ _TEXT_, _TEXT_. _TEXT_, _TEXT_. <br/> 
+_TEXT_. _TEXT_. _TEXT_. <br/> 
   <figure data-layout="center" data-align="center">
-  ![__TEXT__](___TEXT___TEXT___)
+  ![_TEXT_](/883654669/output/screenshot-20250218-151504.png)
   </figure>
-_TEXT_. _TEXT_.<br/> **__TEXT__**  _TEXT_, _TEXT_.<br/> <br/> 
+_TEXT_. _TEXT_.<br/> _TEXT_.<br/> <br/> 
   <figure data-layout="center" data-align="center">
-  ![__TEXT__](___TEXT___TEXT___)
+  ![_TEXT_](/883654669/output/screenshot-20250218-152238.png)
   </figure>
-_TEXT_. _TEXT_`___TEXT___TEXT___TEXT___` _TEXT_, _TEXT_.<br/>
+_TEXT_. _TEXT_.<br/>
   <figure data-layout="center" data-align="center">
-  ![__TEXT__](___TEXT___TEXT___)
+  ![_TEXT_](/883654669/output/screenshot-20250218-152527.png)
   </figure>


### PR DESCRIPTION
## Description
skeleton 변환 기능을 개선합니다.
- 하나의 문장은 _TEXT_. 가 됩니다. , 는 _TEXT_ 에 포함됩니다.
- 이미지 링크에서 link text 는 _TEXT_ 가 되지만, uri 에 해당하는 path 는 그대로 보존합니다.
  - .mdx: `![QueryPie Web &gt; 프로필 메뉴](/544112828/output/screenshot-20240804-173002.png)`
  - .skel.mdx: `![_TEXT_](/544112828/output/screenshot-20240804-173002.png)`

## Additional notes
- 
