### PR TITLE
skill: translation, mdx-skeleton-comparison

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,40 @@
+# Claude Skills for QueryPie Documentation
+
+This directory contains Claude skills that help with various tasks in the QueryPie documentation repository.
+
+## Available Skills
+
+### Documentation Skills
+- **documentation.md** - Guidelines for writing and editing MDX documentation files
+- **translation.md** - Guidelines for translating content between languages (en, ja, ko)
+- **confluence-mdx.md** - Guidelines for working with Confluence to MDX conversion workflows
+- **mdx-skeleton-comparison.md** - Guidelines for detecting inconsistencies between original and translated MDX files using skeleton comparison
+
+### Development Skills
+- **code-review.md** - Guidelines for reviewing code changes in this repository
+
+## Usage
+
+These skills are automatically available to Claude when working in this repository. They provide context-specific guidance for:
+
+- Writing and maintaining MDX documentation
+- Translating content across multiple languages
+- Working with Confluence conversion scripts
+- Detecting inconsistencies between original and translated MDX files
+- Reviewing code changes
+
+## Project Structure
+
+This repository uses:
+- **Next.js 15** with **Nextra 4** for documentation
+- **TypeScript 5** for type safety
+- **React 19** for UI components
+- **MDX** format for content files
+- Multi-language support: English (en), Japanese (ja), Korean (ko)
+
+## Content Locations
+
+- Source content: `src/content/{lang}/`
+- Confluence conversion scripts: `confluence-mdx/bin/`
+- Public assets: `public/`
+

--- a/.claude/skills/code-review.md
+++ b/.claude/skills/code-review.md
@@ -1,0 +1,257 @@
+# Code Review Guidelines
+
+## Overview
+
+This skill provides guidelines for reviewing code changes in the QueryPie documentation repository.
+
+## Project Context
+
+- **Framework**: Next.js 15 with Nextra 4
+- **Language**: TypeScript 5, React 19
+- **Content**: MDX files for documentation
+- **Build System**: npm-based with Vercel deployment
+
+## Review Focus Areas
+
+### 1. Code Quality
+
+#### TypeScript
+
+- **Type Safety**: Ensure proper type annotations
+- **No `any` Types**: Avoid `any` unless absolutely necessary
+- **Type Definitions**: Check that types are properly defined
+- **Error Handling**: Verify error handling is appropriate
+
+#### React Components
+
+- **Component Structure**: Check component organization
+- **Props Types**: Verify prop types are defined
+- **Hooks Usage**: Ensure hooks follow React rules
+- **Performance**: Look for unnecessary re-renders
+
+#### Code Style
+
+- **Consistency**: Follow existing code style
+- **Naming**: Use clear, descriptive names
+- **Comments**: Code comments should be in English (project preference)
+- **Formatting**: Check indentation and spacing
+
+### 2. Documentation Content
+
+#### MDX Files
+
+- **Frontmatter**: Verify frontmatter is correct
+- **Structure**: Check heading hierarchy
+- **Links**: Verify internal and external links work
+- **Images**: Ensure image paths are correct
+- **Multi-language**: Check all three language versions (en, ja, ko) if applicable
+
+#### Content Quality
+
+- **Accuracy**: Verify technical accuracy
+- **Completeness**: Check that content is complete
+- **Consistency**: Ensure consistency across language versions
+- **Formatting**: Verify markdown formatting is correct
+
+### 3. Build and Deployment
+
+#### Build Process
+
+- **No Build Errors**: Ensure `npm run build` succeeds
+- **Type Errors**: Check for TypeScript compilation errors
+- **Linting**: Verify no linting errors
+- **Warnings**: Review and address warnings
+
+#### Deployment
+
+- **Vercel Configuration**: Check `vercel.json` if modified
+- **Environment Variables**: Verify environment variables are documented
+- **Deployment Scripts**: Review `scripts/deploy/` changes
+
+### 4. Testing
+
+#### Test Coverage
+
+- **New Features**: Ensure new features have tests
+- **Test Quality**: Verify tests are meaningful
+- **Test Execution**: Check that tests pass
+
+#### Manual Testing
+
+- **Local Dev**: Verify `npm run dev` works
+- **Content Rendering**: Check that MDX renders correctly
+- **Navigation**: Verify navigation works
+- **Responsive**: Check responsive design if UI changes
+
+## Review Checklist
+
+### Pre-Review
+
+- [ ] PR description is clear
+- [ ] Changes are logically grouped
+- [ ] Related issues are referenced
+
+### Code Review
+
+- [ ] Code follows project conventions
+- [ ] No obvious bugs or issues
+- [ ] Error handling is appropriate
+- [ ] Performance considerations addressed
+- [ ] Security concerns addressed (if applicable)
+
+### Documentation Review
+
+- [ ] MDX files have correct frontmatter
+- [ ] All three language versions updated (if applicable)
+- [ ] Links are working
+- [ ] Images are properly referenced
+- [ ] Content is accurate and complete
+- [ ] Formatting is consistent
+
+### Build and Test
+
+- [ ] Build succeeds without errors
+- [ ] No TypeScript errors
+- [ ] No linting errors
+- [ ] Tests pass (if applicable)
+- [ ] Local dev server works
+
+### Final Check
+
+- [ ] All review comments addressed
+- [ ] No merge conflicts
+- [ ] Ready for merge
+
+## Common Issues to Watch For
+
+### TypeScript Issues
+
+- Missing type annotations
+- Use of `any` type
+- Incorrect type definitions
+- Missing null checks
+
+### React Issues
+
+- Missing key props in lists
+- Incorrect hook usage
+- Memory leaks (missing cleanup)
+- Unnecessary re-renders
+
+### MDX Issues
+
+- Missing frontmatter
+- Broken markdown syntax
+- Incorrect image paths
+- Broken internal links
+- Inconsistent structure across languages
+
+### Build Issues
+
+- Import errors
+- Missing dependencies
+- Configuration errors
+- Type errors
+
+## Review Comments
+
+### Providing Feedback
+
+1. **Be Specific**: Point to exact lines or sections
+2. **Be Constructive**: Suggest improvements, not just problems
+3. **Be Respectful**: Maintain professional tone
+4. **Explain Why**: Help understand the reasoning
+
+### Comment Types
+
+- **Must Fix**: Critical issues that must be addressed
+- **Should Fix**: Important issues that should be addressed
+- **Nice to Have**: Suggestions for improvement
+- **Questions**: Clarifications needed
+
+## Language-Specific Considerations
+
+### Multi-language Content
+
+When reviewing documentation changes:
+
+1. **Check All Languages**: Verify en, ja, ko versions
+2. **Structure Alignment**: Ensure same structure across languages
+3. **Link Consistency**: Check links work in all languages
+4. **Translation Quality**: Verify translations are accurate
+
+### Code Comments
+
+- Code comments should be in English (project preference)
+- Comments should explain "why" not "what"
+- Keep comments up to date with code changes
+
+## Automated Checks
+
+### Before Review
+
+- Check CI/CD status
+- Review automated test results
+- Check linting results
+- Verify build status
+
+### Tools
+
+- **TypeScript Compiler**: Type checking
+- **ESLint**: Code linting
+- **Build Process**: Compilation check
+- **Vercel Preview**: Deployment preview
+
+## Best Practices
+
+1. **Review Promptly**: Don't let PRs sit for too long
+2. **Be Thorough**: Check all aspects, not just code
+3. **Test Locally**: If possible, test changes locally
+4. **Communicate Clearly**: Use clear, specific feedback
+5. **Approve When Ready**: Don't block on minor issues
+6. **Follow Up**: Check that feedback is addressed
+
+## Special Cases
+
+### Large PRs
+
+- Break into smaller PRs if possible
+- Focus on high-level structure first
+- Review incrementally if needed
+
+### Refactoring
+
+- Ensure functionality is preserved
+- Check test coverage
+- Verify no regressions
+
+### New Features
+
+- Check documentation is updated
+- Verify all language versions updated
+- Ensure tests are included
+
+### Bug Fixes
+
+- Verify the fix addresses the issue
+- Check for similar issues elsewhere
+- Ensure tests prevent regression
+
+## Approval Criteria
+
+A PR should be approved when:
+
+1. Code quality is good
+2. Documentation is accurate and complete
+3. Build succeeds
+4. Tests pass (if applicable)
+5. No critical issues remain
+6. Minor issues can be addressed in follow-up
+
+## Resources
+
+- **Project README**: `/README.md`
+- **Development Guide**: `/docs/DEVELOPMENT.md`
+- **Confluence Workflow**: `/confluence-mdx/README.md`
+- **Build Commands**: See `package.json` scripts
+

--- a/.claude/skills/confluence-mdx.md
+++ b/.claude/skills/confluence-mdx.md
@@ -1,0 +1,298 @@
+# Confluence to MDX Conversion Guidelines
+
+## Overview
+
+This skill provides guidelines for working with the Confluence to MDX conversion workflow in the QueryPie documentation repository.
+
+## Project Context
+
+- **Conversion Scripts**: Located in `confluence-mdx/bin/`
+- **Python Environment**: Uses Python 3 with virtual environment
+- **Input Format**: Confluence XHTML exports
+- **Output Format**: MDX files in `src/content/{lang}/`
+- **Workflow**: Multi-step process from Confluence to final MDX
+
+## Directory Structure
+
+```
+confluence-mdx/
+├── bin/                    # Conversion scripts
+│   ├── pages_of_confluence.py
+│   ├── translate_titles.py
+│   ├── generate_commands_for_xhtml2markdown.py
+│   ├── confluence_xhtml_to_markdown.py
+│   └── xhtml2markdown.ko.sh
+├── var/                    # Working directory for Confluence data
+│   ├── list.txt           # Page list (Korean titles)
+│   ├── list.en.txt        # Page list (English titles)
+│   └── {page_id}/         # Per-page data
+│       ├── page.yaml      # Page metadata
+│       └── page.xhtml     # Page content
+├── etc/                    # Configuration and translation files
+│   └── korean-titles-translations.txt
+├── target/                 # Output directory
+│   ├── en/
+│   ├── ja/
+│   ├── ko/
+│   └── public/            # Public assets
+└── tests/                  # Test cases
+    └── testcases/
+```
+
+## Conversion Workflow
+
+### Step 1: Collect Confluence Data
+
+**Script**: `pages_of_confluence.py`
+
+**Purpose**: Download pages and metadata from Confluence API
+
+**Usage**:
+```bash
+cd confluence-mdx
+source venv/bin/activate
+
+# Full download with attachments (first time or when attachments change)
+python bin/pages_of_confluence.py --attachments
+
+# Regular update (pages only)
+python bin/pages_of_confluence.py
+
+# Update specific page and children
+python bin/pages_of_confluence.py --page-id 123456789 --attachments
+
+# Generate/update list.txt from local data
+python bin/pages_of_confluence.py --local >var/list.txt
+```
+
+**Output**:
+- `var/list.txt`: Tab-separated list of pages (ID, path, title)
+- `var/{page_id}/page.yaml`: Page metadata
+- `var/{page_id}/page.xhtml`: Page content in XHTML format
+- `var/{page_id}/attachments/`: Downloaded attachments (if `--attachments` used)
+
+### Step 2: Translate Titles
+
+**Script**: `translate_titles.py`
+
+**Purpose**: Translate Korean page titles to English
+
+**Usage**:
+```bash
+python bin/translate_titles.py
+```
+
+**Input**: `var/list.txt` (Korean titles)
+**Output**: `var/list.en.txt` (English titles)
+**Translation Source**: `etc/korean-titles-translations.txt`
+
+**Note**: If titles are not translated, update `etc/korean-titles-translations.txt`
+
+### Step 3: Generate Conversion Commands
+
+**Script**: `generate_commands_for_xhtml2markdown.py`
+
+**Purpose**: Generate shell script with conversion commands
+
+**Usage**:
+```bash
+python bin/generate_commands_for_xhtml2markdown.py var/list.en.txt >bin/xhtml2markdown.ko.sh
+chmod +x bin/xhtml2markdown.ko.sh
+```
+
+**Output**: `bin/xhtml2markdown.ko.sh` - Executable script with conversion commands
+
+### Step 4: Convert XHTML to MDX
+
+**Script**: `xhtml2markdown.ko.sh` (generated in step 3)
+
+**Purpose**: Execute conversion of all XHTML files to MDX
+
+**Usage**:
+```bash
+./bin/xhtml2markdown.ko.sh
+```
+
+**Process**: 
+- Calls `confluence_xhtml_to_markdown.py` for each page
+- Converts XHTML to Markdown/MDX format
+- Handles special cases: code blocks, tables, macros, etc.
+
+**Output**:
+- `target/ko/`: MDX files for Korean content
+- `target/public/`: Public assets (images, attachments)
+
+## Core Conversion Script
+
+### confluence_xhtml_to_markdown.py
+
+**Purpose**: Convert individual XHTML file to Markdown/MDX
+
+**Usage**:
+```bash
+python bin/confluence_xhtml_to_markdown.py input.xhtml output.mdx
+```
+
+**Features**:
+- Handles CDATA sections in code blocks
+- Converts tables with colspan/rowspan
+- Processes Confluence-specific macros
+- Preserves structure and formatting
+
+## Testing
+
+### Test Framework
+
+**Location**: `confluence-mdx/tests/`
+
+**Test Cases**: `tests/testcases/`
+- Each test case has:
+  - `page.xhtml`: Input XHTML
+  - `expected.mdx`: Expected output
+  - `output.mdx`: Generated output (created during test)
+
+### Running Tests
+
+```bash
+cd confluence-mdx/tests
+
+# Run all tests
+make test
+
+# Run specific test
+make test-one TEST_ID=<test_id>
+
+# Run with debug logging
+make debug
+
+# Clean output files
+make clean
+```
+
+## Common Tasks
+
+### Adding New Pages from Confluence
+
+1. Download new pages:
+   ```bash
+   python bin/pages_of_confluence.py --page-id <new_page_id> --attachments
+   ```
+
+2. Update list:
+   ```bash
+   python bin/pages_of_confluence.py --local >var/list.txt
+   ```
+
+3. Translate titles:
+   ```bash
+   python bin/translate_titles.py
+   ```
+
+4. Regenerate conversion script:
+   ```bash
+   python bin/generate_commands_for_xhtml2markdown.py var/list.en.txt >bin/xhtml2markdown.ko.sh
+   ```
+
+5. Convert:
+   ```bash
+   ./bin/xhtml2markdown.ko.sh
+   ```
+
+### Updating Existing Pages
+
+1. Download updated pages:
+   ```bash
+   python bin/pages_of_confluence.py --page-id <page_id>
+   ```
+
+2. Convert only changed pages:
+   ```bash
+   # Manual conversion for specific page
+   python bin/confluence_xhtml_to_markdown.py \
+     var/{page_id}/page.xhtml \
+     target/ko/path/to/page.mdx
+   ```
+
+### Handling Translation Issues
+
+If titles are not properly translated:
+
+1. Check `etc/korean-titles-translations.txt`
+2. Add missing translations in format:
+   ```
+   Korean Title<TAB>English Title
+   ```
+3. Re-run `translate_titles.py`
+
+## Python Environment Setup
+
+### Initial Setup
+
+```bash
+cd confluence-mdx
+python3 -m venv venv
+source venv/bin/activate
+pip install requests beautifulsoup4 pyyaml
+```
+
+### Activating Environment
+
+```bash
+cd confluence-mdx
+source venv/bin/activate
+```
+
+### Deactivating Environment
+
+```bash
+deactivate
+```
+
+## Best Practices
+
+1. **Backup Before Conversion**: Always backup existing MDX files before running conversion
+2. **Test Locally**: Test converted files with `npm run dev` before committing
+3. **Review Changes**: Manually review converted content, especially:
+   - Code blocks
+   - Tables
+   - Images and links
+   - Special formatting
+4. **Incremental Updates**: Use `--page-id` for updating specific pages instead of full conversion
+5. **Attachment Handling**: Use `--attachments` flag when attachments are updated
+6. **Version Control**: Commit `var/list.txt` and `var/list.en.txt` for tracking
+7. **Translation Maintenance**: Keep `korean-titles-translations.txt` updated
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Missing Translations**: Update `etc/korean-titles-translations.txt`
+2. **Broken Links**: Check image paths and internal links after conversion
+3. **Formatting Issues**: Review special cases in `confluence_xhtml_to_markdown.py`
+4. **API Errors**: Check Confluence API credentials and rate limits
+5. **Test Failures**: Compare `output.mdx` with `expected.mdx` to identify issues
+
+### Debug Mode
+
+Enable debug logging:
+```bash
+python bin/confluence_xhtml_to_markdown.py input.xhtml output.mdx --log-level debug
+```
+
+## Integration with Documentation Workflow
+
+After conversion:
+
+1. Review converted MDX files in `target/ko/`
+2. Copy to `src/content/ko/` (if needed)
+3. Test with local dev server: `npm run dev`
+4. Make manual adjustments if needed
+5. Update other language versions (en, ja) if structure changes
+
+## Notes
+
+- Conversion is primarily for Korean (ko) content
+- English and Japanese versions may need separate workflows
+- Manual editing is often required after conversion
+- Test cases help ensure conversion quality
+

--- a/.claude/skills/documentation.md
+++ b/.claude/skills/documentation.md
@@ -1,0 +1,147 @@
+# Documentation Writing Guidelines
+
+## Overview
+
+This skill provides guidelines for writing and editing MDX documentation files in the QueryPie documentation repository.
+
+## Project Context
+
+- **Framework**: Next.js 15 with Nextra 4
+- **Content Format**: MDX (Markdown with JSX)
+- **Languages**: English (en), Japanese (ja), Korean (ko)
+- **Content Location**: `src/content/{lang}/`
+
+## MDX File Structure
+
+### Frontmatter
+
+Every MDX file must start with frontmatter:
+
+```yaml
+---
+title: 'Page Title'
+---
+```
+
+### Common Imports
+
+For components from Nextra:
+
+```jsx
+import { Callout } from 'nextra/components'
+```
+
+## Writing Guidelines
+
+### Language-Specific Considerations
+
+1. **English (en)**: Primary language, should be clear and professional
+2. **Korean (ko)**: Should maintain consistency with English version
+3. **Japanese (ja)**: Should maintain consistency with English version
+
+### Content Structure
+
+- Use clear headings (H1 for main title, H2 for major sections, H3 for subsections)
+- Include overview sections when appropriate
+- Use Callout components for important information:
+  ```jsx
+  <Callout type="info">
+    Important information here
+  </Callout>
+  ```
+
+### Images
+
+- Store images in `public/` directory
+- Reference images with relative paths: `/user-manual/workflow/screenshot.png`
+- Use figure components for images with captions:
+  ```jsx
+  <figure data-layout="center" data-align="center">
+    ![Image Description](/path/to/image.png)
+    <figcaption>
+      Caption text
+    </figcaption>
+  </figure>
+  ```
+
+### Tables
+
+- Use standard markdown tables
+- Tables can include data attributes for styling:
+  ```markdown
+  <table data-table-width="760" data-layout="default">
+  ```
+
+### Links
+
+- Use relative paths for internal links
+- Format: `[Link Text](relative/path/to/page)`
+- For cross-language links, maintain the same structure
+
+## File Naming Conventions
+
+- Use kebab-case for file names
+- Match the structure across all languages
+- Example: `user-manual/workflow.mdx` exists in `en/`, `ja/`, and `ko/`
+
+## Best Practices
+
+1. **Consistency**: Maintain the same structure across all language versions
+2. **Clarity**: Write clear, concise documentation
+3. **Completeness**: Ensure all three language versions are updated
+4. **Testing**: Verify MDX files render correctly with `npm run dev`
+5. **Accessibility**: Use descriptive alt text for images
+6. **Code Comments**: Write code comments in English (as per project preference)
+
+## Common Tasks
+
+### Adding a New Page
+
+1. Create MDX file in `src/content/{lang}/` for each language
+2. Add frontmatter with title
+3. Write content following the structure guidelines
+4. Add navigation entries if needed
+5. Test locally with `npm run dev`
+
+### Editing Existing Content
+
+1. Locate the file in the appropriate language directory
+2. Make changes while maintaining consistency with other language versions
+3. Update all three language versions if the change affects structure
+4. Test the changes locally
+
+### Adding Images
+
+1. Place image in appropriate `public/` subdirectory
+2. Reference with absolute path from root: `/path/to/image.png`
+3. Use figure component for better presentation
+
+## Code Examples
+
+When including code examples:
+
+- Use appropriate language tags
+- Keep examples simple and relevant
+- Include comments for clarity (in English)
+
+```bash
+npm run dev
+```
+
+```typescript
+// Example TypeScript code
+const example: string = "value";
+```
+
+## Review Checklist
+
+Before committing documentation changes:
+
+- [ ] Frontmatter is correct
+- [ ] All three language versions are updated (if applicable)
+- [ ] Images are properly referenced
+- [ ] Links are working
+- [ ] Content renders correctly in local dev server
+- [ ] Code examples are accurate
+- [ ] No broken markdown syntax
+

--- a/.claude/skills/mdx-skeleton-comparison.md
+++ b/.claude/skills/mdx-skeleton-comparison.md
@@ -1,0 +1,364 @@
+# MDX Skeleton Comparison Guidelines
+
+## Overview
+
+This skill provides guidelines for detecting inconsistencies between original Korean MDX files and their translations (English and Japanese) using the `mdx_to_skeleton.py` tool. The tool converts MDX files to skeleton format (replacing text content with `_TEXT_` placeholders) to compare document structure across languages.
+
+## Purpose
+
+The goal is to identify structural inconsistencies between:
+- **Original MDX files** (Korean): Located in `confluence-mdx/target/ko/`
+- **Translated MDX files** (English): Located in `confluence-mdx/target/en/`
+- **Translated MDX files** (Japanese): Located in `confluence-mdx/target/ja/`
+
+## Tool: mdx_to_skeleton.py
+
+### Location
+
+The tool is located at: `confluence-mdx/bin/mdx_to_skeleton.py`
+
+### How It Works
+
+The `mdx_to_skeleton.py` script converts MDX files to skeleton format by:
+1. Preserving document structure (headers, lists, code blocks, links, etc.)
+2. Replacing all text content with `_TEXT_` placeholder
+3. Maintaining whitespace and formatting structure
+4. Generating `.skel.mdx` files alongside original `.mdx` files
+
+This allows comparison of document structure across languages without being affected by actual text content differences.
+
+### Usage
+
+To check for inconsistencies between original and translated MDX files:
+
+```bash
+cd confluence-mdx/
+source venv/bin/activate  # Activate Python virtual environment
+bin/mdx_to_skeleton.py --recursive --max-diff=20
+```
+
+**Command Options:**
+- `--recursive`: Process directories recursively (defaults to `target/ko`, `target/ja`, `target/en` if no directories specified)
+- `--max-diff=20`: Maximum number of differences to output before stopping (default: 20)
+
+**What It Does:**
+1. Converts all `.mdx` files in `target/ko/`, `target/ja/`, and `target/en/` to `.skel.mdx` format
+2. Compares each translated skeleton file (English/Japanese) with its Korean equivalent
+3. Reports differences in document structure (whitespace, line breaks, formatting)
+4. Shows original `.mdx` file content for each difference found
+
+## Workflow: Detecting and Fixing Inconsistencies
+
+### Step 1: Run the Comparison Tool
+
+Execute the command as shown above. The tool will:
+- Process all MDX files recursively
+- Generate skeleton files (`.skel.mdx`)
+- Compare translated versions with Korean originals
+- Output differences found (up to `--max-diff` limit)
+
+### Step 2: Analyze the Results
+
+The tool outputs differences in two formats:
+1. **Skeleton diff**: Shows differences in `.skel.mdx` files (structure comparison)
+2. **Original content diff**: Shows differences in original `.mdx` files (actual content)
+
+Look for patterns indicating:
+- Whitespace differences (spaces, tabs, indentation)
+- Line break differences
+- Formatting structure differences
+
+### Step 3: Determine the Cause
+
+There are three possible scenarios when inconsistencies are found:
+
+#### Case 1: Original File Changes (Source Document Updates)
+
+**Symptom**: The skeleton comparison shows differences because the original Korean `.mdx` file has been updated after the translation was completed.
+
+**Cause**: The original Korean file was changed for various reasons:
+- Image insertions or additions
+- Typo corrections
+- Product feature improvements requiring documentation updates
+- Document error corrections
+- Content additions or modifications
+
+**Solution**: Compare the original and translated `.mdx` files to identify differences, then update the translation file to reflect the changes in the original.
+
+**Important Notes:**
+- Check the git log of the original Korean MDX file to see when changes were made
+- **For large-scale batch translations completed by September 25, 2025**: Check the git log to identify changes made after that date
+- The git log will show all modifications to the original file since the batch translation
+- Update the translation to match the current state of the original
+- Ensure all new content is properly translated
+- Maintain consistency with the updated original structure
+
+**How to Identify:**
+- Use `git log` to check when the original file was last modified:
+  ```bash
+  git log --follow --oneline src/content/ko/path/to/file.mdx
+  ```
+- For files in `confluence-mdx/target/ko/`:
+  ```bash
+  git log --follow --oneline confluence-mdx/target/ko/path/to/file.mdx
+  ```
+- Filter changes after September 25, 2025 (post-batch-translation):
+  ```bash
+  git log --follow --oneline --since="2025-09-25" src/content/ko/path/to/file.mdx
+  ```
+- Compare the original file with the translation file
+- Look for added sections, modified content, or structural changes
+- Check if images were added or modified
+
+**Example Fix:**
+If the Korean original was updated to add a new section:
+```markdown
+## 설정
+
+이 기능을 사용하면 데이터베이스에 연결할 수 있습니다.
+
+## 새로운 기능
+
+이제 자동 백업을 지원합니다.
+```
+
+The English translation should be updated to include the new section:
+```markdown
+## Setting
+
+You can connect to the database.
+
+## New Feature
+
+Automatic backup is now supported.
+```
+
+**Workflow for Case 1:**
+1. Check git history of the original Korean file to identify when changes were made (especially changes after September 25, 2025 for post-batch-translation updates)
+2. Review the git log to understand what was changed and why (image additions, typo fixes, feature updates, etc.)
+3. Compare the current original file with the translation file
+4. Identify all differences (added, modified, or removed content)
+5. Translate and add new content following `translation.md` guidelines
+6. Update modified sections to match the original
+7. Remove any content that was removed from the original
+
+#### Case 2: Translation Errors (Incorrect or Incomplete Translation)
+
+**Symptom**: The skeleton comparison shows differences indicating issues in the translation file, such as:
+- Whitespace, line breaks, or formatting differences
+- Missing content (parts of the original were not translated)
+- Untranslated content (original Korean text left in translation)
+- Incorrectly translated content (not following guidelines)
+- Added content (text that doesn't exist in the original)
+
+**Cause**: The translation process failed to follow guidelines or had errors, resulting in:
+- **Whitespace/formatting differences**: The translated `.mdx` file has different whitespace or line breaks compared to the Korean original
+- **Translation not following guidelines**: Content translated incorrectly or not according to `translation.md` guidelines
+- **Missing content**: Parts of the original Korean text were not translated (content omission)
+- **Untranslated content**: Original Korean text was left in the translation file instead of being translated
+- **Added content**: Text that doesn't exist in the original Korean file was added to the translation
+
+**Solution**: Compare the original and translated `.mdx` files to identify differences, then fix and supplement the translation file to match the original.
+
+**Important Notes:**
+- Do NOT modify `mdx_to_skeleton.py` to fix translation issues
+- The translation file should match the original's formatting exactly (spaces, tabs, line breaks, indentation)
+- Review the original Korean file and the translated file side by side
+- Ensure all content from the original is properly translated
+- Remove any untranslated Korean text
+- Remove any content that doesn't exist in the original
+- Follow `translation.md` guidelines for proper translation
+- Maintain the same document structure as the original
+- Refer to `translation.md` guidelines for translation formatting requirements
+
+**How to Identify:**
+- Check the original content diff output from the tool
+- Look for whitespace differences (missing spaces after markdown elements)
+- Look for missing sections, paragraphs, or sentences
+- Look for Korean text in English/Japanese translations
+- Look for content in translations that doesn't appear in the original
+
+**Example Fixes:**
+
+**Whitespace/Formatting Fix:**
+If Korean original has:
+```markdown
+**Setting** 문서
+```
+
+And Japanese translation has:
+```markdown
+**Setting**文書
+```
+
+The Japanese translation should be fixed to:
+```markdown
+**Setting** 文書
+```
+(Note the space after `**Setting**`)
+
+**Missing Content Fix:**
+If Korean original has:
+```markdown
+## 설정
+
+이 기능을 사용하면 데이터베이스에 연결할 수 있습니다.
+
+### 주의사항
+
+이 기능은 관리자 권한이 필요합니다.
+```
+
+And English translation has:
+```markdown
+## Setting
+
+You can connect to the database.
+```
+
+The English translation should be updated to include the missing section:
+```markdown
+## Setting
+
+You can connect to the database.
+
+### Note
+
+This feature requires administrator privileges.
+```
+
+#### Case 3: MDX Skeleton Comparison Tool Error
+
+**Symptom**: The skeleton comparison shows differences because the original Korean `.mdx` file has been updated after the translation was completed.
+
+**Cause**: The original Korean file was changed for various reasons:
+- Image insertions or additions
+- Typo corrections
+- Product feature improvements requiring documentation updates
+- Document error corrections
+- Content additions or modifications
+
+**Solution**: Compare the original and translated `.mdx` files to identify differences, then update the translation file to reflect the changes in the original.
+
+**Important Notes:**
+- Check the git log of the original Korean MDX file to see when changes were made
+- **For large-scale batch translations completed by September 25, 2025**: Check the git log to identify changes made after that date
+- The git log will show all modifications to the original file since the batch translation
+- Update the translation to match the current state of the original
+- Ensure all new content is properly translated
+- Maintain consistency with the updated original structure
+
+**How to Identify:**
+- Use `git log` to check when the original file was last modified:
+  ```bash
+  git log --follow --oneline src/content/ko/path/to/file.mdx
+  ```
+- For files in `confluence-mdx/target/ko/`:
+  ```bash
+  git log --follow --oneline confluence-mdx/target/ko/path/to/file.mdx
+  ```
+- Filter changes after September 25, 2025 (post-batch-translation):
+  ```bash
+  git log --follow --oneline --since="2025-09-25" src/content/ko/path/to/file.mdx
+  ```
+- Compare the original file with the translation file
+- Look for added sections, modified content, or structural changes
+- Check if images were added or modified
+
+**Example Fix:**
+If the Korean original was updated to add a new section:
+```markdown
+## 설정
+
+이 기능을 사용하면 데이터베이스에 연결할 수 있습니다.
+
+## 새로운 기능
+
+이제 자동 백업을 지원합니다.
+```
+
+The English translation should be updated to include the new section:
+```markdown
+## Setting
+
+You can connect to the database.
+
+## New Feature
+
+Automatic backup is now supported.
+```
+
+**Workflow for Case 1:**
+1. Check git history of the original Korean file to identify when changes were made (especially changes after September 25, 2025 for post-batch-translation updates)
+2. Review the git log to understand what was changed and why (image additions, typo fixes, feature updates, etc.)
+3. Compare the current original file with the translation file
+4. Identify all differences (added, modified, or removed content)
+5. Translate and add new content following `translation.md` guidelines
+6. Update modified sections to match the original
+7. Remove any content that was removed from the original
+
+## Best Practices
+
+### When to Check for Inconsistencies
+
+- After bulk translation updates
+- Before committing translation changes
+- When reviewing translation quality
+- After manual edits to translated files
+- **After updates to original Korean files**: Check git log for changes made after September 25, 2025 (the date when large-scale batch translation was completed) to identify post-translation updates (Case 1)
+- When reviewing translation completeness
+- When original files are updated due to product feature improvements, typo corrections, or documentation fixes
+
+### Translation Guidelines
+
+When fixing translation files (Case 1, Case 2), follow these guidelines from `translation.md`:
+
+1. **Preserve Formatting**: Maintain exact markdown formatting, line breaks, and whitespace from the Korean original
+2. **Whitespace Consistency**: Ensure spaces around markdown elements match the original
+   - After inline code: `` `code` text `` (space after backtick)
+   - After links: `[text](url) text` (space after closing parenthesis)
+   - After HTML tags: `<br/> text` (space after tag)
+   - After formatting: `**text** text` (space after closing markers)
+3. **Line Breaks**: Match line breaks exactly with the original
+4. **Indentation**: Preserve indentation for lists, code blocks, and nested structures
+
+### Excluding Files from Comparison
+
+Some files may be intentionally different across languages. To exclude files from comparison:
+
+1. Use `--exclude` option:
+   ```bash
+   bin/mdx_to_skeleton.py --recursive --max-diff=5 --exclude /index.skel.mdx /other-file.skel.mdx
+   ```
+
+2. Or configure in `ignore_skeleton_diff.yaml` (see script documentation)
+
+## Related Files
+
+- **Tool Script**: `confluence-mdx/bin/mdx_to_skeleton.py`
+- **Supporting Modules**: 
+  - `confluence-mdx/bin/skeleton_diff.py` - Comparison logic
+  - `confluence-mdx/bin/skeleton_common.py` - Common utilities
+- **Translation Guidelines**: `docs/translation.md`
+- **Test Files**: `confluence-mdx/tests/test_mdx_to_skeleton.py`
+
+## Example Output
+
+When differences are found, the tool outputs:
+
+```
++ diff -u -U 2 -b target/ko/path/file.skel.mdx target/en/path/file.skel.mdx
+--- target/ko/path/file.skel.mdx
++++ target/en/path/file.skel.mdx
+@@ -10,7 +10,7 @@
+  ## _TEXT_
+  
+  _TEXT_
+-**_TEXT_** _TEXT_
++**_TEXT_**_TEXT_
+  
+  _TEXT_
+```
+
+This shows that the English translation is missing a space after `**_TEXT_**`, which should be fixed in the English `.mdx` file.
+

--- a/.claude/skills/translation.md
+++ b/.claude/skills/translation.md
@@ -1,0 +1,312 @@
+# Translation Guidelines
+
+## Overview
+
+This skill provides guidelines for translating content in the QueryPie documentation repository, which supports three languages: English (en), Japanese (ja), and Korean (ko).
+
+**Important**: The source language is **Korean (ko)**, not English. All translations should be done from Korean to English and Japanese.
+
+## Project Context
+
+- **Languages**: English (en), Japanese (ja), Korean (ko)
+- **Content Location**: `src/content/{lang}/`
+- **Source Language**: Korean (ko) - the original content
+- **Target Languages**: English (en), Japanese (ja)
+- **Translation Direction**: ko → en, ko → ja
+
+## Translation Principles
+
+### Consistency
+
+1. **Terminology**: Use consistent technical terms across all languages
+2. **Structure**: Maintain the same document structure across languages
+3. **Formatting**: Preserve all markdown formatting, code blocks, and components
+4. **Links**: Update internal links to match the language structure
+
+### Accuracy
+
+1. **Technical Terms**: Preserve technical terms appropriately (may use English terms in some contexts)
+2. **Context**: Maintain the meaning and context of the original
+3. **Tone**: Match the professional tone of the documentation
+4. **Completeness**: Ensure all content is translated, including alt text and captions
+
+## File Structure
+
+### Directory Organization
+
+```
+src/content/
+├── ko/          # Korean (source/original)
+├── en/          # English (translated from Korean)
+└── ja/          # Japanese (translated from Korean)
+```
+
+Each language directory should have the same file structure. The path and filename after the language directory must be identical across all languages.
+
+### File Naming
+
+- Use the same file names across all languages
+- Use kebab-case: `user-manual/workflow.mdx`
+- Example: All three languages have `user-manual/workflow.mdx`
+
+## Translation Workflow
+
+### Source Content
+
+- **Original Content**: `src/content/ko/` - Korean MDX files are the source
+- **MDX Format**: Markdown with JSX extensions
+- **Inter-document Links**: MDX documents contain links that reference each other
+
+### When Translating New Content
+
+1. **Start with Korean**: Korean version in `src/content/ko/` is the source
+2. **Translate to English**: Create English version in `src/content/en/` maintaining structure
+3. **Translate to Japanese**: Create Japanese version in `src/content/ja/` maintaining structure
+4. **Verify Consistency**: Check that all three versions have the same structure and file paths
+
+### When Updating Existing Content
+
+1. **Identify Changes**: Check Korean source for updates
+2. **Update Translations**: Update English and Japanese versions to match Korean changes
+3. **Maintain Alignment**: Ensure sections, headings, and links align across languages
+4. **Test**: Verify all language versions render correctly with `npm run build`
+
+### Translation Process Guidelines
+
+1. **Batch Processing**: Translate or review 50 documents at a time, then request review
+2. **Build Verification**: After translation, run `npm run build` to verify MDX files build correctly
+   - Fix any build errors by checking error messages
+   - Repeat until `npm run build` succeeds
+   - Run `npm run build` directly without asking for confirmation
+3. **No Re-translation**: Do not re-translate already translated documents unless specifically instructed
+4. **No Re-review**: Do not perform proofreading on documents that already have review results unless specifically instructed
+5. **Feedback**: Report any typos, grammar errors, or inappropriate expressions found in Korean source, as well as any difficulties encountered during translation
+
+## Special Considerations
+
+### Frontmatter
+
+Translate the title in frontmatter. The Korean source has the original title:
+
+```yaml
+---
+title: 'Workflow'  # Korean (source)
+---
+```
+
+```yaml
+---
+title: 'Workflow'  # English (translated)
+---
+```
+
+```yaml
+---
+title: 'ワークフロー'  # Japanese (translated)
+---
+```
+
+### Code Blocks
+
+- **Do NOT translate code**: Keep code examples in their original language
+- **Comments in code**: Code comments should remain in English (project preference)
+- **Language tags**: Keep language tags as-is: ````bash`, ````typescript`, etc.
+
+### Component Usage
+
+Preserve all component syntax:
+
+```jsx
+import { Callout } from 'nextra/components'
+
+<Callout type="info">
+  Translated content here
+</Callout>
+```
+
+### Links
+
+- **Keep relative paths**: Maintain relative paths in links across all languages
+- **Translate link text**: Only the link text should be translated, not the path
+
+```markdown
+# Korean (source)
+[Workflow](user-manual/workflow)
+
+# English (translated)
+[Workflow](user-manual/workflow)
+
+# Japanese (translated)
+[ワークフロー](user-manual/workflow)
+```
+
+### Images
+
+- **Image Location**: Images are stored in `public/` directory
+- **Image Path**: Determined by the MDX file path
+  - For `src/content/ko/path/filename.mdx`, images are in `public/path/filename/`
+- **Image Names**: Typically `screenshot-yyyymmdd-hhmmss.png` or `image-yyyymmdd-hhmmss.png`
+- **Shared Across Languages**: Images are language-agnostic and shared across all language versions
+- **No Image Replacement**: Do not replace images when translating; use the same images from Korean source
+
+**Translate only alt text and captions**:
+
+```jsx
+# Korean (source)
+<figure>
+  ![Workflow 메뉴](/user-manual/workflow/screenshot-20240902-172212.png)
+  <figcaption>
+    Workflow 메뉴
+  </figcaption>
+</figure>
+
+# English (translated)
+<figure>
+  ![Workflow Menu](/user-manual/workflow/screenshot-20240902-172212.png)
+  <figcaption>
+    Workflow Menu
+  </figcaption>
+</figure>
+
+# Japanese (translated)
+<figure>
+  ![Workflowメニュー](/user-manual/workflow/screenshot-20240902-172212.png)
+  <figcaption>
+    Workflowメニュー
+  </figcaption>
+</figure>
+```
+
+## Language-Specific Guidelines
+
+### Korean (ko) - Source Language
+
+- This is the original source content
+- Use appropriate honorifics when addressing users
+- Technical terms may be kept in English if commonly used
+- Maintain professional tone
+- Use proper spacing and punctuation
+
+### English (en) - Translated Language
+
+- **Standard English**: Use standard English
+- **Formal but Friendly**: Use formal expressions appropriate for a software company providing high-quality technical support
+  - Prefer friendly conversational tone over stiff and dry style
+  - Avoid casual, everyday colloquial expressions or light tone used among friends
+- **Clear and Concise**: Professional but accessible
+- **Use Active Voice**: When possible
+- **Technical Terms**: Should be clearly defined
+
+### Japanese (ja) - Translated Language
+
+- **Standard Japanese**: Use standard Japanese
+- **Formal but Friendly**: Use formal expressions appropriate for a software company providing high-quality technical support
+  - Prefer friendly conversational tone over stiff and dry style
+  - Avoid casual, everyday colloquial expressions or light tone used among friends
+- **Use Appropriate Keigo**: Honorific language when addressing users
+- **Technical Terms**: May be kept in English or use katakana
+- **Maintain Professional Tone**: Follow Japanese typography rules
+
+## Critical Translation Rules
+
+### Markdown Formatting
+
+- **Preserve Formatting**: Maintain all markdown expressions, line breaks, and formatting from Korean source
+- **Keep Structure**: Tables, lists, emphasis (e.g., `**text**`) should match Korean source exactly
+- **Keep Emphasis Markers**: Maintain `**Example Phrase**` format; do not replace with `<strong>`
+- **Fix Inconsistencies**: If English/Japanese translation has different markdown formatting than Korean source, fix it to match
+
+### HTML Encoding
+
+- **Do NOT Decode**: Do not arbitrarily decode properly escaped strings from Korean source
+- **Keep HTML Entities**: Maintain HTML-encoded strings as-is
+  - Example: Keep `&lt;token&gt;` as-is, do not convert to `<token>`
+  - Example: Keep `{querypie url}` with backquote, do not remove it
+
+### Document Structure
+
+- **Same Path Structure**: File paths and names must be identical across languages
+  - `src/content/ko/path/filename.mdx` → `src/content/en/path/filename.mdx`
+  - `src/content/ko/path/filename.mdx` → `src/content/ja/path/filename.mdx`
+- **Relative Links**: Maintain relative paths in links
+
+## Common Translation Patterns
+
+### UI Elements
+
+- Buttons, menus, and UI elements: Translate to match the actual UI language
+- If UI is in English, may keep English terms in other languages
+
+### Technical Terms
+
+- Database terms: May keep English (e.g., "SQL", "Query")
+- Product names: Keep as-is (e.g., "QueryPie")
+- Feature names: Translate appropriately
+
+### Navigation Terms
+
+- Menu items: Translate to match user interface
+- Section headers: Translate fully
+- Breadcrumbs: Translate appropriately
+
+## Quality Checklist
+
+Before completing a translation:
+
+- [ ] Korean source is correctly identified and used
+- [ ] All content is translated from Korean (no Korean text left untranslated in en/ja versions)
+- [ ] Frontmatter title is translated
+- [ ] Code blocks are preserved (not translated)
+- [ ] Image alt text and captions are translated
+- [ ] Image paths are correct (based on MDX file path)
+- [ ] Links use relative paths and are maintained
+- [ ] Technical terms are handled consistently
+- [ ] Markdown formatting matches Korean source exactly
+- [ ] HTML-encoded strings are preserved (e.g., `&lt;`, `&gt;`)
+- [ ] Structure matches Korean source (same file paths and names)
+- [ ] File renders correctly in local dev server
+- [ ] `npm run build` succeeds without errors
+
+## Tools and Resources
+
+### Translation Files
+
+- Korean title translations: `confluence-mdx/etc/korean-titles-translations.txt`
+- Used by `translate_titles.py` script
+
+### Testing Translations
+
+```bash
+# Run local dev server
+npm run dev
+
+# Navigate to each language version
+# http://localhost:3000/en/...
+# http://localhost:3000/ja/...
+# http://localhost:3000/ko/...
+```
+
+## Best Practices
+
+1. **Review Korean Source**: Always review the Korean source (`src/content/ko/`) to understand context
+2. **Maintain Structure**: Keep the same heading hierarchy and organization as Korean source
+3. **Preserve Formatting**: Don't change markdown syntax or component usage - match Korean source exactly
+4. **Build Verification**: Always run `npm run build` after translation to verify MDX files build correctly
+5. **Test Locally**: Test translated content in the dev server (`npm run dev`)
+6. **Consistency**: Use the same translation for repeated terms
+7. **Formal but Friendly Tone**: Use formal expressions appropriate for enterprise software documentation, but prefer friendly conversational tone
+8. **Code Comments**: Keep code comments in English (project preference)
+9. **Batch Processing**: Work on 50 documents at a time, then request review
+10. **Report Issues**: Report typos, grammar errors, or inappropriate expressions found in Korean source
+
+## Target Audience
+
+This documentation is provided by QueryPie, a software development company, to:
+- End users
+- Customer company employees
+- Security officers
+- Customer engineers
+- Business partner engineers
+
+Maintain a tone appropriate for enterprise software documentation with high-quality technical support.
+


### PR DESCRIPTION
## Description
- `.claude/skills/` 에 Claude Skill 을 추가합니다.
- Cursor 가 기본으로 작성한 Skill 을 추가합니다.
- `translation.md`의 내용을 보완합니다.
- `mdx-skeleton-comparison.md`을 작성하여 추가합니다.

## Additional notes
- 
