### PR TITLE
feat: mdx_to_skeleton.py 개선: 다중 디렉토리 처리 및 파일 비교 기능 추가

### DIFF
--- a/confluence-mdx/bin/mdx_to_skeleton.py
+++ b/confluence-mdx/bin/mdx_to_skeleton.py
@@ -527,10 +527,14 @@ def get_mdx_files(directory: Path) -> set[str]:
     return relative_paths
 
 
-def compare_files():
+def compare_files(verbose: bool = False):
     """
     Compare .mdx files across target/en, target/ja, and target/ko directories.
     Outputs comparison results to stdout.
+    
+    Args:
+        verbose: If False, skip files that exist in all three languages.
+                 If True, output all files.
     """
     base_dir = Path('target')
     dirs = {
@@ -556,6 +560,10 @@ def compare_files():
         ko_exists = file_path in file_sets['ko']
         en_exists = file_path in file_sets['en']
         ja_exists = file_path in file_sets['ja']
+        
+        # Skip if all three languages exist and not verbose
+        if not verbose and ko_exists and en_exists and ja_exists:
+            continue
         
         # Format output: /path/to/file.mdx ko en ja
         ko_status = 'ko' if ko_exists else '-'
@@ -628,13 +636,18 @@ def main():
         action='store_true',
         help='Compare .mdx files across target/en, target/ja, and target/ko directories'
     )
+    parser.add_argument(
+        '--verbose',
+        action='store_true',
+        help='When used with --compare, output all files including those that exist in all three languages'
+    )
     
     args = parser.parse_args()
     
     try:
         if args.compare:
             # Compare mode
-            compare_files()
+            compare_files(verbose=args.verbose)
             return 0
         elif args.recursive is not None:
             # Recursive mode: process directories


### PR DESCRIPTION
## Description
- `--recursive` 옵션에서 여러 디렉토리를 입력받을 수 있도록 개선하고, 기본값으로 `target/en`, `target/ja`, `target/ko` 지정
  - `--recursive` 출력 개선: 성공한 파일은 출력하지 않고, 실패한 파일만 출력하며, 각 디렉토리별 통계 정보 제공
  - `--recursive` 처리 로직을 `process_directories_recursive()` 함수로 분리하여 코드 구조 개선
- `--compare` 옵션 추가: 3개 언어 디렉토리의 `.mdx` 파일 존재 여부 비교
  - `--verbose` 옵션 추가: `--compare`와 함께 사용 시 모든 파일 출력 (기본값은 누락된 파일만 출력)

## Additional notes
```
% ./bin/mdx_to_skeleton.py --recursive
target/en: 263 successful, 0 errors
target/ja: 263 successful, 0 errors
target/ko: 263 successful, 0 errors
Total: 789 successful, 0 errors
% 

# 3개 언어 파일 목록이 동일한 경우
% ./bin/mdx_to_skeleton.py --compare

# 일본어 파일이 없는 경우
% ./bin/mdx_to_skeleton.py --compare
/querypie-overview/installation-and-customer-support.mdx ko en -
# 한국어 파일이 없는 경우 추가
% ./bin/mdx_to_skeleton.py --compare
/querypie-overview/installation-and-customer-support.mdx ko en -
/release-notes/980-9812.mdx - en ja
% 
```