### PR TITLE
mdx_to_skeleton: Improve test_mdx_to_skeleton.py

### DIFF
--- a/confluence-mdx/tests/test_mdx_to_skeleton.py
+++ b/confluence-mdx/tests/test_mdx_to_skeleton.py
@@ -24,11 +24,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'bin'))
 
 from mdx_to_skeleton import (
     ContentProtector,
-    TextProcessor,
     process_yaml_frontmatter,
-    process_text_line,
-    process_markdown_line,
-    _process_html_line,
     convert_mdx_to_skeleton,
 )
 
@@ -60,93 +56,142 @@ def test_content_protector_extract_yaml_frontmatter():
 
 def test_content_protector_extract_code_blocks():
     """Test code block extraction"""
-    protector = ContentProtector()
+    # Note: extract_code_blocks method has been removed. Code blocks are now handled
+    # directly by MarkdownItProcessor using tokens. Test via convert_mdx_to_skeleton.
+    import tempfile
+    import shutil
     
-    text = "Some text\n```python\nprint('hello')\n```\nMore text"
-    result = protector.extract_code_blocks(text)
-    
-    assert "```python\nprint('hello')\n```" not in result
-    assert "__CODE_BLOCK_1__" in result
-    assert len(protector.protected_sections) == 1
-    assert protector.protected_sections[0].content == "```python\nprint('hello')\n```"
+    tmp_dir = Path(tempfile.mkdtemp())
+    try:
+        input_file = tmp_dir / "test.mdx"
+        input_file.write_text("""
+Some text
+```python
+print('hello')
+```
+More text
+""")
+        
+        output_path, _ = convert_mdx_to_skeleton(input_file)
+        content = output_path.read_text()
+        
+        expected = """
+_TEXT_
+```python
+print('hello')
+```
+_TEXT_
+"""
+        assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
+    finally:
+        shutil.rmtree(tmp_dir)
 
 
 def test_content_protector_extract_inline_code():
     """Test inline code extraction"""
-    protector = ContentProtector()
+    # Note: extract_inline_code method has been removed. Inline code is now handled
+    # directly by MarkdownItProcessor using tokens. Test via convert_mdx_to_skeleton.
+    import tempfile
+    import shutil
     
-    text = "Use `print()` function"
-    result = protector.extract_inline_code(text)
-    
-    assert "`print()`" not in result
-    assert "`__INLINE_CODE_1__`" in result
-    assert len(protector.protected_sections) == 1
-    assert protector.protected_sections[0].content == "print()"
+    tmp_dir = Path(tempfile.mkdtemp())
+    try:
+        input_file = tmp_dir / "test.mdx"
+        input_file.write_text("Use `print()` function")
+        
+        output_path, _ = convert_mdx_to_skeleton(input_file)
+        content = output_path.read_text()
+        
+        expected = """_TEXT_ `print()` _TEXT_"""
+        assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
+    finally:
+        shutil.rmtree(tmp_dir)
 
 
 def test_content_protector_extract_urls():
     """Test URL extraction from links and images"""
-    protector = ContentProtector()
+    # Note: extract_urls method has been removed. URLs are now handled
+    # directly by MarkdownItProcessor using tokens. Test via convert_mdx_to_skeleton.
+    import tempfile
+    import shutil
     
-    # Test regular link
-    text = "Visit [Google](https://google.com)"
-    result = protector.extract_urls(text)
-    
-    assert "https://google.com" not in result
-    assert "__URL_1__" in result
-    assert len(protector.protected_sections) == 1
-    assert protector.protected_sections[0].content == "https://google.com"
-    
-    # Test image link (now handled in extract_urls)
-    protector2 = ContentProtector()
-    text2 = "![Alt](/path/to/image.png)"
-    result2 = protector2.extract_urls(text2)
-    assert "![Alt](/path/to/image.png)" not in result2
-    assert "__IMAGE_LINK_1__" in result2
-    assert len(protector2.protected_sections) == 1
-    assert protector2.protected_sections[0].content == "![_TEXT_](/path/to/image.png)"
+    tmp_dir = Path(tempfile.mkdtemp())
+    try:
+        # Test regular link
+        input_file = tmp_dir / "test.mdx"
+        input_file.write_text("Visit [Google](https://google.com)")
+        
+        output_path, _ = convert_mdx_to_skeleton(input_file)
+        content = output_path.read_text()
+        
+        expected = """_TEXT_ [_TEXT_](https://google.com)"""
+        assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
+    finally:
+        shutil.rmtree(tmp_dir)
 
 
 def test_content_protector_extract_image_links():
     """Test image link extraction (now integrated in extract_urls)"""
-    protector = ContentProtector()
+    # Note: extract_urls method has been removed. Image links are now handled
+    # directly by MarkdownItProcessor using tokens. Test via convert_mdx_to_skeleton.
+    import tempfile
+    import shutil
     
-    text = "![Alt text](/path/to/image.png)"
-    result = protector.extract_urls(text)
-    
-    assert "![Alt text](/path/to/image.png)" not in result
-    assert "__IMAGE_LINK_1__" in result
-    assert len(protector.protected_sections) == 1
-    assert protector.protected_sections[0].content == "![_TEXT_](/path/to/image.png)"
+    tmp_dir = Path(tempfile.mkdtemp())
+    try:
+        input_file = tmp_dir / "test.mdx"
+        input_file.write_text("![Alt text](/path/to/image.png)")
+        
+        output_path, _ = convert_mdx_to_skeleton(input_file)
+        content = output_path.read_text()
+        
+        expected = """![_TEXT_](/path/to/image.png)"""
+        assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
+    finally:
+        shutil.rmtree(tmp_dir)
 
 
 def test_content_protector_extract_html_entities():
     """Test HTML entity extraction"""
-    protector = ContentProtector()
+    # Note: extract_html_entities method has been removed. HTML entities are now handled
+    # directly by MarkdownItProcessor using tokens. Test via convert_mdx_to_skeleton.
+    # HTML entities are preserved as-is according to the implementation.
+    import tempfile
+    import shutil
     
-    text = "Use &amp; and &lt; symbols"
-    result = protector.extract_html_entities(text)
-    
-    assert "&amp;" not in result
-    assert "&lt;" not in result
-    assert "__HTML_ENTITY_1__" in result
-    assert "__HTML_ENTITY_2__" in result
+    tmp_dir = Path(tempfile.mkdtemp())
+    try:
+        input_file = tmp_dir / "test.mdx"
+        input_file.write_text("Use &amp; and &lt; symbols")
+        
+        output_path, _ = convert_mdx_to_skeleton(input_file)
+        content = output_path.read_text()
+        
+        expected = """_TEXT_ &amp; _TEXT_ &lt; _TEXT_"""
+        assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
+    finally:
+        shutil.rmtree(tmp_dir)
 
 
 def test_content_protector_restore_all():
     """Test restoration of all protected sections"""
-    protector = ContentProtector()
+    # Note: extract_inline_code and extract_urls methods have been removed.
+    # Test via convert_mdx_to_skeleton to verify code and links are preserved.
+    import tempfile
+    import shutil
     
-    # Extract multiple sections
-    text = "Code: `print()` and link [text](url)"
-    text = protector.extract_inline_code(text)
-    text = protector.extract_urls(text)
-    
-    # Restore
-    result = protector.restore_all(text)
-    
-    assert "`print()`" in result
-    assert "url" in result
+    tmp_dir = Path(tempfile.mkdtemp())
+    try:
+        input_file = tmp_dir / "test.mdx"
+        input_file.write_text("Code: `print()` and link [text](url)")
+        
+        output_path, _ = convert_mdx_to_skeleton(input_file)
+        content = output_path.read_text()
+        
+        expected = """_TEXT_ `print()` _TEXT_ [_TEXT_](url)"""
+        assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
+    finally:
+        shutil.rmtree(tmp_dir)
 
 
 # ============================================================================
@@ -155,106 +200,150 @@ def test_content_protector_restore_all():
 
 def test_text_processor_replace_text_in_content_empty():
     """Test text replacement with empty string"""
-    processor = TextProcessor()
-    assert processor.replace_text_in_content("") == ""
-    assert processor.replace_text_in_content("   ") == "   "
+    # Note: TextProcessor class has been removed. Text processing is now handled
+    # by MarkdownItProcessor using tokens. Test via convert_mdx_to_skeleton.
+    # Whitespace-only lines are preserved as-is.
+    import tempfile
+    import shutil
+    
+    tmp_dir = Path(tempfile.mkdtemp())
+    try:
+        input_file = tmp_dir / "test.mdx"
+        input_file.write_text("   ")
+        
+        output_path, _ = convert_mdx_to_skeleton(input_file)
+        content = output_path.read_text()
+        
+        expected = "   "
+        assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
+    finally:
+        shutil.rmtree(tmp_dir)
 
 
 def test_text_processor_preserve_markdown_formatting():
     """Test markdown formatting preservation (now integrated in _replace_text_with_placeholders)"""
-    processor = TextProcessor()
+    # Note: TextProcessor class has been removed. Text processing is now handled
+    # by MarkdownItProcessor using tokens. Test via convert_mdx_to_skeleton.
+    import tempfile
+    import shutil
     
-    # Test bold
-    text = "**bold text**"
-    result = processor.replace_text_in_content(text)
-    assert "**_TEXT_**" in result
-    
-    # Test italic - can have spaces inside, must have space or line boundary before and after
-    text = "This is *italic text* here"
-    result = processor.replace_text_in_content(text)
-    assert "*_TEXT_*" in result
-    
-    # Test italic at start of line
-    text = "*italic text* at start"
-    result = processor.replace_text_in_content(text)
-    assert "*_TEXT_*" in result
-    
-    # Test italic at end of line
-    text = "text *italic text*"
-    result = processor.replace_text_in_content(text)
-    assert "*_TEXT_*" in result
-    
-    # Test italic with underscore at end of line
-    text = "text _italic text_"
-    result = processor.replace_text_in_content(text)
-    assert "_TEXT_" in result
-    
-    # Test link
-    text = "[link text](url)"
-    result = processor.replace_text_in_content(text)
-    assert "[_TEXT_]" in result
+    tmp_dir = Path(tempfile.mkdtemp())
+    try:
+        input_file = tmp_dir / "test.mdx"
+        input_file.write_text("""**bold text**
+
+This is *italic text* here
+
+*italic text* at start
+
+text *italic text*
+
+text _italic text_
+
+[link text](url)
+""")
+        
+        output_path, _ = convert_mdx_to_skeleton(input_file)
+        content = output_path.read_text()
+        
+        expected = """**_TEXT_**
+
+_TEXT_ *_TEXT_* _TEXT_
+
+*_TEXT_* _TEXT_
+
+_TEXT_ *_TEXT_*
+
+_TEXT_
+
+[_TEXT_](url)
+"""
+        assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
+    finally:
+        shutil.rmtree(tmp_dir)
 
 
 def test_text_processor_replace_remaining_text():
     """Test remaining text replacement (now integrated in _replace_text_with_placeholders)"""
-    processor = TextProcessor()
+    # Note: TextProcessor class has been removed. Text processing is now handled
+    # by MarkdownItProcessor using tokens. Test via convert_mdx_to_skeleton.
+    import tempfile
+    import shutil
     
-    # Simple text
-    text = "Hello world"
-    result = processor.replace_text_in_content(text)
-    assert result == "_TEXT_"
-    
-    # Text with punctuation
-    text = "Hello, world!"
-    result = processor.replace_text_in_content(text)
-    assert result == "_TEXT_"
-    
-    # Text with markdown formatting
-    text = "**bold** and more text"
-    result = processor.replace_text_in_content(text)
-    assert "**_TEXT_**" in result
-    assert "_TEXT_" in result
+    tmp_dir = Path(tempfile.mkdtemp())
+    try:
+        input_file = tmp_dir / "test.mdx"
+        input_file.write_text("""Hello world
+
+Hello, world!
+
+**bold** and more text
+""")
+        
+        output_path, _ = convert_mdx_to_skeleton(input_file)
+        content = output_path.read_text()
+        
+        expected = """_TEXT_
+
+_TEXT_
+
+**_TEXT_** _TEXT_
+"""
+        assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
+    finally:
+        shutil.rmtree(tmp_dir)
 
 
 def test_text_processor_cleanup_text():
     """Test cleanup of consecutive _TEXT_ placeholders"""
-    processor = TextProcessor()
+    # Note: TextProcessor class has been removed. Text processing is now handled
+    # by MarkdownItProcessor using tokens. Test via convert_mdx_to_skeleton.
+    import tempfile
+    import shutil
     
-    # Multiple consecutive _TEXT_
-    text = "_TEXT_ _TEXT_ _TEXT_"
-    result = processor._cleanup_text(text)
-    assert result == "_TEXT_"
-    
-    # With underscores
-    text = "_TEXT____TEXT_"
-    result = processor._cleanup_text(text)
-    assert result == "_TEXT_"
-    
-    # Mixed
-    text = "_TEXT_  _TEXT_"
-    result = processor._cleanup_text(text)
-    assert result == "_TEXT_"
+    tmp_dir = Path(tempfile.mkdtemp())
+    try:
+        input_file = tmp_dir / "test.mdx"
+        input_file.write_text("Multiple words here")
+        
+        output_path, _ = convert_mdx_to_skeleton(input_file)
+        content = output_path.read_text()
+        
+        expected = """_TEXT_"""
+        assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
+    finally:
+        shutil.rmtree(tmp_dir)
 
 
 def test_text_processor_replace_text_in_content_full():
     """Test full text replacement flow"""
-    processor = TextProcessor()
+    # Note: TextProcessor class has been removed. Text processing is now handled
+    # by MarkdownItProcessor using tokens. Test via convert_mdx_to_skeleton.
+    import tempfile
+    import shutil
     
-    # Simple text
-    text = "Hello world"
-    result = processor.replace_text_in_content(text)
-    assert result == "_TEXT_"
-    
-    # Text with bold
-    text = "This is **bold** text"
-    result = processor.replace_text_in_content(text)
-    assert "**_TEXT_**" in result
-    assert "_TEXT_" in result
-    
-    # Text with punctuation
-    text = "Hello, world! How are you?"
-    result = processor.replace_text_in_content(text)
-    assert result == "_TEXT_"
+    tmp_dir = Path(tempfile.mkdtemp())
+    try:
+        input_file = tmp_dir / "test.mdx"
+        input_file.write_text("""Hello world
+
+This is **bold** text
+
+Hello, world! How are you?
+""")
+        
+        output_path, _ = convert_mdx_to_skeleton(input_file)
+        content = output_path.read_text()
+        
+        expected = """_TEXT_
+
+_TEXT_ **_TEXT_** _TEXT_
+
+_TEXT_
+"""
+        assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
+    finally:
+        shutil.rmtree(tmp_dir)
 
 
 # ============================================================================
@@ -298,81 +387,151 @@ def test_process_yaml_frontmatter():
 
 def test_process_text_line_empty():
     """Test processing empty line"""
-    processor = TextProcessor()
-    assert process_text_line("", processor) == ""
-    assert process_text_line("   ", processor) == "   "
+    # Note: process_text_line function has been removed. Line processing is now handled
+    # by MarkdownItProcessor using tokens. Test via convert_mdx_to_skeleton.
+    # Whitespace-only lines are preserved as-is.
+    import tempfile
+    import shutil
+    
+    tmp_dir = Path(tempfile.mkdtemp())
+    try:
+        input_file = tmp_dir / "test.mdx"
+        input_file.write_text("   ")
+        
+        output_path, _ = convert_mdx_to_skeleton(input_file)
+        content = output_path.read_text()
+        
+        expected = "   "
+        assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
+    finally:
+        shutil.rmtree(tmp_dir)
 
 
 def test_process_text_line_import():
     """Test processing import statement"""
-    processor = TextProcessor()
-    line = "import { Component } from 'react'"
-    assert process_text_line(line, processor) == line
+    # Note: process_text_line function has been removed. Line processing is now handled
+    # by MarkdownItProcessor using tokens. Test via convert_mdx_to_skeleton.
+    # Import statements are preserved as-is according to the implementation.
+    import tempfile
+    import shutil
+    
+    tmp_dir = Path(tempfile.mkdtemp())
+    try:
+        input_file = tmp_dir / "test.mdx"
+        input_file.write_text("import { Component } from 'react'")
+        
+        output_path, _ = convert_mdx_to_skeleton(input_file)
+        content = output_path.read_text()
+        
+        expected = """import { Component } from 'react'"""
+        assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
+    finally:
+        shutil.rmtree(tmp_dir)
 
 
 def test_process_text_line_code_block():
     """Test processing code block markers"""
-    processor = TextProcessor()
-    line = "```python"
-    assert process_text_line(line, processor) == line
+    # Note: process_text_line function has been removed. Line processing is now handled
+    # by MarkdownItProcessor using tokens. Test via convert_mdx_to_skeleton.
+    import tempfile
+    import shutil
     
-    line = "```"
-    assert process_text_line(line, processor) == line
+    tmp_dir = Path(tempfile.mkdtemp())
+    try:
+        input_file = tmp_dir / "test.mdx"
+        input_file.write_text("```python\ncode here\n```")
+        
+        output_path, _ = convert_mdx_to_skeleton(input_file)
+        content = output_path.read_text()
+        
+        expected = """```python
+code here
+```"""
+        assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
+    finally:
+        shutil.rmtree(tmp_dir)
 
 
 def test_process_markdown_line_header():
     """Test processing markdown header"""
-    processor = TextProcessor()
+    # Note: process_markdown_line function has been removed. Line processing is now handled
+    # by MarkdownItProcessor using tokens. Test via convert_mdx_to_skeleton.
+    import tempfile
+    import shutil
     
-    line = "# Header"
-    result = process_markdown_line(line, processor)
-    assert result.startswith("# ")
-    assert "_TEXT_" in result
-    
-    line = "## Subheader"
-    result = process_markdown_line(line, processor)
-    assert result.startswith("## ")
-    assert "_TEXT_" in result
+    tmp_dir = Path(tempfile.mkdtemp())
+    try:
+        input_file = tmp_dir / "test.mdx"
+        input_file.write_text("""# Header
+
+## Subheader
+""")
+        
+        output_path, _ = convert_mdx_to_skeleton(input_file)
+        content = output_path.read_text()
+        
+        expected = """# _TEXT_
+
+## _TEXT_
+"""
+        assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
+    finally:
+        shutil.rmtree(tmp_dir)
 
 
 def test_process_markdown_line_list():
     """Test processing markdown list"""
-    processor = TextProcessor()
+    # Note: process_markdown_line function has been removed. Line processing is now handled
+    # by MarkdownItProcessor using tokens. Test via convert_mdx_to_skeleton.
+    import tempfile
+    import shutil
     
-    # Unordered list
-    line = "* Item one"
-    result = process_markdown_line(line, processor)
-    assert result.startswith("* ")
-    assert "_TEXT_" in result
-    
-    # Ordered list
-    line = "1. Item one"
-    result = process_markdown_line(line, processor)
-    assert result.startswith("1. ")
-    assert "_TEXT_" in result
-    
-    # Nested list
-    line = "    * Nested item"
-    result = process_markdown_line(line, processor)
-    assert result.startswith("    * ")
-    assert "_TEXT_" in result
+    tmp_dir = Path(tempfile.mkdtemp())
+    try:
+        input_file = tmp_dir / "test.mdx"
+        input_file.write_text("""* Item one
+
+1. Item one
+
+    * Nested item
+""")
+        
+        output_path, _ = convert_mdx_to_skeleton(input_file)
+        content = output_path.read_text()
+        
+        expected = """* _TEXT_
+1. _TEXT_
+    *     _TEXT_
+"""
+        assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
+    finally:
+        shutil.rmtree(tmp_dir)
 
 
 def test_process_html_line():
     """Test processing HTML line"""
-    processor = TextProcessor()
+    # Note: _process_html_line function has been removed. HTML processing is now handled
+    # by MarkdownItProcessor using tokens. Test via convert_mdx_to_skeleton.
+    import tempfile
+    import shutil
     
-    line = "<p>Hello world</p>"
-    result = _process_html_line(line, processor)
-    assert "<p>" in result
-    assert "</p>" in result
-    assert "_TEXT_" in result
-    
-    line = "<figure><img src='test.png' /></figure>"
-    result = _process_html_line(line, processor)
-    assert "<figure>" in result
-    assert "<img" in result
-    assert "</figure>" in result
+    tmp_dir = Path(tempfile.mkdtemp())
+    try:
+        input_file = tmp_dir / "test.mdx"
+        input_file.write_text("""<p>Hello world</p>
+
+<figure><img src='test.png' /></figure>
+""")
+        
+        output_path, _ = convert_mdx_to_skeleton(input_file)
+        content = output_path.read_text()
+        
+        expected = """<p>Hello world</p>
+<figure><img src='test.png' /></figure>
+"""
+        assert content == expected, f"Expected:\n{expected!r}\nGot:\n{content!r}"
+    finally:
+        shutil.rmtree(tmp_dir)
 
 
 # ============================================================================


### PR DESCRIPTION
## Description
- mdx_to_skeleton.py 의 리팩토링을 수행하기 전에, test_mdx_to_skeleton.py 를 개선합니다.
- mdx_to_skeleton.py 내부의 모듈, 함수에 대한 테스트를 수행하지 않고, 상위 레벨의 MDX 변환 기능에 대한 테스트를 수행하도록, 변경합니다.
- 리팩토링에 따라, main code 의 구조, 작동방식이 변경하더라도, 겉보기 MDX 변환 기능은 그대로 유지되고, 테스트케이스를 변경하지 않아도 됩니다.

## Additional notes
- 
