### PR TITLE
mdx_to_skeleton: skeleton mdx 의 공백 정규화

### DIFF
--- a/confluence-mdx/bin/skeleton_diff.py
+++ b/confluence-mdx/bin/skeleton_diff.py
@@ -151,8 +151,9 @@ def compare_with_korean_skel(current_skel_path: Path) -> Tuple[bool, Optional[st
 
     # Run diff command
     try:
-        # Build diff command with unified format (-U 2 for 2 lines of context)
-        diff_cmd = ['diff', '-U', '2', str(korean_skel_path), str(current_skel_path)]
+        # Build diff command with unified format (-U 2 for 2 lines of context, -b to ignore whitespace amount differences)
+        # Note: -b ignores amount of whitespace but preserves line breaks and whitespace presence/absence
+        diff_cmd = ['diff', '-u', '-U', '2', '-b', str(korean_skel_path), str(current_skel_path)]
 
         # Print command with "+ " prefix
         print(f"+ {' '.join(diff_cmd)}")

--- a/confluence-mdx/tests/test_mdx_to_skeleton.py
+++ b/confluence-mdx/tests/test_mdx_to_skeleton.py
@@ -403,9 +403,15 @@ Some content here.
         assert output_path.name == "test.skel.mdx"
         
         content = output_path.read_text()
-        assert "title: '_TEXT_'" in content or "title: \"_TEXT_\"" in content
-        assert "# " in content
-        assert "_TEXT_" in content
+        expected = """---
+title: '_TEXT_'
+---
+
+# _TEXT_
+
+_TEXT_
+"""
+        assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
     finally:
         shutil.rmtree(tmp_dir)
 
@@ -430,9 +436,15 @@ Some text.
         output_path, _ = convert_mdx_to_skeleton(input_file)
         content = output_path.read_text()
         
-        assert "```python" in content
-        assert "print('hello')" in content
-        assert "_TEXT_" in content
+        expected = """# _TEXT_
+
+```python
+print('hello')
+```
+
+_TEXT_
+"""
+        assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
     finally:
         shutil.rmtree(tmp_dir)
 
@@ -455,11 +467,13 @@ More text.
         output_path, _ = convert_mdx_to_skeleton(input_file)
         content = output_path.read_text()
         
-        # Image alt text should be replaced with _TEXT_, URL should be preserved
-        # Note: Current implementation may replace entire image with _TEXT_
-        # This test verifies the basic functionality
-        assert "_TEXT_" in content
-        assert "# " in content
+        expected = """# _TEXT_
+
+![_TEXT_](/path/to/image.png)
+
+_TEXT_
+"""
+        assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
     finally:
         shutil.rmtree(tmp_dir)
 
@@ -482,13 +496,13 @@ More text.
         output_path, _ = convert_mdx_to_skeleton(input_file)
         content = output_path.read_text()
         
-        # Link text should be replaced with _TEXT_
-        # Note: Current implementation may not preserve URLs in all cases
-        # This test verifies basic text replacement functionality
-        assert "_TEXT_" in content
-        assert "# " in content
-        # Link structure should be present (brackets)
-        assert "[" in content or "_TEXT_" in content
+        expected = """# _TEXT_
+
+_TEXT_ [_TEXT_](https://google.com) _TEXT_
+
+_TEXT_
+"""
+        assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
     finally:
         shutil.rmtree(tmp_dir)
 
@@ -511,9 +525,13 @@ More content.
         output_path, _ = convert_mdx_to_skeleton(input_file)
         content = output_path.read_text()
         
-        assert "**_TEXT_**" in content
-        assert "*_TEXT_*" in content
-        assert "_TEXT_" in content
+        expected = """# _TEXT_
+
+_TEXT_ **_TEXT_** _TEXT_ *_TEXT_* _TEXT_
+
+_TEXT_
+"""
+        assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
     finally:
         shutil.rmtree(tmp_dir)
 
@@ -537,9 +555,14 @@ def test_convert_mdx_to_skeleton_with_lists():
         output_path, _ = convert_mdx_to_skeleton(input_file)
         content = output_path.read_text()
         
-        assert "* _TEXT_" in content
-        assert "1. _TEXT_" in content
-        assert "2. _TEXT_" in content
+        expected = """# _TEXT_
+
+* _TEXT_
+* _TEXT_
+    1. _TEXT_
+    2. _TEXT_
+"""
+        assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
     finally:
         shutil.rmtree(tmp_dir)
 
@@ -716,7 +739,7 @@ def test_complex_list_item_with_bold_and_inline_code():
         
         expected = """# _TEXT_
 
-1. **_TEXT_** _TEXT_ `On`_TEXT_
+1. **_TEXT_** _TEXT_ `On` _TEXT_
 """
         assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
     finally:
@@ -914,7 +937,7 @@ def test_complex_list_with_html_and_figure():
         expected = """
 1. **_TEXT_**
     * _TEXT_
-    * _TEXT_ <br/> 
+    * _TEXT_ <br/>
       <figure data-layout="center" data-align="center">
       ![_TEXT_](/880181257/output/Screenshot-2025-03-06-at-2.22.22-PM.png)
       </figure>
@@ -944,7 +967,7 @@ def test_callout_with_external_link():
         
         expected = """<Callout type="info">
 _TEXT_ **_TEXT_** _TEXT_
-_TEXT_ [_TEXT_](https://docs.querypie.com/ko/querypie-manual/10.1.0/workflow-configurations)_TEXT_
+_TEXT_ [_TEXT_](https://docs.querypie.com/ko/querypie-manual/10.1.0/workflow-configurations) _TEXT_
 </Callout>
 """
         assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
@@ -1051,7 +1074,7 @@ def test_list_item_with_html_br_and_emoji():
         content = output_path.read_text()
 
         expected = """
-4. _TEXT_ <br/>_TEXT_<br/>_TEXT_ `{{..}}` _TEXT_ <br/> 
+4. _TEXT_ <br/> _TEXT_ <br/> _TEXT_ `{{..}}` _TEXT_ <br/>
 """
         assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
     finally:
@@ -1074,7 +1097,7 @@ def test_list_item_with_multiple_inline_codes_and_quotes():
         content = output_path.read_text()
 
         expected = """
-_TEXT_ `${KUBECONFIG}`_TEXT_ `${HOME}/.kube/config`_TEXT_
+_TEXT_ `${KUBECONFIG}` _TEXT_ `${HOME}/.kube/config` _TEXT_
 """
         assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
     finally:
@@ -1131,10 +1154,10 @@ _TEXT_
       <figure data-layout="center" data-align="center">
       ![_TEXT_](/544145591/output/Screenshot-2025-06-12-at-1.33.58-PM.png)
       <figcaption>
-      _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_<br/>
+      _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ <br/>
       </figcaption>
       </figure>
-* _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_<br/>
+* _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ <br/>
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/544145591/output/image-20251110-030113.png)
   </figure>
@@ -1152,6 +1175,31 @@ _TEXT_
           ![_TEXT_](/544145591/output/Screenshot-2025-06-16-at-10.30.14-AM.png)
           </figure>
 
+"""
+        assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
+    finally:
+        shutil.rmtree(tmp_dir)
+
+
+def test_japanese_list_item_with_link_and_bold():
+    """Test Japanese list item with link and bold text"""
+    import tempfile
+    import shutil
+
+    tmp_dir = Path(tempfile.mkdtemp())
+    try:
+        input_file = tmp_dir / "test.mdx"
+        input_file.write_text("""
+    * 자세한 내용은 [DB Connections](connection-management/db-connections) 내 **Privilege Setting** 문서 참고
+    * 詳細内容は[DB Connections](connection-management/db-connections)内 **Privilege Setting** 文書参考
+""")
+
+        output_path, _ = convert_mdx_to_skeleton(input_file)
+        content = output_path.read_text()
+
+        expected = """
+    * _TEXT_ [_TEXT_](connection-management/db-connections) _TEXT_ **_TEXT_** _TEXT_
+    * _TEXT_ [_TEXT_](connection-management/db-connections) _TEXT_ **_TEXT_** _TEXT_
 """
         assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
     finally:
@@ -1222,6 +1270,7 @@ def run_all_tests():
         test_list_item_with_html_br_and_emoji,
         test_list_item_with_multiple_inline_codes_and_quotes,
         test_complex_workflow_approval_rules_with_figures,
+        test_japanese_list_item_with_link_and_bold,
     ]
     
     passed = 0

--- a/confluence-mdx/tests/testcases/544112828/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544112828/expected.skel.mdx
@@ -92,7 +92,7 @@ _TEXT_
 
 ### _TEXT_
 
-1. _TEXT_<br/>_TEXT_ `Port` _TEXT_ `Proxy Credentials` _TEXT_
+1. _TEXT_ <br/> _TEXT_ `Port` _TEXT_ `Proxy Credentials` _TEXT_
 
 <figure data-layout="center" data-align="center">
 ![_TEXT_](/544112828/output/screenshot-20240730-151001.png)
@@ -131,7 +131,7 @@ _TEXT_ &gt; _TEXT_ &gt; _TEXT_
 _TEXT_
 </Callout>
 
-_TEXT_ <br/>_TEXT_
+_TEXT_ <br/> _TEXT_
 
 * _TEXT_
 
@@ -258,7 +258,7 @@ _TEXT_
 * **_TEXT_** _TEXT_
 * **_TEXT_** _TEXT_
 
-_TEXT_ `${KUBECONFIG}`_TEXT_ `${HOME}/.kube/config`_TEXT_
+_TEXT_ `${KUBECONFIG}` _TEXT_ `${HOME}/.kube/config` _TEXT_
 ```
 export KUBECONFIG="${HOME}/.kube/config:${HOME}/.kube/querypie-kubeconfig"
 ```

--- a/confluence-mdx/tests/testcases/544145591/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544145591/expected.skel.mdx
@@ -100,10 +100,10 @@ _TEXT_
       <figure data-layout="center" data-align="center">
       ![_TEXT_](/544145591/output/Screenshot-2025-06-12-at-1.33.58-PM.png)
       <figcaption>
-      _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_<br/>
+      _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ <br/>
       </figcaption>
       </figure>
-* _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_<br/>
+* _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ <br/>
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/544145591/output/image-20251110-030113.png)
   </figure>
@@ -131,14 +131,14 @@ _TEXT_
 
 _TEXT_
 
-* _TEXT_ `User Attribute`_TEXT_ `Key`_TEXT_ `Value`_TEXT_
+* _TEXT_ `User Attribute` _TEXT_ `Key` _TEXT_ `Value` _TEXT_
 * _TEXT_ `Key:Value` _TEXT_ `Workflow` _TEXT_
-* **_TEXT_** `User Attribute Key`_TEXT_ `Value`_TEXT_ `Workflow` _TEXT_
+* **_TEXT_** `User Attribute Key` _TEXT_ `Value` _TEXT_ `Workflow` _TEXT_
 
 ### _TEXT_
 
 <Callout type="info">
-_TEXT_<br/>_TEXT_
+_TEXT_ <br/> _TEXT_
 _TEXT_
 </Callout>
 

--- a/confluence-mdx/tests/testcases/544377869/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544377869/expected.skel.mdx
@@ -32,7 +32,7 @@ _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
 4. `Proxy Usage` _TEXT_
 5. _TEXT_
     1. **_TEXT_** _TEXT_
-    2. **_TEXT_** _TEXT_ <br/>_TEXT_
+    2. **_TEXT_** _TEXT_ <br/> _TEXT_
 6. **_TEXT_** _TEXT_
 
 _TEXT_
@@ -55,6 +55,6 @@ _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
 
 1. _TEXT_
 2. _TEXT_
-3. _TEXT_ `Kill`_TEXT_
+3. _TEXT_ `Kill` _TEXT_
 
 

--- a/confluence-mdx/tests/testcases/544379140/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544379140/expected.skel.mdx
@@ -115,25 +115,25 @@ _TEXT_
 <Callout type="important">
 **_TEXT_**
 
-_TEXT_<br/>
+_TEXT_ <br/>
 
 _TEXT_
 
 - _TEXT_
 
-_TEXT_ `&gt;``&lt;``&lt;=``&gt;=``==``!=`<br/>_TEXT_ `x &gt; `_TEXT_
+_TEXT_ `&gt;``&lt;``&lt;=``&gt;=``==``!=` <br/> _TEXT_ `x &gt; ` _TEXT_
 
 - _TEXT_
 
-_TEXT_ `== (equals)``!= (not equals)``contains`<br/>_TEXT_ `x == 'abc'``x != 'abc'``contains(x, 'ab')`
+_TEXT_ `== (equals)``!= (not equals)``contains` <br/> _TEXT_ `x == 'abc'``x != 'abc'``contains(x, 'ab')`
 
 - _TEXT_
 
-_TEXT_ `== (equals)``!= (not equals)``&& (and)``|| (or)`<br/>_TEXT_ `x == `_TEXT_
+_TEXT_ `== (equals)``!= (not equals)``&& (and)``|| (or)` <br/> _TEXT_ `x == ` _TEXT_
 
 - _TEXT_
 
-_TEXT_ `x[? @ == 'value']``list[? @ &gt; `_TEXT_ `]`
+_TEXT_ `x[? @ == 'value']``list[? @ &gt; ` _TEXT_ `]`
 
 
 _TEXT_
@@ -142,7 +142,7 @@ _TEXT_
 
 - _TEXT_ `||` _TEXT_
 
-- _TEXT_ `( )`_TEXT_
+- _TEXT_ `( )` _TEXT_
 
 
 _TEXT_

--- a/confluence-mdx/tests/testcases/544381877/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544381877/expected.skel.mdx
@@ -33,7 +33,7 @@ _TEXT_
             * _TEXT_**_TEXT_** _TEXT_
             * _TEXT_**_TEXT_** _TEXT_
     6. **_TEXT_** _TEXT_
-        1. **_TEXT_** _TEXT_ `On`_TEXT_ `Off`_TEXT_
+        1. **_TEXT_** _TEXT_ `On` _TEXT_ `Off` _TEXT_
             1. _TEXT_
             2. _TEXT_
         2. **_TEXT_** _TEXT_
@@ -47,8 +47,8 @@ _TEXT_
                 7. `delete`
                 8. `deletecollection`
             2. _TEXT_
-        3. **_TEXT_** _TEXT_ `On`_TEXT_ `Off`_TEXT_
-            1. _TEXT_ `On`_TEXT_
+        3. **_TEXT_** _TEXT_ `On` _TEXT_ `Off` _TEXT_
+            1. _TEXT_ `On` _TEXT_
             2. _TEXT_
                 1. `create`
                 2. `get`

--- a/confluence-mdx/tests/testcases/544384417/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544384417/expected.skel.mdx
@@ -63,7 +63,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_ <br/>_TEXT_
+_TEXT_ <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -77,7 +77,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_ <br/>_TEXT_
+_TEXT_ <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -91,7 +91,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_ <br/>_TEXT_
+_TEXT_ <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -105,7 +105,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_ **_TEXT_**<br/>_TEXT_
+_TEXT_ **_TEXT_** <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -119,7 +119,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_ **_TEXT_**<br/>_TEXT_
+_TEXT_ **_TEXT_** <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -136,7 +136,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_ <br/>_TEXT_
+_TEXT_ <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -150,7 +150,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_ <br/>_TEXT_
+_TEXT_ <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -164,38 +164,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_ <br/>_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-</tr>
-<tr>
-<td rowspan="2">
-_TEXT_
-</td>
-<td>
-_TEXT_ <br/>_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-</tr>
-<tr>
-<td>
-_TEXT_ <br/>_TEXT_
+_TEXT_ <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -212,7 +181,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_ <br/>_TEXT_
+_TEXT_ <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -226,7 +195,38 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_ **_TEXT_**<br/>_TEXT_
+_TEXT_ <br/> _TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+</tr>
+<tr>
+<td rowspan="2">
+_TEXT_
+</td>
+<td>
+_TEXT_ <br/> _TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_ **_TEXT_** <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -246,7 +246,7 @@ _TEXT_
 _TEXT_ **_TEXT_**
 </td>
 <td>
-_TEXT_<br/>_TEXT_
+_TEXT_ <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -260,38 +260,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_<br/>_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-</tr>
-<tr>
-<td rowspan="2">
-_TEXT_
-</td>
-<td>
-_TEXT_ <br/>_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-</tr>
-<tr>
-<td>
-_TEXT_ <br/>_TEXT_
+_TEXT_ <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -308,7 +277,38 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_ <br/>_TEXT_
+_TEXT_ <br/> _TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_ <br/> _TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+</tr>
+<tr>
+<td rowspan="2">
+_TEXT_
+</td>
+<td>
+_TEXT_ <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -322,7 +322,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_ <br/>_TEXT_
+_TEXT_ <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -339,7 +339,7 @@ _TEXT_
 _TEXT_ **_TEXT_**
 </td>
 <td>
-_TEXT_<br/>_TEXT_
+_TEXT_ <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -371,41 +371,10 @@ _TEXT_
 _TEXT_
 </td>
 <td rowspan="2">
-_TEXT_ <br/>**_TEXT_**
+_TEXT_ <br/> **_TEXT_**
 </td>
 <td>
-_TEXT_<br/>_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-</tr>
-<tr>
-<td>
-_TEXT_<br/>_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-<td>
-_TEXT_
-</td>
-</tr>
-<tr>
-<td rowspan="2">
-_TEXT_ **_TEXT_**
-</td>
-<td>
-_TEXT_<br/>_TEXT_
+_TEXT_ <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -419,7 +388,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_<br/>_TEXT_
+_TEXT_ <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -436,7 +405,7 @@ _TEXT_
 _TEXT_ **_TEXT_**
 </td>
 <td>
-_TEXT_<br/>_TEXT_
+_TEXT_ <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -450,7 +419,38 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_<br/>_TEXT_
+_TEXT_ <br/> _TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+</tr>
+<tr>
+<td rowspan="2">
+_TEXT_ **_TEXT_**
+</td>
+<td>
+_TEXT_ <br/> _TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+<td>
+_TEXT_
+</td>
+</tr>
+<tr>
+<td>
+_TEXT_ <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -467,7 +467,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_ **_TEXT_**<br/>_TEXT_
+_TEXT_ **_TEXT_** <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -481,7 +481,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_ <br/>_TEXT_
+_TEXT_ <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -495,7 +495,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-*_TEXT_***_TEXT_**<br/>*_TEXT_*
+*_TEXT_***_TEXT_** <br/> *_TEXT_*
 </td>
 <td>
 *_TEXT_*
@@ -509,7 +509,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_ **_TEXT_**<br/>_TEXT_
+_TEXT_ **_TEXT_** <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -523,7 +523,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_ **_TEXT_**<br/>_TEXT_
+_TEXT_ **_TEXT_** <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -537,7 +537,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_ **_TEXT_**<br/>_TEXT_
+_TEXT_ **_TEXT_** <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -551,7 +551,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_ <br/>_TEXT_
+_TEXT_ <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -568,7 +568,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_ <br/>_TEXT_
+_TEXT_ <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -586,7 +586,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_ <br/>_TEXT_
+_TEXT_ <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -600,7 +600,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_ <br/>_TEXT_
+_TEXT_ <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -614,7 +614,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_ <br/>_TEXT_
+_TEXT_ <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -628,7 +628,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_ <br/>_TEXT_
+_TEXT_ <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -642,7 +642,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_ <br/>_TEXT_
+_TEXT_ <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -657,10 +657,10 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_ <br/>**_TEXT_**
+_TEXT_ <br/> **_TEXT_**
 </td>
 <td>
-_TEXT_<br/>_TEXT_
+_TEXT_ <br/> _TEXT_
 </td>
 <td>
 _TEXT_
@@ -778,12 +778,12 @@ _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
     4. _TEXT_
     5. _TEXT_
 4. **_TEXT_** _TEXT_
-    1. `Scheduling`_TEXT_ `None` _TEXT_
+    1. `Scheduling` _TEXT_ `None` _TEXT_
     2. _TEXT_
     3. _TEXT_
         1. `10.2.8` _TEXT_ `10.2.9` _TEXT_
 5. **_TEXT_** _TEXT_
-    1. `Scheduling`_TEXT_ `Daily``Weekly``Monthly`_TEXT_ `Quarterly` _TEXT_
+    1. `Scheduling` _TEXT_ `Daily``Weekly``Monthly` _TEXT_ `Quarterly` _TEXT_
 6. **_TEXT_** _TEXT_
     1. _TEXT_
     2. _TEXT_

--- a/confluence-mdx/tests/testcases/568918170/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/568918170/expected.skel.mdx
@@ -22,7 +22,7 @@ _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
 
 1. _TEXT_ &gt; _TEXT_
     1. _TEXT_
-    2. _TEXT_ **_TEXT_** _TEXT_ `Confirm`_TEXT_
+    2. _TEXT_ **_TEXT_** _TEXT_ `Confirm` _TEXT_
 2. _TEXT_ `Confirm` _TEXT_
 3. _TEXT_ `OK` _TEXT_
 4. _TEXT_ **_TEXT_** _TEXT_

--- a/confluence-mdx/tests/testcases/692355151/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/692355151/expected.skel.mdx
@@ -19,16 +19,16 @@ _TEXT_
 _TEXT_
 
 <Callout type="info">
-_TEXT_<br/>_TEXT_
+_TEXT_ <br/> _TEXT_
 _TEXT_
 </Callout>
 
 ### _TEXT_
 
 _TEXT_
-_TEXT_ [_TEXT_](.)_TEXT_
+_TEXT_ [_TEXT_](.) _TEXT_
 
-1. _TEXT_ <br/>_TEXT_ 
+1. _TEXT_ <br/> _TEXT_ 
 
 <Callout type="important">
 _TEXT_
@@ -39,7 +39,7 @@ _TEXT_
 ![_TEXT_](/692355151/output/image-20241029-234721.png)
 </figure>
 
-1. _TEXT_<br/>_TEXT_ `Explain` _TEXT_
+1. _TEXT_ <br/> _TEXT_ `Explain` _TEXT_
     1. **_TEXT_** _TEXT_
     2. _TEXT_
         1. **_TEXT_** _TEXT_
@@ -58,15 +58,15 @@ _TEXT_
 </Callout>
 
 1. _TEXT_
-    1. _TEXT_<br/>_TEXT_<br/> <br/>  
+    1. _TEXT_ <br/> _TEXT_ <br/> <br/>  
       <figure data-layout="center" data-align="center">
       ![_TEXT_](/692355151/output/image-20241030-002325.png)
       </figure>
-    2. _TEXT_<br/>_TEXT_ `{JSON}` _TEXT_<br/> <br/>  <br/> <br/>  <br/>_TEXT_
+    2. _TEXT_ <br/> _TEXT_ `{JSON}` _TEXT_ <br/> <br/>  <br/> <br/>  <br/> _TEXT_
       <figure data-layout="center" data-align="center">
       ![_TEXT_](/692355151/output/image-20241030-003040.png)
       <figcaption>
-      `{JSON}`_TEXT_
+      `{JSON}` _TEXT_
       </figcaption>
       </figure>
       <figure data-layout="center" data-align="center">
@@ -78,7 +78,7 @@ _TEXT_
 
 ### _TEXT_
 
-1. _TEXT_<br/>_TEXT_
+1. _TEXT_ <br/> _TEXT_
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/692355151/output/image-20241030-004258.png)
   </figure>
@@ -88,7 +88,7 @@ _TEXT_
 _TEXT_
 </Callout>
 
-1. _TEXT_<br/>_TEXT_ 
+1. _TEXT_ <br/> _TEXT_ 
 
 _TEXT_ **_TEXT_** _TEXT_ **_TEXT_** _TEXT_
 _TEXT_

--- a/confluence-mdx/tests/testcases/793608206/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/793608206/expected.skel.mdx
@@ -138,7 +138,7 @@ _TEXT_
 </td>
 <td>
 _TEXT_
-* _TEXT_ `{querypie_domain}`_TEXT_ `{workflow_uuid}`
+* _TEXT_ `{querypie_domain}` _TEXT_ `{workflow_uuid}`
 </td>
 <td>
 _TEXT_

--- a/confluence-mdx/tests/testcases/880181257/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/880181257/expected.skel.mdx
@@ -20,7 +20,7 @@ import { Callout } from 'nextra/components'
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/880181257/output/Screenshot-2025-03-06-at-1.22.28-PM.png)
   </figure>
-7. _TEXT_ `Submit`_TEXT_
+7. _TEXT_ `Submit` _TEXT_
 8. _TEXT_ &gt; _TEXT_ &gt; _TEXT_
 
 <Callout type="important">
@@ -30,7 +30,7 @@ import { Callout } from 'nextra/components'
 * _TEXT_
 </Callout>
 
-_TEXT_ <br/>_TEXT_
+_TEXT_ <br/> _TEXT_
 
 1. **_TEXT_**
     * _TEXT_
@@ -69,7 +69,7 @@ _TEXT_ <br/>_TEXT_
       </figure>
 2. **_TEXT_**
     * _TEXT_
-    * _TEXT_ <br/>_TEXT_
+    * _TEXT_ <br/> _TEXT_
       <figure data-layout="center" data-align="center">
       ![_TEXT_](/880181257/output/Screenshot-2025-03-06-at-2.23.37-PM.png)
       </figure>

--- a/confluence-mdx/tests/testcases/883654669/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/883654669/expected.skel.mdx
@@ -12,7 +12,7 @@ _TEXT_
 
 <Callout type="info">
 _TEXT_ **_TEXT_** _TEXT_
-_TEXT_ [_TEXT_](https://docs.querypie.com/ko/querypie-manual/10.1.0/workflow-configurations)_TEXT_
+_TEXT_ [_TEXT_](https://docs.querypie.com/ko/querypie-manual/10.1.0/workflow-configurations) _TEXT_
 </Callout>
 
 #### _TEXT_
@@ -25,19 +25,19 @@ _TEXT_ [_TEXT_](https://docs.querypie.com/ko/querypie-manual/10.1.0/workflow-con
 _TEXT_
 
 
-1. [_TEXT_](https://api.slack.com/apps) _TEXT_ `Create an App` _TEXT_<br/> <br/> 
+1. [_TEXT_](https://api.slack.com/apps) _TEXT_ `Create an App` _TEXT_ <br/> <br/> 
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/883654669/output/image-20231227-065658.png)
   </figure>
-2. _TEXT_ `From a manifest` _TEXT_<br/> <br/> 
+2. _TEXT_ `From a manifest` _TEXT_ <br/> <br/> 
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/883654669/output/screenshot-20250218-131725.png)
   </figure>
-3. _TEXT_<br/> <br/> 
+3. _TEXT_ <br/> <br/> 
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/883654669/output/image-20231227-065951.png)
   </figure>
-4. _TEXT_ <br/>_TEXT_<br/>_TEXT_ `{{..}}` _TEXT_ <br/> 
+4. _TEXT_ <br/> _TEXT_ <br/> _TEXT_ `{{..}}` _TEXT_ <br/> 
   ```
 {
     "display_information": {
@@ -68,7 +68,7 @@ _TEXT_
     }
 }
   ```
-5. _TEXT_ `Create` _TEXT_<br/> <br/> 
+5. _TEXT_ `Create` _TEXT_ <br/> <br/> 
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/883654669/output/image-20240115-220447.png)
   </figure>
@@ -76,7 +76,7 @@ _TEXT_
 ### _TEXT_
 
 1. _TEXT_ &gt; _TEXT_ `Install to Workspace` _TEXT_
-2. _TEXT_ `허용`_TEXT_ <br/> 
+2. _TEXT_ `허용` _TEXT_ <br/> 
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/883654669/output/image-20240115-221520.png)
   </figure>
@@ -104,11 +104,11 @@ _TEXT_
 
 _TEXT_
 
-1. _TEXT_ &gt; _TEXT_ `Generate Token and Scope` _TEXT_<br/> <br/> 
+1. _TEXT_ &gt; _TEXT_ `Generate Token and Scope` _TEXT_ <br/> <br/> 
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/883654669/output/screenshot-20250218-140951.png)
   </figure>
-2. _TEXT_ `connections:write` _TEXT_<br/> <br/> 
+2. _TEXT_ `connections:write` _TEXT_ <br/> <br/> 
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/883654669/output/screenshot-20250218-141555.png)
   </figure>
@@ -116,7 +116,7 @@ _TEXT_
 
 ### _TEXT_
 
-1. _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ `Configure` _TEXT_<br/> <br/> 
+1. _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ `Configure` _TEXT_ <br/> <br/> 
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/883654669/output/screenshot-20250310-113509.png)
   <figcaption>
@@ -126,7 +126,7 @@ _TEXT_
 2. _TEXT_
 3. _TEXT_
     * **_TEXT_** _TEXT_
-    * **_TEXT_** _TEXT_<br/> <br/> 
+    * **_TEXT_** _TEXT_ <br/> <br/> 
       <figure data-layout="center" data-align="center">
       ![_TEXT_](/883654669/output/image-20231003-054240.png)
       <figcaption>
@@ -137,14 +137,14 @@ _TEXT_
 
 ### _TEXT_
 
-1. _TEXT_<br/> <br/> 
+1. _TEXT_ <br/> <br/> 
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/883654669/output/screenshot-20250310-113950.png)
   <figcaption>
   _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_ &gt; _TEXT_
   </figcaption>
   </figure>
-2. `Edit` _TEXT_<br/>
+2. `Edit` _TEXT_ <br/>
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/883654669/output/screenshot-20250218-152840.png)
   <figcaption>
@@ -161,11 +161,11 @@ _TEXT_
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/883654669/output/screenshot-20250218-151504.png)
   </figure>
-2. _TEXT_<br/>**_TEXT_** _TEXT_<br/> <br/> 
+2. _TEXT_ <br/> **_TEXT_** _TEXT_ <br/> <br/> 
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/883654669/output/screenshot-20250218-152238.png)
   </figure>
-3. _TEXT_ `Details` _TEXT_<br/>
+3. _TEXT_ `Details` _TEXT_ <br/>
   <figure data-layout="center" data-align="center">
   ![_TEXT_](/883654669/output/screenshot-20250218-152527.png)
   </figure>


### PR DESCRIPTION
## Description
- Skeleton MDX 에서 공백 차이가 발생하지 않도록, Markdown Syntax 항목 사이의 공백을 정규화합니다.
- `--recursive`의 diff 에서 공백 1개 이상의 경우, 1개와 동등하게 처리하도록, `-b` 옵션을 추가합니다.
- test_mdx_to_skeleton.py 에 테스트케이스를 추가합니다.
