### PR TITLE
mdx_to_skeleton: 리팩토링 및 TDD 테스트 추가

### DIFF
--- a/confluence-mdx/bin/mdx_to_skeleton.py
+++ b/confluence-mdx/bin/mdx_to_skeleton.py
@@ -241,6 +241,15 @@ class TextProcessor:
             matched = False
             
             # 1. ContentProtector placeholders (most specific, must be first)
+            # Match placeholders in parentheses: (__URL_1__) or (__IMAGE_LINK_1__)
+            paren_placeholder_match = re.match(r'\((__[A-Z_]+_\d+__)\)', text[i:])
+            if paren_placeholder_match:
+                tokens.append(('placeholder', paren_placeholder_match.group(0)))
+                i += len(paren_placeholder_match.group(0))
+                matched = True
+                continue
+            
+            # Match other placeholders: `__INLINE_CODE_1__` or __HTML_ENTITY_1__
             placeholder_match = re.match(r'`__[A-Z_]+_\d+__`|__[A-Z_]+_\d+__', text[i:])
             if placeholder_match:
                 tokens.append(('placeholder', placeholder_match.group(0)))

--- a/confluence-mdx/tests/test_mdx_to_skeleton.py
+++ b/confluence-mdx/tests/test_mdx_to_skeleton.py
@@ -910,6 +910,33 @@ def test_complex_list_with_html_and_figure():
         shutil.rmtree(tmp_dir)
 
 
+def test_callout_with_external_link():
+    """Test Callout component with version information, bold text, and links"""
+    import tempfile
+    import shutil
+    
+    tmp_dir = Path(tempfile.mkdtemp())
+    try:
+        input_file = tmp_dir / "test.mdx"
+        input_file.write_text("""<Callout type="info">
+본 문서는  **10.2.6 또는 그 이상의 버전** 에 적용됩니다.
+10.2.5 또는 그 이하 버전의 Slack 연동 방법은 [10.1.0 버전 매뉴얼 문서](https://docs.querypie.com/ko/querypie-manual/10.1.0/workflow-configurations)를 참고해주세요.
+</Callout>
+""")
+        
+        output_path, _ = convert_mdx_to_skeleton(input_file)
+        content = output_path.read_text()
+        
+        expected = """<Callout type="info">
+_TEXT_ **_TEXT_** _TEXT_
+_TEXT_ [_TEXT_](https://docs.querypie.com/ko/querypie-manual/10.1.0/workflow-configurations)_TEXT_
+</Callout>
+"""
+        assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
+    finally:
+        shutil.rmtree(tmp_dir)
+
+
 # ============================================================================
 # Test Runner
 # ============================================================================
@@ -966,6 +993,8 @@ def run_all_tests():
         test_list_item_with_html_entities_and_text,
         test_nested_list_items_with_periods,
         test_list_item_with_multiple_inline_codes,
+        test_complex_list_with_html_and_figure,
+        test_callout_with_external_link,
     ]
     
     passed = 0

--- a/confluence-mdx/tests/testcases/544112828/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544112828/expected.skel.mdx
@@ -8,34 +8,34 @@ import { Callout } from 'nextra/components'
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 
 
 ### _TEXT_
 
-1. _TEXT_.
+1. _TEXT_ `Agent Download` _TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544112828/output/screenshot-20240804-173002.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
-2. _TEXT_.
+2. _TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544112828/output/image-20240723-154847.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
 <Callout type="info">
-_TEXT_.
+_TEXT_
 </Callout>
 
-3. _TEXT_.
+3. _TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544112828/output/screenshot-20240804-174002.png)
@@ -44,44 +44,44 @@ _TEXT_
 </figcaption>
 </figure>
 
-4. _TEXT_.
-_TEXT_.
+4. _TEXT_
+_TEXT_ `Next` _TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544112828/output/agent-03.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
 
 ### _TEXT_
 
-1. _TEXT_.
+1. _TEXT_ `Login` _TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544112828/output/screenshot-20240804-173713.png)
 </figure>
 
-2. _TEXT_.
+2. _TEXT_ `Continue` _TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544112828/output/screenshot-20240729-171236.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
-3. _TEXT_.
+3. _TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544112828/output/screenshot-20240729-171314.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
-4. _TEXT_.
+4. _TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544112828/output/screenshot-20240804-174209.png)
@@ -92,16 +92,16 @@ _TEXT_
 
 ### _TEXT_
 
-_TEXT_.<br/>_TEXT_.
+1. _TEXT_<br/>_TEXT_ `Port` _TEXT_ `Proxy Credentials` _TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544112828/output/screenshot-20240730-151001.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
-2. _TEXT_.
+2. _TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544112828/output/agent-07.png)
@@ -113,61 +113,61 @@ _TEXT_
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 
-#### _TEXT_. 
+#### _TEXT_
 
-* _TEXT_.
-* _TEXT_. 
+* _TEXT_ `Role` _TEXT_ `OK` _TEXT_
+* _TEXT_ &gt; _TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544112828/output/screenshot-20240730-162653.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
 <Callout type="info">
-_TEXT_.
+_TEXT_
 </Callout>
 
-#### <br/>_TEXT_.
+_TEXT_<br/>_TEXT_
 
-* _TEXT_.
+* _TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544112828/output/screenshot-20240730-161729.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
-* _TEXT_. 
-* _TEXT_.
+* _TEXT_
+* _TEXT_ `OK` _TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544112828/output/screenshot-20240730-162532.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
-#### _TEXT_. 
+#### _TEXT_
 
-_TEXT_.
-_TEXT_.
+_TEXT_
+_TEXT_
 
-_TEXT_.
+_TEXT_
 ```
 $ cd .ssh
 ```
 
-_TEXT_.
+_TEXT_
 ```
 $ vi config
 ```
 
-_TEXT_.
+_TEXT_ `wq` _TEXT_
 ```
 Host {{Server Name}}
   Hostname {{Server URL}}
@@ -176,16 +176,16 @@ Host {{Server Name}}
 ```
 
 <Callout type="info">
-_TEXT_.
-_TEXT_.
+_TEXT_
+_TEXT_
 ```
 Host *
   ProxyCommand qpa ssh %r %h %p
 ```
 </Callout>
 
-_TEXT_.
-_TEXT_.
+_TEXT_
+_TEXT_ &gt; _TEXT_
 ```
 $ ssh deploy@{{Server Name}}
 ```
@@ -197,54 +197,54 @@ $ ssh deploy@{{Server Name}}
 ![_TEXT_](/544112828/output/kubernetes-agent-access-flow.png)
 </figure>
 
-* _TEXT_.
-* _TEXT_.
-* _TEXT_.
-* _TEXT_.
+* _TEXT_ `kubeconfig` _TEXT_
+* _TEXT_
+* _TEXT_
+* _TEXT_
 
-#### _TEXT_. 
+#### _TEXT_
 
-_TEXT_.
-_TEXT_.
+_TEXT_ `Role` _TEXT_
+_TEXT_ `OK` _TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544112828/output/screenshot-20240730-152705.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
 <Callout type="info">
-_TEXT_.
+_TEXT_
 </Callout>
 
 
-#### _TEXT_. 
+#### _TEXT_
 
-_TEXT_.
-_TEXT_.
+_TEXT_
+_TEXT_ `🔍` _TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544112828/output/screenshot-20240730-161141.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
-#### _TEXT_. 
+#### _TEXT_
 
-_TEXT_.
+_TEXT_ `KubeConfig Path` _TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544112828/output/screenshot-20240730-154623.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
-*  _TEXT_.
-    * _TEXT_.
-    * _TEXT_. 
+*  **_TEXT_** : _TEXT_
+    * _TEXT_ `$HOME/.kube/querypie-kubeconfig` _TEXT_
+    * _TEXT_ `Upload` _TEXT_
 
 
 <figure data-layout="center" data-align="center">
@@ -254,26 +254,26 @@ _TEXT_
 </figcaption>
 </figure>
 
-*  _TEXT_.
-*  _TEXT_.
-*  _TEXT_.
+*  **_TEXT_** : _TEXT_ `🔽` _TEXT_
+*  **_TEXT_** : _TEXT_
+*  **_TEXT_** : _TEXT_
 
-_TEXT_.
+_TEXT_`${KUBECONFIG}`_TEXT_`${HOME}/.kube/config`_TEXT_
 ```
 export KUBECONFIG="${HOME}/.kube/config:${HOME}/.kube/querypie-kubeconfig"
 ```
 
-_TEXT_.
+_TEXT_
 ```
 export KUBECONFIG="${KUBECONFIG}:<user-specified-path>"
 ```
 
-_TEXT_.
-
-* _TEXT_
-* _TEXT_
-
 _TEXT_
+
+* _TEXT_[_TEXT_](https://kubernetes.io/ko/docs/concepts/configuration/organize-cluster-access-kubeconfig/#kubeconfig-%ED%8C%8C%EC%9D%BC-%EB%B3%91%ED%95%A9)
+* _TEXT_[_TEXT_](https://kubernetes.io/ko/docs/tasks/access-application-cluster/configure-access-multiple-clusters/#kubeconfig-%ED%99%98%EA%B2%BD-%EB%B3%80%EC%88%98-%EC%84%A4%EC%A0%95)
+
+_TEXT_ `Copy` _TEXT_
 ```
 export KUBECONFIG="${KUBECONFIG}:${HOME}/.kube/querypie-kubeconfig"
 ```
@@ -281,27 +281,27 @@ export KUBECONFIG="${KUBECONFIG}:${HOME}/.kube/querypie-kubeconfig"
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 #### _TEXT_
 
-_TEXT_.
+_TEXT_ `⚙️` _TEXT_ `Reset All Settings` _TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544112828/output/screenshot-20240730-153518.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
 
 #### _TEXT_
 
-_TEXT_.
+_TEXT_ `Reset All Settings` _TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544112828/output/screenshot-20240730-153524.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 

--- a/confluence-mdx/tests/testcases/544113141/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544113141/expected.skel.mdx
@@ -6,82 +6,82 @@ title: '_TEXT_'
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 
 ### _TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544113141/output/image-20240730-070842.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
-1. _TEXT_.
-2. _TEXT_.
-3. _TEXT_.
-    1.  _TEXT_
-    2.  _TEXT_
-    3.  _TEXT_
-4. _TEXT_.
+1. _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
+2. _TEXT_
+3. _TEXT_
+    1.  **_TEXT_** : _TEXT_
+    2.  **_TEXT_** : _TEXT_
+    3.  **_TEXT_** : _TEXT_
+4. _TEXT_
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/544113141/output/image-20240730-064139.png)
   </figure>
-    1.  _TEXT_
-    2.  _TEXT_
-    3.  _TEXT_
-    4.  _TEXT_
-    5.  _TEXT_
-5. _TEXT_.
+    1.  **_TEXT_** : _TEXT_
+    2.  **_TEXT_** : _TEXT_
+    3.  **_TEXT_** : _TEXT_
+    4.  **_TEXT_** : _TEXT_
+    5.  **_TEXT_** : _TEXT_
+5. _TEXT_
 6. _TEXT_
-    1.  _TEXT_
-    2.  _TEXT_
-    3.  _TEXT_
-    4.  _TEXT_
-        1. _TEXT_
-        2. _TEXT_
-    5.  _TEXT_
-    6.  _TEXT_
-    7.  _TEXT_
-    8.  _TEXT_
-    9.  _TEXT_
-    10.  _TEXT_
-    11.  _TEXT_
-    12.  _TEXT_
-    13.  _TEXT_
-    14.  _TEXT_
-    15.  _TEXT_
-    16.  _TEXT_
-    17.  _TEXT_
-    18.  _TEXT_
+    1.  **_TEXT_** : _TEXT_
+    2.  **_TEXT_** : _TEXT_
+    3.  **_TEXT_** : _TEXT_
+    4.  **_TEXT_** : _TEXT_
+        1.  : _TEXT_ : _TEXT_
+        2.  : _TEXT_ : _TEXT_
+    5.  **_TEXT_** : _TEXT_
+    6.  **_TEXT_** : _TEXT_
+    7.  **_TEXT_** : _TEXT_
+    8.  **_TEXT_** : _TEXT_
+    9.  **_TEXT_** : _TEXT_
+    10.  **_TEXT_****_TEXT_** : _TEXT_
+    11.  **_TEXT_** : _TEXT_
+    12.  **_TEXT_** : _TEXT_
+    13.  **_TEXT_** : _TEXT_
+    14.  **_TEXT_** : _TEXT_
+    15.  **_TEXT_** : _TEXT_
+    16.  **_TEXT_****_TEXT_** : _TEXT_
+    17.  **_TEXT_** : _TEXT_
+    18.  **_TEXT_****_TEXT_** : _TEXT_
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544113141/output/image-20240730-065045.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
 * _TEXT_
-    1.  _TEXT_
-        1. _TEXT_
-        2. _TEXT_
-    2.  _TEXT_
-    3.  _TEXT_
-    4.  _TEXT_
-    5.  _TEXT_
-    6.  _TEXT_
-    7.  _TEXT_
-    8.  _TEXT_
-    9.  _TEXT_
-    10.  _TEXT_
-    11.  _TEXT_
-    12.  _TEXT_
-    13.  _TEXT_
-    14.  _TEXT_
-    15.  _TEXT_
-    16.  _TEXT_
+    1.  **_TEXT_** : _TEXT_
+        1.  : _TEXT_ : _TEXT_
+        2.  : _TEXT_ : _TEXT_
+    2.  **_TEXT_** : _TEXT_
+    3.  **_TEXT_** : _TEXT_
+    4.  **_TEXT_** : _TEXT_
+    5.  **_TEXT_****_TEXT_** : _TEXT_
+    6.  **_TEXT_** : _TEXT_
+    7.  **_TEXT_****_TEXT_** : _TEXT_
+    8.  **_TEXT_** : _TEXT_
+    9.  **_TEXT_****_TEXT_** : _TEXT_
+    10.  **_TEXT_** : _TEXT_
+    11.  **_TEXT_** : _TEXT_
+    12.  **_TEXT_** : _TEXT_
+    13.  **_TEXT_** : _TEXT_
+    14.  **_TEXT_** : _TEXT_
+    15.  **_TEXT_** : _TEXT_
+    16.  **_TEXT_** : _TEXT_

--- a/confluence-mdx/tests/testcases/544145591/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544145591/expected.skel.mdx
@@ -8,41 +8,41 @@ import { Callout } from 'nextra/components'
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544145591/output/image-20250822-103044.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
 ### _TEXT_
 
-*  _TEXT_.
-*  _TEXT_
-*  _TEXT_.
-*  _TEXT_.
-*  _TEXT_. 
-*  _TEXT_.
-*  _TEXT_. 
+*  **_TEXT_** : _TEXT_
+*  **_TEXT_** : _TEXT_
+*  **_TEXT_** : _TEXT_
+*  **_TEXT_** : _TEXT_
+*  **_TEXT_** : _TEXT_
+*  **_TEXT_** : _TEXT_
+*  **_TEXT_** : _TEXT_
 
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544145591/output/image-20240805-014838.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544145591/output/Screenshot-2025-08-25-at-5.36.19-PM.png)
@@ -50,72 +50,72 @@ _TEXT_.
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 
-_TEXT_.
-_TEXT_.
+_TEXT_
+_TEXT_
 
-* _TEXT_. 
-
-### _TEXT_
-
-_TEXT_.
-_TEXT_.
-
-* _TEXT_.
-    * _TEXT_. 
-    * _TEXT_. 
-* _TEXT_.
+* _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
+_TEXT_
 
-* _TEXT_.
-* _TEXT_.
-* _TEXT_.
+* _TEXT_
+    * _TEXT_ : _TEXT_
+    * _TEXT_ : _TEXT_
+* _TEXT_
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 
-* _TEXT_.
-* _TEXT_.
-    * _TEXT_
-    * _TEXT_
-* _TEXT_.
+* _TEXT_
+* _TEXT_
+* _TEXT_
+
+### _TEXT_
+
+_TEXT_
+
+* _TEXT_
+* _TEXT_
+    * _TEXT_ : _TEXT_
+    * _TEXT_ : _TEXT_
+* _TEXT_
 
 ### _TEXT_
 
 <Callout type="info">
-_TEXT_.
-* _TEXT_.
-* _TEXT_. 
+_TEXT_
+* _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
+* _TEXT_
 </Callout>
 
-_TEXT_.
+_TEXT_ : _TEXT_
 
 * _TEXT_
-    * _TEXT_.
+    * _TEXT_
       <figure data-layout="center" data-align="center">
-      ! _TEXT_<br/>_TEXT_.
+      ![_TEXT_](/544145591/output/Screenshot-2025-06-12-at-1.33.58-PM.png)
       <figcaption>
-      _TEXT_<br/>
+      _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_<br/>
       </figcaption>
       </figure>
-_TEXT_.<br/>
+* _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ : _TEXT_<br/>
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/544145591/output/image-20251110-030113.png)
   </figure>
-    * _TEXT_.
+    * _TEXT_ : _TEXT_
 * _TEXT_
-    * _TEXT_.
+    * _TEXT_
         * _TEXT_
           <figure data-layout="center" data-align="center">
           ![_TEXT_](/544145591/output/image-20250508-022114.png)
           </figure>
 * _TEXT_
-    * _TEXT_.
+    * _TEXT_
         * _TEXT_
           <figure data-layout="center" data-align="center">
           ![_TEXT_](/544145591/output/Screenshot-2025-06-16-at-10.30.14-AM.png)
@@ -123,27 +123,27 @@ _TEXT_.<br/>
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544145591/output/Screenshot-2025-06-26-at-6.35.32-PM.png)
 </figure>
 
-_TEXT_.
+_TEXT_
 
-* _TEXT_.
-* _TEXT_.
-*  _TEXT_.
+* _TEXT_ `User Attribute`_TEXT_ `Key`_TEXT_ `Value`_TEXT_
+* _TEXT_ `Key:Value` _TEXT_ `Workflow` _TEXT_
+*  **_TEXT_**`User Attribute Key`_TEXT_ `Value`_TEXT_ `Workflow` _TEXT_
 
 ### _TEXT_
 
 <Callout type="info">
-_TEXT_.<br/>_TEXT_.
-_TEXT_.
+_TEXT_<br/>_TEXT_
+_TEXT_
 </Callout>
 
-_TEXT_.
-_TEXT_.
+_TEXT_
+_TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544145591/output/image-20250926-112444.png)
@@ -161,67 +161,67 @@ _TEXT_
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544145591/output/Screenshot-2025-05-09-at-3.18.32-PM.png)
 </figure>
 
 
-_TEXT_.
-_TEXT_.
+_TEXT_
+_TEXT_
 
-*  _TEXT_
-    * _TEXT_. 
-*  _TEXT_
+*  **_TEXT_** : _TEXT_
+    * _TEXT_
+*  **_TEXT_** : _TEXT_
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544145591/output/Screenshot-2025-05-09-at-8.33.07-PM.png)
 </figure>
 
-_TEXT_.
-_TEXT_.
+_TEXT_ `Send Request` _TEXT_
+_TEXT_
 
 * _TEXT_
-    * _TEXT_.
-    * _TEXT_.
+    * _TEXT_ &gt; _TEXT_ &gt; _TEXT_
+    * _TEXT_ `Send Request` _TEXT_
 * _TEXT_
-    * _TEXT_.
-    * _TEXT_
+    * _TEXT_ &gt; _TEXT_ &gt; _TEXT_
+    * _TEXT_ `Send Request` _TEXT_
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544145591/output/Screenshot-2025-05-09-at-8.40.28-PM.png)
 </figure>
 
-_TEXT_.
+_TEXT_
 
 * _TEXT_
+    * _TEXT_ &gt; _TEXT_ &gt; _TEXT_
+        * _TEXT_
+        * _TEXT_
     * _TEXT_
-        * _TEXT_.
-        * _TEXT_.
+        * _TEXT_
     * _TEXT_
-        * _TEXT_.
-    * _TEXT_
-        * _TEXT_.
-        * _TEXT_.
+        * _TEXT_
+        * _TEXT_ : _TEXT_
 * _TEXT_
+    * _TEXT_ &gt; _TEXT_ &gt; _TEXT_
+        * _TEXT_
     * _TEXT_
-        * _TEXT_.
-    * _TEXT_
-        * _TEXT_.
-        * _TEXT_.
+        * _TEXT_
+        * _TEXT_
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544145591/output/image-20250822-111454.png)
@@ -230,36 +230,36 @@ _TEXT_
 </figcaption>
 </figure>
 
-_TEXT_.
+`+Routing Rule` _TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544145591/output/image-20250822-112026.png)
 </figure>
 
-*  _TEXT_.
-*  _TEXT_.
-    *  _TEXT_.
-    *  _TEXT_.
-*   _TEXT_.
-*  _TEXT_.
+*  **_TEXT_** : _TEXT_
+*  **_TEXT_** : _TEXT_
+    *  **_TEXT_** : _TEXT_
+    *  **_TEXT_** : _TEXT_
+*   **_TEXT_** : _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
+*  **_TEXT_** : _TEXT_
 
 #### _TEXT_
 
-* _TEXT_.
-    * _TEXT_.
-    * _TEXT_.
-    * _TEXT_. 
-* _TEXT_.
-    * _TEXT_.
-    * _TEXT_.
-    * _TEXT_.
+* _TEXT_ `Add` _TEXT_
+    * _TEXT_ : _TEXT_
+    * _TEXT_ : _TEXT_
+    * _TEXT_ : _TEXT_
+* _TEXT_ `Add` _TEXT_
+    * _TEXT_ : _TEXT_
+    * _TEXT_ : _TEXT_
+    * _TEXT_ : _TEXT_
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544145591/output/image-20250825-002423.png)
 </figure>
 
-_TEXT_.
+_TEXT_

--- a/confluence-mdx/tests/testcases/544178405/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544178405/expected.skel.mdx
@@ -4,14 +4,14 @@ title: '_TEXT_'
 
 # _TEXT_
 
-### _TEXT_.
+### _TEXT_
 
-_TEXT_.
-_TEXT_.
+_TEXT_
+_TEXT_
 
-_TEXT_.
-_TEXT_.
-_TEXT_.
+_TEXT_
+_TEXT_ `Go to Admin Page` _TEXT_
+_TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544178405/output/screenshot-20240801-145006.png)
@@ -21,10 +21,10 @@ _TEXT_
 </figure>
 
 
-### _TEXT_?
+### _TEXT_
 
-_TEXT_.
-_TEXT_.
+_TEXT_
+_TEXT_
 
 <table data-table-width="760" data-layout="default" local-id="96d34ea4-8772-49af-9ba2-14ea36b1f3e1">
 <colgroup>
@@ -37,10 +37,10 @@ _TEXT_.
 <th>
 </th>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
-_TEXT_
+**_TEXT_**
 </th>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
-_TEXT_
+**_TEXT_**
 </th>
 </tr>
 <tr>
@@ -48,10 +48,10 @@ _TEXT_
 _TEXT_
 </td>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <td>
-* _TEXT_
+* [_TEXT_]_TEXT_
     * _TEXT_
 </td>
 </tr>
@@ -60,12 +60,12 @@ _TEXT_
 _TEXT_
 </td>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <td>
-* _TEXT_
+* [_TEXT_]_TEXT_
     * _TEXT_
-* _TEXT_
+* [_TEXT_]_TEXT_
     * _TEXT_
 </td>
 </tr>
@@ -74,16 +74,16 @@ _TEXT_
 _TEXT_
 </td>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <td>
 * _TEXT_
-    * _TEXT_
-    * _TEXT_
-    * _TEXT_
+    * [_TEXT_]_TEXT_
+    * [_TEXT_]_TEXT_
+    * [_TEXT_]_TEXT_
 * _TEXT_
-    * _TEXT_
-* _TEXT_
+    * [_TEXT_]_TEXT_
+* [_TEXT_]_TEXT_
 </td>
 </tr>
 <tr>
@@ -91,10 +91,10 @@ _TEXT_
 _TEXT_
 </td>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <td>
-* _TEXT_
+* [_TEXT_]_TEXT_
 </td>
 </tr>
 <tr>
@@ -102,10 +102,10 @@ _TEXT_
 _TEXT_
 </td>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <td>
-* _TEXT_
+* [_TEXT_]_TEXT_
 </td>
 </tr>
 <tr>
@@ -113,11 +113,11 @@ _TEXT_
 _TEXT_
 </td>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <td>
-* _TEXT_
-* _TEXT_
+* [_TEXT_]_TEXT_
+* [_TEXT_]_TEXT_
 </td>
 </tr>
 <tr>
@@ -125,22 +125,22 @@ _TEXT_
 _TEXT_
 </td>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <td>
-* _TEXT_
+* [_TEXT_]_TEXT_
 </td>
 </tr>
 </tbody>
 </table>
 
 
-### _TEXT_?
+### _TEXT_
 
-_TEXT_.
-_TEXT_.
-_TEXT_.
-_TEXT_.
+_TEXT_
+_TEXT_
+_TEXT_
+_TEXT_
 
 <table data-table-width="760" data-layout="default" local-id="1c770267-da7f-48dc-b1e3-817744eeec38">
 <colgroup>
@@ -153,10 +153,10 @@ _TEXT_.
 <th>
 </th>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
-_TEXT_
+**_TEXT_**
 </th>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
-_TEXT_
+**_TEXT_**
 </th>
 </tr>
 <tr>
@@ -164,13 +164,13 @@ _TEXT_
 _TEXT_
 </td>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <td>
-* _TEXT_
-* _TEXT_
-* _TEXT_
-* _TEXT_
+* [_TEXT_]_TEXT_
+* [_TEXT_]_TEXT_
+* [_TEXT_]_TEXT_
+* [_TEXT_]_TEXT_
 </td>
 </tr>
 <tr>
@@ -178,11 +178,11 @@ _TEXT_
 _TEXT_
 </td>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <td>
-* _TEXT_
-* _TEXT_
+* [_TEXT_]_TEXT_
+* [_TEXT_]_TEXT_
 </td>
 </tr>
 <tr>
@@ -190,11 +190,11 @@ _TEXT_
 _TEXT_
 </td>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <td>
-* _TEXT_
-* _TEXT_
+* [_TEXT_]_TEXT_
+* [_TEXT_]_TEXT_
 </td>
 </tr>
 <tr>
@@ -202,13 +202,13 @@ _TEXT_
 _TEXT_
 </td>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <td>
-* _TEXT_
-* _TEXT_
-* _TEXT_
-* _TEXT_
+* [_TEXT_]_TEXT_
+* [_TEXT_]_TEXT_
+* [_TEXT_]_TEXT_
+* [_TEXT_]_TEXT_
 </td>
 </tr>
 </tbody>

--- a/confluence-mdx/tests/testcases/544211126/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544211126/expected.skel.mdx
@@ -4,15 +4,15 @@ title: '_TEXT_'
 
 # _TEXT_
 
-### _TEXT_.
+### _TEXT_
 
-_TEXT_.
+_TEXT_
 
 
-### _TEXT_?
+### _TEXT_
 
-_TEXT_.
-_TEXT_.
+_TEXT_
+_TEXT_
 
 <table data-table-width="760" data-layout="default" local-id="c53b8e8a-3f68-476f-aa0a-03f2f0eb700f">
 <colgroup>
@@ -25,10 +25,10 @@ _TEXT_.
 <th>
 </th>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
-_TEXT_
+**_TEXT_**
 </th>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
-_TEXT_
+**_TEXT_**
 </th>
 </tr>
 <tr>
@@ -36,10 +36,10 @@ _TEXT_
 _TEXT_
 </td>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
-_TEXT_
+**_TEXT_**
 </th>
 <td>
-* _TEXT_
+* [_TEXT_]_TEXT_
 </td>
 </tr>
 <tr>
@@ -47,10 +47,10 @@ _TEXT_
 _TEXT_
 </td>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
-_TEXT_
+**_TEXT_**
 </th>
 <td>
-* _TEXT_
+* [_TEXT_]_TEXT_
 </td>
 </tr>
 <tr>
@@ -58,19 +58,19 @@ _TEXT_
 _TEXT_
 </td>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
-_TEXT_
+**_TEXT_**
 </th>
 <td>
-* _TEXT_
-* _TEXT_
-* _TEXT_
-* _TEXT_
-* _TEXT_
-* _TEXT_
-* _TEXT_
-* _TEXT_
-* _TEXT_
-* _TEXT_
+* [_TEXT_]_TEXT_
+* [_TEXT_]_TEXT_
+* [_TEXT_]_TEXT_
+* [_TEXT_]_TEXT_
+* [_TEXT_]_TEXT_
+* [_TEXT_]_TEXT_
+* [_TEXT_]_TEXT_
+* [_TEXT_]_TEXT_
+* [_TEXT_]_TEXT_
+* [_TEXT_]_TEXT_
 </td>
 </tr>
 <tr>
@@ -78,22 +78,22 @@ _TEXT_
 _TEXT_
 </td>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
-_TEXT_
+**_TEXT_**
 </th>
 <td>
 * _TEXT_
-    * _TEXT_
-    * _TEXT_
-    * _TEXT_
+    * [_TEXT_]_TEXT_
+    * [_TEXT_]_TEXT_
+    * [_TEXT_]_TEXT_
 * _TEXT_
-    * _TEXT_
-    * _TEXT_
-    * _TEXT_
+    * [_TEXT_]_TEXT_
+    * [_TEXT_]_TEXT_
+    * [_TEXT_]_TEXT_
 * _TEXT_
-    * _TEXT_
+    * [_TEXT_]_TEXT_
 * _TEXT_
-    * _TEXT_
-    * _TEXT_
+    * [_TEXT_]_TEXT_
+    * [_TEXT_]_TEXT_
 </td>
 </tr>
 <tr>
@@ -101,10 +101,10 @@ _TEXT_
 _TEXT_
 </td>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
-_TEXT_
+**_TEXT_**
 </th>
 <td>
-* _TEXT_
+* [_TEXT_]_TEXT_
 </td>
 </tr>
 <tr>
@@ -112,10 +112,10 @@ _TEXT_
 _TEXT_
 </td>
 <th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
-_TEXT_
+**_TEXT_**
 </th>
 <td>
-* _TEXT_
+* [_TEXT_]_TEXT_
 </td>
 </tr>
 </tbody>

--- a/confluence-mdx/tests/testcases/544375741/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544375741/expected.skel.mdx
@@ -8,11 +8,11 @@ title: '_TEXT_'
 
 ## _TEXT_
 
-_TEXT_.
-_TEXT_.
+ : _TEXT_ [_TEXT_]_TEXT_
+ : _TEXT_ [_TEXT_]_TEXT_
 ---
 
-## _TEXT_. 
+## _TEXT_
 
 #### _TEXT_
 
@@ -30,10 +30,10 @@ _TEXT_.
 <tbody>
 <tr>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 </tr>
 <tr>
@@ -47,10 +47,10 @@ _TEXT_
 </tbody>
 </table>
 
-*  _TEXT_.
+*  **_TEXT_** _TEXT_ **_TEXT_** _TEXT_
 ---
 
-## _TEXT_. 
+## _TEXT_
 
 #### _TEXT_
 
@@ -68,10 +68,10 @@ _TEXT_
 <tbody>
 <tr>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 </tr>
 <tr>
@@ -85,30 +85,30 @@ _TEXT_
 </tbody>
 </table>
 
-*  _TEXT_.
+*  **_TEXT_** _TEXT_ **_TEXT_** _TEXT_
 ---
 
-## _TEXT_. 
+## _TEXT_
 
 #### _TEXT_
 
-_TEXT_
+`/api/external/audit-logs`
 
 ##### _TEXT_
 
 * _TEXT_
-* _TEXT_.
+* _TEXT_ **_TEXT_** _TEXT_
 
 ##### _TEXT_
 
-* _TEXT_.
+* _TEXT_ **_TEXT_** _TEXT_
 ---
 
-## _TEXT_. 
+## _TEXT_
 
 #### _TEXT_
 
-_TEXT_
+`/api/external/notification-channels`
 
 ##### _TEXT_
 
@@ -122,18 +122,18 @@ _TEXT_
 <tbody>
 <tr>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 </tr>
 <tr>
 <td>
-* _TEXT_.
-* _TEXT_.
-* _TEXT_.
-* _TEXT_.
+* _TEXT_
+* _TEXT_
+* _TEXT_
+* _TEXT_
 </td>
 <td>
 * _TEXT_
@@ -145,7 +145,7 @@ _TEXT_
 </tbody>
 </table>
 
-*  _TEXT_.
+*  **_TEXT_** _TEXT_ **_TEXT_** _TEXT_
 
 ##### _TEXT_
 

--- a/confluence-mdx/tests/testcases/544377869/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544377869/expected.skel.mdx
@@ -8,53 +8,53 @@ import { Callout } from 'nextra/components'
 
 ### _TEXT_
 
-_TEXT_.
-_TEXT_.
-_TEXT_.
-_TEXT_.
+_TEXT_
+_TEXT_
+_TEXT_
+_TEXT_
 
 
 ### _TEXT_
 
-_TEXT_.
-_TEXT_.
+_TEXT_
+_TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544377869/output/image-20240725-070857.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
-1. _TEXT_.
-2. _TEXT_.
-3. _TEXT_.
-4. _TEXT_.
-5. _TEXT_.
-    1.  _TEXT_.
-    _TEXT_. <br/> _TEXT_.
-6.  _TEXT_.
+1. _TEXT_
+2. _TEXT_
+3. _TEXT_
+4. `Proxy Usage` _TEXT_
+5. _TEXT_
+    1.  **_TEXT_** : _TEXT_
+    2.  **_TEXT_** : _TEXT_<br/>_TEXT_
+6.  **_TEXT_** : _TEXT_
 
-_TEXT_.
-_TEXT_.
+_TEXT_
+_TEXT_
 
 
 ### _TEXT_
 
 <Callout type="info">
-_TEXT_.
-_TEXT_.
+_TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
+_TEXT_ [_TEXT_]_TEXT_
 </Callout>
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544377869/output/image-20240725-071030.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
-1. _TEXT_.
-2. _TEXT_.
-3. _TEXT_.
+1. _TEXT_
+2. _TEXT_
+3. _TEXT_ `Kill`_TEXT_
 
 

--- a/confluence-mdx/tests/testcases/544379140/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544379140/expected.skel.mdx
@@ -8,19 +8,19 @@ import { Callout } from 'nextra/components'
 
 ### _TEXT_
 
-_TEXT_.
-_TEXT_.
-_TEXT_.
-_TEXT_.
+_TEXT_
+_TEXT_
+_TEXT_
+_TEXT_
 
 <Callout type="important">
-_TEXT_.
+_TEXT_
 </Callout>
 
-_TEXT_
+**_TEXT_**
 
+_TEXT_ **_TEXT_** _TEXT_ **_TEXT_** _TEXT_ **_TEXT_** _TEXT_
 _TEXT_
-| --------------------------------------- | --------------------- | ------------ |
 _TEXT_
 _TEXT_
 _TEXT_
@@ -64,132 +64,132 @@ _TEXT_
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544379140/output/image-20240714-063656.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
-1. _TEXT_.
-2. _TEXT_.
-3. _TEXT_.
-    *  _TEXT_.
-    *  _TEXT_.
-    *  _TEXT_.
+1. _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
+2. _TEXT_
+3. _TEXT_
+    *  **_TEXT_** : _TEXT_
+    *  **_TEXT_** : _TEXT_
+    *  **_TEXT_** : _TEXT_
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 _TEXT_
 
-_TEXT_.
-_TEXT_.
+_TEXT_ &gt; _TEXT_ &gt; _TEXT_ `Create Task` _TEXT_
+_TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544379140/output/screenshot-20250116-131805.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
-1.  _TEXT_.
-2.  _TEXT_. 
-    1. _TEXT_.
-    2. _TEXT_.
-3.  _TEXT_.
-4.  _TEXT_.
-    1. _TEXT_.
-    2. _TEXT_.
-5.  _TEXT_.
-6.  _TEXT_. 
-7.  _TEXT_. 
-    1. _TEXT_.
-8.  _TEXT_. 
-    1. _TEXT_.
-    2. _TEXT_.
-9. _TEXT_. 
+1.  **_TEXT_** : _TEXT_
+2.  **_TEXT_** : _TEXT_
+    1. _TEXT_
+    2. _TEXT_
+3.  **_TEXT_** : _TEXT_ **_TEXT_** _TEXT_
+4.  **_TEXT_** : _TEXT_
+    1. _TEXT_
+    2. _TEXT_
+5.  **_TEXT_** : _TEXT_
+6.  **_TEXT_** : _TEXT_
+7.  **_TEXT_** : _TEXT_
+    1. _TEXT_ **_TEXT_** _TEXT_
+8.  **_TEXT_** : _TEXT_
+    1. _TEXT_
+    2. _TEXT_
+9. `Create` _TEXT_ : _TEXT_
 
 <Callout type="info">
+**_TEXT_**
 _TEXT_
-_TEXT_.
 </Callout>
 
 <Callout type="important">
-_TEXT_
+**_TEXT_**
 
-_TEXT_.<br/>
-
-_TEXT_.
-
-- _TEXT_
-
-_TEXT_<br/>_TEXT_
-
-- _TEXT_
-
-_TEXT_<br/>_TEXT_
-
-- _TEXT_
-
-_TEXT_<br/>_TEXT_
-
-- _TEXT_
-
-_TEXT_
-
-
-_TEXT_.
-
-- _TEXT_.
-
-- _TEXT_.
-
-- _TEXT_.
-
+_TEXT_<br/>
 
 _TEXT_
 
 - _TEXT_
 
-- _TEXT_
+_TEXT_`&gt;``&lt;``&lt;=``&gt;=``==``!=`<br/>_TEXT_`x &gt; `_TEXT_
 
 - _TEXT_
 
+_TEXT_`== (equals)``!= (not equals)``contains`<br/>_TEXT_`x == 'abc'``x != 'abc'``contains(x, 'ab')`
+
 - _TEXT_
+
+_TEXT_`== (equals)``!= (not equals)``&& (and)``|| (or)`<br/>_TEXT_`x == `_TEXT_
+
+- _TEXT_
+
+_TEXT_`x[? @ == 'value']``list[? @ &gt; `_TEXT_`]`
+
+
+_TEXT_
+
+- _TEXT_`&&` _TEXT_
+
+- _TEXT_`||` _TEXT_
+
+- _TEXT_ : _TEXT_`( )`_TEXT_
+
+
+_TEXT_
+
+- _TEXT_`actionType == 'SQL_EXECUTION'`
+
+- _TEXT_`actionType == 'SQL_EXECUTION' && executedFrom == 'WEB_EDITOR'`
+
+- _TEXT_`connectionName == 'database1' || connectionName == 'database2'`
+
+- _TEXT_`(connectionName == 'database1' || connectionName == 'database2') && replicationType == 'SINGLE'`
 </Callout>
 
 
 <Callout type="important">
+**_TEXT_**
+
+_TEXT_
 _TEXT_
 
-_TEXT_.
-_TEXT_.
-
-1. _TEXT_.
-2. _TEXT_. 
-3. _TEXT_.
+1. _TEXT_
+2. _TEXT_
+3. _TEXT_
 </Callout>
 
 
 ### _TEXT_
 
-_TEXT_.
-_TEXT_.
-
-_TEXT_.
-
-1. _TEXT_.
-2. _TEXT_.
-
-<Callout type="important">
+_TEXT_
 _TEXT_
 
-_TEXT_.
+_TEXT_
 
-_TEXT_.
+1. _TEXT_ : _TEXT_
+2. _TEXT_ : _TEXT_
+
+<Callout type="important">
+**_TEXT_**
+
+_TEXT_*_TEXT_*_TEXT_
+
+_TEXT_ &gt; _TEXT_ `Export a file with Encryption` _TEXT_
 </Callout>
 
 
 ### _TEXT_
 
-_TEXT_.
-_TEXT_.
-_TEXT_.
+_TEXT_
+_TEXT_
+_TEXT_

--- a/confluence-mdx/tests/testcases/544381877/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544381877/expected.skel.mdx
@@ -6,58 +6,58 @@ title: '_TEXT_'
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544381877/output/image-20240721-054859.png)
 </figure>
 
-1. _TEXT_.
-2. _TEXT_.
-3.  _TEXT_
-    1.  _TEXT_. 
-        * _TEXT_. 
-    2.  _TEXT_. 
-        * _TEXT_. 
-    3.  _TEXT_. 
+1. _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
+2. _TEXT_ `+ Create Cluster` _TEXT_
+3.  **_TEXT_** : _TEXT_
+    1.  **_TEXT_** : _TEXT_
+        * _TEXT_
+    2.  **_TEXT_** : _TEXT_
+        * _TEXT_
+    3.  **_TEXT_** : _TEXT_
     4. 
-    5.  _TEXT_.
-        1.  _TEXT_. 
-        2.  _TEXT_.
-        3.  _TEXT_.
-            * _TEXT_. 
-            * _TEXT_. 
-    6.  _TEXT_. 
-        1.  _TEXT_
-            1. _TEXT_. 
-            2. _TEXT_. 
-        2.  _TEXT_. 
+    5.  **_TEXT_** : _TEXT_
+        1.  **_TEXT_** : _TEXT_
+        2.  **_TEXT_** : _TEXT_
+        3.  **_TEXT_** : _TEXT_
+            *  : _TEXT_ : _TEXT_
+            *  : _TEXT_ : _TEXT_
+    6.  **_TEXT_** : _TEXT_
+        1.  **_TEXT_** : _TEXT_ `On`_TEXT_ `Off`_TEXT_
             1. _TEXT_
-                1. _TEXT_
-                2. _TEXT_
-                3. _TEXT_
-                4. _TEXT_
-                5. _TEXT_
-                6. _TEXT_
-                7. _TEXT_
-                8. _TEXT_
-            2. _TEXT_. 
-        3.  _TEXT_
-            1. _TEXT_. 
             2. _TEXT_
-                1. _TEXT_
-                2. _TEXT_
-4.  _TEXT_. 
-    1.  _TEXT_. 
-        1. _TEXT_. 
-        2. _TEXT_. 
-    2.  _TEXT_.
-5. _TEXT_. 
+        2.  **_TEXT_** : _TEXT_
+            1. _TEXT_
+                1. `get` 
+                2. `list` 
+                3. `watch` 
+                4. `create`
+                5. `update`
+                6. `patch`
+                7. `delete`
+                8. `deletecollection`
+            2. _TEXT_ : _TEXT_
+        3.  **_TEXT_** : _TEXT_ `On`_TEXT_ `Off`_TEXT_
+            1. _TEXT_ `On`_TEXT_
+            2. _TEXT_
+                1. `create`
+                2. `get`
+4.  **_TEXT_** : _TEXT_ `+ Add Tag` _TEXT_
+    1.  **_TEXT_** : _TEXT_
+        1. _TEXT_
+        2. _TEXT_
+    2.  **_TEXT_** : _TEXT_
+5. _TEXT_ `Save` _TEXT_
 
 
 ### _TEXT_
@@ -66,10 +66,10 @@ _TEXT_.
 ![_TEXT_](/544381877/output/image-20240511-033842.png)
 </figure>
 
-* _TEXT_.
-* _TEXT_. 
+* _TEXT_
+* _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
 <details>
-<summary>_TEXT_.</summary>
+<summary>_TEXT_*_TEXT_*_TEXT_</summary>
 ```
 #!/bin/bash
 
@@ -169,7 +169,7 @@ ${CA_CERT}"
 ```
 </details>
 
-* _TEXT_. 
+* _TEXT_
   ```
 chmod +x generate_kubepie_sa.sh
 ./generate_kubepie_sa.sh

--- a/confluence-mdx/tests/testcases/544384417/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544384417/expected.skel.mdx
@@ -7,22 +7,22 @@ import { Callout } from 'nextra/components'
 # _TEXT_
 
 <Callout type="important">
-_TEXT_.
+_TEXT_
 </Callout>
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 
-_TEXT_.
+_TEXT_
 
 <Callout type="info">
-_TEXT_.
+_TEXT_
 </Callout>
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 
 <table data-table-width="958" data-layout="center" local-id="cfcbf091-3775-4454-bff4-924bf43e88f4">
 <a id="table-1"></a>
@@ -37,22 +37,22 @@ _TEXT_.
 <tbody>
 <tr>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 </tr>
 <tr>
@@ -86,7 +86,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 <tr>
@@ -100,12 +100,12 @@ _TEXT_
 _TEXT_
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 <tr>
 <td>
-_TEXT_<br/>_TEXT_
+_TEXT_ **_TEXT_**<br/>_TEXT_
 </td>
 <td>
 _TEXT_
@@ -114,12 +114,12 @@ _TEXT_
 _TEXT_
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 <tr>
 <td>
-_TEXT_<br/>_TEXT_
+_TEXT_ **_TEXT_**<br/>_TEXT_
 </td>
 <td>
 _TEXT_
@@ -128,7 +128,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 <tr>
@@ -145,7 +145,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 <tr>
@@ -159,7 +159,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 <tr>
@@ -173,38 +173,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
--
-</td>
-</tr>
-<tr>
-<td rowspan="2">
 _TEXT_
-</td>
-<td>
-_TEXT_<br/>_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
--
-</td>
-</tr>
-<tr>
-<td>
-_TEXT_<br/>_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
--
 </td>
 </tr>
 <tr>
@@ -221,7 +190,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 <tr>
@@ -235,7 +204,38 @@ _TEXT_
 _TEXT_
 </td>
 <td>
--
+_TEXT_
+</td>
+</tr>
+<tr>
+<td rowspan="2">
+_TEXT_
+</td>
+<td>
+_TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_ **_TEXT_**<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
 </td>
 </tr>
 <tr>
@@ -243,7 +243,7 @@ _TEXT_
 _TEXT_
 </td>
 <td rowspan="2">
-_TEXT_
+_TEXT_ **_TEXT_**
 </td>
 <td>
 _TEXT_<br/>_TEXT_
@@ -255,7 +255,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 <tr>
@@ -269,7 +269,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 <tr>
@@ -286,7 +286,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 <tr>
@@ -300,7 +300,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 <tr>
@@ -331,12 +331,12 @@ _TEXT_
 _TEXT_
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 <tr>
 <td rowspan="2">
-_TEXT_
+_TEXT_ **_TEXT_**
 </td>
 <td>
 _TEXT_<br/>_TEXT_
@@ -348,22 +348,22 @@ _TEXT_
 _TEXT_
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 <tr>
 <td>
-_TEXT_
-_TEXT_
-</td>
-<td>
+_TEXT_ **_TEXT_**
 _TEXT_
 </td>
 <td>
 _TEXT_
 </td>
 <td>
--
+_TEXT_
+</td>
+<td>
+_TEXT_
 </td>
 </tr>
 <tr>
@@ -371,7 +371,7 @@ _TEXT_
 _TEXT_
 </td>
 <td rowspan="2">
-_TEXT_<br/>_TEXT_
+_TEXT_<br/>**_TEXT_**
 </td>
 <td>
 _TEXT_<br/>_TEXT_
@@ -383,7 +383,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 <tr>
@@ -397,43 +397,12 @@ _TEXT_
 _TEXT_
 </td>
 <td>
--
-</td>
-</tr>
-<tr>
-<td rowspan="2">
 _TEXT_
-</td>
-<td>
-_TEXT_<br/>_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
--
-</td>
-</tr>
-<tr>
-<td>
-_TEXT_<br/>_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
--
 </td>
 </tr>
 <tr>
 <td rowspan="2">
-_TEXT_
+_TEXT_ **_TEXT_**
 </td>
 <td>
 _TEXT_<br/>_TEXT_
@@ -445,7 +414,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 <tr>
@@ -459,7 +428,38 @@ _TEXT_
 _TEXT_
 </td>
 <td>
--
+_TEXT_
+</td>
+</tr>
+<tr>
+<td rowspan="2">
+_TEXT_ **_TEXT_**
+</td>
+<td>
+_TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
 </td>
 </tr>
 <tr>
@@ -467,35 +467,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_<br/>_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
--
-</td>
-</tr>
-<tr>
-<td>
-_TEXT_<br/>_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
--
-</td>
-</tr>
-<tr>
-<td>
-_TEXT_<br/> _TEXT_
+_TEXT_ **_TEXT_**<br/>_TEXT_
 </td>
 <td>
 _TEXT_
@@ -518,7 +490,63 @@ _TEXT_
 _TEXT_
 </td>
 <td>
--
+_TEXT_
+</td>
+</tr>
+<tr>
+<td>
+*_TEXT_***_TEXT_**<br/>*_TEXT_*
+</td>
+<td>
+*_TEXT_*
+</td>
+<td>
+*_TEXT_*
+</td>
+<td>
+*_TEXT_*
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_ **_TEXT_**<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_ **_TEXT_**<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_ **_TEXT_**<br/>_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
 </td>
 </tr>
 <tr>
@@ -532,35 +560,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
--
-</td>
-</tr>
-<tr>
-<td>
-_TEXT_<br/>_TEXT_
-</td>
-<td>
 _TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
--
-</td>
-</tr>
-<tr>
-<td>
-_TEXT_<br/>_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
--
 </td>
 </tr>
 <tr>
@@ -609,7 +609,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 <tr>
@@ -623,7 +623,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 <tr>
@@ -637,7 +637,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 <tr>
@@ -657,7 +657,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_<br/>_TEXT_
+_TEXT_<br/>**_TEXT_**
 </td>
 <td>
 _TEXT_<br/>_TEXT_
@@ -669,7 +669,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 </tbody>
@@ -677,177 +677,177 @@ _TEXT_
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_ &gt; _TEXT_
 
 <Callout type="info">
-_TEXT_.
+_TEXT_
 </Callout>
 
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544384417/output/screenshot-20241223-112238.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
 
-1.  _TEXT_.
-2.  _TEXT_.
-3.  _TEXT_.
-4.  _TEXT_.
+1.  **_TEXT_** : _TEXT_
+2.  **_TEXT_** : _TEXT_
+3.  **_TEXT_** : _TEXT_
+4.  **_TEXT_** : _TEXT_
     1. _TEXT_
     2. _TEXT_
     3. _TEXT_
-5.  _TEXT_.
-6.  _TEXT_.
+5.  **_TEXT_** : _TEXT_
+6.  **_TEXT_** : _TEXT_
+    1. _TEXT_ : _TEXT_
+    2. _TEXT_ : _TEXT_
+    3. _TEXT_ : _TEXT_
+    4. _TEXT_ : _TEXT_
+    5. _TEXT_ : _TEXT_
+7.  **_TEXT_** : _TEXT_
+8.  **_TEXT_** : _TEXT_
+9.  **_TEXT_** : _TEXT_
+10.  **_TEXT_** : _TEXT_
+    1. _TEXT_ : _TEXT_
+    2. _TEXT_ : _TEXT_
+    3. _TEXT_ : _TEXT_
+11.  **_TEXT_** : _TEXT_
     1. _TEXT_
     2. _TEXT_
     3. _TEXT_
-    4. _TEXT_
-    5. _TEXT_
-7.  _TEXT_.
-8.  _TEXT_.
-9.  _TEXT_. 
-10.  _TEXT_.
-    1. _TEXT_
-    2. _TEXT_
-    3. _TEXT_
-11.  _TEXT_.
-    1. _TEXT_.
-    2. _TEXT_.
-    3. _TEXT_.
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544384417/output/screenshot-20241223-112524.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
 
-1.  _TEXT_.
-    1. _TEXT_.
-2.  _TEXT_. 
-    1. _TEXT_.
-3.  _TEXT_. 
-4.  _TEXT_.
-5.  _TEXT_.
-6.  _TEXT_. 
-7.  _TEXT_.
-8.  _TEXT_.
-9.  _TEXT_. 
-    1. _TEXT_. 
-    2. _TEXT_
-    3. _TEXT_
-    4. _TEXT_
-    5. _TEXT_
-        * _TEXT_.
-        * _TEXT_.
-        * _TEXT_.
-10.  _TEXT_.
+1.  **_TEXT_** : _TEXT_
     1. _TEXT_
-    2. _TEXT_
-    3. _TEXT_. 
-    4. _TEXT_
+2.  **_TEXT_** : _TEXT_
+    1. _TEXT_
+3.  **_TEXT_** : _TEXT_
+4.  **_TEXT_** : _TEXT_
+5.  **_TEXT_** : _TEXT_
+6.  **_TEXT_** : _TEXT_
+7.  **_TEXT_** : _TEXT_
+8.  **_TEXT_** : _TEXT_
+9.  **_TEXT_** : _TEXT_
+    1. _TEXT_ : _TEXT_
+    2. _TEXT_ : _TEXT_
+    3. _TEXT_ : _TEXT_
+    4. _TEXT_ : _TEXT_
+    5. _TEXT_ : _TEXT_
+        * _TEXT_
+        * _TEXT_
+        * _TEXT_
+10.  **_TEXT_** : _TEXT_
+    1. _TEXT_ : _TEXT_
+    2. _TEXT_ : _TEXT_
+    3. _TEXT_ : _TEXT_
+    4. _TEXT_ : _TEXT_
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_ `+ Create Task` _TEXT_
 
-_TEXT_.
+_TEXT_ `+ Add Section` _TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544384417/output/screenshot-20241209-104337.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
-1.  _TEXT_.
-2.  _TEXT_. 
-3.  _TEXT_.
-    1. _TEXT_.
-    2. _TEXT_.
-    3. _TEXT_.
-    4. _TEXT_.
-    5. _TEXT_.
-4.  _TEXT_
-    1. _TEXT_.
-    2. _TEXT_.
-    3. _TEXT_.
-        1.  _TEXT_.
-5.  _TEXT_
-    1. _TEXT_.
-6.  _TEXT_
-    1. _TEXT_.
+1.  **_TEXT_** : _TEXT_
+2.  **_TEXT_** : _TEXT_
+3.  **_TEXT_** : _TEXT_
+    1. _TEXT_ : _TEXT_
+    2. _TEXT_ : _TEXT_
+    3. _TEXT_ : _TEXT_
+    4. _TEXT_ : _TEXT_
+    5. _TEXT_ : _TEXT_
+4.  **_TEXT_** : _TEXT_
+    1. `Scheduling`_TEXT_ `None` _TEXT_
     2. _TEXT_
-    3. _TEXT_
-7.  _TEXT_
-    1. _TEXT_.
+    3. _TEXT_ : _TEXT_
+        1.  `10.2.8` _TEXT_ `10.2.9` _TEXT_
+5.  **_TEXT_** : _TEXT_
+    1. `Scheduling`_TEXT_ `Daily``Weekly``Monthly`_TEXT_ `Quarterly` _TEXT_
+6.  **_TEXT_** : _TEXT_
+    1. _TEXT_
+    2. _TEXT_ : _TEXT_
+    3. _TEXT_ : _TEXT_
+7.  **_TEXT_** : _TEXT_
+    1. _TEXT_
     2. _TEXT_
 
-_TEXT_.
+_TEXT_ `Preview` _TEXT_
 
-_TEXT_.
+`Save` _TEXT_
 
-### _TEXT_
+### _TEXT_**_TEXT_**
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544384417/output/screenshot-20241223-104529.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
-_TEXT_.
+_TEXT_ : _TEXT_ `Duplicate Task` _TEXT_
 
-_TEXT_.
+_TEXT_
 
-*  _TEXT_
-*  _TEXT_
-*  _TEXT_
+*  **_TEXT_** _TEXT_
+*  **_TEXT_** _TEXT_
+*  **_TEXT_** _TEXT_
     * _TEXT_
-*  _TEXT_
-*  _TEXT_
+*  **_TEXT_** _TEXT_
+*  **_TEXT_** _TEXT_
     * _TEXT_
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 
-1.  _TEXT_.
+1.  **_TEXT_** : _TEXT_
+    1. _TEXT_ : _TEXT_
+        * _TEXT_ : _TEXT_
+        * _TEXT_ : _TEXT_
+        * _TEXT_ &gt; _TEXT_ : _TEXT_
+2.  **_TEXT_** : _TEXT_
+    1. _TEXT_`Service:Homepage` _TEXT_
+        * _TEXT_ : _TEXT_
+        * _TEXT_ : _TEXT_
+        * _TEXT_ &gt; _TEXT_`Service:Homepage`
+    2. _TEXT_
+        * _TEXT_
+        * _TEXT_
+    3. _TEXT_
+3.  **_TEXT_** _TEXT_
+    1. _TEXT_ : _TEXT_
+4.  **_TEXT_** : _TEXT_
     1. _TEXT_
-        * _TEXT_
-        * _TEXT_
-        * _TEXT_
-2.  _TEXT_.
+    2. _TEXT_
+5.  **_TEXT_** : _TEXT_
+    1. _TEXT_ : _TEXT_
+6.  **_TEXT_** : _TEXT_
+    1. _TEXT_ : _TEXT_
+7.  **_TEXT_** : _TEXT_
     1. _TEXT_
-        * _TEXT_
-        * _TEXT_
-        * _TEXT_
-    2. _TEXT_.
-        * _TEXT_.
-        * _TEXT_.
-    3. _TEXT_.
-3.  _TEXT_.
+8.  **_TEXT_** : _TEXT_
     1. _TEXT_
-4.  _TEXT_.
-    1. _TEXT_.
-    2. _TEXT_.
-5.  _TEXT_.
-    1. _TEXT_
-6.  _TEXT_.
-    1. _TEXT_
-7.  _TEXT_.
-    1. _TEXT_.
-8.  _TEXT_.
-    1. _TEXT_.
-    2. _TEXT_. 
-    3. _TEXT_.
-    4. _TEXT_.
+    2. _TEXT_
+    3. _TEXT_
+    4. _TEXT_

--- a/confluence-mdx/tests/testcases/568918170/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/568918170/expected.skel.mdx
@@ -8,7 +8,7 @@ import { Callout } from 'nextra/components'
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 
 
 ### _TEXT_
@@ -16,42 +16,42 @@ _TEXT_.
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/568918170/output/screenshot-20240802-114129.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
-1. _TEXT_. 
-    1. _TEXT_. 
-    2. _TEXT_. 
-2. _TEXT_. 
-3. _TEXT_. 
-4. _TEXT_.
+1. _TEXT_ &gt; _TEXT_
+    1. _TEXT_
+    2. _TEXT_ **_TEXT_** _TEXT_ `Confirm`_TEXT_
+2. _TEXT_ `Confirm` _TEXT_
+3. _TEXT_ `OK` _TEXT_
+4. _TEXT_ **_TEXT_** _TEXT_
 
 
 
 ### _TEXT_
 
-_TEXT_.
-_TEXT_.
+_TEXT_
+_TEXT_
 
-#### _TEXT_. 
+#### _TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/568918170/output/screenshot-20240802-120401.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
-*  _TEXT_
-*  _TEXT_
-*  _TEXT_
-*  _TEXT_
-*  _TEXT_.
+*  **_TEXT_** : _TEXT_
+*  **_TEXT_** : _TEXT_
+*  **_TEXT_** : _TEXT_
+*  **_TEXT_** : _TEXT_
+*  **_TEXT_**`Save` _TEXT_ `Save` _TEXT_
 
-#### _TEXT_. 
+#### _TEXT_
 
-_TEXT_.
+_TEXT_
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/568918170/output/screenshot-20240802-120741.png)
 <figcaption>
@@ -65,32 +65,32 @@ _TEXT_
 </figcaption>
 </figure>
 <Callout type="info">
-_TEXT_.
-_TEXT_.
+_TEXT_
+_TEXT_
 </Callout>
 
-#### _TEXT_. 
+#### _TEXT_
 
-* _TEXT_. 
-    *  _TEXT_
-    *  _TEXT_.
-* _TEXT_. 
+* _TEXT_
+    *  **_TEXT_** : _TEXT_
+    *  **_TEXT_** : _TEXT_
+* _TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/568918170/output/screenshot-20240802-124638.png)
 </figure>
 
-#### _TEXT_. 
+#### _TEXT_
 
-* _TEXT_. 
-_TEXT_
+* _TEXT_
+**_TEXT_**
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/568918170/output/screenshot-20240725-153533.png)
 <figcaption>
 _TEXT_
 </figcaption>
 </figure>
-_TEXT_
+**_TEXT_**
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/568918170/output/screenshot-20240725-152141.png)
 <figcaption>
@@ -98,33 +98,33 @@ _TEXT_
 </figcaption>
 </figure>
 <Callout type="info">
-_TEXT_.
-_TEXT_.
+_TEXT_
+_TEXT_ [_TEXT_]_TEXT_
 </Callout>
 
-#### _TEXT_. 
+#### _TEXT_
 
-* _TEXT_. 
+* _TEXT_ &gt; _TEXT_
 
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/568918170/output/image-20230824-110815.png)
 <figcaption>
-_TEXT_
+_TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
 </figcaption>
 </figure>
 
-1. _TEXT_. 
+1. _TEXT_ &gt; _TEXT_
 
 <Callout type="info">
-_TEXT_.
+_TEXT_ *_TEXT_* _TEXT_
 </Callout>
 
-1. _TEXT_. 
-2. _TEXT_. 
-3. _TEXT_.
-4. _TEXT_.
+1. _TEXT_ `Resubmit` _TEXT_
+2. _TEXT_
+3. `Save` _TEXT_
+4. _TEXT_ &gt; _TEXT_ &gt; _TEXT_

--- a/confluence-mdx/tests/testcases/692355151/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/692355151/expected.skel.mdx
@@ -7,93 +7,93 @@ import { Callout } from 'nextra/components'
 # _TEXT_
 
 <Callout type="info">
-_TEXT_.
-_TEXT_.
-_TEXT_.
-_TEXT_.
+_TEXT_
+_TEXT_
+_TEXT_
+_TEXT_
 </Callout>
 
 ### _TEXT_
 
-_TEXT_.
-_TEXT_.
+_TEXT_
+_TEXT_
 
 <Callout type="info">
-_TEXT_?<br/>_TEXT_.
-_TEXT_.
+_TEXT_<br/>_TEXT_
+_TEXT_
 </Callout>
 
 ### _TEXT_
 
-_TEXT_.
-_TEXT_.
+_TEXT_
+_TEXT_[_TEXT_]_TEXT_
 
-_TEXT_.  <br/>_TEXT_. 
+1.  _TEXT_<br/>_TEXT_
 
 <Callout type="important">
-_TEXT_.
-_TEXT_.
+_TEXT_
+_TEXT_
 </Callout>
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/692355151/output/image-20241029-234721.png)
 </figure>
 
-_TEXT_. <br/>_TEXT_.
-    1.  _TEXT_.
+1. _TEXT_<br/>_TEXT_ `Explain` _TEXT_
+    1.  **_TEXT_** : _TEXT_
     2. _TEXT_
-        1.  _TEXT_.
-        2.  _TEXT_. 
+        1.  **_TEXT_** : _TEXT_
+        2.  **_TEXT_** : _TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/692355151/output/image-20241029-235845.png)
 </figure>
 
 <Callout type="important">
-* _TEXT_. 
-* _TEXT_.
+* _TEXT_
+* _TEXT_
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/692355151/output/image-20241030-001252.png)
 </figure>
 </Callout>
 
 1. _TEXT_
-    _TEXT_. <br/>_TEXT_.<br/> <br/>  
+    1. _TEXT_<br/>_TEXT_<br/> <br/>  
       <figure data-layout="center" data-align="center">
       ![_TEXT_](/692355151/output/image-20241030-002325.png)
       </figure>
-    _TEXT_. <br/>_TEXT_.<br/> <br/>  <br/> <br/>  <br/>_TEXT_.
+    2. _TEXT_<br/>_TEXT_ `{JSON}` _TEXT_<br/> <br/>  <br/> <br/>  <br/>_TEXT_
       <figure data-layout="center" data-align="center">
       ![_TEXT_](/692355151/output/image-20241030-003040.png)
       <figcaption>
-      _TEXT_.
+      `{JSON}`_TEXT_
       </figcaption>
       </figure>
       <figure data-layout="center" data-align="center">
       ![_TEXT_](/692355151/output/image-20241030-003129.png)
       <figcaption>
-      _TEXT_.
+      _TEXT_
       </figcaption>
       </figure>
 
 ### _TEXT_
 
-_TEXT_. <br/>_TEXT_.
+1. _TEXT_<br/>_TEXT_
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/692355151/output/image-20241030-004258.png)
   </figure>
 
 <Callout type="important">
-_TEXT_.
-_TEXT_.
+_TEXT_
+_TEXT_
 </Callout>
 
-_TEXT_. <br/>_TEXT_. 
+1. _TEXT_<br/>_TEXT_
 
+_TEXT_ **_TEXT_** _TEXT_ **_TEXT_** _TEXT_
 _TEXT_
-| -------------------- | ------------------------------------------- |
 _TEXT_
 
 <Callout type="important">
-_TEXT_.
+_TEXT_
 </Callout>

--- a/confluence-mdx/tests/testcases/793608206/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/793608206/expected.skel.mdx
@@ -4,13 +4,13 @@ title: '_TEXT_'
 
 # _TEXT_
 
-_TEXT_.
+_TEXT_
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 
-_TEXT_.
+_TEXT_
 
 <table data-table-width="811" data-layout="center" local-id="c749b9ca-9033-4c2b-b8fa-3880ad5a8736">
 <colgroup>
@@ -22,16 +22,16 @@ _TEXT_.
 <tbody>
 <tr>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 </tr>
 <tr>
@@ -39,14 +39,14 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{requestTitle}}`
 </td>
 <td>
 _TEXT_
-* _TEXT_
+* _TEXT_ : _TEXT_
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 <tr>
@@ -54,14 +54,14 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{assignees}}`
 </td>
 <td>
 _TEXT_
-* _TEXT_
+* _TEXT_ : _TEXT_
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 <tr>
@@ -69,14 +69,14 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{comment}}`
 </td>
 <td>
 _TEXT_
-* _TEXT_.
+* _TEXT_ : _TEXT_
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 <tr>
@@ -84,14 +84,14 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{userName}}`
 </td>
 <td>
 _TEXT_
-* _TEXT_
+* _TEXT_ : _TEXT_
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 <tr>
@@ -99,14 +99,14 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{email}}`
 </td>
 <td>
 _TEXT_
-* _TEXT_.
+* _TEXT_[_TEXT_]_TEXT_ : _TEXT_
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 <tr>
@@ -114,7 +114,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{accessType}}`
 </td>
 <td>
 _TEXT_
@@ -126,7 +126,7 @@ _TEXT_
 * _TEXT_
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 <tr>
@@ -134,14 +134,14 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{link}}`
 </td>
 <td>
 _TEXT_
-* _TEXT_
+* _TEXT_ : _TEXT_`{querypie_domain}`_TEXT_`{workflow_uuid}`
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 <tr>
@@ -149,14 +149,14 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{workflowUuid}}`
 </td>
 <td>
 _TEXT_
-* _TEXT_
+* _TEXT_ : _TEXT_
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 <tr>
@@ -164,14 +164,14 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{id}}`
 </td>
 <td>
 _TEXT_
-* _TEXT_
+* _TEXT_ : _TEXT_
 </td>
 <td>
--
+_TEXT_
 </td>
 </tr>
 <tr>
@@ -179,7 +179,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{urgent}}`
 </td>
 <td>
 _TEXT_
@@ -204,16 +204,16 @@ _TEXT_
 <tbody>
 <tr>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 </tr>
 <tr>
@@ -221,7 +221,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{expirationDate}}`
 </td>
 <td>
 _TEXT_
@@ -236,7 +236,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{approvalExpirationDate}}`
 </td>
 <td>
 _TEXT_
@@ -250,7 +250,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{accessExpirationDate}}`
 </td>
 <td>
 _TEXT_
@@ -264,13 +264,13 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{connectionPrivilegeNames}}`
 </td>
 <td>
 _TEXT_
 * _TEXT_
-    * _TEXT_
-    * _TEXT_
+    * _TEXT_ : _TEXT_
+    * _TEXT_ : _TEXT_
 </td>
 <td>
 _TEXT_
@@ -291,16 +291,16 @@ _TEXT_
 <tbody>
 <tr>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 </tr>
 <tr>
@@ -308,7 +308,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{sqlText}}`
 </td>
 <td>
 _TEXT_
@@ -323,7 +323,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{contentType}}`
 </td>
 <td>
 _TEXT_
@@ -338,7 +338,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{clusterGroupUuid}}`
 </td>
 <td>
 _TEXT_
@@ -352,7 +352,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{clusterGroupName}}`
 </td>
 <td>
 _TEXT_
@@ -366,7 +366,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{clusterId}}`
 </td>
 <td>
 _TEXT_
@@ -380,7 +380,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{databaseType}}`
 </td>
 <td>
 _TEXT_
@@ -394,7 +394,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{databaseName}}`
 </td>
 <td>
 _TEXT_
@@ -408,7 +408,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{useLedgerApprovalRule}}`
 </td>
 <td>
 _TEXT_
@@ -422,36 +422,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
-_TEXT_
-_TEXT_
-</td>
-</tr>
-<tr>
-<td>
-_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-</tr>
-<tr>
-<td>
-_TEXT_
-</td>
-<td>
-_TEXT_
+`{{targetDate}}`
 </td>
 <td>
 _TEXT_
@@ -466,7 +437,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{preferredExecutionDate}}`
 </td>
 <td>
 _TEXT_
@@ -480,7 +451,36 @@ _TEXT_
 _TEXT_
 </td>
 <td>
+`{{dueDate}}`
+</td>
+<td>
 _TEXT_
+</td>
+<td>
+_TEXT_
+_TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`{{approvalExpirationDate}}`
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_
+</td>
+<td>
+`{{executionExpirationDate}}`
 </td>
 <td>
 _TEXT_
@@ -504,16 +504,16 @@ _TEXT_
 <tbody>
 <tr>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 </tr>
 <tr>
@@ -521,7 +521,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{clusterGroupUuid}}`
 </td>
 <td>
 _TEXT_
@@ -535,7 +535,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{clusterGroupName}}`
 </td>
 <td>
 _TEXT_
@@ -549,7 +549,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{clusterId}}`
 </td>
 <td>
 _TEXT_
@@ -563,7 +563,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{databaseType}}`
 </td>
 <td>
 _TEXT_
@@ -577,7 +577,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{databaseName}}`
 </td>
 <td>
 _TEXT_
@@ -591,7 +591,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{exportType}}`
 </td>
 <td>
 _TEXT_
@@ -606,7 +606,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{exportDetail}}`
 </td>
 <td>
 _TEXT_
@@ -622,7 +622,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{targetDate}}`
 </td>
 <td>
 _TEXT_
@@ -636,7 +636,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{preferredExecutionDate}}`
 </td>
 <td>
 _TEXT_
@@ -650,7 +650,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{dueDate}}`
 </td>
 <td>
 _TEXT_
@@ -664,7 +664,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{approvalExpirationDate}}`
 </td>
 <td>
 _TEXT_
@@ -678,7 +678,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{executionExpirationDate}}`
 </td>
 <td>
 _TEXT_
@@ -702,16 +702,16 @@ _TEXT_
 <tbody>
 <tr>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 </tr>
 <tr>
@@ -719,7 +719,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{clusterGroupUuid}}`
 </td>
 <td>
 _TEXT_
@@ -733,7 +733,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{clusterGroupName}}`
 </td>
 <td>
 _TEXT_
@@ -747,7 +747,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{databaseType}}`
 </td>
 <td>
 _TEXT_
@@ -761,7 +761,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{databaseName}}`
 </td>
 <td>
 _TEXT_
@@ -775,7 +775,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{tableName}}`
 </td>
 <td>
 _TEXT_
@@ -789,11 +789,11 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{columnNames}}`
 </td>
 <td>
 _TEXT_
-* _TEXT_
+* _TEXT_[_TEXT_]
 </td>
 <td>
 _TEXT_
@@ -804,13 +804,13 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{unmaskingExpiration}}`
 </td>
 <td>
 _TEXT_
 * _TEXT_
     * _TEXT_
-    * _TEXT_
+    * _TEXT_ : _TEXT_
 </td>
 <td>
 _TEXT_
@@ -821,7 +821,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{approvalExpirationDate}}`
 </td>
 <td>
 _TEXT_
@@ -845,16 +845,16 @@ _TEXT_
 <tbody>
 <tr>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 </tr>
 <tr>
@@ -862,7 +862,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{clusterGroupUuid}}`
 </td>
 <td>
 _TEXT_
@@ -876,7 +876,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{clusterGroupName}}`
 </td>
 <td>
 _TEXT_
@@ -890,7 +890,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{databaseType}}`
 </td>
 <td>
 _TEXT_
@@ -904,7 +904,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{databaseName}}`
 </td>
 <td>
 _TEXT_
@@ -918,7 +918,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{tableName}}`
 </td>
 <td>
 _TEXT_
@@ -932,11 +932,11 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{columnNames}}`
 </td>
 <td>
 _TEXT_
-* _TEXT_
+* _TEXT_[_TEXT_]
 </td>
 <td>
 _TEXT_
@@ -947,13 +947,13 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{restrictedDataAccessExpiration}}`
 </td>
 <td>
 _TEXT_
 * _TEXT_
     * _TEXT_
-    * _TEXT_
+    * _TEXT_ : _TEXT_
 </td>
 <td>
 _TEXT_
@@ -964,7 +964,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{approvalExpirationDate}}`
 </td>
 <td>
 _TEXT_
@@ -988,16 +988,16 @@ _TEXT_
 <tbody>
 <tr>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 </tr>
 <tr>
@@ -1005,7 +1005,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{clusterGroupUuid}}`
 </td>
 <td>
 _TEXT_
@@ -1019,7 +1019,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{clusterGroupName}}`
 </td>
 <td>
 _TEXT_
@@ -1033,7 +1033,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{dataScopeType}}`
 </td>
 <td>
 _TEXT_
@@ -1047,7 +1047,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{databaseType}}`
 </td>
 <td>
 _TEXT_
@@ -1061,7 +1061,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{databaseName}}`
 </td>
 <td>
 _TEXT_
@@ -1075,7 +1075,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{tableName}}`
 </td>
 <td>
 _TEXT_
@@ -1089,11 +1089,11 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{columnNames}}`
 </td>
 <td>
 _TEXT_
-* _TEXT_
+* _TEXT_[_TEXT_]
 </td>
 <td>
 _TEXT_
@@ -1104,13 +1104,13 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{expiration}}`
 </td>
 <td>
 _TEXT_
 * _TEXT_
     * _TEXT_
-    * _TEXT_
+    * _TEXT_ : _TEXT_
 </td>
 <td>
 _TEXT_
@@ -1121,7 +1121,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{approvalExpirationDate}}`
 </td>
 <td>
 _TEXT_
@@ -1145,16 +1145,16 @@ _TEXT_
 <tbody>
 <tr>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 </tr>
 <tr>
@@ -1162,7 +1162,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{serverGroupName}}`
 </td>
 <td>
 _TEXT_
@@ -1176,7 +1176,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{serverNames}}`
 </td>
 <td>
 _TEXT_
@@ -1193,7 +1193,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{serverAccounts}}`
 </td>
 <td>
 _TEXT_
@@ -1210,7 +1210,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{expirationDate}}`
 </td>
 <td>
 _TEXT_
@@ -1225,7 +1225,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{approvalExpirationDate}}`
 </td>
 <td>
 _TEXT_
@@ -1239,7 +1239,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{accessExpirationDate}}`
 </td>
 <td>
 _TEXT_
@@ -1253,7 +1253,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{triggerCondition}}`
 </td>
 <td>
 _TEXT_
@@ -1267,7 +1267,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{duration}}`
 </td>
 <td>
 _TEXT_
@@ -1291,16 +1291,16 @@ _TEXT_
 <tbody>
 <tr>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 </tr>
 <tr>
@@ -1308,7 +1308,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{serverGroupName}}`
 </td>
 <td>
 _TEXT_
@@ -1322,7 +1322,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{serverNames}}`
 </td>
 <td>
 _TEXT_
@@ -1339,7 +1339,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{serverAccounts}}`
 </td>
 <td>
 _TEXT_
@@ -1356,7 +1356,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{expirationDate}}`
 </td>
 <td>
 _TEXT_
@@ -1371,7 +1371,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{approvalExpirationDate}}`
 </td>
 <td>
 _TEXT_
@@ -1385,7 +1385,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{accessExpirationDate}}`
 </td>
 <td>
 _TEXT_
@@ -1399,7 +1399,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{triggerCondition}}`
 </td>
 <td>
 _TEXT_
@@ -1413,7 +1413,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{duration}}`
 </td>
 <td>
 _TEXT_
@@ -1437,16 +1437,16 @@ _TEXT_
 <tbody>
 <tr>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 <th>
-_TEXT_
+**_TEXT_**
 </th>
 </tr>
 <tr>
@@ -1454,7 +1454,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{service}}`
 </td>
 <td>
 _TEXT_
@@ -1469,7 +1469,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{roleName}}`
 </td>
 <td>
 _TEXT_
@@ -1483,7 +1483,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{expirationDate}}`
 </td>
 <td>
 _TEXT_
@@ -1498,7 +1498,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{approvalExpirationDate}}`
 </td>
 <td>
 _TEXT_
@@ -1512,7 +1512,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_
+`{{roleExpirationDate}}`
 </td>
 <td>
 _TEXT_
@@ -1526,15 +1526,15 @@ _TEXT_
 
 ### _TEXT_
 
+_TEXT_ **_TEXT_** _TEXT_ **_TEXT_** _TEXT_ **_TEXT_** _TEXT_ **_TEXT_** _TEXT_
 _TEXT_
-| ------------------------ | ---------------------------- | ------------------------------ | ----------- |
-_TEXT_
-_TEXT_
-_TEXT_
+_TEXT_ `{{approvalExpirationDate}}` _TEXT_
+_TEXT_ `{{webAppName}}` _TEXT_
+_TEXT_ `{{accessDuration}}` _TEXT_
 
 ### _TEXT_
 
+_TEXT_ **_TEXT_** _TEXT_ **_TEXT_** _TEXT_ **_TEXT_** _TEXT_ **_TEXT_** _TEXT_
 _TEXT_
-| ------------------------ | ---------------------------- | -------- | ----------- |
-_TEXT_
-_TEXT_
+_TEXT_ `{{approvalExpirationDate}}` _TEXT_
+_TEXT_ `{{ipAddresses}}` _TEXT_

--- a/confluence-mdx/tests/testcases/880181257/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/880181257/expected.skel.mdx
@@ -8,68 +8,68 @@ import { Callout } from 'nextra/components'
 
 #### _TEXT_
 
-1. _TEXT_.
-_TEXT_. <br/> 
+1. _TEXT_
+2. _TEXT_ `Submit Request` _TEXT_<br/> 
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/880181257/output/Screenshot-2025-03-06-at-1.19.24-PM.png)
   </figure>
-3. _TEXT_.
-4. _TEXT_.
-5. _TEXT_. 
-_TEXT_. <br/> 
+3. _TEXT_
+4. _TEXT_
+5. _TEXT_
+6. _TEXT_<br/> 
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/880181257/output/Screenshot-2025-03-06-at-1.22.28-PM.png)
   </figure>
-7. _TEXT_. 
-8. _TEXT_.
+7. _TEXT_ `Submit`_TEXT_
+8. _TEXT_ &gt; _TEXT_ &gt; _TEXT_
 
 <Callout type="important">
-_TEXT_
-* _TEXT_. 
-* _TEXT_.
-* _TEXT_.
+**_TEXT_**
+* _TEXT_
+* _TEXT_ : _TEXT_
+* _TEXT_
 </Callout>
 
-#### <br/>_TEXT_
+_TEXT_<br/>_TEXT_
 
-1.  _TEXT_
-    * _TEXT_.
-    _TEXT_. <br/> 
+1.  **_TEXT_**
+    * _TEXT_
+    * _TEXT_<br/> 
       <figure data-layout="center" data-align="center">
       ![_TEXT_](/880181257/output/Screenshot-2025-03-06-at-2.05.26-PM.png)
       </figure>
-2.  _TEXT_
-    * _TEXT_.
-    _TEXT_. <br/> 
+2.  **_TEXT_**
+    * _TEXT_
+    * _TEXT_<br/> 
       <figure data-layout="center" data-align="center">
       ![_TEXT_](/880181257/output/Screenshot-2025-03-06-at-2.08.11-PM.png)
       </figure>
-    * _TEXT_.
-    * _TEXT_.
-3.  _TEXT_
-    * _TEXT_.
-    *  _TEXT_
-    * _TEXT_.
+    * _TEXT_
+    * _TEXT_
+3.  **_TEXT_**
+    * _TEXT_
+    *  **_TEXT_**
+    * _TEXT_
       <figure data-layout="center" data-align="center">
       ![_TEXT_](/880181257/output/Screenshot-2025-03-06-at-2.18.26-PM.png)
       </figure>
 
 <Callout type="important">
-_TEXT_
-* _TEXT_.
+**_TEXT_**
+* _TEXT_
 </Callout>
 
 #### _TEXT_
 
-1.  _TEXT_
-    * _TEXT_. 
-    _TEXT_. <br/> 
+1.  **_TEXT_**
+    * _TEXT_
+    * _TEXT_<br/> 
       <figure data-layout="center" data-align="center">
       ![_TEXT_](/880181257/output/Screenshot-2025-03-06-at-2.22.22-PM.png)
       </figure>
-2.  _TEXT_
-    * _TEXT_.
-    _TEXT_.  <br/> _TEXT_.
+2.  **_TEXT_**
+    * _TEXT_
+    * _TEXT_<br/>_TEXT_
       <figure data-layout="center" data-align="center">
       ![_TEXT_](/880181257/output/Screenshot-2025-03-06-at-2.23.37-PM.png)
       </figure>

--- a/confluence-mdx/tests/testcases/883654669/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/883654669/expected.skel.mdx
@@ -8,11 +8,11 @@ import { Callout } from 'nextra/components'
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 
 <Callout type="info">
-_TEXT_.
-_TEXT_.
+_TEXT_ **_TEXT_** _TEXT_
+_TEXT_ [_TEXT_](https://docs.querypie.com/ko/querypie-manual/10.1.0/workflow-configurations)_TEXT_
 </Callout>
 
 #### _TEXT_
@@ -22,22 +22,22 @@ _TEXT_.
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 
 
-_TEXT_.<br/> <br/> 
+1. [_TEXT_](https://api.slack.com/apps) _TEXT_ `Create an App` _TEXT_<br/> <br/> 
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/883654669/output/image-20231227-065658.png)
   </figure>
-_TEXT_.<br/> <br/> 
+2. _TEXT_ `From a manifest` _TEXT_<br/> <br/> 
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/883654669/output/screenshot-20250218-131725.png)
   </figure>
-_TEXT_.<br/> <br/> 
+3. _TEXT_<br/> <br/> 
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/883654669/output/image-20231227-065951.png)
   </figure>
-_TEXT_. <br/>_TEXT_.<br/>_TEXT_. <br/> 
+4. _TEXT_<br/>_TEXT_<br/> : _TEXT_*_TEXT_*_TEXT_`{{..}}` _TEXT_<br/> 
   ```
 {
     "display_information": {
@@ -68,26 +68,26 @@ _TEXT_. <br/>_TEXT_.<br/>_TEXT_. <br/>
     }
 }
   ```
-_TEXT_.<br/> <br/> 
+5. _TEXT_ `Create` _TEXT_<br/> <br/> 
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/883654669/output/image-20240115-220447.png)
   </figure>
 
 ### _TEXT_
 
-1. _TEXT_. 
-_TEXT_. <br/> 
+1. _TEXT_ &gt; _TEXT_ `Install to Workspace` _TEXT_
+2. _TEXT_ `허용`_TEXT_<br/> 
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/883654669/output/image-20240115-221520.png)
   </figure>
-3. _TEXT_.
+3. _TEXT_
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/883654669/output/image-20240115-221618.png)
   </figure>
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_ &gt; _TEXT_ **_TEXT_** _TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/883654669/output/image-20240418-022640.png)
@@ -97,75 +97,75 @@ _TEXT_.
 ### _TEXT_
 
 <Callout type="info">
-_TEXT_.
+_TEXT_
 * _TEXT_
 * _TEXT_
 </Callout>
 
-_TEXT_.
+_TEXT_
 
-_TEXT_.<br/> <br/> 
+1. _TEXT_ &gt; _TEXT_ `Generate Token and Scope` _TEXT_<br/> <br/> 
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/883654669/output/screenshot-20250218-140951.png)
   </figure>
-_TEXT_.<br/> <br/> 
+2. _TEXT_ `connections:write` _TEXT_<br/> <br/> 
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/883654669/output/screenshot-20250218-141555.png)
   </figure>
-3. _TEXT_.
+3. _TEXT_ `xapp-` _TEXT_
 
 ### _TEXT_
 
-_TEXT_.<br/> <br/> 
+1. _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ `Configure` _TEXT_<br/> <br/> 
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/883654669/output/screenshot-20250310-113509.png)
   <figcaption>
-  _TEXT_
+  _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
   </figcaption>
   </figure>
-2. _TEXT_.
-3. _TEXT_.
-    *  _TEXT_
-    _TEXT_<br/> <br/> 
+2. _TEXT_
+3. _TEXT_
+    *  **_TEXT_** : _TEXT_
+    *  **_TEXT_** : _TEXT_<br/> <br/> 
       <figure data-layout="center" data-align="center">
       ![_TEXT_](/883654669/output/image-20231003-054240.png)
       <figcaption>
       _TEXT_
       </figcaption>
       </figure>
-4. _TEXT_.
+4. `Save` _TEXT_
 
 ### _TEXT_
 
-_TEXT_.<br/> <br/> 
+1. _TEXT_<br/> <br/> 
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/883654669/output/screenshot-20250310-113950.png)
   <figcaption>
-  _TEXT_
+  _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
   </figcaption>
   </figure>
-_TEXT_.<br/>
+2. `Edit` _TEXT_<br/>
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/883654669/output/screenshot-20250218-152840.png)
   <figcaption>
-  _TEXT_
+  _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
   </figcaption>
   </figure>
 
 
 ### _TEXT_
 
-_TEXT_.
+_TEXT_
 
-_TEXT_. <br/> 
+1. _TEXT_ &gt; _TEXT_<br/> 
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/883654669/output/screenshot-20250218-151504.png)
   </figure>
-_TEXT_.<br/> _TEXT_.<br/> <br/> 
+2. _TEXT_<br/>**_TEXT_** _TEXT_<br/> <br/> 
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/883654669/output/screenshot-20250218-152238.png)
   </figure>
-_TEXT_.<br/>
+3. _TEXT_ `Details` _TEXT_<br/>
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/883654669/output/screenshot-20250218-152527.png)
   </figure>

--- a/confluence-mdx/tests/testcases/panels/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/panels/expected.skel.mdx
@@ -1,35 +1,35 @@
 import { Callout } from 'nextra/components'
 
 <Callout type="info">
-_TEXT_.
+_TEXT_
 </Callout>
 ---
 
 <Callout type="important">
-This is a note panel.
+_TEXT_
 </Callout>
 ---
 
 <Callout type="error">
-_TEXT_.
+_TEXT_
 </Callout>
 ---
 
 <Callout type="default">
-This is a success panel.
+_TEXT_
 </Callout>
 ---
 
 <Callout type="important">
-_TEXT_.
+_TEXT_
 </Callout>
 ---
 
 <Callout type="info" emoji="🌈">
-This is a custom panel.
+_TEXT_
 </Callout>
 ---
 
-_TEXT_.
+_TEXT_
 
 


### PR DESCRIPTION
## Description
### 리팩토링 내용
1. 코드 라인 수 대폭 감소: 954줄 → 351줄 (603줄 삭제, 약 63% 감소)
2. 클래스 기반 구조로 재구성: `ContentProtector`, `TextProcessor` 클래스로 기능 분리
3. `ProtectedSection`을 `dataclass`로 단순화하여 코드 가독성 향상
4. 이미지 링크 처리 통합: `extract_urls`와 `extract_image_links` 통합으로 중복 제거
5. 텍스트 교체 로직 통합: `_preserve_markdown_formatting`과 `_replace_remaining_text`를 하나의 메서드로 통합
6. YAML 처리 단순화: 플래그 기반 상태 관리 제거, frontmatter 즉시 처리
7. HTML 처리 단순화: 인덱스 기반 수동 파싱을 정규식 기반으로 변경
8. URL 체크 로직 헬퍼 함수화: `_is_path_url` 함수로 중복 제거
9. TDD 기반 단위 테스트 추가: 초기 테스트 파일 추가 (656줄)
10. 기존 기능 보존: YAML frontmatter, 코드 블록, URL, HTML 엔티티 보호 기능 유지

## 그 외 변경사항
1. 텍스트 처리 로직 개선: 정규식 기반에서 token-based parsing으로 변경하여 정확도 향상
2. 테스트 커버리지 확대: 추가 테스트 케이스 작성 (37개 테스트 함수, 357줄 추가)
3. 버그 수정: 텍스트 처리 및 마크다운 포맷팅 보존 로직 개선
4. 코드 안정성 향상: 다양한 엣지 케이스 처리 개선
5. 문서화 개선: Whitespace Preservation Rules 명시 및 주석 보강

