### PR TITLE
mdx: 영어 문서 불일치 수정 7

### DIFF
--- a/src/content/en/administrator-manual.mdx
+++ b/src/content/en/administrator-manual.mdx
@@ -10,7 +10,7 @@ As a QueryPie administrator, you can manage resources and permissions, solution 
 Depending on the licenses provided and the administrator roles assigned to you, the available settings menus may differ.
 
 To access the Admin page, first sign in to QueryPie.
-After a successful sign‑in you will land on the user dashboard, and if your account has been granted an administrator role, a Go to Admin Page button appears at the top right.
+After a successful sign‑in you will land on the user dashboard, and if your account has been granted an administrator role, a `Go to Admin Page` button appears at the top right.
 Click this button to open the Admin page in a new tab.
 
 <figure data-layout="center" data-align="center">

--- a/src/content/en/administrator-manual/audit.mdx
+++ b/src/content/en/administrator-manual/audit.mdx
@@ -12,8 +12,8 @@ User and administrator login/logout, permission grants and revocations, access t
 
 ### Available Features
 
-*  **Audit Log Export**  :  Audit logs can be extracted and saved as files through the **Audit Log Export** menu. 
-*  **Report Generation**  :  QueryPie data status can be output in report format through the **Report** menu. 
+*  **Audit Log Export**  :  **Audit Log Export**  Audit logs can be extracted and saved as files through the menu. 
+*  **Report Generation**  :  **Report**  QueryPie data status can be output in report format through the menu. 
 *  **Audit Log Viewing**  :  Real-time log viewing, searching, and filtering are available through **individual log pages** under the Audit menu.
 
 

--- a/src/content/en/administrator-manual/databases/connection-management.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management.mdx
@@ -6,7 +6,8 @@ title: 'Connection Management'
 
 ### Overview
 
-This document provides a guide for effectively managing databases in QueryPie. You can check methods for synchronizing databases from Cloud Providers at once through cloud synchronization features and methods for manually registering databases.
+This document provides a guide for effectively managing databases in QueryPie.
+You can check methods for synchronizing databases from Cloud Providers at once through cloud synchronization features and methods for manually registering databases.
 
 ### DB Connection Management Guide Quick Access
 

--- a/src/content/en/administrator-manual/databases/connection-management/cloud-providers.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/cloud-providers.mdx
@@ -59,7 +59,9 @@ Please note that when deleting a Cloud Provider, all resources synchronized thro
 
 <Callout type="info">
 **What is Cloud Synchronization Dry Run?**
-It serves to test and verify the cloud synchronization process, allowing you to check in advance what the synchronization results will be. When changing existing integration information, unexpected results may occur due to user input errors. To prevent such problems in advance, users can change existing information and then perform a "Dry Run" to test the entered content in advance.
+It serves to test and verify the cloud synchronization process, allowing you to check in advance what the synchronization results will be.
+When changing existing integration information, unexpected results may occur due to user input errors.
+To prevent such problems in advance, users can change existing information and then perform a "Dry Run" to test the entered content in advance.
 </Callout>
 
 <figure data-layout="center" data-align="center">

--- a/src/content/en/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-aws.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-aws.mdx
@@ -8,7 +8,8 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-QueryPie supports AWS integration for database registration and management. You can synchronize resources within AWS to register them as databases managed by QueryPie, and grant access permissions and set policies for users and groups for the synchronized databases.
+QueryPie supports AWS integration for database registration and management.
+You can synchronize resources within AWS to register them as databases managed by QueryPie, and grant access permissions and set policies for users and groups for the synchronized databases.
 
 
 ### Registering AWS Integration Information in QueryPie

--- a/src/content/en/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-google-cloud.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-google-cloud.mdx
@@ -8,7 +8,8 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-QueryPie supports Google Cloud (GCP) integration for database registration and management. You can synchronize resources within GCP to register them as databases managed by QueryPie, and grant access permissions and set policies for users and groups for the synchronized databases.
+QueryPie supports Google Cloud (GCP) integration for database registration and management.
+You can synchronize resources within GCP to register them as databases managed by QueryPie, and grant access permissions and set policies for users and groups for the synchronized databases.
 
 ### Registering GCP Integration Information in QueryPie
 
@@ -81,7 +82,8 @@ Administrator &gt; Databases &gt; Connection Management &gt; Cloud Providers &gt
     6. Replication Frequency: Changeable
 
 <Callout type="important">
-Synchronization settings saved without the "Save Credential for Synchronization" option enabled can be enabled by checking the checkbox on the detail page. Like when creating new ones, this setting **cannot be disabled again after being enabled**, so you must choose carefully.
+Synchronization settings saved without the "Save Credential for Synchronization" option enabled can be enabled by checking the checkbox on the detail page.
+Like when creating new ones, this setting **cannot be disabled again after being enabled**, so you must choose carefully.
 </Callout>
 
 ### Synchronization through Service Account

--- a/src/content/en/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-ms-azure.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-ms-azure.mdx
@@ -8,7 +8,8 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-QueryPie supports MS Azure integration for database registration and management. You can synchronize resources within Azure to register them as databases managed by QueryPie, and grant access permissions and set policies for users and groups for the synchronized databases.
+QueryPie supports MS Azure integration for database registration and management.
+You can synchronize resources within Azure to register them as databases managed by QueryPie, and grant access permissions and set policies for users and groups for the synchronized databases.
 
 
 ### Registering Azure Integration Information in QueryPie

--- a/src/content/en/administrator-manual/databases/connection-management/db-connections.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/db-connections.mdx
@@ -85,7 +85,9 @@ Administrator &gt; Databases &gt; Connection Management &gt; DB Connections &gt;
 
 <Callout type="info">
 **What is Cluster Mode?**
-Generally, when synchronizing through Cloud Provider, it is registered in cluster structure for Primary and Secondary cluster and endpoint management. Even when manually registering connections, you can register connections in cluster structure through the Cluster toggle button. When using Cluster mode, you can manage access permissions in cluster and instance endpoint structure, and **for purposes such as load balancing and permission management, you can grant permissions only to specific instance endpoints to certain users**.
+Generally, when synchronizing through Cloud Provider, it is registered in cluster structure for Primary and Secondary cluster and endpoint management.
+Even when manually registering connections, you can register connections in cluster structure through the Cluster toggle button.
+When using Cluster mode, you can manage access permissions in cluster and instance endpoint structure, and **for purposes such as load balancing and permission management, you can grant permissions only to specific instance endpoints to certain users**.
 </Callout>
 
 
@@ -192,7 +194,8 @@ DB Account items are displayed differently depending on the Secret Engine type s
 
 ### Additional Settings
 
-You can configure additional settings for DB connections in the tab area at the bottom of the page. Refer to the description for each item.
+You can configure additional settings for DB connections in the tab area at the bottom of the page.
+Refer to the description for each item.
 
 #### Additional Information
 

--- a/src/content/en/administrator-manual/databases/connection-management/kerberos-configurations.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/kerberos-configurations.mdx
@@ -6,11 +6,13 @@ title: 'Kerberos Configurations'
 
 ### Overview
 
-The Kerberos Configurations page allows you to register and manage internal Kerberos keytab configurations. Users can easily select registered Kerberos configurations when needed.
+The Kerberos Configurations page allows you to register and manage internal Kerberos keytab configurations.
+Users can easily select registered Kerberos configurations when needed.
 
 ### Registering Kerberos Keytab
 
-Click the `Create Keytab` button in the top right of the Kerberos Configurations page. Upload the keytab file, enter the name of the Kerberos configuration, and click the `Save` button to save.
+Click the `Create Keytab` button in the top right of the Kerberos Configurations page.
+Upload the keytab file, enter the name of the Kerberos configuration, and click the `Save` button to save.
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Databases &gt; Connection Management &gt; Kerberos Configurations &gt; Create Keytab](/administrator-manual/databases/connection-management/kerberos-configurations/screenshot-20240731-111247.png)
@@ -34,7 +36,8 @@ Administrator &gt; Databases &gt; Connection Management &gt; Kerberos Configurat
 
 ### Deleting Kerberos Keytab
 
-Select the item you want to delete from the list in the Kerberos Configurations page with a checkbox, and the `Delete` button will be displayed. Click the button and click the `Delete` button in the confirmation modal to complete deletion.
+Select the item you want to delete from the list in the Kerberos Configurations page with a checkbox, and the `Delete` button will be displayed.
+Click the button and click the `Delete` button in the confirmation modal to complete deletion.
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Databases &gt; Connection Management &gt; Kerberos Configurations &gt; Delete Keytab](/administrator-manual/databases/connection-management/kerberos-configurations/screenshot-20240731-111214.png)
@@ -46,7 +49,8 @@ Administrator &gt; Databases &gt; Connection Management &gt; Kerberos Configurat
 
 ### Changing Kerberos Client Configuration
 
-Click the `⚙️` button in the top right of the Kerberos Configurations page to expose the Kerberos client configuration change modal to apply to QueryPie. Click the `Save` button to save the changes.
+Click the `⚙️` button in the top right of the Kerberos Configurations page to expose the Kerberos client configuration change modal to apply to QueryPie.
+Click the `Save` button to save the changes.
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Databases &gt; Connection Management &gt; Kerberos Configurations &gt; Kerberos Configuration Setting](/administrator-manual/databases/connection-management/kerberos-configurations/screenshot-20240731-111234.png)

--- a/src/content/en/administrator-manual/databases/dac-general-configurations.mdx
+++ b/src/content/en/administrator-manual/databases/dac-general-configurations.mdx
@@ -22,7 +22,9 @@ Manages settings applied to DB access control.
 
 #### Query Sharing
 
-<br/>Query Sharing is a feature that sends queries written in QueryPie SQL Editor to Git to share with other users. By default, query sharing settings are off, and clicking the `Query Sharing Setting` button opens a settings modal. When Query Sharing option is set to On, additional input fields are displayed.
+<br/>Query Sharing is a feature that sends queries written in QueryPie SQL Editor to Git to share with other users.
+By default, query sharing settings are off, and clicking the `Query Sharing Setting` button opens a settings modal.
+When Query Sharing option is set to On, additional input fields are displayed.
 <figure data-layout="center" data-align="center">
 ![screenshot-20240726-145003.png](/administrator-manual/databases/dac-general-configurations/screenshot-20240726-145003.png)
 </figure>
@@ -51,7 +53,7 @@ For descriptions of OAuth or SSH authentication using GitHub, please refer to th
 </Callout>
 
 
-When Query Sharing configuration is complete, Query Sharing is displayed as **On**.
+When Query Sharing configuration is complete, Query Sharing is displayed as  **On** .
 
 You can use the query sharing feature on the SQL Editor screen.
 
@@ -78,7 +80,7 @@ Query Audit Detail
 
 *  **Advanced Privilege Setting**  : Account control by privilege permission (Default: Off)
     * When set to On, Privilege Settings tab is displayed at the bottom of Connection Details page
-    * For detailed information, refer to **Privilege Setting** document in [DB Connections](connection-management/db-connections)
+    * For detailed information, refer to [DB Connections](connection-management/db-connections) for the  **Privilege Setting**  document
 *  **Unmasking Zones** : Setting to allow users who have been granted permission to view masked data through Unmasking request or users registered as allowed users of masking policies to view in unmasked state only when accessing from specific IPs (ranges), even if they are exception targets of masking policies. (Default: Off) <br/>Reference: [Unmasking Zones detailed description](dac-general-configurations/unmasking-zones)
 *  **Ledger Table Management :**  Setting to activate or deactivate Ledger table management functionality that can force workflow approval and reason input by designating specific tables as Ledger. (Default: Off)
 *  **Select Purpose Duration for Agent :**  Setting to prevent re-input for a specified time when users accessing DB through Proxy with 3rd party tools input reasons for reason input mandatory target data. Only configurable when Ledger Table Management is On. (Default: 10 minutes)
@@ -91,7 +93,8 @@ Query Audit Detail
       </figure>
 
 <Callout type="important">
-Queries blocked by Restricted Statement policies are blocked from execution even if approved through SQL Request. Do not enter queries that should be allowed for execution by certain users.
+Queries blocked by Restricted Statement policies are blocked from execution even if approved through SQL Request.
+Do not enter queries that should be allowed for execution by certain users.
 </Callout>
 
 *  **Justification Length**  : When "User Action Purpose Required" option is activated in Connection settings or reason input is forced by Ledger table management policies, reason input must be made through Web Editor or Agent. Administrators specify the minimum and maximum values for the number of characters entered in the input field.
@@ -124,7 +127,8 @@ Query Audit
 
 <Callout type="info">
 **Reason Input Mandatory Settings for DB Operations**
-From version 9.17.0, this feature has been changed to detailed connection settings. For detailed configuration methods, please refer to **Additional Settings** in [DB Connections](connection-management/db-connections).
+From version 9.17.0, this feature has been changed to detailed connection settings.
+For detailed configuration methods, please refer to [DB Connections](connection-management/db-connections) for  **Additional Settings** .
 </Callout>
 
 *  **Maximum Policy Exception Period**  : Sets the maximum validity period (in hours) for policy exceptions such as Unmasking. This setting affects the Workflow application form and the administrator's manual policy settings when the New DAC Policy Management feature is enabled. 

--- a/src/content/en/administrator-manual/databases/db-access-control.mdx
+++ b/src/content/en/administrator-manual/databases/db-access-control.mdx
@@ -6,7 +6,9 @@ title: 'DB Access Control'
 
 ### Overview
 
-The DB Access Control menu provides various forms of access control based on roles and attributes to manage database access and security at a high level. Only authenticated users can access databases that have been granted access permissions through QueryPie, and SQL execution is restricted based on predefined SQL statement combinations. From initial QueryPie user authentication to database access, important data can be safely protected through IP range control, long-term non-access control, time and day-of-week control, table/column query restrictions, etc., and all changes to security policies are immediately applied to user sessions so that updated measures can be applied in real time.
+The DB Access Control menu provides various forms of access control based on roles and attributes to manage database access and security at a high level.
+Only authenticated users can access databases that have been granted access permissions through QueryPie, and SQL execution is restricted based on predefined SQL statement combinations.
+From initial QueryPie user authentication to database access, important data can be safely protected through IP range control, long-term non-access control, time and day-of-week control, table/column query restrictions, etc., and all changes to security policies are immediately applied to user sessions so that updated measures can be applied in real time.
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Databases &gt; DB Access Control &gt; Access Control](/administrator-manual/databases/db-access-control/screenshot-20240731-113229.png)

--- a/src/content/en/administrator-manual/databases/ledger-management.mdx
+++ b/src/content/en/administrator-manual/databases/ledger-management.mdx
@@ -15,7 +15,8 @@ The existing ledger table policy feature was provided as a separate license, but
 </Callout>
 
 
-Administrators can set up ledgers at the table level of the database through the Ledger Table Policy menu, and when a 'Ledger Approval Rule' is mapped to a table, it goes through the ledger workflow process. By mapping a ledger approval rule, the table immediately takes on the characteristics of a ledger table.
+Administrators can set up ledgers at the table level of the database through the Ledger Table Policy menu, and when a 'Ledger Approval Rule' is mapped to a table, it goes through the ledger workflow process.
+By mapping a ledger approval rule, the table immediately takes on the characteristics of a ledger table.
 
 * When a user executes INSERT / UPDATE / DELETE queries on a ledger table,
     * When a user attempts to modify queries in QueryPie Web Editor and 3rd-party editor for that table, the user will be notified that they must go through SQL Request.

--- a/src/content/en/administrator-manual/databases/monitoring.mdx
+++ b/src/content/en/administrator-manual/databases/monitoring.mdx
@@ -14,10 +14,12 @@ In QueryPie, query execution has three paths.
 * Using SQL Request in Workflow, after going through approval, the Executor presses the execute button to execute when approval is complete.
 * Execute through QueryPie Proxy using 3rd party tools (such as DBeaver) (user agent method) or using URLs (agent-less).
 
-Queries executed as above can be monitored through Running Queries and Proxy Management, and administrators can force stop them if necessary. (Available from 10.3.0 onwards)
+Queries executed as above can be monitored through Running Queries and Proxy Management, and administrators can force stop them if necessary.
+(Available from 10.3.0 onwards)
 
 <Callout type="info">
-From 10.3.0, the query force stop feature has been added to the Running Queries feature that was previously only available for monitoring under Audit. Proxy Management had session force functionality from before and has only been moved to under Monitoring.
+From 10.3.0, the query force stop feature has been added to the Running Queries feature that was previously only available for monitoring under Audit.
+Proxy Management had session force functionality from before and has only been moved to under Monitoring.
 </Callout>
 
 

--- a/src/content/en/administrator-manual/databases/new-policy-management.mdx
+++ b/src/content/en/administrator-manual/databases/new-policy-management.mdx
@@ -8,15 +8,21 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-The existing QueryPie DAC provides data policies such as Data Access, Data Masking, Sensitive Data. Ledger Table Management. However, these policies must be set individually for each connection, and rules must be applied for each table and column. And it does not provide import and export functions for policies.
+The existing QueryPie DAC provides data policies such as Data Access, Data Masking, Sensitive Data.
+Ledger Table Management.
+However, these policies must be set individually for each connection, and rules must be applied for each table and column.
+And it does not provide import and export functions for policies.
 
-From 10.2.6, to improve these inconveniences, a new policy management feature is provided. Through the tag-based policy application feature, after mapping DBMS paths and tags, when policies are applied, policies can be dynamically assigned by tags. You can set access to only specific tables through tags assigned to tables.
+From 10.2.6, to improve these inconveniences, a new policy management feature is provided.
+Through the tag-based policy application feature, after mapping DBMS paths and tags, when policies are applied, policies can be dynamically assigned by tags.
+You can set access to only specific tables through tags assigned to tables.
 
 ### Using the New Policy Management Feature
 
 To use the new policy management feature, you must first enable the feature.
 
-In General &gt; Company management &gt; Security, set New DAC Policy Management to `Enable` in the DB Connection Security sub-item. (Default value Disable)<br/>
+In General &gt; Company management &gt; Security, set New DAC Policy Management to `Enable` in the DB Connection Security sub-item.
+(Default value Disable)<br/>
 
 <figure data-layout="center" data-align="center">
 ![Enable New DAC Policy Management](/administrator-manual/databases/new-policy-management/image-20250307-114537.png)

--- a/src/content/en/administrator-manual/databases/policies.mdx
+++ b/src/content/en/administrator-manual/databases/policies.mdx
@@ -8,7 +8,8 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-QueryPie data access policies are features that allow administrators to manage and apply access policies for each data source to protect personal information and sensitive information within the organization. You can set up access to only the minimum information necessary for business purposes for users or groups by applying table/column restrictions, masking, and sensitive data policies for each connection, which is the data source unit of QueryPie.
+QueryPie data access policies are features that allow administrators to manage and apply access policies for each data source to protect personal information and sensitive information within the organization.
+You can set up access to only the minimum information necessary for business purposes for users or groups by applying table/column restrictions, masking, and sensitive data policies for each connection, which is the data source unit of QueryPie.
 
 
 ### Data Access Policy Guide Quick Access

--- a/src/content/en/administrator-manual/multi-agent-limitations.mdx
+++ b/src/content/en/administrator-manual/multi-agent-limitations.mdx
@@ -9,7 +9,7 @@ This document outlines the limitations of QueryPie Multi Agent.
 #### Version
 
 * Multi Agent is available in version 10.2.5 or later.
-    * If version >= 10.2.5, you can register and use QueryPie hosts of different versions.
+    * If version &gt;= 10.2.5, you can register and use QueryPie hosts of different versions.
     * However, hosts of version 10.2.4 or earlier cannot be registered.
 * Multi Agent ensures maximum compatibility in versions 10.2.5 and above.
     * Maximum backward compatibility is ensured, and when a host of an incompatible version is registered or attempted to be registered, an update notification is provided. 


### PR DESCRIPTION
## Description
- **문장 구조 개선**: Administrator Manual의 databases 관련 영어 문서에서 긴 문장을 줄바꿈하여 가독성 향상
- **마크다운 포맷팅 개선**: 버튼 이름(`Go to Admin Page`)을 backtick으로 감싸서 코드 스타일 적용
- **문장 재구성**: Audit Log Export, Report Generation 등 메뉴 설명 문장 구조 정리
- **Connection Management 문서 개선**: Overview 섹션 및 Cloud Providers 관련 설명 문장 분리 및 정리
- **Callout 내용 개선**: Cloud Synchronization Dry Run, GCP 동기화 설정 등 Callout 내 문장 구조 개선

## 변경 통계
- 16개 파일 수정
- 59줄 추가, 29줄 삭제
- 주로 `administrator-manual/databases` 섹션의 영어 문서 수정

