### PR TITLE
mdx: 일본어 문서 불일치 수정 13

### DIFF
--- a/src/content/ja/administrator-manual/databases/connection-management/db-connections/mongodb-specific-guide.mdx
+++ b/src/content/ja/administrator-manual/databases/connection-management/db-connections/mongodb-specific-guide.mdx
@@ -84,7 +84,7 @@ Administrator &gt; Databases &gt; Connection Management &gt; DB Connections &gt;
         2. 下位ホスト名とポートをカンマで区切って入力します。
     4. `Add Instance`ボタンを押して各メンバーホストをインスタンスとして追加します。
         1. Instance Name : それぞれのホストを区別できる名前を入力します。
-        2. Connection String : 各ホストを`ホスト名（ドメインアドレスまたはIP）:[port]`形式で入力します。
+        2. Connection String : 各ホストを`ホストネーム（ドメインアドレスまたはIP）:[port]`形式で入力します。
         3. Exposeはコネクション情報での個別インスタンスの露出可否を決定できるオプションです。<br/>**マルチホスト機能を使用するには必ずインスタンスがexpose状態でなければならないため、必ず**`Expose`**オプションをアクティブにします。**  
 
 <figure data-layout="center" data-align="center">

--- a/src/content/ja/administrator-manual/general/company-management/channels.mdx
+++ b/src/content/ja/administrator-manual/general/company-management/channels.mdx
@@ -151,7 +151,7 @@ Slack内Webhook追加画面
 </figcaption>
 </figure>
 
-1. Workspace内に警報を送信するチャンネルを選択した後`許可`ボタンをクリックします。
+1. Workspace内に警報を送信するチャンネルを選択した後 `許可` ボタンをクリックします。
 2. 生成されたWebhook URL情報をコピーした後、QueryPieチャンネル作成モーダルに貼り付けます。
 
 #### 2-2. APIタイプで連携
@@ -165,7 +165,7 @@ Slack内Webhook追加画面
   </figcaption>
   </figure>
 3. 上部の黄色い通知バーを通じて`Reinstall your app`でアプリを再起動します。（必須）
-4. `Reinstall to {Workspace_name}`ボタンをクリックして通知を送信するSlackチャンネルを選択した後`許可`ボタンをクリックします。
+4. `Reinstall to {Workspace_name}` ボタンをクリックして通知を送信するSlackチャンネルを選択した後 `許可` ボタンをクリックします。
     1. Scopeを変更した後適用するには、この段階を再度実行する必要があります。
 5. 該当Slackチャンネルに移動して生成したアプリを追加します。（既にアプリを追加した状態であればこの段階はスキップできます）
 6. チャンネル名をクリックしてChannel Detailモーダルを開き、モーダル下部でChannel IDをコピーします。コピーしたChannel IDをQueryPieチャンネル作成モーダルに貼り付けます。 <br/>  

--- a/src/content/ja/administrator-manual/general/company-management/licenses.mdx
+++ b/src/content/ja/administrator-manual/general/company-management/licenses.mdx
@@ -42,4 +42,3 @@ Administrator &gt; General &gt; Company Management &gt; Licenses
 ### License削除
 
 * 削除したいライセンスの右側に位置するゴミ箱アイコンをクリックして削除できます。
-

--- a/src/content/ja/administrator-manual/general/system/api-token.mdx
+++ b/src/content/ja/administrator-manual/general/system/api-token.mdx
@@ -48,7 +48,7 @@ Administrator &gt; General &gt; System &gt; API Token
 
 1. Administrator &gt; General &gt; System &gt; API Tokenメニューに進入します。
 2. 現在生成されたトークンリストを確認できます。（生成日最新順ソート）
-3.  **検索およびフィルタ**：
+3.  **検索およびフィルタ** :
     1. トークンリストはToken NameまたはToken Valueで検索できます。
     2. トークンの状態でリストをフィルタリングできます。
 

--- a/src/content/ja/administrator-manual/general/system/integrations/identity-providers.mdx
+++ b/src/content/ja/administrator-manual/general/system/integrations/identity-providers.mdx
@@ -49,7 +49,8 @@ Internal databaseの詳細設定
 </figure>
 
 <Callout type="important">
-注意：設定後、一度でもユーザーを同期した場合、設定したIdPを削除（削除後他のIdPに変更）することはできません。IdPを変更または削除する必要がある場合は、Customer Portalを通じてお問い合わせください。
+注意：設定後、一度でもユーザーを同期した場合、設定したIdPを削除（削除後他のIdPに変更）することはできません。
+IdPを変更または削除する必要がある場合は、Customer Portalを通じてお問い合わせください。
 </Callout>
 
 ### LDAP連携
@@ -112,7 +113,8 @@ Group Base DN
 必須
 </td>
 <td data-highlight-colour="#ffffff">
-LDAPサーバーのグループBase DN値を入力します。このパスの下位にあるグループのみがGroupとして同期されます。
+LDAPサーバーのグループBase DN値を入力します。
+このパスの下位にあるグループのみがGroupとして同期されます。
 * 例：`dc=example,dc=com`
 </td>
 </tr>
@@ -149,7 +151,7 @@ Membership Type
 </td>
 <td data-highlight-colour="#ffffff">
 ユーザーにグループ情報が含まれている場合、`Include group information in user entries`を選択し、下位フィールドに参照するAttributeを入力します。
-* 例：`member`、`uniqueMember`、`memberUid`など
+* 例: `member`, `uniqueMember`, `memberUid` 등
 </td>
 </tr>
 <tr>
@@ -193,7 +195,7 @@ LDAPで管理中のユーザー属性をQueryPie内Attributeとマッピング�
 右上の`Add Row`ボタンをクリックすると新しいマッピング行が追加され、各行ごとにLDAP Attributeと対応するQueryPie Attributeを指定できます。
 
 1. 該当機能はAdmin &gt; General &gt; User Management &gt; Profile EditorでSource PriorityがInherit from profile sourceに設定されたQueryPie Attributeに限り適用されます。
-2. QueryPie Attributeの`Username (loginId)`、`Primary Email (email)`項目はLDAP連携設定時に別途入力されるため、該当項目はLDAP–QueryPie Attribute Mapping UIには表示されません。
+2. QueryPie Attributeの`Username (loginId)`, `Primary Email (email)`項目はLDAP連携設定時に別途入力されるため、該当項目はLDAP–QueryPie Attribute Mapping UIには表示されません。
 3. マッピング行削除または変更時、Saveボタンをクリックする必要があり、UI上で変更事項が反映され、Synchronizeを追加でクリックする必要があり、LDAPと実際の同期が実行されます。つまり、Saveは画面上変更、Synchronizeはシステム反映を意味します。
 </Callout>
 
@@ -529,5 +531,7 @@ Custom Identity Providerは認証APIサーバーを使用する特殊な場合�
     *  **Allowed User Deletion Rate Threshold :** 
         * 同期時に既存ユーザーがこの値の比率以上で削除された場合、同期を失敗させる機能です。
         * 0～1の間の値を入力します。（基本値は0.1） <br/> 例）既存ユーザー100名、Allowed User Deletion Rate Threshold 0.1の時、再同期時に削除されたユーザーが10名以上なら同期が失敗します。<br/>11.3.0以前バージョンで同期設定がある状態の時、11.3.0以上にアップデートすると1にマイグレーションされます。
+
+
 
 

--- a/src/content/ja/administrator-manual/general/system/integrations/identity-providers/integrating-with-aws-sso-saml-20.mdx
+++ b/src/content/ja/administrator-manual/general/system/integrations/identity-providers/integrating-with-aws-sso-saml-20.mdx
@@ -8,7 +8,8 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-QueryPieではAWS IAM Identity Centerのユーザーを複数のクラウドアプリケーションおよびSAML 2.0を通じてユーザー連携をサポートします。ユーザーを同期してアクセス権限を付与し、ポリシーを適用できます。
+QueryPieではAWS IAM Identity Centerのユーザーを複数のクラウドアプリケーションおよびSAML 2.0を通じてユーザー連携をサポートします。
+ユーザーを同期してアクセス権限を付与し、ポリシーを適用できます。
 
 <Callout type="important">
 QueryPieのIdentity Providers Integration設定でSAMLをTypeとして選択して設定すると、スケジュールによる定期的な同期はサポートしません。

--- a/src/content/ja/administrator-manual/general/system/integrations/integrating-with-event-callback.mdx
+++ b/src/content/ja/administrator-manual/general/system/integrations/integrating-with-event-callback.mdx
@@ -6,7 +6,8 @@ title: 'Event Callback連携'
 
 ### Overview
 
-Event Callback連携はウェブフック（Webhook）を通じてQueryPieで発生するシステムイベントを顧客社のアプリケーションにリアルタイム送信する機能です。これを通じて主要システムイベント通知を外部サービスと統合して管理できます。
+Event Callback連携はウェブフック（Webhook）を通じてQueryPieで発生するシステムイベントを顧客社のアプリケーションにリアルタイム送信する機能です。
+これを通じて主要システムイベント通知を外部サービスと統合して管理できます。
 
 
 ### Event Callback設定
@@ -36,6 +37,12 @@ Event Callback Integration詳細ページ
         * `USER_DELETED`: ユーザー削除
     *  **Authorization Header** : ウェブフックリクエスト時セキュリティ認証のために必要な認証ヘッダー値を入力します。（例：Authorization: Bearer &lt;token&gt;）
     *  **Description** : 設定に対する説明を入力します。（選択事項）<br/>
+      <figure data-layout="center" data-align="center">
+      ![Event Callback設定ポップアップダイアログ](/administrator-manual/general/system/integrations/integrating-with-event-callback/Screenshot-2025-08-25-at-6.06.50-PM.png)
+      <figcaption>
+      Event Callback設定ポップアップダイアログ
+      </figcaption>
+      </figure>
 
 
 1. `Create`ボタンを押して設定を保存します。
@@ -52,5 +59,8 @@ Event Callback Integration詳細ページ
 1. Administrator &gt; General &gt; System &gt; Integrationsメニューに移動します。
 2. Event Callbackタイルをクリックして詳細ページに移動します。
 3. 生成されたEvent Callbackリストで削除したい項目の左側チェックボックスをチェックします。
-4. リスト左上部で`Delete`ボタンをクリックします
+4. リスト左上部で`Delete`ボタンをクリックします <br/> 
+  <figure data-layout="center" data-align="center">
+  ![Screenshot-2025-08-25-at-6.14.27-PM.png](/administrator-manual/general/system/integrations/integrating-with-event-callback/Screenshot-2025-08-25-at-6.14.27-PM.png)
+  </figure>
 5. 確認ウィンドウが表示されると削除を進行して設定を削除します。

--- a/src/content/ja/administrator-manual/general/system/integrations/integrating-with-syslog.mdx
+++ b/src/content/ja/administrator-manual/general/system/integrations/integrating-with-syslog.mdx
@@ -63,3 +63,4 @@ Administrator &gt; General &gt; System &gt; Integrations &gt; Syslog &gt; Config
 ![image-20251009-045004.png](/administrator-manual/general/system/integrations/integrating-with-syslog/image-20251009-045004.png)
 </figure>
 
+

--- a/src/content/ja/administrator-manual/general/system/integrations/oauth-client-application.mdx
+++ b/src/content/ja/administrator-manual/general/system/integrations/oauth-client-application.mdx
@@ -6,7 +6,8 @@ title: 'OAuth Client Application'
 
 ### Overview
 
-他の外部アプリケーションでユーザーを認証し、データにアクセスできるようにQueryPieがOAuth 2.0 Provider役割を実行できます。外部アプリケーションをクライアントとして登録し、QueryPieが認証トークンを発行して安全にクエリパイのリソースにアクセスできるようにします。
+他の外部アプリケーションでユーザーを認証し、データにアクセスできるようにQueryPieがOAuth 2.0 Provider役割を実行できます。
+外部アプリケーションをクライアントとして登録し、QueryPieが認証トークンを発行して安全にクエリパイのリソースにアクセスできるようにします。
 
 ### OAuth Client Application登録
 

--- a/src/content/ja/administrator-manual/general/user-management/authentication/integrating-with-aws-sso.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/authentication/integrating-with-aws-sso.mdx
@@ -6,7 +6,8 @@ title: 'AWS SSO連携'
 
 ### Overview
 
-QueryPieではAWS IAM Identity Centerのユーザーを複数のクラウドアプリケーションおよびSAML 2.0を通じてユーザー連携をサポートします。ユーザーを同期してアクセス権限を付与しポリシーを適用できます。
+QueryPieではAWS IAM Identity Centerのユーザーを複数のクラウドアプリケーションおよびSAML 2.0を通じてユーザー連携をサポートします。
+ユーザーを同期してアクセス権限を付与しポリシーを適用できます。
 
 ### AWS IAM Identity CenterでQueryPieをアプリケーションとして追加
 
@@ -20,7 +21,7 @@ QueryPieではAWS IAM Identity Centerのユーザーを複数のクラウドア�
 4. ユーザー指定SAML 2.0アプリケーション追加オプション選択後次ボタンをクリックします。
 5. アプリケーション構成 &gt; 表示名にQueryPieを入力します。
 6. アプリケーション属性 &gt; アプリケーション開始URL項目にQueryPieがインストールされたドメインアドレスを以下のように入力します。
-    1. アプリケーションStart URL : https://`{querypie_host}`/saml/login
+    1. アプリケーションStart URL : https://`{querypie_host}`
 7. アプリケーションメタデータ項目にそれぞれ以下のように入力します。
     1. アプリケーションACS URL : https://`{querypie_host}`/saml/sp/acs
     2. アプリケーションSAML対象 : https://`{querypie_host}`/saml/sp/metadata
@@ -44,7 +45,7 @@ QueryPieではAWS IAM Identity Centerのユーザーを複数のクラウドア�
 | loginId               | $`{user:email}`                                  | basic        |
 | email                 | $`{user:email}`                                  | basic        |
 
-`変更事項保存`ボタンをクリックして保存します。
+`変更事項保存` ボタンをクリックして保存します。
 
 ### QueryPieでAWS IAM Identity Center連携設定
 

--- a/src/content/ja/administrator-manual/general/user-management/authentication/integrating-with-ldap.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/authentication/integrating-with-ldap.mdx
@@ -93,7 +93,7 @@ Membership Type
 </td>
 <td>
 ユーザーにグループ情報が含まれる場合、`Include group information in user entries`を選択し、下部フィールドに参照するAttributeを入力します。
-* 例：`member`、`uniqueMember`、`memberUid`など
+* 例：`member`, `uniqueMember`, `memberUid` など
 </td>
 </tr>
 <tr>
@@ -146,7 +146,7 @@ LDAPで管理中のユーザー属性をQueryPie内Attributeとマッピング�
 右上の`Add Row`ボタンをクリックすると新しいマッピング行が追加され、各行ごとにLDAP Attributeと対応するQueryPie Attributeを指定できます。
 
 1. 該当機能はAdmin &gt; General &gt; User Management &gt; Profile EditorでSource PriorityがInherit from profile sourceに設定されたQueryPie Attributeに限り適用されます。
-2. QueryPie Attributeである`Username (loginId)`、`Primary Email (email)`項目はLDAP連携設定時別途入力されるため、該当項目はLDAP–QueryPie Attribute Mapping UIには表示されません。
+2. QueryPie Attributeである`Username (loginId)`, `Primary Email (email)` 項目はLDAP連携設定時別途入力されるため、該当項目はLDAP–QueryPie Attribute Mapping UIには表示されません。
 3. マッピング行削除または変更時、Save ChangesをクリックしなければUI上で変更事項が反映されず、Synchronizeを追加でクリックしなければLDAPと実際の同期が実行されます。つまり、Save Changesは画面上変更、Synchronizeはシステム反映を意味します。
 </Callout>
 
@@ -188,7 +188,7 @@ LDAP Attribute
 </td>
 <td>
 連携するLDAP Attributeを入力します
-* 例：`manager`、`mobile`など
+* 例：`manager`, `mobile` など
 </td>
 </tr>
 <tr>
@@ -200,7 +200,7 @@ QueryPie Attribute
 </td>
 <td>
 マッピング対象となるQueryPie Attributeを選択します。リストにはProfile EditorでInherit from profile sourceに設定された項目のみ表示され、Display NameとVariable Nameが一緒に表示されます。
-* 例：`Manager ID (managerId)`、<br/>`Mobile Phone (mobilePhone)`など
+* 例：`Manager ID (managerId)`, <br/>`Mobile Phone (mobilePhone)` など
 </td>
 </tr>
 </tbody>
@@ -238,5 +238,17 @@ QueryPie Attribute
 
 ### QueryPieでLDAP認証してログイン
 
-1. Administrator &gt; General &gt; User Management &gt; UsersまたはGroupsメニューで同期されたユーザーおよびグループを確認できます。
+1. Administrator &gt; General &gt; User Management &gt; UsersまたはGroupsメニューで同期されたユーザーおよびグループを確認できます。 <br/>  
+  <figure data-layout="center" data-align="center">
+  ![Admin &gt; General &gt; User Management &gt; Users](/administrator-manual/general/user-management/authentication/integrating-with-ldap/screenshot-20241209-215940.png)
+  <figcaption>
+  Admin &gt; General &gt; User Management &gt; Users
+  </figcaption>
+  </figure>
 2. これでログインページでIDおよびPassword項目にLDAP認証情報を入力後ログインできます。
+  <figure data-layout="center" data-align="center">
+  ![QueryPie Log In](/administrator-manual/general/user-management/authentication/integrating-with-ldap/image-20240723-063737.png)
+  <figcaption>
+  QueryPie Log In
+  </figcaption>
+  </figure>

--- a/src/content/ja/administrator-manual/general/user-management/provisioning/okta-provisioning-integration-guide.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/provisioning/okta-provisioning-integration-guide.mdx
@@ -7,7 +7,8 @@ import { Callout } from 'nextra/components'
 # [Okta]プロビジョニング連動ガイド
 
 <Callout type="info">
-本ガイドは、OktaのApp Integration Wizard（AIW）を基にQueryPieとSCIM連動を実装する方法を案内します。本製品のSCIM機能はRPC 7643を基にSCIM 2.0基本規格に合わせて製作されたため、他社Identity Provider連動時にも該当ガイドに従って必要な情報をQueryPieで収集して連動を進行してください。
+本ガイドは、OktaのApp Integration Wizard（AIW）を基にQueryPieとSCIM連動を実装する方法を案内します。
+本製品のSCIM機能はRPC 7643を基にSCIM 2.0基本規格に合わせて製作されたため、他社Identity Provider連動時にも該当ガイドに従って必要な情報をQueryPieで収集して連動を進行してください。
 </Callout>
 
 ### Prerequisites
@@ -39,15 +40,15 @@ Okta APIを活用したアウトバウンドユーザー同期を設定する予
 #### OktaカスタムSCIMアプリ生成
 
 <figure data-layout="center" data-align="center">
-![Okta Admin Console > Applications > Applications > Create App Integration > SAML 2.0 > Configure SAML](/administrator-manual/general/user-management/provisioning/okta-provisioning-integration-guide/image-20240723-050205.png)
+![Okta Admin Console &gt; Applications &gt; Applications &gt; Create App Integration &gt; SAML 2.0 &gt; Configure SAML](/administrator-manual/general/user-management/provisioning/okta-provisioning-integration-guide/image-20240723-050205.png)
 <figcaption>
-Okta Admin Console > Applications > Applications > Create App Integration > SAML 2.0 > Configure SAML
+Okta Admin Console &gt; Applications &gt; Applications &gt; Create App Integration &gt; SAML 2.0 &gt; Configure SAML
 </figcaption>
 </figure>
 
 1. [Oktaサービス](https://login.okta.com/)に接続して管理者アカウントでログインします。
 2. 右上の`Admin`ボタンをクリックして管理者コンソールに接続します。
-3. Okta管理者ページの左側パネルでApplications > Applicationsメニューに移動します。
+3. Okta管理者ページの左側パネルでApplications &gt; Applicationsメニューに移動します。
 4. `Create App Integration`ボタンをクリックします。
 5. カスタムSCIM連動を目的としてSign-in methodで**SAML 2.0**オプションを選択した後、`Next`ボタンをクリックします。
 6. General SettingsステップでGeneral Settings内の値を適切に定義した後、下部の`Next`ボタンをクリックします。
@@ -72,9 +73,9 @@ Okta Admin Console > Applications > Applications > Create App Integration > SAML
 #### Okta-QueryPie Provisioning連動
 
 <figure data-layout="center" data-align="center">
-![Okta Admin Console > Applications > Applications > Custom SCIM App > Provisioning > Integration](/administrator-manual/general/user-management/provisioning/okta-provisioning-integration-guide/image-20240723-054522.png)
+![Okta Admin Console &gt; Applications &gt; Applications &gt; Custom SCIM App &gt; Provisioning &gt; Integration](/administrator-manual/general/user-management/provisioning/okta-provisioning-integration-guide/image-20240723-054522.png)
 <figcaption>
-Okta Admin Console > Applications > Applications > Custom SCIM App > Provisioning > Integration
+Okta Admin Console &gt; Applications &gt; Applications &gt; Custom SCIM App &gt; Provisioning &gt; Integration
 </figcaption>
 </figure>
 
@@ -93,7 +94,7 @@ Okta Admin Console > Applications > Applications > Custom SCIM App > Provisionin
         * Push Groups
         * Import Groups
     4. Authentication Mode：「**HTTP Header**」
-    5. HTTP Header > Authorization：QueryPieで生成したSCIM専用access token値を挿入します。
+    5. HTTP Header &gt; Authorization：QueryPieで生成したSCIM専用access token値を挿入します。
 3. Test Connector Configurationボタンを押して接続テストを進行します。
 4. 「*Connector configured successfully*」文句と共にポップアップが現れると、`Close`ボタンをクリックします。
 5. 下部の`Save`ボタンを押して接続設定を保存します。
@@ -104,9 +105,9 @@ Okta Admin Console > Applications > Applications > Custom SCIM App > Provisionin
 #### SCIM API有効化およびチェック
 
 <figure data-layout="center" data-align="center">
-![Okta Admin Console > Applications > Applications > Custom SCIM App > Provisioning > To App](/administrator-manual/general/user-management/provisioning/okta-provisioning-integration-guide/image-20240430-034915.png)
+![Okta Admin Console &gt; Applications &gt; Applications &gt; Custom SCIM App &gt; Provisioning &gt; To App](/administrator-manual/general/user-management/provisioning/okta-provisioning-integration-guide/image-20240430-034915.png)
 <figcaption>
-Okta Admin Console > Applications > Applications > Custom SCIM App > Provisioning > To App
+Okta Admin Console &gt; Applications &gt; Applications &gt; Custom SCIM App &gt; Provisioning &gt; To App
 </figcaption>
 </figure>
 
@@ -140,7 +141,7 @@ QueryPieプロファイル内のstaticIp、macAddressなど一部attribute項目
 
 ##### [OktaでCustom Attributeを設定する例]
 
-1. SCIMアプリのProvisioningタブ > To App下部の`Go to Profile Editor`をクリックします。
+1. SCIMアプリのProvisioningタブ &gt; To App下部の`Go to Profile Editor`をクリックします。
   <figure data-layout="center" data-align="center">
   ![image-20240712-082412.png](/administrator-manual/general/user-management/provisioning/okta-provisioning-integration-guide/image-20240712-082412.png)
   </figure>
@@ -189,9 +190,9 @@ QueryPieプロファイル内のstaticIp、macAddressなど一部attribute項目
 #### グループProvisioningチェック
 
 <figure data-layout="center" data-align="center">
-![Okta Admin Console > Applications > Applications > Custom SCIM App > Push Groups](/administrator-manual/general/user-management/provisioning/okta-provisioning-integration-guide/image-20240430-062231.png)
+![Okta Admin Console &gt; Applications &gt; Applications &gt; Custom SCIM App &gt; Push Groups](/administrator-manual/general/user-management/provisioning/okta-provisioning-integration-guide/image-20240430-062231.png)
 <figcaption>
-Okta Admin Console > Applications > Applications > Custom SCIM App > Push Groups
+Okta Admin Console &gt; Applications &gt; Applications &gt; Custom SCIM App &gt; Push Groups
 </figcaption>
 </figure>
 

--- a/src/content/ja/administrator-manual/general/user-management/users.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/users.mdx
@@ -53,7 +53,8 @@ Descriptionタイプ別表示
 
 ### 手動でユーザー追加
 
-組織に新しいユーザーを手動で追加します。ユーザーを追加した後、グループおよびポリシーに割り当てて権限を付与できます。
+組織に新しいユーザーを手動で追加します。
+ユーザーを追加した後、グループおよびポリシーに割り当てて権限を付与できます。
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; General &gt; User Management &gt; Users &gt; Add User](/administrator-manual/general/user-management/users/screenshot-20240726-093805.png)
@@ -107,7 +108,11 @@ Administrator &gt; General &gt; User Management &gt; Users
 
 ### ユーザー詳細情報照会
 
-Usersページでユーザーをクリックすると詳細情報ページに進入します。登録された情報の照会およびユーザー管理作業を実行できます。ユーザープロファイルに登録された属性でAttribute-based Access Control（ABAC）を実装できます。ユーザー詳細情報はそれぞれProfile、Groups、Admin Roles、Allowed Zones、Tagsタブで区分されます。各項目別説明は[ユーザープロファイル文書](users/user-profile)を参照してください。
+Usersページでユーザーをクリックすると詳細情報ページに進入します。
+登録された情報の照会およびユーザー管理作業を実行できます。
+ユーザープロファイルに登録された属性でAttribute-based Access Control（ABAC）を実装できます。
+ユーザー詳細情報はそれぞれProfile、Groups、Admin Roles、Allowed Zones、Tagsタブで区分されます。
+各項目別説明は[ユーザープロファイル文書](users/user-profile)を参照してください。
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; General &gt; User Management &gt; Users &gt; List Details](/administrator-manual/general/user-management/users/screenshot-20240726-093748.png)

--- a/src/content/ja/administrator-manual/general/user-management/users/user-profile.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/users/user-profile.mdx
@@ -16,18 +16,18 @@ import { Callout } from 'nextra/components'
 ユーザーのAttribute（属性）を照会できるタブです。各Attribute別説明はこのページ下部の**参照：ユーザーAttributeリスト**項目を参照してください。
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; General &gt; User Management &gt; Users > List Details > Profileタブ](/administrator-manual/general/user-management/users/user-profile/image-20240526-063720.png)
+![Administrator &gt; General &gt; User Management &gt; Users &gt; List Details &gt; Profileタブ](/administrator-manual/general/user-management/users/user-profile/image-20240526-063720.png)
 <figcaption>
-Administrator &gt; General &gt; User Management &gt; Users > List Details > Profileタブ
+Administrator &gt; General &gt; User Management &gt; Users &gt; List Details &gt; Profileタブ
 </figcaption>
 </figure>
 
 ### Groups
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; General &gt; User Management &gt; Users > List Details > Groupsタブ](/administrator-manual/general/user-management/users/user-profile/image-20240514-162350.png)
+![Administrator &gt; General &gt; User Management &gt; Users &gt; List Details &gt; Groupsタブ](/administrator-manual/general/user-management/users/user-profile/image-20240514-162350.png)
 <figcaption>
-Administrator &gt; General &gt; User Management &gt; Users > List Details > Groupsタブ
+Administrator &gt; General &gt; User Management &gt; Users &gt; List Details &gt; Groupsタブ
 </figcaption>
 </figure>
 
@@ -40,9 +40,9 @@ Administrator &gt; General &gt; User Management &gt; Users > List Details > Grou
 ### Admin Roles
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; General &gt; User Management &gt; Users > List Details > Admin Rolesタブ](/administrator-manual/general/user-management/users/user-profile/image-20240514-162730.png)
+![Administrator &gt; General &gt; User Management &gt; Users &gt; List Details &gt; Admin Rolesタブ](/administrator-manual/general/user-management/users/user-profile/image-20240514-162730.png)
 <figcaption>
-Administrator &gt; General &gt; User Management &gt; Users > List Details > Admin Rolesタブ
+Administrator &gt; General &gt; User Management &gt; Users &gt; List Details &gt; Admin Rolesタブ
 </figcaption>
 </figure>
 


### PR DESCRIPTION
## Description

한국어 원문과 일본어 번역문의 문서가 불일치하는 경우를 찾아 일본어 번역문을 수정합니다.
- **문장 구조 개선**: 긴 문장을 여러 줄로 분리하여 가독성 향상
- **포맷팅 정리**: 공백 및 구두점 형식 통일
- **문서 보강**: Event Callback, LDAP 연동 가이드에 스크린샷 이미지 추가
- **HTML 엔티티 수정**: `>` 기호를 `&gt;`로 변경하여 올바른 렌더링 보장
- **문서 구조 개선**: 불필요한 공백 제거 및 문장 분리

### 수정된 파일

DB 연결, 회사 관리, 시스템 통합, 인증, 프로비저닝, 사용자 관리 관련 문서 14개 파일 수정 (76 insertions, 41 deletions)

