### PR TITLE
mdx: 영어 문서 불일치 수정 2

### DIFF
--- a/src/content/en/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-google-cloud.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-google-cloud.mdx
@@ -96,3 +96,5 @@ Synchronization settings saved without the "Save Credential for Synchronization"
 * CloudSQL : CloudSQL Viewer
 * BigQuery : BigQuery Administrator
 </Callout>
+
+

--- a/src/content/en/administrator-manual/databases/connection-management/db-connections.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/db-connections.mdx
@@ -105,7 +105,13 @@ Administrator &gt; Databases &gt; Connection Management &gt; DB Connections
     *  **Database Type** : DB type (eg. MySQL, MairaDB, PostgreSQL…)
     *  **Cloud Provider** : Cloud provider type (AWS, Azure, GCP, or QueryPie Connection)
     *  **Favorite View** : Favorite setting status
-        * There is a button for favorite setting on the far right of the table. 
+        * There is a button for favorite setting on the far right of the table. <br/>  
+          <figure data-layout="center" data-align="center">
+          ![Favorite setting button](/administrator-manual/databases/connection-management/db-connections/screenshot-20240730-222905.png)
+          <figcaption>
+          Favorite setting button
+          </figcaption>
+          </figure>
     *  **SSL Status** : SSL activation status
     *  **Label** : Whether it's a ledger DB
     *  **Tag** : Tags assigned to connections
@@ -226,6 +232,9 @@ Additional Information tab
 **User Action Purpose Required** <br/>From 11.2.0, reason input for SQL Execute events in User Action Purpose Required options has been improved to also be received through Agent.<br/>&lt; Limitations &gt;
 * When using 3rd party tools (DBeaver, DataGrip, etc.), only SQL Execute items can be forced to require reason input.
 * Queries sent internally by 3rd party tools (queries that show DB schema in tree structure or display data types in UI) are also detected as SQL Execute and require reason input. Example) Reason input popup appears even when no query is entered immediately after initial connection. In this case, since SQL statement types are not judged, it can cause considerable inconvenience depending on settings. Therefore, the value of the Query Purpose Duration for Agent option in Database &gt; General &gt; Configurations must be adjusted appropriately.<br/>
+  <figure data-layout="center" data-align="center">
+  ![image-20250825-020520.png](/administrator-manual/databases/connection-management/db-connections/image-20250825-020520.png)
+  </figure>
 </Callout>
 
 <Callout type="info">

--- a/src/content/en/administrator-manual/databases/connection-management/kerberos-configurations.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/kerberos-configurations.mdx
@@ -19,6 +19,7 @@ Administrator &gt; Databases &gt; Connection Management &gt; Kerberos Configurat
 </figcaption>
 </figure>
 
+
 ### Viewing Kerberos Keytab
 
 You can view the list of registered keytabs on the Kerberos Configurations page.
@@ -29,6 +30,7 @@ You can view the list of registered keytabs on the Kerberos Configurations page.
 Administrator &gt; Databases &gt; Connection Management &gt; Kerberos Configurations
 </figcaption>
 </figure>
+
 
 ### Deleting Kerberos Keytab
 
@@ -41,6 +43,7 @@ Administrator &gt; Databases &gt; Connection Management &gt; Kerberos Configurat
 </figcaption>
 </figure>
 
+
 ### Changing Kerberos Client Configuration
 
 Click the `⚙️` button in the top right of the Kerberos Configurations page to expose the Kerberos client configuration change modal to apply to QueryPie. Click the `Save` button to save the changes.
@@ -51,3 +54,5 @@ Click the `⚙️` button in the top right of the Kerberos Configurations page t
 Administrator &gt; Databases &gt; Connection Management &gt; Kerberos Configurations &gt; Kerberos Configuration Setting
 </figcaption>
 </figure>
+
+

--- a/src/content/en/administrator-manual/databases/connection-management/ssh-configurations.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/ssh-configurations.mdx
@@ -15,6 +15,7 @@ Administrator &gt; Databases &gt; Connection Management &gt; SSH Configuration &
 </figcaption>
 </figure>
 
+
 1. Navigate to Connection Management &gt; SSH Configuration menu from the Databases settings menu.
 2. Click the `Create SSH` button in the top right.
 3. Enter information for SSH tunneling registration.

--- a/src/content/en/administrator-manual/databases/connection-management/ssl-configurations.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/ssl-configurations.mdx
@@ -15,6 +15,7 @@ Administrator &gt; Databases &gt; Connection Management &gt; SSL Configuration &
 </figcaption>
 </figure>
 
+
 1. Navigate to Connection Management &gt; SSL Configuration menu from the Databases settings menu.
 2. Click the `Create SSL` button in the top right.
 3. Enter the following information for SSL certificate registration:

--- a/src/content/en/administrator-manual/databases/dac-general-configurations.mdx
+++ b/src/content/en/administrator-manual/databases/dac-general-configurations.mdx
@@ -86,6 +86,9 @@ Query Audit Detail
     * Statement : Enter strings to restrict execution when included in queries (case insensitive)
     * Allowed User : Specify users allowed to execute the corresponding statement (multiple selection possible, group-level specification not possible)
     * Queries containing entered Restricted Statement are blocked when executed
+      <figure data-layout="center" data-align="center">
+      ![image-20240326-011036.png](/administrator-manual/databases/dac-general-configurations/image-20240326-011036.png)
+      </figure>
 
 <Callout type="important">
 Queries blocked by Restricted Statement policies are blocked from execution even if approved through SQL Request. Do not enter queries that should be allowed for execution by certain users.
@@ -93,6 +96,9 @@ Queries blocked by Restricted Statement policies are blocked from execution even
 
 *  **Justification Length**  : When "User Action Purpose Required" option is activated in Connection settings or reason input is forced by Ledger table management policies, reason input must be made through Web Editor or Agent. Administrators specify the minimum and maximum values for the number of characters entered in the input field.
     * The minimum input value is 1 and the maximum value is 1000.<br/>
+      <figure data-layout="center" data-align="center">
+      ![image-20250824-233845.png](/administrator-manual/databases/dac-general-configurations/image-20250824-233845.png)
+      </figure>
 *  **Query Annotation**  : Automatically records annotations specified by administrators when performing queries. When the feature is activated, annotations are recorded using the following 3 templates. As of 10.4.0, limited to Redshift support.
     * User Name: `{{userName}}` : Display Name of the user who performed the query.
     * Login ID: `{{loginId}}` : Login ID of the user who performed the query.

--- a/src/content/en/administrator-manual/databases/new-policy-management.mdx
+++ b/src/content/en/administrator-manual/databases/new-policy-management.mdx
@@ -8,7 +8,7 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-The existing QueryPie DAC provides data policies such as Data Access, Data Masking, Sensitive Data, and Ledger Table Management. However, these policies must be set individually for each connection, and rules must be applied for each table and column. And it does not provide import and export functions for policies.
+The existing QueryPie DAC provides data policies such as Data Access, Data Masking, Sensitive Data. Ledger Table Management. However, these policies must be set individually for each connection, and rules must be applied for each table and column. And it does not provide import and export functions for policies.
 
 From 10.2.6, to improve these inconveniences, a new policy management feature is provided. Through the tag-based policy application feature, after mapping DBMS paths and tags, when policies are applied, policies can be dynamically assigned by tags. You can set access to only specific tables through tags assigned to tables.
 


### PR DESCRIPTION
## Description
- 영어 Administrator Manual의 databases 관련 문서에서 한국어 원문과의 구조 불일치 수정
- 이미지 추가: `db-connections.mdx`, `dac-general-configurations.mdx`에 누락된 스크린샷 이미지 추가
- 줄바꿈 정리: 여러 파일에 빈 줄 추가하여 한국어 원문과 일치하도록 수정
- 총 7개 파일 수정: 26줄 추가, 2줄 삭제

## Additional notes
- 
