### PR TITLE
mdx: 일본어 문서 불일치 수정 18

### DIFF
--- a/src/content/ja/administrator-manual/audit/database-logs/access-control-logs.mdx
+++ b/src/content/ja/administrator-manual/audit/database-logs/access-control-logs.mdx
@@ -26,6 +26,9 @@ Administrator &gt; Audit &gt; Databases &gt; Access Control Logs
     4.  **Privilege Name**  : ユーザー接続権限名
     5.  **DB Host**  : DBホスト
 4. 検索フィールド右側フィルターボタンをクリックしてAND/OR条件で以下のフィルタリングが可能です。
+  <figure data-layout="center" data-align="center">
+  ![image-20240730-073211.png](/administrator-manual/audit/database-logs/access-control-logs/image-20240730-073211.png)
+  </figure>
     1.  **Connection Name**  : DBコネクション名
     2.  **Database Type** : データベースタイプ
     3.  **Event**  : 権限付与/回収イベントタイプ

--- a/src/content/ja/administrator-manual/audit/database-logs/account-lock-history.mdx
+++ b/src/content/ja/administrator-manual/audit/database-logs/account-lock-history.mdx
@@ -21,6 +21,9 @@ Administrator &gt; Audit &gt; Databases &gt; Account Lock History
 2. テーブルに発生時点降順でリストにログが露出されます。
 3. テーブル左上の検索欄を通じてユーザー名で検索が可能です。
 4. 検索フィールド右側フィルターボタンをクリックして **Action At** に対する日時範囲を再指定してフィルタリングが可能です。
+  <figure data-layout="center" data-align="center">
+  ![image-20240730-071155.png](/administrator-manual/audit/database-logs/account-lock-history/image-20240730-071155.png)
+  </figure>
     1.  **Connection Name**  : 接続したDBコネクション名
     2.  **Database Type** : データベースタイプ
     3.  **Lock Status**  : ロックタイプ

--- a/src/content/ja/administrator-manual/audit/database-logs/db-access-history.mdx
+++ b/src/content/ja/administrator-manual/audit/database-logs/db-access-history.mdx
@@ -24,6 +24,9 @@ Administrator &gt; Audit &gt; Databases &gt; DB Access History
     2.  **Error Message**  : アクセスエラーメッセージ内構文
     3.  **Client IP**  : ユーザーIP
 4. 検索フィールド右側フィルターボタンをクリックしてAND/OR条件で以下のフィルタリングが可能です。
+  <figure data-layout="center" data-align="center">
+  ![image-20240730-064139.png](/administrator-manual/audit/database-logs/db-access-history/image-20240730-064139.png)
+  </figure>
     1.  **Connection Name**  : 接続したDBコネクション名
     2.  **Database Type** : データベースタイプ
     3.  **Action Type** : Connect / Disconnectの有無

--- a/src/content/ja/administrator-manual/audit/database-logs/dml-snapshots.mdx
+++ b/src/content/ja/administrator-manual/audit/database-logs/dml-snapshots.mdx
@@ -21,6 +21,9 @@ Administrator &gt; Audit &gt; Databases &gt; DML Snapshots
 2. クエリ実行当月基準でログが降順で照会されます。
 3. テーブル左上の検索欄を通じてユーザー名で検索が可能です。
 4. 検索フィールド右側フィルターボタンをクリックしてAND/OR条件で以下のフィルタリングが可能です。
+  <figure data-layout="center" data-align="center">
+  ![image-20240730-094947.png](/administrator-manual/audit/database-logs/dml-snapshots/image-20240730-094947.png)
+  </figure>
     1.  **Connection Name**  : 接続したDBコネクション名
     2.  **Executed At**  : 実行日時
     3.  **Statement** : 構文タイプ（Insert/Update/Delete）

--- a/src/content/ja/administrator-manual/audit/database-logs/query-audit.mdx
+++ b/src/content/ja/administrator-manual/audit/database-logs/query-audit.mdx
@@ -23,7 +23,10 @@ Administrator &gt; Audit &gt; Databases &gt; Query Audit
     1.  **Name**  : ユーザー名
     2.  **Table(s)**  : 呼び出しテーブル名
 4. 検索フィールド右側フィルターボタンをクリックしてAND/OR条件で以下のフィルタリングが可能です。
-    1.  **Connection Name**  : 接続したDB接続名
+  <figure data-layout="center" data-align="center">
+  ![image-20240730-091338.png](/administrator-manual/audit/database-logs/query-audit/image-20240730-091338.png)
+  </figure>
+    1.  **Connection Name**  : 接続したDBコネクション名
     2.  **Database Type** : データベースタイプ
     3.  **SQL Type** : SQL構文タイプ
     4.  **Action Type** : アクションタイプ

--- a/src/content/ja/administrator-manual/audit/database-logs/running-queries.mdx
+++ b/src/content/ja/administrator-manual/audit/database-logs/running-queries.mdx
@@ -27,6 +27,9 @@ Administrator &gt; Audit &gt; Databases &gt; Running Queries
 1. Administrator &gt; Audit &gt; Databases &gt; Running Queriesメニューに移動します。
 2. 当日基準で降順でログが照会されます。
 3. テーブル左上のフィルターボタンをクリックしてAND/OR条件で以下のフィルタリングが可能です。
+  <figure data-layout="center" data-align="center">
+  ![image-20240730-081641.png](/administrator-manual/audit/database-logs/running-queries/image-20240730-081641.png)
+  </figure>
     1.  **SQL Type** : SQL構文タイプ
     2.  **Action At**  : クエリ実行日時範囲
     3.  **Executed From**  : クエリ実行主体

--- a/src/content/ja/administrator-manual/audit/general-logs/activity-logs.mdx
+++ b/src/content/ja/administrator-manual/audit/general-logs/activity-logs.mdx
@@ -21,15 +21,15 @@ Administrator &gt; Audit &gt; General &gt; Activity Logs
 </figure>
 
 1. Administrator &gt; Audit &gt; General &gt; Activity Logsメニューにアクセスします。
-2. **照会期間**: 基本的に今月のログ一覧が最新順で照会されます。
-   1. 照会期間の変更には、フィルターパネルを開き、**Action At**で照会基準日を変更してください。
-3. **Action Type**: リソース変更内容を簡略に確認できます。形式は以下の通りです。
-   1. `{変更が加えられたリソースタイプ}` `{Created | Updated | Deleted…}` : 特定のリソースが作成、変更、または削除された場合
-       * 例: `DB Connection Created`, `Server Updated`, `Kubernetes Policy Deleted`
-   2. `{変更が加えられたリソースタイプ}` `{修正が媒介されたリソースタイプ}` `{Created | Updated | Deleted | Assigned | Unassigned…}` : 特定のリソースに他のリソースが追加、変更、削除、割り当て、または回収された場合
-       * 例: `Server Group Server Added`, `Server Group Account Updated` , `Kubernetes Role Policy Unassigned`
-   3. 特定のAction Typeでログ一覧をフィルタリングできます。
-4. **Target**: Activity Logsで、管理者の行為により変更が加えられたリソースタイプの名前を確認できます。
+2.  **照会期間**  : 基本的に今月のログ一覧が最新順で照会されます。
+    1. 照会期間の変更には、フィルターパネルを開き、 **Action At** で照会基準日を変更してください。
+3.  **Action Type**  : リソース変更内容を簡略に確認できます。形式は以下の通りです。
+    1. `{変更が加えられたリソースタイプ}` `{Created | Updated | Deleted…}` : 特定のリソースが作成、変更、または削除された場合
+        * 例: `DB Connection Created`, `Server Updated`, `Kubernetes Policy Deleted`
+    2. `{変更が加えられたリソースタイプ}` `{修正が媒介されたリソースタイプ}` `{Created | Updated | Deleted | Assigned | Unassigned…}` : 特定のリソースに他のリソースが追加、変更、削除、割り当て、または回収された場合
+        * 例: `Server Group Server Added`, `Server Group Account Updated` , `Kubernetes Role Policy Unassigned`
+    3. 特定のAction Typeでログ一覧をフィルタリングできます。
+4.  **Target**  : Activity Logsで、管理者の行為により変更が加えられたリソースタイプの名前を確認できます。
 
 
 ### Activity Logs詳細内容の照会
@@ -42,13 +42,13 @@ Administrator &gt; Audit &gt; General &gt; Activity Logs &gt; Activity Logs Deta
 </figure>
 
 1. 一覧の一行をクリックするとDrawerが開き、詳細内容を確認できます。
-2. **Affected Data**: 該当行為により変更されたデータ内訳を表示します。各カラムの意味は以下の通りです。
-   1. Label : データカラム名
-   2. Before : アクション以前の値
-   3. After : アクション以後の値
-3. **Related Logs**: 該当行為について、連鎖的または同時に発生したログを表示します。前後ログをすべて含みます。
-   1. 管理者が直接引き起こした行為だけでなく、それに伴って派生したシステムの自動行為を確認できます。
-   2. Related Logsに表示された行為ログは、それぞれ個別ログとしても残っています。
+2.  **Affected Data**  : 該当行為により変更されたデータ内訳を表示します。各カラムの意味は以下の通りです。
+    1. Label : データカラム名
+    2. Before : アクション以前の値
+    3. After : アクション以後の値
+3.  **Related Logs**  : 該当行為について、連鎖的または同時に発生したログを表示します。前後ログをすべて含みます。
+    1. 管理者が直接引き起こした行為だけでなく、それに伴って派生したシステムの自動行為を確認できます。
+    2. Related Logsに表示された行為ログは、それぞれ個別ログとしても残っています。
 
 <Callout type="info">
 11.3.0からActivity Logsの詳細画面（Drawer）でChanges Onlyチェックボックスが追加され、変更された項目のみをフィルタリングして表示できるよう改善されました。また、空値の場合は「-（ダッシュ）」の代わりに「&lt;null&gt;」で表示されるように変更されました。


### PR DESCRIPTION
## 개요

docs/todo-01.txt 파일에 나열된 10개의 일본어 Audit Logs 관련 번역 문서의 한국어 원문과의 불일치를 수정했습니다.

## 수정 내용

### 수정된 파일 (7개)

#### 1. Database Logs 관련 (6개 파일)
- `src/content/ja/administrator-manual/audit/database-logs/access-control-logs.mdx`
- `src/content/ja/administrator-manual/audit/database-logs/account-lock-history.mdx`
- `src/content/ja/administrator-manual/audit/database-logs/db-access-history.mdx`
- `src/content/ja/administrator-manual/audit/database-logs/dml-snapshots.mdx`
- `src/content/ja/administrator-manual/audit/database-logs/query-audit.mdx`
- `src/content/ja/administrator-manual/audit/database-logs/running-queries.mdx`

**주요 수정 사항:**
- 필터 패널 이미지 추가 (한국어 원문에는 있으나 일본어 번역에서 누락)
- 용어 통일: `DB接続名` → `DBコネクション名`

#### 2. General Logs 관련 (1개 파일)
- `src/content/ja/administrator-manual/audit/general-logs/activity-logs.mdx`

**주요 수정 사항:**
- 목록 항목의 들여쓰기 포맷 수정 (한국어 원문과 일치하도록)
- 공백 추가 (`**필드명**` → ` **필드명** `)

### 수정되지 않은 파일 (3개)
다음 파일들은 한국어 원문과 일치하여 수정이 필요하지 않았습니다:
- `src/content/ja/administrator-manual/audit/database-logs/policy-audit-logs.mdx`
- `src/content/ja/administrator-manual/audit/database-logs/policy-exception-logs.mdx`
- `src/content/ja/administrator-manual/audit/general-logs/reverse-tunnels.mdx`

## 검증 결과

- 한국어 원문과 일본어 번역문의 구조 일치 확인
- 누락된 이미지 복원 완료
- 포맷팅 통일 완료

## 영향 범위

- 수정 파일: 7개
- 추가 라인: 35줄
- 삭제 라인: 17줄