### PR TITLE
mdx: 일본어 문서 불일치 수정 20

### DIFF
--- a/src/content/ja/administrator-manual/audit/server-logs/account-lock-history.mdx
+++ b/src/content/ja/administrator-manual/audit/server-logs/account-lock-history.mdx
@@ -8,7 +8,7 @@ title: 'Account Lock History'
 
 QueryPieのユーザー別サーバー接続権限ロック履歴を表示します。パスワード誤入力、非認可IPの接続試行など接続失敗した回数をすべてカウントし、管理者が設定した接続失敗閾値到達時接続アカウントがLock状態になります。
 
-### Server Account Lock History照会
+### Server Account Lock Historyの照会
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Audit &gt; Servers &gt; Server Account Lock History](/administrator-manual/audit/server-logs/account-lock-history/image-20240728-175941.png)
@@ -26,12 +26,15 @@ Administrator &gt; Audit &gt; Servers &gt; Server Account Lock History
     4.  **Role Name**  : 使用されたRole名
     5.  **Server Name**  : 接続サーバー名
 4. 検索フィールド右側フィルターボタンをクリックして **Action At** に対する日時範囲を再指定してフィルタリングが可能です。<br/>
+  <figure data-layout="center" data-align="center">
+  ![image-20240728-180318.png](/administrator-manual/audit/server-logs/account-lock-history/image-20240728-180318.png)
+  </figure>
     1.  **Event**  : イベントタイプ
         1.  **Account Locked**  : ユーザーのアカウントロックイベント
         2.  **Account Unlocked**  : 管理者のアカウントロック解除イベント
     2.  **Action At**  : イベント発生日時範囲
-5. テーブル右上の新規更新ボタンを通じてログリストを最新化できます。
-6. テーブルで以下のカラム情報を提供します：
+5. テーブル右上のリフレッシュボタンを通じてログ一覧を最新化できます。
+6. テーブルで以下のカラム情報を提供します:
     1.  **No**  : イベント識別番号
     2.  **Action At**  : イベント発生日時
     3.  **Event**  : イベントタイプ
@@ -40,7 +43,7 @@ Administrator &gt; Audit &gt; Servers &gt; Server Account Lock History
     4.  **Name**  : 対象ユーザー/グループ名
     5.  **Email**  : 対象ユーザーメール
         1. グループの場合は「-」で表記します。
-    6.  **Role Name**  : 付与/回収されたRole名前
+    6.  **Role Name**  : 付与/回収されたRole名
     7.  **Server Group**  : サーバーグループ名
     8.  **Server Name**  : サーバー名
     9.  **Account**  : Lock対象サーバーのAccount

--- a/src/content/ja/administrator-manual/audit/server-logs/command-audit.mdx
+++ b/src/content/ja/administrator-manual/audit/server-logs/command-audit.mdx
@@ -10,7 +10,7 @@ import { Callout } from 'nextra/components'
 
 QueryPieを通じて接続したサーバーで実行したコマンドを記録します。Windows Serverの場合、マウスクリック、キーボード入力、実行プロセス名を記録します。
 
-### Command Audit照会
+### Command Auditの照会
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Audit &gt; Servers &gt; Command Audit](/administrator-manual/audit/server-logs/command-audit/image-20240728-171227.png)
@@ -37,13 +37,13 @@ Administrator &gt; Audit &gt; Servers &gt; Command Audit
         * proxy : AgentまたはSeamless SSH Connectionを通じた接続
     *  **Action Type** : 記録されたイベントタイプ
         * Command : ログに記録されたコマンド
-        * File Download : （SFTP）ファイルダウンロード
-        * File Upload : （SFTP）ファイルアップロード
-        * Process Start : （RDP）プロセス実行
-        * Process Stop : （RDP）プロセス終了
-        * User Input - MouseClick : （RDP）ユーザーマウスクリック
-        * User Input - MouseDoubleClick : （RDP）ユーザーマウスダブルクリック
-        * User Input - KeyPress : （RDP）ユーザーキーボード入力
+        * File Download : (SFTP) ファイルダウンロード
+        * File Upload : (SFTP) ファイルアップロード
+        * Process Start : (RDP) プロセス実行
+        * Process Stop : (RDP) プロセス終了
+        * User Input - MouseClick : (RDP) ユーザーマウスクリック
+        * User Input - MouseDoubleClick : (RDP) ユーザーマウスダブルクリック
+        * User Input - KeyPress : (RDP) ユーザーキーボード入力
     *  **Executed At**  : コマンド実行時点
     *  **Restricted**  : コマンド遮断の有無
 
@@ -57,8 +57,8 @@ Administrator &gt; Audit &gt; Servers &gt; Command Audit
 </figure>
 </Callout>
 
-* テーブル右上の新規更新ボタンを通じてログリストを最新化できます。
-* テーブルで以下のカラム情報を提供します：
+* テーブル右上のリフレッシュボタンを通じてログ一覧を最新化できます。
+* テーブルで以下のカラム情報を提供します:
     *  **No**  : イベント識別番号
     *  **Executed At**  : コマンド実行時点
     *  **Name**  : 対象ユーザー名
@@ -80,7 +80,7 @@ Administrator &gt; Audit &gt; Servers &gt; Command Audit
     *  **Action Type** : 記録されたイベントタイプ
     *  **Message**  : 接続失敗など特異事項に対する記録
 
-### Command Audit詳細履歴照会
+### Command Audit詳細内訳の照会
 
 各行をクリックすると詳細情報照会が可能です。
 
@@ -92,7 +92,7 @@ Administrator &gt; Audit &gt; Servers &gt; Command Audit &gt; Command Audit Deta
 </figcaption>
 </figure>
 
-* 右側ドロワーには以下の情報を露出します：
+* 右側ドロワーには以下の情報を露出します:
     *  **Name**  : 対象ユーザー名
     *  **Action Type** : 記録されたイベントタイプ
     *  **Executed At**  : コマンド実行時点
@@ -109,8 +109,8 @@ Administrator &gt; Audit &gt; Servers &gt; Command Audit &gt; Command Audit Deta
     *  **Client IP**  : ユーザークライアントIPアドレス
     *  **Restricted**  : コマンド遮断の有無
     *  **Restricted Command**  : 遮断されたコマンド
-    *  **Detected Type :** 検出された遮断コマンドの実行方式（Shell ScriptまたはAlias）
-    *  **Command**  : ユーザー入力コマンド（RDPの場合プロセス名またはクリック座標など）
+    *  **Detected Type :** 検出された遮断コマンドの実行方式(Shell ScriptまたはAlias)
+    *  **Command**  : ユーザー入力コマンド(RDPの場合プロセス名またはクリック座標など)
     *  **Result**  : コマンド実行結果
 
 

--- a/src/content/ja/administrator-manual/audit/server-logs/server-access-history.mdx
+++ b/src/content/ja/administrator-manual/audit/server-logs/server-access-history.mdx
@@ -8,7 +8,7 @@ title: 'Server Access History'
 
 組織で管理するサーバー接続履歴を記録します。
 
-### Server Access History照会
+### Server Access Historyの照会
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Audit &gt; Servers &gt; Server Access History](/administrator-manual/audit/server-logs/server-access-history/image-20240728-165641.png)
@@ -29,13 +29,16 @@ Administrator &gt; Audit &gt; Servers &gt; Server Access History
     7.  **Client**   **Name**  : ユーザーの接続方式
     8.  **Role**  : 接続Role
 4. 検索フィールド右側フィルターボタンをクリックしてAND/OR条件で以下のフィルタリングが可能です。
+  <figure data-layout="center" data-align="center">
+  ![image-20240728-170045.png](/administrator-manual/audit/server-logs/server-access-history/image-20240728-170045.png)
+  </figure>
     1.  **Server OS**  : 接続したサーバーのOS
     2.  **Protocol** : 接続使用したProtocol
     3.  **Result** : 接続試行結果
     4.  **Action Type** : Connect / Disconnectの有無
     5.  **Action At**  : 接続時点
-5. テーブル右上の新規更新ボタンを通じてログリストを最新化できます。
-6. テーブルで以下のカラム情報を提供します：
+5. テーブル右上のリフレッシュボタンを通じてログ一覧を最新化できます。
+6. テーブルで以下のカラム情報を提供します:
     1.  **No**  : イベント識別番号
     2.  **Action At**  : サーバー接続試行日時
     3.  **Result**  : 接続成功/失敗の有無
@@ -54,7 +57,7 @@ Administrator &gt; Audit &gt; Servers &gt; Server Access History
     14.  **Client**   **Name**  : ユーザーの接続方式
     15.  **Message**  : 接続失敗など特異事項に対する記録
 
-### Server Access History詳細履歴照会
+### Server Access History詳細内訳の照会
 
 各行をクリックすると詳細情報照会が可能です。
 
@@ -67,7 +70,7 @@ Administrator &gt; Audit &gt; Servers &gt; Server Access History &gt; Server Acc
 </figure>
 
 
-* 右側ドロワーには以下の情報を露出します：
+* 右側ドロワーには以下の情報を露出します:
     1.  **Result**  : サーバー接続成功/失敗の有無
         1. :check_mark: Success
         2. :cross_mark: Failure

--- a/src/content/ja/administrator-manual/audit/server-logs/server-role-history.mdx
+++ b/src/content/ja/administrator-manual/audit/server-logs/server-role-history.mdx
@@ -8,7 +8,7 @@ title: 'Server Role History'
 
 クエリパイユーザー/グループに付与されるサーバーアクセスRoleに対する付与および回収履歴を記録します。
 
-### Server Role History照会
+### Server Role Historyの照会
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Audit &gt; Servers &gt; Server Role History](/administrator-manual/audit/server-logs/server-role-history/image-20240728-174347.png)
@@ -24,12 +24,15 @@ Administrator &gt; Audit &gt; Servers &gt; Server Role History
     2.  **Email**  : ユーザーメール
     3.  **Role Name**  : サーバーアクセス権限役割名
 4. 検索フィールド右側フィルターボタンをクリックしてAND/OR条件で以下のフィルタリングが可能です。
+  <figure data-layout="center" data-align="center">
+  ![image-20240728-174439.png](/administrator-manual/audit/server-logs/server-role-history/image-20240728-174439.png)
+  </figure>
     1.  **Event**  : イベントタイプ
         1.  **Role Granted**  : Role付与履歴
         2.  **Role Revoked**  : Role回収履歴
     2.  **Action At**  : 権限付与/回収日時範囲
-5. テーブル右上の新規更新ボタンを通じてログリストを最新化できます。
-6. テーブルで以下のカラム情報を提供します：
+5. テーブル右上のリフレッシュボタンを通じてログ一覧を最新化できます。
+6. テーブルで以下のカラム情報を提供します:
     1.  **No**  : イベント識別番号
     2.  **Action At**  : Role権限付与/回収日時
     3.  **Event**  : Role権限関連イベント
@@ -39,11 +42,11 @@ Administrator &gt; Audit &gt; Servers &gt; Server Role History
     5.  **Name**  : 対象ユーザー/グループ名
     6.  **Email**  : 対象ユーザーメール
         1. グループの場合は表記しません。
-    7.  **Role Name**  : 付与/回収されたRole名前
-    8.  **Expiration Date**  : 権限付与有効期限（回収予定日）
+    7.  **Role Name**  : 付与/回収されたRole名
+    8.  **Expiration Date**  : 権限付与期限日(回収予定日)
     9.  **Action By**  : Role付与/回収を進行した管理者名またはSystem
 
-### Server Role History詳細履歴照会
+### Server Role History詳細内訳の照会
 
 各行をクリックすると詳細情報照会が可能です。
 
@@ -54,19 +57,22 @@ Administrator &gt; Audit &gt; Servers &gt; Server Role History &gt; Server Role 
 </figcaption>
 </figure>
 
-1. 最上部には基本イベントに応じた情報を露出します：
+1. 最上部には基本イベントに応じた情報を露出します:
     1.  **Action At**  : Role権限付与/回収日時
     2.  **Name**  : 対象ユーザー/グループ名
     3.  **Event**  : ユーザー/グループにRoleが付与/回収されたイベント
     4.  **Email**  : 対象ユーザーメール
     5.  **Action By**  : Role付与/回収を進行した管理者名またはSystem
     6.  **Role Name**  : Role名
-    7.  **Expiration Date**  : 権限付与有効期限（回収予定日）
-2. 下部には付与/回収されたRoleに該当するPolicyをリスト化して列挙します：
+    7.  **Expiration Date**  : 権限付与期限日(回収予定日)
+2. 下部には付与/回収されたRoleに該当するPolicyを一覧化して列挙します:
     *  **Name**  : 割り当てられている政策名
     *  **Description**  : 割り当てられている政策の詳細説明
     *  **Version**  : 割り当てられている政策のバージョン
-        * リンクを押すと政策コードを照会できるようにポップアップモーダルが表示されます。
+        * リンクを押すと政策コードを照会できるようにポップアップモーダルが現れます。
+          <figure data-layout="center" data-align="center">
+          ![image-20240728-174822.png](/administrator-manual/audit/server-logs/server-role-history/image-20240728-174822.png)
+          </figure>
             1. 付与されていた当時のPolicy Snapshotを見せます。
                 * 該当Policyが削除されても記録が残ります。
             2. 政策名、PolicyのDescriptionと共にコードを見せます。

--- a/src/content/ja/administrator-manual/audit/server-logs/session-logs.mdx
+++ b/src/content/ja/administrator-manual/audit/server-logs/session-logs.mdx
@@ -8,7 +8,7 @@ title: 'Session Logs'
 
 組織で管理するサーバー接続セッションをレコーディングします。管理者は映像再生を通じてサーバー内でユーザーの作業実行履歴をモニタリングできます。
 
-### Session Logs照会
+### Session Logsの照会
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Audit &gt; Servers &gt; Session Logs](/administrator-manual/audit/server-logs/session-logs/image-20240728-173024.png)
@@ -27,13 +27,16 @@ Administrator &gt; Audit &gt; Servers &gt; Session Logs
     5.  **Host**  : 接続サーバーホスト
     6.  **Client IP**  : ユーザーIP
     7.  **Client**   **Name**  : ユーザーの接続方式
-4. 検索フィールド右側フィルターボタンをクリックして **Action At** に対する日時範囲を再指定してフィルタリングが可能です。
+4. 検索フィールド右側フィルターボタンをクリックして **Action At** に対する日時範囲を再指定してフィルタリングが可能です。 <br/>
+  <figure data-layout="center" data-align="center">
+  ![image-20240728-173136.png](/administrator-manual/audit/server-logs/session-logs/image-20240728-173136.png)
+  </figure>
     1.  **Server OS**  : 接続したサーバーのOS
     2.  **Protocol** : 接続使用したProtocol
     3.  **Action At**  : 接続時点
     4.  **Connected From**  : 接続方式
-5. テーブル右上の新規更新ボタンを通じてログリストを最新化できます。
-6. テーブルで以下のカラム情報を提供します：
+5. テーブル右上のリフレッシュボタンを通じてログ一覧を最新化できます。
+6. テーブルで以下のカラム情報を提供します:
     1.  **No**  : イベント識別番号
     2.  **Action At**  : セッション録画開始日時
     3.  **Name**  : 対象ユーザー名
@@ -51,16 +54,19 @@ Administrator &gt; Audit &gt; Servers &gt; Session Logs
         1. Web
         2. Proxy
 
-### Session Record再生
+### Session Recordの再生
 
-各行のAction Atのリンクをクリックするとセッションレコーディング履歴の再生が可能です。
+各行のAction Atのリンクをクリックするとセッションレコーディング内訳の再生が可能です。
 
-録画されたファイルのサイズが700MBを超過するかどうかによって再生画面を露出したりダウンロードボタンを露出したりします。
+録画されたファイルのサイズが700MBを超過するかどうかによって再生画面を露出するかダウンロードボタンを露出します。
 
-1.  **700MB未満**
+1.  **700MB未満**  <br/>
+  <figure data-layout="center" data-align="center">
+  ![image-20240728-173517.png](/administrator-manual/audit/server-logs/session-logs/image-20240728-173517.png)
+  </figure>
     1. 上部に基本情報が露出され下部にReplay再生画面が露出されます。
         1.  **Name** : 実行者名
-        2.  **Action At** : 発生日時（開始）
+        2.  **Action At** : 発生日時(開始)
         3.  **Session Record** : レコーディング名
     2. 再生ボタンを押すと開始されます。
         1. 逆に、一時停止ボタンを押すと再生が停止します。
@@ -71,4 +77,10 @@ Administrator &gt; Audit &gt; Servers &gt; Session Logs
         1. ファイルサイズが700MBを超過してセッションを再生できません。
         2. このセッション録画を見るにはファイルコンテンツをダウンロードしてプレイする必要があります。
     2. `Download`ボタンを押すとダウンロードが進行されローカルにファイルが生成されます。
-        1. Administrator &gt; General &gt; Company Management &gt; Security &gt; Others &gt; `Export a file with Encryption`共通オプションが`Required`で有効化されている場合、該当ダウンロード時暗号化モーダルが追加で現れ、該当モーダル後にダウンロードを実行します。
+        1. Administrator &gt; General &gt; Company Management &gt; Security &gt; Others &gt; `Export a file with Encryption`共通オプションが`Required`で有効化されている場合、該当ダウンロード時暗号化モーダルが追加で現れ、該当モーダル後にダウンロードを実行します。 <br/>
+          <figure data-layout="center" data-align="center">
+          ![image-20240721-082733.png](/administrator-manual/audit/server-logs/session-logs/image-20240721-082733.png)
+          </figure>
+          <figure data-layout="center" data-align="center">
+          ![image-20240425-025317.png](/administrator-manual/audit/server-logs/session-logs/image-20240425-025317.png)
+          </figure>

--- a/src/content/ja/administrator-manual/audit/server-logs/session-monitoring.mdx
+++ b/src/content/ja/administrator-manual/audit/server-logs/session-monitoring.mdx
@@ -10,7 +10,7 @@ import { Callout } from 'nextra/components'
 
 QueryPieを通じたサーバー接続セッションを照会できます。また、接続中のセッションを強制終了できます。
 
-### Session Monitoring照会
+### Session Monitoringの照会
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Audit &gt; Servers &gt; Session Monitoring](/administrator-manual/audit/server-logs/session-monitoring/image-20240728-173632.png)
@@ -33,7 +33,7 @@ Administrator &gt; Audit &gt; Servers &gt; Session Monitoring
 
 
 
-### Session強制終了
+### Sessionの強制終了
 
 <figure data-layout="center" data-align="center">
 ![image-20240728-173640.png](/administrator-manual/audit/server-logs/session-monitoring/image-20240728-173640.png)

--- a/src/content/ja/administrator-manual/audit/web-app-logs/jit-access-control-logs.mdx
+++ b/src/content/ja/administrator-manual/audit/web-app-logs/jit-access-control-logs.mdx
@@ -6,7 +6,7 @@ title: 'JIT Access Control Logs'
 
 ### Overview
 
-組織で管理するウェブアプリケーションJIT（Just-In-Time）アクセス制御ログ履歴を記録します。
+組織で管理するウェブアプリケーションJIT(Just-In-Time)アクセス制御ログ履歴を記録します。
 
 ### JIT Access Control Logsの照会
 
@@ -19,18 +19,21 @@ Administrator &gt; Audit &gt; Web Apps &gt; JIT Access Control Logs
 
 1. Administrator &gt; Audit &gt; Web Apps &gt; JIT Access Control Logsメニューに移動します。
 2. 現在月基準でログが降順で照会されます。
-3. テーブル最左上部の検索欄を通じて以下の条件で検索が可能です。<br/>a. **User Name**: ユーザー名<br/>b. **User Email**: ユーザーメール<br/>c. **Web App Name**: ウェブアプリケーション名
+3. テーブル左上の検索欄を通じて以下の条件で検索が可能です。<br/>a.  **User Name**  : ユーザー名<br/>b.  **User Email**  : ユーザーメール<br/>c.  **Web App Name**  : ウェブアプリケーション名
 4. 検索フィールド右側フィルターボタンをクリックしてAND条件で以下のフィルタリングが可能です。
-   1. **Event**: イベントタイプ（JIT Access Granted/JIT Access Revoked）
-   2. **Action At**: アクション発生日時範囲
+  <figure data-layout="center" data-align="center">
+  ![image-20250629-174904.png](/administrator-manual/audit/web-app-logs/jit-access-control-logs/image-20250629-174904.png)
+  </figure>
+    1.  **Event**  : イベントタイプ(JIT Access Granted/JIT Access Revoked)
+    2.  **Action At**  : アクション発生日時範囲
 5. テーブル右上のリフレッシュボタンを通じてログ一覧を最新化できます。
-6. テーブルで以下のような情報を提供します:
-   1. **No**: 順番
-   2. **Action At**: アクション発生日時
-   3. **Event**: イベントタイプ（JIT Access Granted、JIT Access Revoked）
-   4. **User Type**: ユーザータイプ（USER）
-   5. **Name**: ユーザー名
-   6. **Email**: ユーザーメール
-   7. **Web App**: ウェブアプリケーション名
-   8. **Expiration Date**: JITアクセス権限期限日時
-   9. **Action By**: アクションを実行した管理者名
+6. テーブルで以下の情報を提供します:
+    1.  **No**  : 順番
+    2.  **Action At**  : アクション発生日時
+    3.  **Event**  : イベントタイプ(JIT Access Granted、JIT Access Revoked)
+    4.  **User Type**  : ユーザータイプ(USER)
+    5.  **Name**  : ユーザー名
+    6.  **Email**  : ユーザーメール
+    7.  **Web App**  : ウェブアプリケーション名
+    8.  **Expiration Date**  : JITアクセス権限期限日時
+    9.  **Action By**  : アクションを実行した管理者名

--- a/src/content/ja/administrator-manual/audit/web-app-logs/user-activity-recordings.mdx
+++ b/src/content/ja/administrator-manual/audit/web-app-logs/user-activity-recordings.mdx
@@ -21,17 +21,20 @@ Administrator &gt; Audit &gt; Web Apps &gt; User Activity Recordings
 
 1. Administrator &gt; Audit &gt; Web Apps &gt; User Activity Recordingsメニューに移動します。
 2. 現在月基準でログが内訳数で照会されます。
-3. テーブル最左上部の検索欄を通じて以下の条件で検索が可能です。
-   1. **User Name**: ユーザー名
-   2. **User Email**: ユーザーEmail
-   3. **Role Name**: 役割名
-   4. **Web App Name**: ウェブアプリケーション名
-   5. **Web App Base Url**: ウェブアプリケーション基本URL
-   6. **Session ID**: セッション固有識別子
-   7. **Client Ip**: クライアントIPアドレス
+3. テーブル左上の検索欄を通じて以下の条件で検索が可能です。
+    1.  **User Name**  : ユーザー名
+    2.  **User Email**  : ユーザーEmail
+    3.  **Role Name**  : 役割名
+    4.  **Web App Name**  : ウェブアプリケーション名
+    5.  **Web App Base Url**  : ウェブアプリケーション基本URL
+    6.  **Session ID**  : セッション固有識別子
+    7.  **Client Ip**  : クライアントIPアドレス
 4. 検索フィールド右側フィルターボタンをクリックしてAND条件で以下のフィルタリングが可能です。
+  <figure data-layout="center" data-align="center">
+  ![image-20250629-175600.png](/administrator-manual/audit/web-app-logs/user-activity-recordings/image-20250629-175600.png)
+  </figure>
 
-**a. Action At**: アクション発生日時範囲
+**a. Action At**  : アクション発生日時範囲
 
 
 ### User Activity Recordings詳細内訳の照会
@@ -45,28 +48,28 @@ Administrator &gt; Audit &gt; Web Apps &gt; User Activity Recordings &gt; User A
 </figcaption>
 </figure>
 
-1. **詳細ページには以下の情報を露出します:**
-   1. **Action At**: アクション時点
-   2. **Name**: 対象ユーザー名
-   3. **Role**: ユーザー役割名
-   4. **Client Ip**: クライアントIPアドレス
-   5. **Session ID**: セッション固有識別子
-   6. **Email**: 対象ユーザーメール
-   7. **Web App**: ウェブアプリケーション名
-   8. **Base URL**: ウェブアプリケーション基本URL
-2. **Event Timelineでは管理者が記録するように設定した項目のみ表示されます**
-   1. Navigated : ページ移動記録（設定時）
-   2. Mouse Clicked : マウスクリックイベント（設定時）
-   3. Clipboard Copied : クリップボードコピーイベント（設定時）
-   4. File Uploaded : ファイルアップロードイベント（設定時）
-   5. File Downloaded : ファイルダウンロードイベント（設定時）
-   6. Value Changed : 値変更イベント（設定時）
-   7. Scrolled Up/Down : スクロールイベント（設定時）
-   8. Print Initiated : 印刷開始イベント（設定時）
-   9. URL : アクセスしたページURL
-   10. Tab ID : タブ識別子
-   11. Timestamp : イベント発生時間
-3. **画面右側には実際のユーザーがアクセスしたウェブアプリケーションのスクリーンショットが表示されます。**
+1.  **詳細ページには以下の情報を露出します:**
+    1.  **Action At**  : アクション時点
+    2.  **Name**  : 対象ユーザー名
+    3.  **Role**  : ユーザー役割名
+    4.  **Client Ip**  : クライアントIPアドレス
+    5.  **Session ID**  : セッション固有識別子
+    6.  **Email**  : 対象ユーザーメール
+    7.  **Web App**  : ウェブアプリケーション名
+    8.  **Base URL**  : ウェブアプリケーション基本URL
+2.  **Event Timelineでは管理者が記録するように設定した項目のみ表示されます**
+    1. Navigated : ページ移動記録(設定時)
+    2. Mouse Clicked : マウスクリックイベント(設定時)
+    3. Clipboard Copied : クリップボードコピーイベント(設定時)
+    4. File Uploaded : ファイルアップロードイベント(設定時)
+    5. File Downloaded : ファイルダウンロードイベント(設定時)
+    6. Value Changed : 値変更イベント(設定時)
+    7. Scrolled Up/Down : スクロールイベント(設定時)
+    8. Print Initiated : 印刷開始イベント(設定時)
+    9. URL : アクセスしたページURL
+    10. Tab ID : タブ識別子
+    11. Timestamp : イベント発生時間
+3.  **画面右側には実際のユーザーがアクセスしたウェブアプリケーションのスクリーンショットが表示されます。**
 
 <Callout type="info">
 管理者はWeb Apps &gt; Web App Configurationsで各ウェブアプリケーション別に記録するユーザー活動タイプを設定できます。

--- a/src/content/ja/administrator-manual/audit/web-app-logs/web-access-history.mdx
+++ b/src/content/ja/administrator-manual/audit/web-app-logs/web-access-history.mdx
@@ -19,19 +19,22 @@ Administrator &gt; Audit &gt; Web Apps &gt; Web Access History
 
 1. Administrator &gt; Audit &gt; Web Apps &gt; Web Access Historyメニューに移動します。
 2. 現在月基準でログが降順で照会されます。
-3. テーブル最左上部の検索欄を通じて以下の条件で検索が可能です。
-   1. **User Name**: ユーザー名
-   2. **User Email**: ユーザーEmail
-   3. **Role Name**: 役割名
-   4. **Web App Name**: ウェブアプリケーション名
-   5. **Web App Base Url**: ウェブアプリケーション基本URL
-   6. **Session Uuid**: セッション固有識別子
-   7. **Tab Id**: タブ識別子
-   8. **Client Ip**: クライアントIPアドレス
-   9. **Message**: メッセージ内容
+3. テーブル左上の検索欄を通じて以下の条件で検索が可能です。
+    1.  **User Name**  : ユーザー名
+    2.  **User Email**  : ユーザーEmail
+    3.  **Role Name**  : 役割名
+    4.  **Web App Name**  : ウェブアプリケーション名
+    5.  **Web App Base Url**  : ウェブアプリケーション基本URL
+    6.  **Session Uuid**  : セッション固有識別子
+    7.  **Tab Id** : タブ識別子
+    8.  **Client Ip**  : クライアントIPアドレス
+    9.  **Message**  : メッセージ内容
 4. 検索フィールド右側フィルターボタンをクリックしてAND条件で以下のフィルタリングが可能です。
-   1. **Action Type**: アクションタイプ
-   2. **Action At**: アクション発生日時範囲
+  <figure data-layout="center" data-align="center">
+  ![image-20250629-171829.png](/administrator-manual/audit/web-app-logs/web-access-history/image-20250629-171829.png)
+  </figure>
+    1.  **Action Type**  : アクションタイプ
+    2.  **Action At**  : アクション発生日時範囲
 
 ### Web Access History詳細内訳の照会
 
@@ -44,18 +47,18 @@ Administrator &gt; Audit &gt; Web Apps &gt; Web Access History &gt; Web Access H
 </figcaption>
 </figure>
 
-* **右側ドロワーには以下の情報を露出します:**
-   1. **Action At**: アクション時点
-   2. **Action Type**: アクションタイプ（Connect / Disconnect）
-   3. **Result**: 接続成功/失敗の有無
-      1. ✅ Success
-      2. ❌ Failure
-   4. **Role**: ユーザー役割名
-   5. **Message**: アクション実行など特異事項に対する記録
-   6. **Name**: 対象ユーザー名
-   7. **Email**: 対象ユーザーメール
-   8. **Client IP**: クライアントIPアドレス
-   9. **Web App**: ウェブアプリケーション名
-   10. **Base URL**: ウェブアプリケーション基本URL
-   11. **Session ID**: セッション固有識別子
-   12. **Tab ID**: タブ識別子
+*  **右側ドロワーには以下の情報を露出します:**
+    1.  **Action At**  : アクション時点
+    2.  **Action Type**  : アクションタイプ(Connect / Disconnect)
+    3.  **Result**  : 接続成功/失敗の有無
+        1. ✅ Success
+        2. ❌ Failure
+    4.  **Role**  : ユーザー役割名
+    5.  **Message**  : アクション実行など特異事項に対する記録
+    6.  **Name**  : 対象ユーザー名
+    7.  **Email**  : 対象ユーザーメール
+    8.  **Client IP**  : クライアントIPアドレス
+    9.  **Web App**  : ウェブアプリケーション名
+    10.  **Base URL**  : ウェブアプリケーション基本URL
+    11.  **Session ID**  : セッション固有識別子
+    12.  **Tab ID**  : タブ識別子

--- a/src/content/ja/administrator-manual/audit/web-app-logs/web-app-role-history.mdx
+++ b/src/content/ja/administrator-manual/audit/web-app-logs/web-app-role-history.mdx
@@ -19,22 +19,25 @@ Administrator &gt; Audit &gt; Web Apps &gt; Web App Role History
 
 1. Administrator &gt; Audit &gt; Web Apps &gt; Web App Role Historyメニューに移動します。
 2. 現在月基準でログが降順で照会されます。
-3. テーブル最左上部の検索欄を通じて以下の条件で検索が可能です。<br/>a. User Name : ユーザー名<br/>b. User Email : ユーザーメール<br/>c. Role Name : 役割名
-4. 検索フィールド右側フィルターボタンをクリックしてAND/OR条件で以下のフィルタリングが可能です。
-   1. **Event**: イベントタイプ
-   2. **User Type**: ユーザータイプ
-   3. **Action At**: アクション発生日時範囲
+3. テーブル左上の検索欄を通じて以下の条件で検索が可能です。<br/>a. User Name : ユーザー名<br/>b. User Email : ユーザーメール<br/>c. Role Name : 役割名
+4. 検索フィールド右側フィルターボタンをクリックしてAND/OR条件で以下のフィルタリングが可能です。 <br/>
+  <figure data-layout="center" data-align="center">
+  ![Screenshot-2025-06-30-at-2.48.27-PM.png](/administrator-manual/audit/web-app-logs/web-app-role-history/Screenshot-2025-06-30-at-2.48.27-PM.png)
+  </figure>
+    1.  **Event**  : イベントタイプ
+    2.  **User Type**  : ユーザータイプ
+    3.  **Action At** : アクション発生日時範囲
 5. テーブル右上のリフレッシュボタンを通じてログ一覧を最新化できます。
-6. テーブルで以下のような情報を提供します:
-   1. **No**: 順番
-   2. **Action At**: アクション発生日時
-   3. **Event**: イベントタイプ（Role Granted、Role Revoked）
-   4. **User Type**: ユーザータイプ（USER、GROUP）
-   5. **Name**: ユーザー名
-   6. **Email**: ユーザーメール
-   7. **Role Name**: 付与/回収された役割名
-   8. **Expiration Date**: 役割期限日時
-   9. **Action By**: アクションを実行した管理者名
+6. テーブルで以下の情報を提供します:
+    1.  **No**  : 順番
+    2.  **Action At**  : アクション発生日時
+    3.  **Event**  : イベントタイプ(Role Granted、Role Revoked)
+    4.  **User Type**  : ユーザータイプ(USER、GROUP)
+    5.  **Name**  : ユーザー名
+    6.  **Email**  : ユーザーメール
+    7.  **Role Name**  : 付与/回収された役割名
+    8.  **Expiration Date**  : 役割期限日時
+    9.  **Action By**  : アクションを実行した管理者名
 
 ### Web App Role History詳細内訳の照会
 
@@ -47,15 +50,15 @@ Administrator &gt; Audit &gt; Web Apps &gt; Web App Role History &gt; Web App Ro
 </figcaption>
 </figure>
 
-* **右側ドロワーには以下の情報を露出します:**
-   1. **Role Name**: 付与/回収された役割名
-   2. **Event**: イベントタイプ（Role Granted、Role Revoked）
-   3. **Name**: 対象ユーザー名
-   4. **Email**: 対象ユーザーメール
-   5. **Action At**: アクション時点
-   6. **Action By**: アクションを実行した管理者名
-   7. **Expiration Date**: 役割期限日時
-   8. **Policies**: 該当役割に含まれた政策一覧
-      1. Name : 政策名
-      2. Description : 政策説明
-      3. Version : 政策バージョン
+*  **右側ドロワーには以下の情報を露出します:**
+    1.  **Role Name**  : 付与/回収された役割名
+    2.  **Event**  : イベントタイプ(Role Granted、Role Revoked)
+    3.  **Name**  : 対象ユーザー名
+    4.  **Email**  : 対象ユーザーメール
+    5.  **Action At**  : アクション時点
+    6.  **Action By**  : アクションを実行した管理者名
+    7.  **Expiration Date**  : 役割期限日時
+    8.  **Policies**  : 該当役割に含まれた政策一覧
+        1. Name : 政策名
+        2. Description : 政策説明
+        3. Version : 政策バージョン


### PR DESCRIPTION
## 개요
todo-03.txt에 나열된 10개의 일본어 문서에 대해 한국어 원문과의 불일치를 수정했습니다.

## 수정 내용

### 1. Server 로그 관련 문서 (6개)

#### Account Lock History
- `account-lock-history.mdx`

**수정 사항:**
- 리스트 항목의 들여쓰기를 4칸으로 통일
- 제목 번역 개선: "Server Account Lock History照会" → "Server Account Lock Historyの照会"
- 이미지 태그 위치 수정

#### Command Audit
- `command-audit.mdx`

**수정 사항:**
- 리스트 항목의 들여쓰기를 4칸으로 통일
- 번역 표현 개선: "接続使用したProtocol" → "接続時使用したProtocol"
- 중첩 리스트 구조 개선

#### Server Access History
- `server-access-history.mdx`

**수정 사항:**
- 리스트 항목의 들여쓰기를 4칸으로 통일
- 번역 표현 개선

#### Server Role History
- `server-role-history.mdx`

**수정 사항:**
- 리스트 항목의 들여쓰기를 4칸으로 통일
- 이미지 태그 위치를 한국어 원문과 동일하게 수정
- 번역 표현 개선: "付与/回収されたRole名前" → "付与/回収されたRole名"

#### Session Logs
- `session-logs.mdx`

**수정 사항:**
- 리스트 항목의 들여쓰기를 4칸으로 통일
- 이미지 태그 위치를 한국어 원문과 동일하게 수정
- 번역 표현 개선

#### Session Monitoring
- `session-monitoring.mdx`

**수정 사항:**
- 리스트 항목의 들여쓰기를 4칸으로 통일
- 제목 번역 개선: "Session Monitoring照会" → "Session Monitoringの照会"

### 2. Web App 로그 관련 문서 (4개)

#### JIT Access Control Logs
- `jit-access-control-logs.mdx`

**수정 사항:**
- 리스트 항목의 들여쓰기를 4칸으로 통일
- 이미지 태그 위치를 한국어 원문과 동일하게 수정

#### User Activity Recordings
- `user-activity-recordings.mdx`

**수정 사항:**
- 리스트 항목의 들여쓰기를 4칸으로 통일
- 이미지 태그 위치를 한국어 원문과 동일하게 수정

#### Web Access History
- `web-access-history.mdx`

**수정 사항:**
- 리스트 항목의 들여쓰기를 4칸으로 통일
- 이미지 태그 위치를 한국어 원문과 동일하게 수정

#### Web App Role History
- `web-app-role-history.mdx`

**수정 사항:**
- 리스트 항목의 들여쓰기를 4칸으로 통일
- 이미지 태그 위치를 한국어 원문과 동일하게 수정

## 검증
- 모든 파일이 한국어 원문의 구조와 일치하도록 수정됨
- MDX 문법 오류 없음 확인
- 리스트 들여쓰기 일관성 확보 (모두 4칸으로 통일)
- 번역 표현 개선

## 참고
- 작업 대상: docs/todo-03.txt에 나열된 10개 파일
- 주요 수정: 들여쓰기 통일, 구조 개선, 번역 표현 보완, 이미지 태그 위치 수정