### PR TITLE
mdx: 일본어 문서 불일치 수정 7

### DIFF
--- a/src/content/ja/administrator-manual/databases/monitoring.mdx
+++ b/src/content/ja/administrator-manual/databases/monitoring.mdx
@@ -14,10 +14,12 @@ import { Callout } from 'nextra/components'
 * WorkflowのSQL Requestを使用して決裁を経た後、承認が完了するとExecutorが実行ボタンを押して実行。
 * 3rd party tool（DBeaverなど）を使用（ユーザーAgent方式）またはURLを使用（Agent-less）してクエリパイProxyを通じて実行。
 
-上記のように実行されたクエリはRunning Queries、Proxy Managementを通じて状態を報告し、必要時に管理者が強制的に停止できます。（10.3.0以降から可能）
+上記のように実行されたクエリはRunning Queries、Proxy Managementを通じて状態を報告し、必要時に管理者が強制的に停止できます。
+(10.3.0以降から可能)
 
 <Callout type="info">
-10.3.0からAuditの下位項目としてモニタリングのみ可能だったRunning Queries機能にクエリ強制停止機能が追加されました。Proxy Managementはセッション強制機能が以前から存在していて位置のみMonitoring下位に移動されました。
+10.3.0からAuditの下位項目としてモニタリングのみ可能だったRunning Queries機能にクエリ強制停止機能が追加されました。
+Proxy Managementはセッション強制機能が以前から存在していて位置のみMonitoring下位に移動されました。
 </Callout>
 
 

--- a/src/content/ja/querypie-overview/proxy-management/enable-database-proxy.mdx
+++ b/src/content/ja/querypie-overview/proxy-management/enable-database-proxy.mdx
@@ -8,12 +8,16 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-データベース接続へのアクセス時にProxy接続をサポートしています。基本的にQueryPieが提供するWeb SQLエディターを通じて接続にアクセスできるほか、QueryPieで生成したProxy Credential情報またはAgentを通じた既存のDB username/passwordで使用していたツールから接続にアクセスできます。Web SQLエディターと合わせてProxy接続をサポートすることで、様々なユーザー環境でも問題なく接続アクセスを制御し、ポリシーを適用し、ログを記録できます。現在Proxy接続は、MySQL、MariaDB、Oracle、PostgreSQL、Redshift、Trino、SQLServer、MongoDBをサポートしています。
+データベース接続へのアクセス時にProxy接続をサポートしています。
+基本的にQueryPieが提供するWeb SQLエディターを通じて接続にアクセスできるほか、QueryPieで生成したProxy Credential情報またはAgentを通じた既存のDB username/passwordで使用していたツールから接続にアクセスできます。
+Web SQLエディターと合わせてProxy接続をサポートすることで、様々なユーザー環境でも問題なく接続アクセスを制御し、ポリシーを適用し、ログを記録できます。
+現在Proxy接続は、MySQL、MariaDB、Oracle、PostgreSQL、Redshift、Trino、SQLServer、MongoDBをサポートしています。
 
 
 ### Proxy使用オプションの活性化
 
-基本的にはProxy使用オプションが非活性化されています。アクセスを許可する接続でProxy使用の可否を活性化します。
+基本的にはProxy使用オプションが非活性化されています。
+アクセスを許可する接続でProxy使用の可否を活性化します。
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Databases &gt; Connection Management &gt; DB Connections &gt; Connection Details &gt; Proxy Usage](/querypie-overview/proxy-management/enable-database-proxy/image-20240725-070857.png)
@@ -28,16 +32,18 @@ Administrator &gt; Databases &gt; Connection Management &gt; DB Connections &gt;
 4. `Proxy Usage`オプションをチェックして活性化します。
 5. 2つのProxy認証方式のうち1つを選択します。
     1.  **Use QueryPie registered account** : 管理者が接続情報ページ内に保存したDB username / password基準でProxy接続情報を生成する方式です。ユーザーはAgentまたは別途生成されたProxy Credential情報を利用してProxyに接続できます。
-    2.  **Use existing database account with Agent**  : ユーザーが既存に使用していたDB username / passwordを使用できる方式でProxy接続情報が生成されます。ユーザーはAgentで実行後、localhostとport情報を利用してProxyに接続できます。※ユーザーのDB username / password認証を使用する場合、Agentを通じてのみ接続可能です。
+    2.  **Use existing database account with Agent**  : ユーザーが既存に使用していたDB username / passwordを使用できる方式でProxy接続情報が生成されます。ユーザーはAgentで実行後、localhostとport情報を利用してProxyに接続できます。 <br/> ※ユーザーのDB username / password認証を使用する場合、Agentを通じてのみ接続可能です。
 6.  **Network ID**  : Reverse SSH機能を使用する場合に必要な設定値です。
 
-Proxy Usageオプションを活性化すると、Proxyで接続できるPortが該当接続に割り当てられます。ユーザーは該当オプションが活性化されるとProxy接続情報を確認でき、管理者のみ該当Proxyオプションを設定できます。
+Proxy Usageオプションを活性化すると、Proxyで接続できるPortが該当接続に割り当てられます。
+ユーザーは該当オプションが活性化されるとProxy接続情報を確認でき、管理者のみ該当Proxyオプションを設定できます。
 
 
 ### Proxy使用が活性化された接続を確認する
 
 <Callout type="info">
-10.3.0からDatabases &gt; Connection Management &gt; Proxy ManagementはDatabases &gt; Monitoring &gt; Proxy Managementに移動されました。10.3.0以降のバージョンユーザーは[Proxy Management](../../administrator-manual/databases/monitoring/proxy-management)をご参照ください。
+10.3.0からDatabases &gt; Connection Management &gt; Proxy ManagementはDatabases &gt; Monitoring &gt; Proxy Managementに移動されました。
+10.3.0以降のバージョンユーザーは[Proxy Management](../../administrator-manual/databases/monitoring/proxy-management)をご参照ください。
 </Callout>
 
 <figure data-layout="center" data-align="center">

--- a/src/content/ja/release-notes/9100-9104/external-api-changes-9100-version.mdx
+++ b/src/content/ja/release-notes/9100-9104/external-api-changes-9100-version.mdx
@@ -21,7 +21,7 @@ title: 'External API変更事項（9.10.0バージョン）'
 
 ### 追加されたExternal API
 
-* Workflow API（既存Access Approval APIとApproval APIを代替します。）
+* Workflow API (既存Access Approval APIとApproval APIを代替します.)
     * [Access Request] Detail
     * [Access Request] Approve
     * [Access Request] Reject
@@ -32,7 +32,7 @@ title: 'External API変更事項（9.10.0バージョン）'
     * [SQL Request] Approve
     * [SQL Request] Reject
     * All Requests
-* Approval Rule API V2（既存Approval Rule APIを代替します。）
+* Approval Rule API V2 (既存Approval Rule APIを代替します.)
     * List
     * Add approval rule
     * Remove approval rule
@@ -48,5 +48,319 @@ title: 'External API変更事項（9.10.0バージョン）'
     * Detail
 * Approval API
     * List of Approval
+---
 
-（詳細な変更内容は元のドキュメントを参照してください）
+#### Access Approval API - List of Access Approval
+
+`GET /api/external/access-approvals`
+
+Requestの変更事項
+
+* Query Parameterとして使用できる `status` が変更されました。 `PARTIALLY_APPROVED` が `IN_PROGRESS` に代替され、 `NONE` が削除されました。
+    *  **before**  : `"NONE"` `"PENDING"` `"CANCELED"` `"REJECTED"` `"PARTIALLY_APPROVED"` `"APPROVED"` `"EXPIRED"`
+    *  **after**  : `"PENDING"` `"CANCELED"` `"REJECTED"` `"IN_PROGRESS"` `"APPROVED"` `"EXPIRED"`
+
+Response変更事項
+
+* `currentDegree` が削除されました。
+* `approvalStatus` が変更されました。
+    *  **before**  : `"NONE"` `"PENDING"` `"CANCELED"` `"REJECTED"` `"PARTIALLY_APPROVED"` `"APPROVED"` `"EXPIRED"`
+    *  **after**  : `"PENDING"` `"CANCELED"` `"REJECTED"` `"IN_PROGRESS"` `"APPROVED"` `"EXPIRED"`
+* `updatedUser` が削除されました。
+* `lines` の `uuid` が削除されました。
+* `lines` の `degree` が `step` に代替されました。
+* `lines` の `approvedAt` が `actionAt` に代替されました。
+* `lines` の `status` が変更されました。
+    *  **before**  : `"PENDING"` `"REQUESTED"` `"CANCELED"` `"APPROVED"` `"REJECTED"` `"SQL_EXECUTED"` `"SQL_CANCELED"` `"SQL_SUCCEED"` `"SQL_FAILED"` `"CONFIRMED"`
+    *  **after**  : `"NONE"` `"PENDING"` `"CANCELED"` `"APPROVED"` `"REJECTED"` `"EXECUTED"` `"UNREAD"` `"CONFIRMED"`
+* `lines` の `type` が変更されました。
+    *  **before**  : `"REPORTER"` `"APPROVER"` `"EXECUTOR"` `"REFERRER"` `"REVIEWER"`
+    *  **after :** `"APPROVER"` `"EXECUTOR"` `"REVIEWER"`
+* `connections` の `clusterGroupDescription` が削除されました。
+* `connections` の `databaseName` が削除されました。
+* `connections` の `schemaName` が削除されました。
+
+Response変更前例示
+```
+{
+  "list": [
+    {
+      "approvalStatus": "PENDING",
+      "connections": [
+        {
+          "clusterGroupDescription": "Cluster Group description",
+          "clusterGroupName": "Cluster Group Name",
+          "clusterGroupUuid": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3",
+          "clusterHost": "Cluster Host",
+          "clusterReplicationType": "`MASTER`, `SLAVE`, `SINGLE`",
+          "clusterUuid": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3",
+          "databaseName": "Database Name",
+          "roleName": "Role Name",
+          "roleUuid": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3",
+          "schemaName": "Schema Name",
+          "uuid": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3"
+        }
+      ],
+      "createdAt": "2019-08-24T14:15:22Z",
+      "createdUser": "User Information",
+      "currentDegree": 1,
+      "description": "Approval Description",
+      "id": 0,
+      "lines": [
+        {
+          "approvedAt": "2019-08-24T14:15:22Z",
+          "comment": "comment",
+          "degree": 1,
+          "status": "APPROVED",
+          "type": "APPROVER",
+          "userDepartment": "string",
+          "userEmail": "string",
+          "userLoginId": "string",
+          "userName": "string",
+          "userType": "USER",
+          "userUuid": "string",
+          "uuid": "UUID"
+        }
+      ],
+      "title": "Approval Title",
+      "type": "ACCESS",
+      "updatedAt": "2019-08-24T14:15:22Z",
+      "updatedUser": "User Information",
+      "uuid": "UUID"
+    }
+  ],
+  "page": {
+    "currentPage": 0,
+    "pageSize": 0,
+    "totalElements": 0,
+    "totalPages": 0
+  }
+}
+```
+
+Response変更後例示
+```
+{
+  "list": [
+    {
+      "approvalStatus": "PENDING",
+      "connections": [
+        {
+          "clusterGroupName": "Cluster Group Name",
+          "clusterGroupUuid": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3",
+          "clusterHost": "Cluster Host",
+          "clusterReplicationType": "`MASTER`, `SLAVE`, `SINGLE`",
+          "clusterUuid": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3",
+          "roleName": "Role Name",
+          "roleUuid": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3",
+          "uuid": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3"
+        }
+      ],
+      "createdAt": "2019-08-24T14:15:22Z",
+      "createdUser": "User Information",
+      "description": "Approval Description",
+      "id": 0,
+      "lines": [
+        {
+          "actionAt": "2019-08-24T14:15:22Z",
+          "comment": "comment",
+          "status": "APPROVED",
+          "step": 1,
+          "type": "APPROVER",
+          "userDepartment": "string",
+          "userEmail": "string",
+          "userLoginId": "string",
+          "userName": "string",
+          "userType": "USER",
+          "userUuid": "string"
+        }
+      ],
+      "title": "Approval Title",
+      "type": "ACCESS",
+      "updatedAt": "2019-08-24T14:15:22Z",
+      "uuid": "UUID"
+    }
+  ],
+  "page": {
+    "currentPage": 0,
+    "pageSize": 0,
+    "totalElements": 0,
+    "totalPages": 0
+  }
+}
+```
+
+
+---
+
+#### Approval Rule API - Detail
+
+`GET /api/external/approval-rules/{uuid}`
+
+Response変更事項
+
+* `approvalCondition` が削除されました。
+* `executionCondition` が変更されました。
+    *  **before**  : `"NONE"` `"MANUAL"` `"SELF"` `"CONNECTION_OWNER"` `"ANY"`
+    *  **after**  : `"ADMIN_ONLY"` `"ALL_USERS"` `"FIXED"` `"CONNECTION_OWNER"`
+* `reviewEnabled` が削除されました。
+* `urgentMode` が追加されました。
+* `lines` の `degree` が `step` に代替されました。
+* `lines` の `type` が変更されました。
+    *  **before**  : `"REPORTER"` `"APPROVER"` `"EXECUTOR"` `"REFERRER"` `"REVIEWER"`
+    *  **after**  : `"APPROVER"` `"EXECUTOR"` `"REVIEWER"`
+* `lines` の `resourceType` が変更されました。
+    *  **before**  : `USER`, `ROLE`
+    *  **after**  : `USER`, `GROUP`
+* `lines` の `uuid` が削除されました。
+
+Response変更前例示
+```
+{
+  "approvalCondition": "MANUAL",
+  "createdAt": "2019-08-24T14:15:22Z",
+  "executionCondition": "MANUAL",
+  "lines": [
+    {
+      "degree": 1,
+      "resourceType": "USER",
+      "resourceUuid": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3",
+      "type": "APPROVER",
+      "uuid": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3"
+    }
+  ],
+  "name": "Default Rule",
+  "requestType": "SQL",
+  "reviewEnabled": true,
+  "updatedAt": "2019-08-24T14:15:22Z",
+  "uuid": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3"
+}
+```
+
+Response変更後例示
+```
+{
+  "createdAt": "2019-08-24T14:15:22Z",
+  "executionCondition": "ADMIN_ONLY",
+  "lines": [
+    {
+      "resourceType": "USER",
+      "resourceUuid": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3",
+      "step": 1,
+      "type": "APPROVER"
+    }
+  ],
+  "name": "Default Rule",
+  "requestType": "SQL",
+  "updatedAt": "2019-08-24T14:15:22Z",
+  "urgentMode": true,
+  "uuid": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3"
+}
+```
+
+
+---
+
+#### Approval API - List of Approval
+
+`GET /api/external/approvals`
+
+Response変更事項
+
+* `currentDegree` が削除されました。
+* `approvalStatus` が変更されました。
+    *  **before**  : `"NONE"` `"PENDING"` `"CANCELED"` `"REJECTED"` `"PARTIALLY_APPROVED"` `"APPROVED"` `"EXPIRED"`
+    *  **after**  : `"PENDING"` `"CANCELED"` `"REJECTED"` `"IN_PROGRESS"` `"APPROVED"` `"EXPIRED"`
+* `updatedUser` が削除されました。
+* `lines` の `uuid` が削除されました。
+* `lines` の `degree` が `step` に代替されました。
+* `lines` の `approvedAt` が `actionAt` に代替されました。
+* `lines` の `status` が変更されました。
+    *  **before**  : `"PENDING"` `"REQUESTED"` `"CANCELED"` `"APPROVED"` `"REJECTED"` `"SQL_EXECUTED"` `"SQL_CANCELED"` `"SQL_SUCCEED"` `"SQL_FAILED"` `"CONFIRMED"`
+    *  **after**  : `"NONE"` `"PENDING"` `"CANCELED"` `"APPROVED"` `"REJECTED"` `"EXECUTED"` `"UNREAD"` `"CONFIRMED"`
+* `lines` の `type` が変更されました。
+    *  **before**  : `"REPORTER"` `"APPROVER"` `"EXECUTOR"` `"REFERRER"` `"REVIEWER"`
+    *  **after :** `"APPROVER"` `"EXECUTOR"` `"REVIEWER"`
+
+Response変更前例示
+```
+{
+  "list": [
+    {
+      "approvalStatus": "PENDING",
+      "createdAt": "2019-08-24T14:15:22Z",
+      "createdUser": "User Information",
+      "currentDegree": 1,
+      "description": "Approval Description",
+      "id": 0,
+      "lines": [
+        {
+          "approvedAt": "2019-08-24T14:15:22Z",
+          "comment": "comment",
+          "degree": 1,
+          "status": "APPROVED",
+          "type": "APPROVER",
+          "userDepartment": "string",
+          "userEmail": "string",
+          "userLoginId": "string",
+          "userName": "string",
+          "userType": "USER",
+          "userUuid": "string",
+          "uuid": "UUID"
+        }
+      ],
+      "title": "Approval Title",
+      "type": "ACCESS",
+      "updatedAt": "2019-08-24T14:15:22Z",
+      "updatedUser": "User Information",
+      "uuid": "UUID"
+    }
+  ],
+  "page": {
+    "currentPage": 0,
+    "pageSize": 0,
+    "totalElements": 0,
+    "totalPages": 0
+  }
+}
+```
+
+Response変更後例示
+```
+{
+  "list": [
+    {
+      "approvalStatus": "PENDING",
+      "createdAt": "2019-08-24T14:15:22Z",
+      "createdUser": "User Information",
+      "description": "Approval Description",
+      "id": 0,
+      "lines": [
+        {
+          "actionAt": "2019-08-24T14:15:22Z",
+          "comment": "comment",
+          "status": "APPROVED",
+          "step": 1,
+          "type": "APPROVER",
+          "userDepartment": "string",
+          "userEmail": "string",
+          "userLoginId": "string",
+          "userName": "string",
+          "userType": "USER",
+          "userUuid": "string"
+        }
+      ],
+      "title": "Approval Title",
+      "type": "ACCESS",
+      "updatedAt": "2019-08-24T14:15:22Z",
+      "uuid": "UUID"
+    }
+  ],
+  "page": {
+    "currentPage": 0,
+    "pageSize": 0,
+    "totalElements": 0,
+    "totalPages": 0
+  }
+}
+```

--- a/src/content/ja/release-notes/9120-91214/menu-improvement-guide-9120.mdx
+++ b/src/content/ja/release-notes/9120-91214/menu-improvement-guide-9120.mdx
@@ -49,3 +49,5 @@ import { Callout } from 'nextra/components'
 <figure data-layout="center" data-align="center">
 ![9.png](/release-notes/9120-91214/menu-improvement-guide-9120/9.png)
 </figure>
+
+

--- a/src/content/ja/release-notes/990-998/external-api-changes-9810-version-994-version.mdx
+++ b/src/content/ja/release-notes/990-998/external-api-changes-9810-version-994-version.mdx
@@ -22,33 +22,1682 @@ title: 'External API変更事項（9.8.10バージョン > 9.9.4バージョン�
 | --------------------------- | -------------------- | ------------- |
 |  **Header Parameter name**  | X-QueryPie-Api-Token | Authorization |
 
+
 ---
 
 ## 2. Alert API
 
 #### 変更/改善事項
 
-* 各Alert TypeごとにAPIが分離されました
-* List APIは簡単な情報のみ返すよう変更
-* 新規Detail API、Create API、Update APIが各タイプ別に追加
+<table data-table-width="760" data-layout="default" local-id="dde603df-3268-4faf-a41d-602a0c651910">
+<colgroup>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**API(9.8.10)**
+</th>
+<th>
+**変更点**
+</th>
+</tr>
+<tr>
+<th>
+**(GET) List**
+</th>
+<td>
+* 各Alertの  **すべての情報** を返却 <br/>→ 各Alertの  **簡単な情報** を返却するように変更されました。
+* 各Alert Type別にAlertの詳細情報を返却する  **Detail API追加** されました。
+</td>
+</tr>
+<tr>
+<th>
+**(POST) Create**
+</th>
+<td>
+*  **1つのAPI** で全てのTypeのAlertを生成可能 <br/>→ 各Alert Type別に  **生成APIが分離** しました。
+* 既存Create API削除されました。
+</td>
+</tr>
+<tr>
+<th>
+**(PUT) Update**
+</th>
+<td>
+*  **1つのAPI** で全てのTypeのAlertを修正可能 <br/>→ 各Alert Type別に  **修正APIを分離** しました。
+* 既存Update API削除されました。
+</td>
+</tr>
+<tr>
+<th>
+**(Delete) Delete**
+</th>
+<td>
+* 変更点なし。
+</td>
+</tr>
+</tbody>
+</table>
 
-#### 新規APIエンドポイント
+#### [新規](POST) Create, (PUT) Update, (GET) Detail API
 
-* SQL Execution: `/api/external/alerts/sql-execution`
-* Prevented SQL Execution: `/api/external/alerts/prevented-sql-execution`
-* DB Connection Attempt: `/api/external/alerts/db-connection-attempt`
-* Sensitive Data Access: `/api/external/alerts/sensitive-data-access`
-* Data Export: `/api/external/alerts/data-export`
-* Workflow New Request: `/api/external/alerts/workflow-new-request`
-* Unusual Login Attempt（新規）: `/api/external/alerts/unusual-login-attempt`
+* 詳細なリクエスト内容はDocs参照
+
+<table data-table-width="760" data-layout="default" local-id="07d79f85-952c-4830-a77e-c026ab9a37ca">
+<colgroup>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**Alert Type(9.8.10基準)**
+</th>
+<th>
+**Docs位置(9.9.4)**
+</th>
+</tr>
+<tr>
+<td>
+`SQL_EXECUTION`
+</td>
+<td>
+[SQL Execution]<br/>`/api/external/alerts/sql-execution`
+</td>
+</tr>
+<tr>
+<td>
+`SQL_EXECUTION_PREVENTED`
+</td>
+<td>
+[Prevented SQL Execution]<br/>`/api/external/alerts/prevented-sql-execution`
+</td>
+</tr>
+<tr>
+<td>
+`DATABASE_AUTHENTICATION_FAILED`
+</td>
+<td>
+[DB Connection Attempt]<br/>`/api/external/alerts/db-connection-attempt`
+</td>
+</tr>
+<tr>
+<td>
+`SENSITIVE_DATA_BY_POLICY`
+</td>
+<td>
+[Sensitive Data Access]<br/>`api/external/alerts/sensitive-data-access`
+* policy
+</td>
+</tr>
+<tr>
+<td>
+`SENSITIVE_DATA_BY_LEVEL`
+</td>
+<td>
+[Sensitive Data Access]<br/>`api/external/alerts/sensitive-data-access`
+* level
+</td>
+</tr>
+<tr>
+<td>
+`EXCEL_EXPORT`
+</td>
+<td>
+[Data Export]<br/>`api/external/alerts/data-export`
+</td>
+</tr>
+<tr>
+<td>
+`APPROVAL_REQUESTED`
+</td>
+<td>
+[Workflow New Request]<br/>`/api/external/alerts/workflow-new-request`
+</td>
+</tr>
+<tr>
+<td>
+
+</td>
+<td>
+[Unusual Login Attempt](新規)<br/>`/api/external/alerts/unusual-login-attempt`
+</td>
+</tr>
+</tbody>
+</table>
+
+#### (GET) List
+
+`/api/external/notifications`
+
+##### Request
+
+* 変更点なし
+
+##### Response
+
+<table data-table-width="760" data-layout="default" local-id="4a964f40-a620-417f-bd2f-52c24b38404e">
+<colgroup>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**変更前**
+</th>
+<th>
+**変更後**
+</th>
+</tr>
+<tr>
+<td>
+```json
+{
+  "list": [
+    {
+      "condition": {...},
+      "description": "",
+      "lastAt": "2019-08-24T14:15:22Z",
+      "lastStatus": "UNDEFINED",
+      "notification": {...},
+      "policy": {...},
+      "template": "{{userName}} executed {{expRows}} rows.",
+      "uuid": "a5ac2279-b715-4819-a00d-daba81739057"
+    },
+    ...
+  ],
+  "page": {...}
+}
+```
+</td>
+<td>
+```json
+{
+  "list": [
+    {
+      "alertType": "SQL Execution",
+      "lastAt": "2019-08-24T14:15:22Z",
+      "lastStatus": "UNDEFINED",
+      "name": "string",
+      "template": "{{userName}} executed {{expRows}} rows.",
+      "uuid": "a5ac2279-b715-4819-a00d-daba81739057"
+    },
+    ...
+  ],
+  "page": {...}
+}
+```
+</td>
+</tr>
+</tbody>
+</table>
+
+
 
 ---
 
-## 3. その他の主要変更事項
+## 3. Approval Rule API
 
-* Approval Rule APIでRequestTypeに`EXPORT`が追加
-* Audit Log APIでRedisサポート追加
-* Cloud Provider APIで同期化データベースタイプ指定機能追加
-* Connection APIでconnectionAccount構造改善
+#### (GET) List
 
-（詳細な変更内容は元のドキュメントを参照してください）
+`/api/external/approval-rules`
+
+##### Request
+
+* Query Parameter
+*  **RequestType** が `SQL`, `ACCESS` → `SQL`, `EXPORT`, `ACCESS` に `EXPORT`  **が追加** されました。
+
+##### Response
+
+* 変更点なし
+
+
+
+---
+
+## 4. Audit Log API
+
+#### (GET) List of Approval
+
+`/api/external/audit-logs`
+
+##### Request
+
+* Query Parameter
+
+<table data-table-width="760" data-layout="default" local-id="177f70ea-ceb0-4cfd-bbf6-f23d470f037a">
+<colgroup>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**変更前**
+</th>
+<th>
+**変更後**
+</th>
+</tr>
+<tr>
+<td>
+* pageNumber
+* pageSize
+* actionType
+* clusterGroupId
+* clusterId
+* startDate
+* endDate
+* databaseType
+* sqlFullText
+</td>
+<td>
+*  **cursor** 
+*  **count** 
+* actionType
+* clusterGroupId
+* clusterId
+* startDate
+* endDate
+*  **databaseType** 
+* sqlFullText
+</td>
+</tr>
+</tbody>
+</table>
+
+* cursorはResponseの  **nextCursor** を  **そのまま** 使用すればよいです。最初の呼び出しの場合は空にしておきます。
+    * /api/docsに記載されている内容は  **誤った内容** で、以降のバージョンで修正予定です。
+*  **count** は既存pageSizeと同一で、  **max** 値は  **100** です。
+*  **databaseType** に `Redis` が  **追加** されました。
+
+##### Response
+
+<table data-table-width="760" data-layout="default" local-id="932182bb-da8d-497f-a802-b0ac654a837a">
+<colgroup>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**変更前**
+</th>
+<th>
+**変更後**
+</th>
+</tr>
+<tr>
+<td>
+```json
+{
+  "list": [
+    {
+      …
+      "execMillis": 200,
+      "execResult": false,
+      "executedAt": "2019-08-24T14:15:22Z",
+      …
+    }
+  ],
+  "page": {
+    "currentPage": 0,
+    "pageSize": 0,
+    "totalElements": 0,
+    "totalPages": 0
+  }
+}
+```
+
+</td>
+<td>
+```json
+{
+  "hasNext": true,
+  "list": [
+    {
+      …
+      "execMillis": 200,
+      "execResult": false, (Deprecated)
+      "executedAt": "2019-08-24T14:15:22Z",
+      …
+    }
+  ],
+  "nextCursor": "2019-08-24T16:15:22Z"
+}
+```
+</td>
+</tr>
+</tbody>
+</table>
+
+* hasNextフィールドが  **追加** されました。  **Response以降に次のデータがあるか** を表します。
+*  **execResult** が **Deprecated** されました。以降のバージョンで削除されます。
+*  **page** フィールドが  **消えて**   **nextCursor** が  **追加** されました。
+    * RequestのstartDateとendDateの間で現在のResponseのlistのうち  **最も最後の要素のexecutedAt** を意味します。
+    * Requestのcursorに該当値を入れると  **該当時間から続けて** データを取得します。 (startDate, endDateは変更しなくてもよいです。)
+    * /api/docsに記載されている内容は  **誤った内容** で、以降のバージョンで修正予定です。
+
+#### <br/>(GET) Detail
+
+`/api/external/audit-logs/{id}`
+
+##### Request
+
+* 変更点なし
+
+##### Response
+
+<table data-table-width="760" data-layout="default" local-id="faa4a484-fb0f-47b7-978a-23feea65210e">
+<colgroup>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**変更前**
+</th>
+<th>
+**変更後**
+</th>
+</tr>
+<tr>
+<td>
+```json
+{
+      …
+      "execMillis": 200,
+      "execResult": false,
+      "executedAt": "2019-08-24T14:15:22Z",
+      …   
+}
+```
+
+</td>
+<td>
+```json
+{
+      …
+      "execMillis": 200,
+      "execResult": false, (Deprecated)
+      "executedAt": "2019-08-24T14:15:22Z",
+      …
+}
+```
+</td>
+</tr>
+</tbody>
+</table>
+
+*  **execResult** が **Deprecated** されました。以降のバージョンで削除されます。
+
+
+#### (GET) Detail
+
+`/api/external/audit-logs/{uuid}`
+
+##### Request
+
+* 変更点なし
+
+##### Response
+
+<table data-table-width="760" data-layout="default" local-id="e34b740f-592e-49c5-b549-6f54500e8c83">
+<colgroup>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**変更前**
+</th>
+<th>
+**変更後**
+</th>
+</tr>
+<tr>
+<td>
+```json
+{
+      …
+      "execMillis": 200,
+      "execResult": false,
+      "executedAt": "2019-08-24T14:15:22Z",
+      …   
+}
+```
+
+</td>
+<td>
+```json
+{
+      …
+      "execMillis": 200,
+      "execResult": false, (Deprecated)
+      "executedAt": "2019-08-24T14:15:22Z",
+      …
+}
+```
+</td>
+</tr>
+</tbody>
+</table>
+
+*  **execResult** が **Deprecated** されました。以降のバージョンで削除されます。
+
+
+
+---
+
+## 5. Authentication History API
+
+#### (GET) List of Authentication
+
+`/api/external/connection-auth-logs`
+
+##### Request
+
+* Query Parameter
+
+<table data-table-width="760" data-layout="default" local-id="9d2bd396-23e6-44cf-baa2-f17fc0dd9b55">
+<colgroup>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**変更前**
+</th>
+<th>
+**変更後**
+</th>
+</tr>
+<tr>
+<td>
+* pageNumber
+* pageSize
+* actionType
+* clusterGroupId
+* clusterId
+* startDate
+* endDate
+* databaseType
+* sqlFullText
+</td>
+<td>
+* pageNumber
+* pageSize
+*  **actionType** 
+* clusterGroupId
+* clusterId
+* startDate
+* endDate
+*  **databaseType** 
+* sqlFullText
+</td>
+</tr>
+</tbody>
+</table>
+
+*  **actionType** から `LOGIN`, `LOGOUT`, `LOCKED`, `EXPIRED`, `LOCKED_MANUALLY`, `UNLOCK` が  **削除** されました。
+    *  `CONNECT`, `DISCONNECT` のみ使用します。
+*  **databaseType** に `Redis`が  **追加** されました。
+
+##### Response
+
+* 変更点なし
+
+
+
+---
+
+## 6. User Access History API
+
+#### (GET) List of User Access History
+
+`/api/external/system-auth-logs`
+
+##### Request & Response
+
+*  **actionType** から `CONNECT`, `DISCONNECT`が  **削除** されました。
+    *  `LOGIN`, `LOGOUT`, `LOCKED`, `EXPIRED`, `LOCKED_MANUALLY`, `UNLOCK` のみ使用します。
+
+
+
+---
+
+## 7. Cloud Provider API
+
+#### (GET) List of Cloud Provider
+
+`/api/external/cloud-providers`
+
+##### Request
+
+* 変更点なし
+
+##### Response
+
+<table data-table-width="760" data-layout="default" local-id="c43c1c7c-02dd-48b4-a04d-2c66bce49618">
+<colgroup>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**変更前**
+</th>
+<th>
+**変更後**
+</th>
+</tr>
+<tr>
+<td>
+```json
+{
+  "list": [
+    {
+      …
+      "subscriptionId": "string",
+      "targetArn": "string",
+       …
+    }
+  ],
+  "page": {
+    …
+  }
+}
+```
+</td>
+<td>
+```json
+{
+  "list": [
+    {
+      …
+      "subscriptionId": "string",
+      "synchronizableDatabaseTypes": [],
+      "targetArn": "string",
+       …
+    }
+  ],
+  "page": {
+     …
+  }
+}
+```
+</td>
+</tr>
+</tbody>
+</table>
+
+*  **synchronizableDatabaseTypes** が  **追加** されました。
+    *  **同期したいデータベースのタイプ**  (ベンダー) を出力するフィールドです。
+    * `AURORA_MY_SQL`, `AURORA_POSTGRESQL`, `MY_SQL`, `POSTGRESQL`, `MARIA_DB`, `ORACLE`, `SQL_SERVER`, `DYNAMO_DB`, `DOCUMENT_DB`, `REDSHIFT`, `ATHENA`
+
+
+#### (POST) Create Cloud Provider
+
+`/api/external/cloud-providers`
+
+##### Request
+
+<table data-table-width="760" data-layout="default" local-id="7f2d3d42-8253-404f-9149-10b318b6ca3d">
+<colgroup>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**変更前**
+</th>
+<th>
+**変更後**
+</th>
+</tr>
+<tr>
+<td>
+```json
+{
+      …
+      "subscriptionId": "string",
+      "targetArn": "string",
+       …
+}
+```
+
+</td>
+<td>
+```json
+{
+      …
+      "subscriptionId": "string",
+      "synchronizableDatabaseTypes": [],
+      "targetArn": "string",
+       …
+}
+```
+</td>
+</tr>
+</tbody>
+</table>
+
+*  **synchronizableDatabaseTypes** が  **追加** されました。
+    *  **同期したいデータベースのタイプ**  (ベンダー) を入力するフィールドです。
+    * `AURORA_MY_SQL`, `AURORA_POSTGRESQL`, `MY_SQL`, `POSTGRESQL`, `MARIA_DB`, `ORACLE`, `SQL_SERVER`, `DYNAMO_DB`, `DOCUMENT_DB`, `REDSHIFT`, `ATHENA`
+
+##### Response
+
+<table data-table-width="760" data-layout="default" local-id="b16699b8-ecb0-4ee1-ac36-7ac7ea42eae9">
+<colgroup>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**変更前**
+</th>
+<th>
+**変更後**
+</th>
+</tr>
+<tr>
+<td>
+```json
+{
+      …
+      "subscriptionId": "string",
+      "targetArn": "string",
+       …
+ }
+```
+</td>
+<td>
+```json
+{
+      …
+      "subscriptionId": "string",
+      "synchronizableDatabaseTypes": [],
+      "targetArn": "string",
+       …
+}
+```
+</td>
+</tr>
+</tbody>
+</table>
+
+*  **synchronizableDatabaseTypes** が  **追加** されました。
+    *  **同期したいデータベースのタイプ**  (ベンダー) を出力するフィールドです。
+    * `AURORA_MY_SQL`, `AURORA_POSTGRESQL`, `MY_SQL`, `POSTGRESQL`, `MARIA_DB`, `ORACLE`, `SQL_SERVER`, `DYNAMO_DB`, `DOCUMENT_DB`, `REDSHIFT`, `ATHENA`<br/>
+
+#### (PUT) Update Cloud Provider
+
+`/api/external/cloud-providers/{cloudProviderUuid}`
+
+##### Request
+
+<table data-table-width="760" data-layout="default" local-id="f52a5751-3b5e-4888-b0bb-bb102080762d">
+<colgroup>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**変更前**
+</th>
+<th>
+**変更後**
+</th>
+</tr>
+<tr>
+<td>
+```json
+{
+  "cronExpression": "0 0 6 * * ?",
+  "name": "AWS",
+  "proxyAuthType": "QUERYPIE",
+  "proxyEnabled": true,
+  "replicationMode": "MANUAL"
+}
+```
+
+</td>
+<td>
+```json
+{
+  "cronExpression": "0 0 6 * * ?",
+  "name": "AWS",
+  "proxyAuthType": "QUERYPIE",
+  "proxyEnabled": true,
+  "replicationMode": "MANUAL",
+  "synchronizableDatabaseTypes": [
+    "AURORA_MY_SQL"
+  ]
+}
+```
+</td>
+</tr>
+</tbody>
+</table>
+
+*  **synchronizableDatabaseTypes** が  **追加** されました。
+    *  **同期したいデータベースのタイプ**  (ベンダー) を入力するフィールドです。
+    * `AURORA_MY_SQL`, `AURORA_POSTGRESQL`, `MY_SQL`, `POSTGRESQL`, `MARIA_DB`, `ORACLE`, `SQL_SERVER`, `DYNAMO_DB`, `DOCUMENT_DB`, `REDSHIFT`, `ATHENA`
+
+##### Response
+
+<table data-table-width="760" data-layout="default" local-id="1b7cfa33-d4bb-4e89-a7c6-5add7e6663c3">
+<colgroup>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**変更前**
+</th>
+<th>
+**変更後**
+</th>
+</tr>
+<tr>
+<td>
+```json
+{
+      …
+      "subscriptionId": "string",
+      "targetArn": "string",
+       …
+}
+```
+
+</td>
+<td>
+```json
+{
+      …
+      "subscriptionId": "string",
+      "synchronizableDatabaseTypes": [],
+      "targetArn": "string",
+       …
+}
+```
+</td>
+</tr>
+</tbody>
+</table>
+
+*  **synchronizableDatabaseTypes** が  **追加** されました。
+    *  **同期したいデータベースのタイプ**  (ベンダー) を出力するフィールドです。
+    * `AURORA_MY_SQL`, `AURORA_POSTGRESQL`, `MY_SQL`, `POSTGRESQL`, `MARIA_DB`, `ORACLE`, `SQL_SERVER`, `DYNAMO_DB`, `DOCUMENT_DB`, `REDSHIFT`, `ATHENA`
+
+
+
+---
+
+## 8. Cluster Role API
+
+#### (GET) List of Role
+
+`/api/external/roles`
+
+##### Request
+
+* 変更点なし
+
+##### Response
+
+<table data-table-width="760" data-layout="default" local-id="fea50ede-0255-4ec9-960a-1472523b2651">
+<colgroup>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**変更前**
+</th>
+<th>
+**変更後**
+</th>
+</tr>
+<tr>
+<td>
+```json
+{
+  "list": [
+    {
+      ...
+      "privilegeTypes": "SELECT",
+      ...
+    },
+    ...
+  ],
+  "page": {...}
+}
+```
+</td>
+<td>
+```
+{
+  "list": [
+    {
+      ...
+      "privilegeTypes": "SELECT",
+      "privilegeVendor": "SQL",
+      ...
+    },
+    ...
+  ],
+  "page": {...}
+}
+```
+</td>
+</tr>
+</tbody>
+</table>
+
+*  **privilegeVendor** が  **追加** されました。
+    * `SQL`, `REDIS`
+
+#### (POST) Create Role
+
+`/api/external/roles`
+
+##### Request & Response
+
+<table data-table-width="760" data-layout="default" local-id="56c6d3e7-3146-49ff-82ea-4aa792c89003">
+<colgroup>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**変更前**
+</th>
+<th>
+**変更後**
+</th>
+</tr>
+<tr>
+<td>
+```json
+{
+  …
+  "privilegeTypes": "ALL",
+  …
+}
+```
+</td>
+<td>
+```json
+{
+  …
+  "privilegeTypes": "ALL",
+  "privilegeVendor": "SQL",
+  …
+}
+```
+</td>
+</tr>
+</tbody>
+</table>
+
+*  **privilegeVendor** が  **追加** されました。
+    * `SQL`, `REDIS`
+
+#### (PUT) Update Role
+
+`/api/external/roles/{roleUuid}`
+
+##### Request & Response
+
+<table data-table-width="760" data-layout="default" local-id="85cd18b3-fa2c-4df3-a4b5-1b6e9a773256">
+<colgroup>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**変更前**
+</th>
+<th>
+**変更後**
+</th>
+</tr>
+<tr>
+<td>
+```json
+{
+  …
+  "privilegeTypes": "ALL",
+  …
+}
+```
+</td>
+<td>
+```json
+{
+  …
+  "privilegeTypes": "ALL",
+  "privilegeVendor": "SQL",
+  …
+}
+```
+</td>
+</tr>
+</tbody>
+</table>
+
+*  **privilegeVendor** が  **追加** されました。
+    * `SQL`, `REDIS`
+
+
+
+---
+
+## 9. Connection API
+
+#### (GET) List of Cluster Group
+
+`/api/external/connections`
+
+##### Request
+
+* 変更点なし
+
+##### Response
+
+<table data-table-width="760" data-layout="default" local-id="c8555215-eb77-4807-a123-8728d1377f19">
+<colgroup>
+<col/>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+
+</th>
+<th>
+**変更前**
+</th>
+<th>
+**変更後**
+</th>
+</tr>
+<tr>
+<th>
+**Request**
+</th>
+<td>
+-
+</td>
+<td>
+なし
+</td>
+</tr>
+<tr>
+<th>
+**Response**
+</th>
+<td>
+```json
+{
+  "list": [
+    {
+      …
+      "clusters": [
+          …
+      ],
+      "connectionOwners": [
+       …
+      ],
+      "databaseType": "MySQL",
+      "databaseVersion": "5.7.10",
+      "dbUserInfos": [
+        {
+          "dbUserType": "string",
+          "dbUsername": "string"
+        }
+      ],
+      "deleted": false,
+      …
+      "schemaName": "test_db",
+      "useMultipleAccount": true,
+      "useProxy": true,
+      …
+    }
+  ],
+  "page": {
+    …
+  }
+}
+```
+
+</td>
+<td>
+```json
+{
+  "list": [
+    {
+      …
+      "clusters": [
+        …
+      ],
+      "connectionAccount": {
+        "kerberosProtocols": {
+          "admin": {
+            "principal": "string",
+            "realm": "string",
+            "serviceName": "string"
+          },
+          "common": {
+            "principal": "string",
+            "realm": "string",
+            "serviceName": "string"
+          }
+        },
+        "type": "UIDPWD",
+        "useMultipleAccount": false,
+        "usernamePasswords": {
+          "admin": {
+            "username": "string"
+          },
+          "common": {
+            "username": "string"
+          },
+          "proxy": {
+            "username": "string"
+          }
+        }
+      },
+      "connectionOwners": [
+        …
+      ],
+      "databaseType": "MySQL",
+      "databaseVersion": "5.7.10",
+      "deleted": false,
+      …
+      "schemaName": "test_db",
+      "useProxy": true,
+      …
+    }
+  ],
+  "page": {
+    …
+  }
+}
+```
+</td>
+</tr>
+</tbody>
+</table>
+
+*  **dbUserInfo** が  **削除** されました。  **userMultipleAccount** が  **削除** されました。
+    * 該当フィールドの内容はconnectionAccountを通じて伝達されます。<br/>
+*  **connectionAccount** が  **追加** されました。
+    * 接続の  **account**   **情報** を伝達するフィールドです。
+    *  **type** はaccountの  **タイプ** を意味します。
+        * `NOAUTH` `SASL_KERBEROS` `SASL_PLAIN_UID` `UIDPWD` `SASL_PLAIN_UIDPWD_SSL` `NOAUTH_SSL` `DELEGATION_TOKEN` `O_AUTH_CLIENT_CREDENTIALS`
+    *  **useMultipleAccount** は  **マルチアカウント** を使用するかについての  **boolean** 値です。
+    *  **KerberosProtocols** は  **Kerberosアカウント** 情報を伝達するフィールドです。
+        * Kerberosアカウントは  **proxy**   **アカウント** を  **サポートしません。** 
+    *  **usernamePasswords** は  **usernamePassword**   **アカウント** 情報を伝達するフィールドです。
+
+
+#### (POST) Create Cluster Group
+
+`/api/external/connections`
+
+##### Request
+
+<table data-table-width="760" data-layout="default" local-id="a91c0329-8458-4c75-a106-ccdd7a0e25e3">
+<colgroup>
+<col/>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+
+</th>
+<th>
+**変更前**
+</th>
+<th>
+**変更後**
+</th>
+</tr>
+<tr>
+<th>
+**Request**
+</th>
+<td>
+-
+</td>
+<td>
+なし
+</td>
+</tr>
+<tr>
+<th>
+**Response**
+</th>
+<td>
+```json
+{
+      "clusters": [
+          …
+      ],
+      "connectionOwners": [
+       …
+      ],
+      "databaseType": "MySQL",
+      "databaseVersion": "5.7.10",
+      "dbUserInfos": [
+        {
+          "dbUserType": "string",
+          "dbUsername": "string"
+        }
+      ],
+      "deleted": false,
+      …
+}
+```
+
+</td>
+<td>
+```json
+{
+      …
+      "clusters": [
+        …
+      ],
+      "connectionAccount": {
+        "kerberosProtocols": {
+          "admin": {
+            "principal": "string",
+            "realm": "string",
+            "serviceName": "string"
+          },
+          "common": {
+            "principal": "string",
+            "realm": "string",
+            "serviceName": "string"
+          }
+        },
+        "type": "UIDPWD",
+        "useMultipleAccount": false,
+        "usernamePasswords": {
+          "admin": {
+            "username": "string"
+          },
+          "common": {
+            "username": "string"
+          },
+          "proxy": {
+            "username": "string"
+          }
+        }
+      },
+      "connectionOwners": [
+        …
+      ],
+      "databaseType": "MySQL",
+      "databaseVersion": "5.7.10",
+      "deleted": false,
+      …
+}
+```
+</td>
+</tr>
+</tbody>
+</table>
+
+*  **dbUserInfo** が  **削除** されました。  **userMultipleAccount** が  **削除** されました。 
+    * 該当フィールドの内容はconnectionAccountを通じて伝達されます。<br/>
+*  **connectionAccount** が  **追加** されました。
+    * 接続の  **account**   **情報** を伝達するフィールドです。
+    *  **type** はaccountの  **タイプ** を意味します。
+        * `NOAUTH` `SASL_KERBEROS` `SASL_PLAIN_UID` `UIDPWD` `SASL_PLAIN_UIDPWD_SSL` `NOAUTH_SSL` `DELEGATION_TOKEN` `O_AUTH_CLIENT_CREDENTIALS`
+    *  **useMultipleAccount** は  **マルチアカウント** を使用するかについての  **boolean** 値です。
+    *  **KerberosProtocols** は  **Kerberosアカウント** 情報を伝達するフィールドです。
+        * Kerberosアカウントは  **proxy**   **アカウント** を  **サポートしません。** 
+    *  **usernamePasswords** は  **usernamePassword**   **アカウント** 情報を伝達するフィールドです。
+
+##### Response
+
+<table data-table-width="760" data-layout="default" local-id="39575eab-8bc2-45f4-b145-a8b9d33bc1ef">
+<colgroup>
+<col/>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+
+</th>
+<th>
+**変更前**
+</th>
+<th>
+**変更後**
+</th>
+</tr>
+<tr>
+<th>
+**Request**
+</th>
+<td>
+-
+</td>
+<td>
+なし
+</td>
+</tr>
+<tr>
+<th>
+**Response**
+</th>
+<td>
+```json
+{
+      …
+      "clusters": [
+          …
+      ],
+      "connectionOwners": [
+       …
+      ],
+      "databaseType": "MySQL",
+      "databaseVersion": "5.7.10",
+      "dbUserInfos": [
+        {
+          "dbUserType": "string",
+          "dbUsername": "string"
+        }
+      ],
+      "deleted": false,
+      …
+      "schemaName": "test_db",
+      "useMultipleAccount": true,
+      "useProxy": true,
+      …
+}
+```
+
+</td>
+<td>
+```json
+{
+      …
+      "clusters": [
+        …
+      ],
+      "connectionAccount": {
+        "kerberosProtocols": {
+          "admin": {
+            "principal": "string",
+            "realm": "string",
+            "serviceName": "string"
+          },
+          "common": {
+            "principal": "string",
+            "realm": "string",
+            "serviceName": "string"
+          }
+        },
+        "type": "UIDPWD",
+        "useMultipleAccount": false,
+        "usernamePasswords": {
+          "admin": {
+            "username": "string"
+          },
+          "common": {
+            "username": "string"
+          },
+          "proxy": {
+            "username": "string"
+          }
+        }
+      },
+      "connectionOwners": [
+        …
+      ],
+      "databaseType": "MySQL",
+      "databaseVersion": "5.7.10",
+      "deleted": false,
+      …
+      "schemaName": "test_db",
+      "useProxy": true,
+      …
+}
+```
+</td>
+</tr>
+</tbody>
+</table>
+
+*  **dbUserInfo** が  **削除** されました。  **userMultipleAccount** が  **削除** されました。 
+    * 該当フィールドの内容はconnectionAccountを通じて伝達されます。<br/>
+*  **connectionAccount** が  **追加** されました。
+    * 接続の  **account**   **情報** を伝達するフィールドです。
+    *  **type** はaccountの  **タイプ** を意味します。
+        * `NOAUTH` `SASL_KERBEROS` `SASL_PLAIN_UID` `UIDPWD` `SASL_PLAIN_UIDPWD_SSL` `NOAUTH_SSL` `DELEGATION_TOKEN` `O_AUTH_CLIENT_CREDENTIALS`
+    *  **useMultipleAccount** は  **マルチアカウント** を使用するかについての  **boolean** 値です。
+    *  **KerberosProtocols** は  **Kerberosアカウント** 情報を伝達するフィールドです。
+        * Kerberosアカウントは  **proxy**   **アカウント** を  **サポートしません。** 
+    *  **usernamePasswords** は  **usernamePassword**   **アカウント** 情報を伝達するフィールドです。
+
+#### <br/>(PATCH) Update Cluster Group
+
+`/api/external/connections/{uuid}`
+
+##### Request
+
+<table data-table-width="760" data-layout="default" local-id="30d79d2b-4f9e-4cd9-82c4-3e3b2d040226">
+<colgroup>
+<col/>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+
+</th>
+<th>
+**変更前**
+</th>
+<th>
+**変更後**
+</th>
+</tr>
+<tr>
+<th>
+**Request**
+</th>
+<td>
+-
+</td>
+<td>
+なし
+</td>
+</tr>
+<tr>
+<th>
+**Response**
+</th>
+<td>
+```json
+{
+      "clusters": [
+          …
+      ],
+      "connectionOwners": [
+       …
+      ],
+      "databaseType": "MySQL",
+      "databaseVersion": "5.7.10",
+      "dbUserInfos": [
+        {
+          "dbUserType": "string",
+          "dbUsername": "string"
+        }
+      ],
+      "deleted": false,
+      …
+}
+```
+
+</td>
+<td>
+```json
+{
+      …
+      "clusters": [
+        …
+      ],
+      "connectionAccount": {
+        "kerberosProtocols": {
+          "admin": {
+            "principal": "string",
+            "realm": "string",
+            "serviceName": "string"
+          },
+          "common": {
+            "principal": "string",
+            "realm": "string",
+            "serviceName": "string"
+          }
+        },
+        "type": "UIDPWD",
+        "useMultipleAccount": false,
+        "usernamePasswords": {
+          "admin": {
+            "username": "string"
+          },
+          "common": {
+            "username": "string"
+          },
+          "proxy": {
+            "username": "string"
+          }
+        }
+      },
+      "connectionOwners": [
+        …
+      ],
+      "databaseType": "MySQL",
+      "databaseVersion": "5.7.10",
+      "deleted": false,
+      …
+}
+```
+</td>
+</tr>
+</tbody>
+</table>
+
+*  **dbUserInfo** が  **削除** されました。  **userMultipleAccount** が  **削除** されました。 
+    * 該当フィールドの内容はconnectionAccountを通じて伝達されます。<br/>
+*  **connectionAccount** が  **追加** されました。
+    * 接続の  **account**   **情報** を伝達するフィールドです。
+    *  **type** はaccountの  **タイプ** を意味します。
+        * `NOAUTH` `SASL_KERBEROS` `SASL_PLAIN_UID` `UIDPWD` `SASL_PLAIN_UIDPWD_SSL` `NOAUTH_SSL` `DELEGATION_TOKEN` `O_AUTH_CLIENT_CREDENTIALS`
+    *  **useMultipleAccount** は  **マルチアカウント** を使用するかについての  **boolean** 値です。
+    *  **KerberosProtocols** は  **Kerberosアカウント** 情報を伝達するフィールドです。
+        * Kerberosアカウントは  **proxy**   **アカウント** を  **サポートしません。** 
+    *  **usernamePasswords** は  **usernamePassword**   **アカウント** 情報を伝達するフィールドです。
+
+##### Response
+
+<table data-table-width="760" data-layout="default" local-id="55b9a43a-b701-488d-8c41-38951410331d">
+<colgroup>
+<col/>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+
+</th>
+<th>
+**変更前**
+</th>
+<th>
+**変更後**
+</th>
+</tr>
+<tr>
+<th>
+**Request**
+</th>
+<td>
+-
+</td>
+<td>
+なし
+</td>
+</tr>
+<tr>
+<th>
+**Response**
+</th>
+<td>
+```json
+{
+      …
+      "clusters": [
+          …
+      ],
+      "connectionOwners": [
+       …
+      ],
+      "databaseType": "MySQL",
+      "databaseVersion": "5.7.10",
+      "dbUserInfos": [
+        {
+          "dbUserType": "string",
+          "dbUsername": "string"
+        }
+      ],
+      "deleted": false,
+      …
+      "schemaName": "test_db",
+      "useMultipleAccount": true,
+      "useProxy": true,
+      …
+}
+```
+
+</td>
+<td>
+```json
+{
+      …
+      "clusters": [
+        …
+      ],
+      "connectionAccount": {
+        "kerberosProtocols": {
+          "admin": {
+            "principal": "string",
+            "realm": "string",
+            "serviceName": "string"
+          },
+          "common": {
+            "principal": "string",
+            "realm": "string",
+            "serviceName": "string"
+          }
+        },
+        "type": "UIDPWD",
+        "useMultipleAccount": false,
+        "usernamePasswords": {
+          "admin": {
+            "username": "string"
+          },
+          "common": {
+            "username": "string"
+          },
+          "proxy": {
+            "username": "string"
+          }
+        }
+      },
+      "connectionOwners": [
+        …
+      ],
+      "databaseType": "MySQL",
+      "databaseVersion": "5.7.10",
+      "deleted": false,
+      …
+      "schemaName": "test_db",
+      "useProxy": true,
+      …
+}
+```
+</td>
+</tr>
+</tbody>
+</table>
+
+*  **dbUserInfo** が  **削除** されました。  **userMultipleAccount** が  **削除** されました。 
+    * 該当フィールドの内容はconnectionAccountを通じて伝達されます。<br/>
+*  **connectionAccount** が  **追加** されました。
+    * 接続の  **account**   **情報** を伝達するフィールドです。
+    *  **type** はaccountの  **タイプ** を意味します。
+        * `NOAUTH` `SASL_KERBEROS` `SASL_PLAIN_UID` `UIDPWD` `SASL_PLAIN_UIDPWD_SSL` `NOAUTH_SSL` `DELEGATION_TOKEN` `O_AUTH_CLIENT_CREDENTIALS`
+    *  **useMultipleAccount** は  **マルチアカウント** を使用するかについての  **boolean** 値です。
+    *  **KerberosProtocols** は  **Kerberosアカウント** 情報を伝達するフィールドです。
+        * Kerberosアカウントは  **proxy**   **アカウント** を  **サポートしません。** 
+    *  **usernamePasswords** は  **usernamePassword**   **アカウント** 情報を伝達するフィールドです。
+
+
+
+---
+
+## 10. Notification Channels API
+
+#### (GET) List of Notification channel
+
+`/api/external/notification-channels`
+
+##### Request
+
+* Query Parameterフィールド追加
+
+<table data-table-width="760" data-layout="default" local-id="306ad9b1-6ed1-421e-b58c-42ed27d24672">
+<colgroup>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**変更前**
+</th>
+<th>
+**変更後**
+</th>
+</tr>
+<tr>
+<td>
+* …
+</td>
+<td>
+* dataFlowRequest. **filterKey** 
+* dataFlowRequest. **filterValue** 
+* dataFlowRequest. **sortKey** 
+* dataFlowRequest. **sortType** 
+* …
+</td>
+</tr>
+</tbody>
+</table>
+
+* dataflowRequest. **filterKey** は  **フィルターキー** を入れます。 ex) "Title"
+* dataflowRequest. **filterValue** は  **フィルター値 (検索語)** を入れます。 ex) "channelName123"
+* dataflowRequest. **sortKey** は  **sort** する  **カラム名** を入れます。 ex ) "createdAt"
+* dataflowRequest. **sortType** は  **sort** を  **降順** にするか、  **昇順** にするかを入力します。 ex) "ASC", "DESC"
+
+
+

--- a/src/content/ja/release-notes/990-998/external-api-changes-994-version-995-version.mdx
+++ b/src/content/ja/release-notes/990-998/external-api-changes-994-version-995-version.mdx
@@ -22,8 +22,32 @@ title: 'External API変更事項（9.9.4バージョン > 9.9.5バージョン�
 
 ##### Response
 
-* **id**が**追加**されました。
+<table data-table-width="760" data-layout="default" local-id="729f4860-908e-453e-a2ce-586ef92bde21">
+<colgroup>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**変更前**
+</th>
+<th>
+**変更後**
+</th>
+</tr>
+<tr>
+<td>
 
+</td>
+<td>
+* id
+</td>
+</tr>
+</tbody>
+</table>
+
+*  **id** が  **追加** されました。
 ---
 
 ## 2. Approval API
@@ -36,8 +60,32 @@ title: 'External API変更事項（9.9.4バージョン > 9.9.5バージョン�
 
 ##### Response
 
-* **id**が**追加**されました。
+<table data-table-width="760" data-layout="default" local-id="d1aedf57-9c7c-4ffd-abf3-d1381144dd7d">
+<colgroup>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**変更前**
+</th>
+<th>
+**変更後**
+</th>
+</tr>
+<tr>
+<td>
 
+</td>
+<td>
+* id
+</td>
+</tr>
+</tbody>
+</table>
+
+*  **id** が  **追加** されました。
 ---
 
 ## 3. Audit Log API
@@ -49,12 +97,11 @@ title: 'External API変更事項（9.9.4バージョン > 9.9.5バージョン�
 ##### Request
 
 * Query Parameter
-* /api/docsで誤表記されていた**cursor**に関する内容が修正されました。
+* /api/docsで誤表記されていた  **cursor**  に関する内容が修正されました。
 
 ##### Response
 
-* /api/docsで誤表記されていた**nextCursor**に関する内容が修正されました。
-
+* /api/docsで誤表記されていた  **nextCursor**  に関する内容が修正されました。
 ---
 
 ## 4. Notification Channels API
@@ -67,11 +114,38 @@ title: 'External API変更事項（9.9.4バージョン > 9.9.5バージョン�
 
 * Query Parameter
 
-|**変更前**|**変更後**|
-|---|---|
-|* dataFlowRequest.filterKey<br/>* dataFlowRequest.filterValue<br/>* dataFlowRequest.sortKey<br/>* dataFlowRequest.sortType|* filterKey<br/>* filterValue<br/>* sortKey<br/>* sortType|
+<table data-table-width="760" data-layout="default" local-id="a8579e9b-bf3a-44ef-8dbe-bef487c68840">
+<colgroup>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**変更前**
+</th>
+<th>
+**変更後**
+</th>
+</tr>
+<tr>
+<td>
+* dataFlowRequest.filterKey
+* dataFlowRequest.filterValue
+* dataFlowRequest.sortKey
+* dataFlowRequest.sortType
+</td>
+<td>
+* filterKey
+* filterValue
+* sortKey
+* sortType
+</td>
+</tr>
+</tbody>
+</table>
 
-* **名前**が**変更**されました。
+*  **名前** が  **変更** されました。
 
 ##### Response
 

--- a/src/content/ja/user-manual/database-access-control/connecting-to-custom-data-source.mdx
+++ b/src/content/ja/user-manual/database-access-control/connecting-to-custom-data-source.mdx
@@ -28,16 +28,25 @@ import { Callout } from 'nextra/components'
 
 1.  **QueryPie Agent実行** 
     * QueryPie Agentを実行します。
-    * Database項目でCustom Data Sourceを確認できます。
+    * Database項目でCustom Data Sourceを確認できます。<br/> 
+      <figure data-layout="center" data-align="center">
+      ![Screenshot-2025-03-06-at-2.05.26-PM.png](/user-manual/database-access-control/connecting-to-custom-data-source/Screenshot-2025-03-06-at-2.05.26-PM.png)
+      </figure>
 2.  **Connection Guide確認** 
     * AgentでCustom Data Sourceコネクション行をクリックするとPort情報を含む行が見えます。
-    * 上記行を右クリックした後Connection Guideをクリックすると接続情報を確認できます。
+    * 上記行を右クリックした後Connection Guideをクリックすると接続情報を確認できます。<br/> 
+      <figure data-layout="center" data-align="center">
+      ![Screenshot-2025-03-06-at-2.08.11-PM.png](/user-manual/database-access-control/connecting-to-custom-data-source/Screenshot-2025-03-06-at-2.08.11-PM.png)
+      </figure>
     * UID/PWは修正できないdb username、db passwordで表示されます。
     * Privilegesは"-"で表示されます。
 3.  **SQL Toolで接続** 
     * DataGripやその他のSQL Toolを実行します。
     *  **HostとPortはConnection Guideに明記されている情報を入力する必要があります。**  
     * ベンダーに応じて追加情報を入力します。
+      <figure data-layout="center" data-align="center">
+      ![Screenshot-2025-03-06-at-2.18.26-PM.png](/user-manual/database-access-control/connecting-to-custom-data-source/Screenshot-2025-03-06-at-2.18.26-PM.png)
+      </figure>
 
 <Callout type="important">
 **注意事項**
@@ -48,7 +57,13 @@ import { Callout } from 'nextra/components'
 
 1.  **ウェブコネクション目録確認** 
     * ユーザー画面上部Databasesをクリックします。 
-    * 左側コネクション目録でQueryPie Connectionsをクリックするとアクセス権限があるCustom Data Sourceが表示されます。
+    * 左側コネクション目録でQueryPie Connectionsをクリックするとアクセス権限があるCustom Data Sourceが表示されます。<br/> 
+      <figure data-layout="center" data-align="center">
+      ![Screenshot-2025-03-06-at-2.22.22-PM.png](/user-manual/database-access-control/connecting-to-custom-data-source/Screenshot-2025-03-06-at-2.22.22-PM.png)
+      </figure>
 2.  **接続不可案内** 
     * Custom Data Source選択時Connectボタンが非活性化されます。
-    * 下記のようなツールチップが表示されウェブでは接続が不可です。 "Access is only possible through a proxy and cannot be accessed through the web. Please open the QueryPie Agent to connect to the Custom Data Source."
+    * 下記のようなツールチップが表示されウェブでは接続が不可です。<br/> "Access is only possible through a proxy and cannot be accessed through the web. Please open the QueryPie Agent to connect to the Custom Data Source."
+      <figure data-layout="center" data-align="center">
+      ![Screenshot-2025-03-06-at-2.23.37-PM.png](/user-manual/database-access-control/connecting-to-custom-data-source/Screenshot-2025-03-06-at-2.23.37-PM.png)
+      </figure>

--- a/src/content/ja/user-manual/database-access-control/connecting-with-web-sql-editor.mdx
+++ b/src/content/ja/user-manual/database-access-control/connecting-with-web-sql-editor.mdx
@@ -111,7 +111,8 @@ SQL Editor &gt; Queries Panel
 * `Queries` : Query Sharing有効化時、接続されたGitHub RepositoryからSQLクエリインポート/エクスポートが可能です。
 
 <Callout type="info">
-該当機能を使用するためには管理者がクエリ共有設定を事前にする必要があります。（[General](../../administrator-manual/general/company-management/general) &gt;  **クエリ共有設定**  参照）
+該当機能を使用するためには管理者がクエリ共有設定を事前にする必要があります。
+([General](../../administrator-manual/general/company-management/general) &gt;  **クエリ共有設定**  参照)
 </Callout>
 
 #### 4. Object Infoパネル
@@ -162,11 +163,13 @@ SQL Editor &gt; SQL History Panel
 
 #### 6. クエリ実行時理由入力
 
-Ledger政策または接続政策によってクエリを実行時理由入力が強制される場合があります。この場合、ユーザーがクエリを入力すると理由を入力するポップアップが出力されます。以下の図のように「Write the reason for this request」ポップアップダイアログにクエリを実行する理由を入力して`OK`ボタンを押すとクエリ実行結果が出力されます。総300文字まで入力可能です。
+Ledger政策または接続政策によってクエリを実行時理由入力が強制される場合があります。
+この場合、ユーザーがクエリを入力すると理由を入力するポップアップが出力されます。
+以下の図のように「Write the reason for this request」ポップアップダイアログにクエリを実行する理由を入力して`OK`ボタンを押すとクエリ実行結果が出力されます。
+総300文字まで入力可能です。
 
 <figure data-layout="center" data-align="center">
 ![image-20241031-233232.png](/user-manual/database-access-control/connecting-with-web-sql-editor/image-20241031-233232.png)
 </figure>
-
 
 

--- a/src/content/ja/user-manual/workflow/approval-additional-features-proxy-approval-resubmission-etc.mdx
+++ b/src/content/ja/user-manual/workflow/approval-additional-features-proxy-approval-resubmission-etc.mdx
@@ -31,7 +31,8 @@ Workflow &gt; Reviews &gt; All Reviews &gt; Review Details
 
 ### 代理決裁の使用
 
-代理決裁とは承認者役割を一定期間他のユーザーに委任する機能です。使用方法は以下の通りです。
+代理決裁とは承認者役割を一定期間他のユーザーに委任する機能です。
+使用方法は以下の通りです。
 
 #### 1. 代理決裁使用設定
 
@@ -64,7 +65,8 @@ User &gt; 上部メニューバーでプロフィールクリック &gt; Prefere
 </figcaption>
 </figure>
 <Callout type="info">
-代理決裁設定期間中、起案リクエスト者には別途の案内が表示されません。リクエスト者は普段通りApproval RuleおよびApproverを選択すれば問題ありません。
+代理決裁設定期間中、起案リクエスト者には別途の案内が表示されません。
+リクエスト者は普段通りApproval RuleおよびApproverを選択すれば問題ありません。
 </Callout>
 
 #### 3. 委任された代理決裁リクエストの処理
@@ -96,7 +98,8 @@ User &gt; 上部メニューバーでプロフィールクリック &gt; Prefere
 </figcaption>
 </figure>
 <Callout type="info">
-Slack DMを通じたリクエスト通知を使用中であれば、代理決裁者にもWorkflow段階別通知が送信されます。Slack DM通知関連の詳細は[Slack DM個人通知の使用](../../administrator-manual/general/system/integrations/integrating-with-slack-dm/slack-dm-workflow-notification-types)文書をご参照ください。
+Slack DMを通じたリクエスト通知を使用中であれば、代理決裁者にもWorkflow段階別通知が送信されます。
+Slack DM通知関連の詳細は[Slack DM個人通知の使用](../../administrator-manual/general/system/integrations/integrating-with-slack-dm/slack-dm-workflow-notification-types)文書をご参照ください。
 </Callout>
 
 #### 5. 代理決裁設定終了後の起案照会方法

--- a/src/content/ja/user-manual/workflow/requesting-sql-export.mdx
+++ b/src/content/ja/user-manual/workflow/requesting-sql-export.mdx
@@ -8,7 +8,8 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-以下の手順に従ってSQL Export Requestを申請できます。特定のDB接続に対して権限のないデータエクスポートを要求し、承認後、実行者は承認されたデータエクスポートを1回に限り実行できます。
+以下の手順に従ってSQL Export Requestを申請できます。
+特定のDB接続に対して権限のないデータエクスポートを要求し、承認後、実行者は承認されたデータエクスポートを1回に限り実行できます。
 
 
 ### SQL Export Request の申請

--- a/src/content/ja/user-manual/workflow/requesting-sql.mdx
+++ b/src/content/ja/user-manual/workflow/requesting-sql.mdx
@@ -100,7 +100,8 @@ Workflow &gt; Executions &gt; To Do &gt; Request Details &gt; Execute
 
 
 <Callout type="info">
-DML Query実行に対する承認プロセスが強制された場合<br/>`INSERT`、`UPDATE`、`DELETE`構文実行時管理者がWorkflowで承認プロセスを経るようポリシーを作成した場合があります。この場合Web Editorでクエリ実行時下記のようなメッセージが出力されます。<br/>`[ENGINE][30105] In this DML operation, you need to get approval throgh SQL Request.`
+DML Query実行に対する承認プロセスが強制された場合<br/>`INSERT`、`UPDATE`、`DELETE`構文実行時管理者がWorkflowで承認プロセスを経るようポリシーを作成した場合があります。
+この場合Web Editorでクエリ実行時下記のようなメッセージが出力されます。<br/>`[ENGINE][30105] In this DML operation, you need to get approval throgh SQL Request.`
 
 <figure data-layout="center" data-align="center">
 ![Web Editorで警告文](/user-manual/workflow/requesting-sql/image-20250629-155649.png)
@@ -109,7 +110,8 @@ Web Editorで警告文
 </figcaption>
 </figure>
 
-この場合`SEND SQL Request`ボタンをクリックしてすぐにWorkflowのSQL Request様式に移動して要求を進行できます。<br/>適切なApproval Ruleを選択しなければならずDML可否を選択します。DMLの場合Content TypeでFile添付方式で実行できません。
+この場合`SEND SQL Request`ボタンをクリックしてすぐにWorkflowのSQL Request様式に移動して要求を進行できます。<br/>適切なApproval Ruleを選択しなければならずDML可否を選択します。
+DMLの場合Content TypeでFile添付方式で実行できません。
 
 <figure data-layout="center" data-align="center">
 ![WorkflowのSQL Request様式](/user-manual/workflow/requesting-sql/image-20250629-161143.png)

--- a/src/content/ja/user-manual/workflow/requesting-sql/using-execution-plan-explain-feature.mdx
+++ b/src/content/ja/user-manual/workflow/requesting-sql/using-execution-plan-explain-feature.mdx
@@ -7,26 +7,32 @@ import { Callout } from 'nextra/components'
 # 実行計画（Explain）機能の使用
 
 <Callout type="info">
-10.2.0から追加された機能です。（10.2.0基準MySQLのみサポートします。）
-11.2.0から管理者がこの機能を無効化できるように変更されました。ユーザーがこの機能を使用できない場合、管理者が政策的に無効化したものです。
+10.2.0から追加された機能です。
+(10.2.0基準MySQLのみサポートします。)
+11.2.0から管理者がこの機能を無効化できるように変更されました。
+ユーザーがこの機能を使用できない場合、管理者が政策的に無効化したものです。
 </Callout>
 
 ### Overview
 
-ユーザーがWorkflowを通じてSQL Requestを要求する時、該当クエリに対してDBMSで提供する実行計画（Explain構文）を使用してクエリに対する制限的な手順情報を確認できます。この機能はDBMSに依存する機能であるため、WorkflowのSQL Request作成時に接続に該当するDBMSごとに差がある場合があります。
+ユーザーがWorkflowを通じてSQL Requestを要求する時、該当クエリに対してDBMSで提供する実行計画（Explain構文）を使用してクエリに対する制限的な手順情報を確認できます。
+この機能はDBMSに依存する機能であるため、WorkflowのSQL Request作成時に接続に該当するDBMSごとに差がある場合があります。
 
 <Callout type="info">
-実行計画とは？<br/>データベースのオプティマイザーが最も最適なクエリを実行するために生成する一連の作業セットまたは作業手順です。段階的に実行段階を見ることができ、段階別コストを見ることができます。
+実行計画とは？<br/>データベースのオプティマイザーが最も最適なクエリを実行するために生成する一連の作業セットまたは作業手順です。
+段階的に実行段階を見ることができ、段階別コストを見ることができます。
 </Callout>
 
 ### SQL Request作成および実行計画（Explain）実行
 
-QueryPie WorkflowでSQL Requestを作成する基本方法は同じです。（参考：[SQL Request要求](.)）
+QueryPie WorkflowでSQL Requestを作成する基本方法は同じです。
+(参考：[SQL Request要求](.))
 
 1.  MySQL ConnectionおよびDatabase選択<br/>クエリを実行するMySQL ConnectionとDatabaseを選択してクエリを入力します。
 
 <Callout type="important">
-Content Typeは「Text」のみサポートします。「File」を選択すると実行計画（Explain）機能を使用できません。
+Content Typeは「Text」のみサポートします。
+「File」を選択すると実行計画（Explain）機能を使用できません。
 </Callout>
 
 <figure data-layout="center" data-align="center">
@@ -34,7 +40,7 @@ Content Typeは「Text」のみサポートします。「File」を選択する
 </figure>
 
 1. 実行計画（Explain）オプションおよび実行計画実行<br/>クエリエディター下部にあるオプションを選択して`Explain`ボタンを押します。
-    1.  **Attach Explain Results**  : 実行計画の結果をSQL Requestに添付するかを選択するスイッチです。（基本値はOFFです。必要な場合スイッチをONに切り替えて実行計画結果を添付する必要があります。）
+    1.  **Attach Explain Results**  : 実行計画の結果をSQL Requestに添付するかを選択するスイッチです。 (基本値はOFFです。必要な場合スイッチをONに切り替えて実行計画結果を添付する必要があります。) 
     2. 結果表示方式選択
         1.  **Table**  : テーブル形式で結果が表示されます。
         2.  **JSON**  : JSON形式で結果が表示されます。
@@ -52,15 +58,34 @@ Content Typeは「Text」のみサポートします。「File」を選択する
 </Callout>
 
 1. 実行計画（Explain）結果確認
-    1. Table形式の結果確認<br/>以下の図のような結果が表示されます。各フィールドの意味はMySQL reference文書を参照してください。<br/>
-    2. JSON形式の結果確認<br/>JSONを選択してExplainボタンを押すと以下の図のような結果が表示されます。`{JSON}`をクリックすると全体JSON内容を確認できます。<br/> <br/> <br/>エクスポート（Export）する時、管理者設定に応じてパスワード入力を要求するポップアップが出力される場合があります。
+    1. Table形式の結果確認<br/>以下の図のような結果が表示されます。各フィールドの意味はMySQL reference文書を参照してください。<br/> <br/>  
+      <figure data-layout="center" data-align="center">
+      ![image-20241030-002325.png](/user-manual/workflow/requesting-sql/using-execution-plan-explain-feature/image-20241030-002325.png)
+      </figure>
+    2. JSON形式の結果確認<br/>JSONを選択してExplainボタンを押すと以下の図のような結果が表示されます。`{JSON}`をクリックすると全体JSON内容を確認できます。<br/> <br/>  <br/> <br/>  <br/>エクスポート（Export）する時、管理者設定に応じてパスワード入力を要求するポップアップが出力される場合があります。
+      <figure data-layout="center" data-align="center">
+      ![`{JSON}`をクリックすると全体内容を見ることができます。](/user-manual/workflow/requesting-sql/using-execution-plan-explain-feature/image-20241030-003040.png)
+      <figcaption>
+      `{JSON}`をクリックすると全体内容を見ることができます。
+      </figcaption>
+      </figure>
+      <figure data-layout="center" data-align="center">
+      ![JSON結果のコピーとエクスポートが可能です。](/user-manual/workflow/requesting-sql/using-execution-plan-explain-feature/image-20241030-003129.png)
+      <figcaption>
+      JSON結果のコピーとエクスポートが可能です。
+      </figcaption>
+      </figure>
 
 ### その他参考事項
 
 1. 承認者（Approver）の実行計画（Explain）結果確認<br/>承認者はExplain Resultsタブで添付された実行計画（Explain）結果を確認し、承認の参考資料として活用できます。
+  <figure data-layout="center" data-align="center">
+  ![image-20241030-004258.png](/user-manual/workflow/requesting-sql/using-execution-plan-explain-feature/image-20241030-004258.png)
+  </figure>
 
 <Callout type="important">
-承認者が見ることができる実行計画（Explain）結果は申請者が実行計画を実行する時選択したフォーマットでのみ見ることができます。つまり、申請者が実行計画をJSON形式で出力するよう設定して添付して申請した場合、承認者はJSON形式の結果のみ見ることができ、出力形式をテーブルに変更することはできません。
+承認者が見ることができる実行計画（Explain）結果は申請者が実行計画を実行する時選択したフォーマットでのみ見ることができます。
+つまり、申請者が実行計画をJSON形式で出力するよう設定して添付して申請した場合、承認者はJSON形式の結果のみ見ることができ、出力形式をテーブルに変更することはできません。
 </Callout>
 
 1. MySQLで実行計画（Explain）を通じて検討可能な構文<br/>MySQLはバージョン別に実行計画を通じて分析するサポート構文が異なります。


### PR DESCRIPTION
## 변경 사항
- 12개 파일 변경 (2,158줄 추가, 62줄 삭제)
- 주요 변경 영역:
  - Administrator Manual: databases/monitoring, proxy-management
  - Release Notes: external-api-changes 문서들 대폭 업데이트
  - User Manual: workflow, database-access-control 관련 문서

## 변경된 파일
- `administrator-manual/databases/monitoring.mdx`
- `querypie-overview/proxy-management/enable-database-proxy.mdx`
- `release-notes/9100-9104/external-api-changes-9100-version.mdx`
- `release-notes/990-998/external-api-changes-9810-version-994-version.mdx` (대폭 업데이트)
- `release-notes/990-998/external-api-changes-994-version-995-version.mdx`
- `user-manual/workflow/*.mdx` (여러 파일)
- `user-manual/database-access-control/*.mdx` (여러 파일)

