### PR TITLE
mdx: 일본어 문서 불일치 수정 21

### DIFF
--- a/src/content/ja/administrator-manual/audit/web-app-logs/web-event-audit.mdx
+++ b/src/content/ja/administrator-manual/audit/web-app-logs/web-event-audit.mdx
@@ -21,33 +21,36 @@ Administrator &gt; Audit &gt; Web Apps &gt; Web Event Audit
 1. Administrator &gt; Audit &gt; Web Apps &gt; Web Event Auditメニューに移動します。
 2. 現在月基準でログが降順で照会されます。
 3. テーブル最左上部の検索欄を通じて以下の条件で検索が可能です。
-   1. User Name : ユーザー名
-   2. User Email : ユーザーメール
-   3. Role Name : 役割名
-   4. Web App Name : ウェブアプリケーション名
-   5. Content : コンテンツ内容
-   6. Url : アクセスしたURL
-   7. Session Uuid : セッション固有識別子
-   8. Tab Id : タブ識別子
-   9. Client Ip : クライアントIPアドレス
-   10. Message : メッセージ内容
-4. 検索フィールド右側フィルターボタンをクリックしてAND/OR条件で以下のフィルタリングが可能です。
-   1. Event Type : イベントタイプ（Mouse Clicked/Clipboard Copiedなど）
-   2. Result : 実行結果（Success/Failure）
-   3. Action At : アクション発生日時範囲
+    1. User Name : ユーザー名
+    2. User Email : ユーザーメール
+    3. Role Name : 役割名
+    4. Web App Name : ウェブアプリケーション名
+    5. Content : コンテンツ内容
+    6. Url : アクセスしたURL
+    7. Session Uuid : セッション固有識別子
+    8. Tab Id : タブ識別子
+    9. Client Ip : クライアントIPアドレス
+    10. Message : メッセージ内容
+4. 検索フィールド右側フィルターボタンをクリックしてAND/OR条件で以下のフィルタリングが可能です。 <br/> 
+  <figure data-layout="center" data-align="center">
+  ![image-20250629-173418.png](/administrator-manual/audit/web-app-logs/web-event-audit/image-20250629-173418.png)
+  </figure>
+    1. Event Type : イベントタイプ（Mouse Clicked/Clipboard Copiedなど）
+    2. Result : 実行結果（Success/Failure）
+    3. Action At : アクション発生日時範囲
 5. テーブル右上のリフレッシュボタンを通じてログ一覧を最新化できます。
 6. テーブルで以下のカラム情報を提供します:
-   1. **No**: 順番
-   2. **Action At**: アクション発生日時
-   3. **Event Type**: イベントタイプ（Mouse Clicked、Clipboard Copiedなど）
-   4. **Result**: 実行結果（Success/Failure）
-   5. **Name**: ユーザー名
-   6. **Email**: ユーザーメール
-   7. **Web App**: ウェブアプリケーション名
-   8. **URL**: アクセスしたURL
-   9. **Session ID**: セッション固有識別子
-   10. **Tab ID**: タブ識別子
-   11. **Client IP**: クライアントIPアドレス
+    1. **No**: 順番
+    2. **Action At**: アクション発生日時
+    3. **Event Type**: イベントタイプ（Mouse Clicked、Clipboard Copiedなど）
+    4. **Result**: 実行結果（Success/Failure）
+    5. **Name**: ユーザー名
+    6. **Email**: ユーザーメール
+    7. **Web App**: ウェブアプリケーション名
+    8. **URL**: アクセスしたURL
+    9. **Session ID**: セッション固有識別子
+    10. **Tab ID**: タブ識別子
+    11. **Client IP**: クライアントIPアドレス
 
 ### Web Event Audit詳細内訳の照会
 
@@ -61,19 +64,19 @@ Administrator &gt; Audit &gt; Web Apps &gt; Web Event Audit &gt; Event Audit Det
 </figure>
 
 * **右側ドロワーには以下の情報を露出します:**
-   1. **Action At**: アクション時点
-   2. **Event Type**: イベントタイプ（Mouse Clicked、Clipboard Copiedなど）
-   3. **Result**: イベント処理成功/失敗の有無
-      1. ✅ Success
-      2. ❌ Failure
-   4. **Client IP**: クライアントIPアドレス
-   5. **Name**: 対象ユーザー名
-   6. **Email**: 対象ユーザーメール
-   7. **Role**: ユーザー役割名
-   8. **Message**: イベント実行など特異事項に対する記録
-   9. **Web App**: ウェブアプリケーション名
-   10. **URL**: イベントが発生したページURL
-   11. **Session ID**: セッション固有識別子
-   12. **Tab ID**: タブ識別子
-   13. **Clicked Text**: クリックされたテキスト内容（Mouse Clickedイベントの場合）
-   14. **Event Snapshot**: イベント発生時点の画面スクリーンショット
+    1. **Action At**: アクション時点
+    2. **Event Type**: イベントタイプ（Mouse Clicked、Clipboard Copiedなど）
+    3. **Result**: イベント処理成功/失敗の有無
+        1. ✅ Success
+        2. ❌ Failure
+    4. **Client IP**: クライアントIPアドレス
+    5. **Name**: 対象ユーザー名
+    6. **Email**: 対象ユーザーメール
+    7. **Role**: ユーザー役割名
+    8. **Message**: イベント実行など特異事項に対する記録
+    9. **Web App**: ウェブアプリケーション名
+    10. **URL**: イベントが発生したページURL
+    11. **Session ID**: セッション固有識別子
+    12. **Tab ID**: タブ識別子
+    13. **Clicked Text**: クリックされたテキスト内容（Mouse Clickedイベントの場合）
+    14. **Event Snapshot**: イベント発生時点の画面スクリーンショット

--- a/src/content/ja/administrator-manual/databases/connection-management/db-connections/mongodb-specific-guide.mdx
+++ b/src/content/ja/administrator-manual/databases/connection-management/db-connections/mongodb-specific-guide.mdx
@@ -78,8 +78,8 @@ Administrator &gt; Databases &gt; Connection Management &gt; DB Connections &gt;
 2. Connection Nameを指定します。
 3. `Cluster`スイッチをオンにしてクラスター入力をアクティブにした後、以下の情報を入力します。
     1. Type : コネクション情報に露出される領域です。Primary役割が動的に変わる可能性があるため、基本値である`Primary`を選択します。
-    2. Expose : Connection情報画面またはagentの接続対象一覧でクラスターの下位ノード（ホストまたはインスタンス）を展開して見ることができるようにするには"`Expandable`"を、展開して見ることができないようにするには"`Unexpandable`"を、クラスターを隠して下位ノード（ホストまたはインスタンス）のみ表示するには"`Hidden`"を選択します。
-    3. Connection String :
+    2. Expose : Connection情報画面またはagentの接続対象一覧でクラスターの下位ノード（ホストまたはインスタンス）を展開して見ることができるようにするには"`Expandable`"を、展開して見ることができないようにするには"`Unexpandable`"を、クラスターを隠して下位ノード（ホストまたはインスタンス）のみ表示するには"`Hidden`"を選択します。 
+    3. Connection String : 
         1. Scheme選択項目で`mongodb://`を選択します。
         2. 下位ホスト名とポートをカンマで区切って入力します。
     4. `Add Instance`ボタンを押して各メンバーホストをインスタンスとして追加します。
@@ -92,7 +92,7 @@ Administrator &gt; Databases &gt; Connection Management &gt; DB Connections &gt;
 </figure>
 
 1. Authentication DB : Authentication DB（authSource）の値を入力します。
-2. Other Options : Connection stringで使用するオプション中authSourceを除いた残りの値を入力します。<br/>例1）単一オプションのみ使用する場合の形式（ [Key]=[Value] ）: replicaSet=rs0<br/>例2）多重オプションを使用する場合の形式（ [Key]=[Vaule]&[Key]=[Value] ）: replicaSet=rs0&tls=true<br/>**replica set構成の場合、replicaSet=[replicaset name]オプションを入力する必要があります。**
+2. Other Options : Connection stringで使用するオプション中authSourceを除いた残りの値を入力します。<br/>例1）単一オプションのみ使用する場合の形式（ [Key]=[Value] ）: replicaSet=rs0<br/>例2）多重オプションを使用する場合の形式（ [Key]=[Vaule]&[Key]=[Value] ）: replicaSet=rs0&tls=true<br/>**replica set構成の場合、replicaSet=[replicaset name]オプションを入力する必要があります。** 
 3. Secret Store : パスワードおよびキー管理を3rd partyで使用する場合のためのオプションです。基本値QuerypieはQueryPie内部で管理することを意味します。
 4. User Name & Password : 該当データベースのユーザー名とパスワードを入力します。
 5. `Test Connection`ボタンをクリックして、入力した接続情報が有効かを確認できます。
@@ -113,8 +113,8 @@ Clusterモードに対するより詳細な内容は[DB Connections](.)でも確
 2. Connection Nameを指定します。
 3. `Cluster`スイッチをオンにしてクラスター入力をアクティブにした後、以下の情報を入力します。
     1. Type : コネクション情報に露出される領域です。Primary役割が動的に変わる可能性があるため、基本値である`Primary`を選択します。
-    2. Expose : Connection情報画面またはagentの接続対象一覧でクラスターの下位ノード（ホストまたはインスタンス）を展開して見ることができるようにするには"`Expandable`"を、展開して見ることができないようにするには"`Unexpandable`"を、クラスターを隠して下位ノード（ホストまたはインスタンス）のみ表示するには"`Hidden`"を選択します。
-    3. Connection String :
+    2. Expose : Connection情報画面またはagentの接続対象一覧でクラスターの下位ノード（ホストまたはインスタンス）を展開して見ることができるようにするには"`Expandable`"を、展開して見ることができないようにするには"`Unexpandable`"を、クラスターを隠して下位ノード（ホストまたはインスタンス）のみ表示するには"`Hidden`"を選択します。 
+    3. Connection String : 
         1. Scheme選択項目で`mongodb+srv://`を選択します。
         2. ドメイン形式のホスト名（FQDN）を入力します。
         3. `Lookup`ボタンを押します。正常にDNS照会がされた場合、クラスターに含まれたノードがインスタンスとして自動で追加されます。
@@ -139,7 +139,7 @@ Replica Setは replicaSet=[replica set name] オプションが必要ですが�
 
 1. `Cluster`スイッチをオンにしてクラスター入力をアクティブにした後、以下の情報を入力します。
     1. Type : コネクション情報に露出される領域です。Primary役割が動的に変わる可能性があるため、Primary値を維持します。
-    2. Connection String :
+    2. Connection String : 
         1. Scheme選択項目で`mongodb://`を選択します。
         2. 各mongosのホスト名とポートをカンマで区切って入力します。
     3. `Add Instance`ボタンを押して各mongosをインスタンスとして追加します。

--- a/src/content/ja/administrator-manual/general/system/integrations/identity-providers.mdx
+++ b/src/content/ja/administrator-manual/general/system/integrations/identity-providers.mdx
@@ -535,3 +535,4 @@ Custom Identity Providerは認証APIサーバーを使用する特殊な場合�
 
 
 
+

--- a/src/content/ja/administrator-manual/general/system/integrations/integrating-with-slack-dm.mdx
+++ b/src/content/ja/administrator-manual/general/system/integrations/integrating-with-slack-dm.mdx
@@ -25,10 +25,10 @@ Slack AppをQueryPieに連携し、QueryPieからDirect Message通知を受信�
 App Manifestを利用してQueryPie DM連携専用Slack Appを生成します。
 
 
-1. [https://api.slack.com/apps](https://api.slack.com/apps)に移動して`Create an App`をクリックします。<br/>
+1. [https://api.slack.com/apps](https://api.slack.com/apps)に移動して`Create an App`をクリックします。<br/> 
 2. Create an appモーダルで、App生成方式を選択します。`From a manifest`をクリックします。<br/>
 3. Pick a workspaceモーダルでQueryPieと連携するSlack Workspaceを選択した後次の段階に進行します。<br/>
-4. Create app from manifestモーダルでJSON形式のApp Manifestを入力します。<br/>事前に埋められている内容を削除し以下のApp Manifestを貼り付けた後次の段階に進行します。<br/>:light_bulb_on: `{{..}}`内の値は希望する値に変更してください。 <br/> 
+4. Create app from manifestモーダルでJSON形式のApp Manifestを入力します。<br/>事前に埋められている内容を削除し以下のApp Manifestを貼り付けた後次の段階に進行します。<br/>:light_bulb_on: `{{..}}`内の値は希望する値に変更してください。 <br/>
   ```
 {
     "display_information": {

--- a/src/content/ja/administrator-manual/general/user-management/authentication.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/authentication.mdx
@@ -8,7 +8,11 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-SSO（Single Sign-On）統合はユーザー認証およびアクセス管理を向上させると同時に安全な統合認証環境を提供するQueryPie内の必須機能です。組織で使用するアカウントシステムを連携して組織内のユーザーおよびグループをQueryPieに同期できます。管理者は組織内の入社者および退社者を一箇所で管理できます。SSO統合は認証プロセスを簡素化し、ユーザーが組織内で使用中の認証方式でQueryPieを通じてデータベースおよびシステムにアクセスできるようにします。該当ドキュメントではSSO連携方法と主要考慮事項について説明します。
+SSO（Single Sign-On）統合はユーザー認証およびアクセス管理を向上させると同時に安全な統合認証環境を提供するQueryPie内の必須機能です。
+組織で使用するアカウントシステムを連携して組織内のユーザーおよびグループをQueryPieに同期できます。
+管理者は組織内の入社者および退社者を一箇所で管理できます。
+SSO統合は認証プロセスを簡素化し、ユーザーが組織内で使用中の認証方式でQueryPieを通じてデータベースおよびシステムにアクセスできるようにします。
+該当ドキュメントではSSO連携方法と主要考慮事項について説明します。
 
 <Callout type="info">
 11.3.0でAuthentication関連設定がAdmin &gt; General &gt; User Management &gt; AuthenticationからAdmin &gt; General &gt; System &gt; IntegrationのAuthenticationの下位項目であるIdentity Providersに移動されました。
@@ -22,7 +26,7 @@ SSO（Single Sign-On）統合はユーザー認証およびアクセス管理を
 * [Okta](authentication/integrating-with-okta)
 * [LDAP](authentication/integrating-with-ldap)
 * Swivel Secure
-* OneLogin
+* OneLogin 
 * SAML 2.0
 * Custom Identity Provider : API URL入力のみ可能です。
 
@@ -50,7 +54,7 @@ Authenticationタイプ変更が必要な場合にはQueryPie技術サポート�
 
 ### 外部アカウントシステムおよびQueryPie自身アカウント同時使用
 
-* 外部アカウントシステム連携機能を使用する場合でも、QueryPie自身でユーザー、グループを追加して使用できます。
+* 外部アカウントシステム連携機能を使用する場合でも、QueryPie自身でユーザー、グループを追加して使用できます。 
 * ただし、UsernameとEmail項目は固有値で重複して登録できません。
 
 

--- a/src/content/ja/administrator-manual/general/user-management/authentication/integrating-with-google-saml.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/authentication/integrating-with-google-saml.mdx
@@ -6,7 +6,8 @@ title: 'Google SAML連携'
 
 ### Overview
 
-QueryPieではGoogleのユーザーをSAML 2.0を通じてユーザー連携をサポートします。ユーザーを同期してアクセス権限を付与しポリシーを適用できます。
+QueryPieではGoogleのユーザーをSAML 2.0を通じてユーザー連携をサポートします。
+ユーザーを同期してアクセス権限を付与しポリシーを適用できます。
 
 
 ### Google WorkspaceでSAML設定
@@ -25,21 +26,23 @@ QueryPieではGoogleのユーザーをSAML 2.0を通じてユーザー連携を�
 </figure>
 
 
-3. アプリ詳細情報を入力する1段階ページです。アプリ名項目に'QueryPie-SSO'を入力後`続行`ボタンをクリックします。
+3. アプリ詳細情報を入力する1段階ページです。
+アプリ名項目に'QueryPie-SSO'を入力後`続行`ボタンをクリックします。
 
 <figure data-layout="center" data-align="center">
 ![screenshot-20240902-164038.png](/administrator-manual/general/user-management/authentication/integrating-with-google-saml/screenshot-20240902-164038.png)
 </figure>
 
 
-4. 2段階ページでは以下の値を入力します。入力完了後`続行`ボタンをクリックして3段階に移動します。
+4. 2段階ページでは以下の値を入力します。
+入力完了後`続行`ボタンをクリックして3段階に移動します。
 
 <figure data-layout="center" data-align="center">
 ![screenshot-20240902-164356.png](/administrator-manual/general/user-management/authentication/integrating-with-google-saml/screenshot-20240902-164356.png)
 </figure>
 
-* ACS URL : `https://{QueryPie Host}/saml/sp/acs`
-* エンティティID : `https://{QueryPie Host}/saml/sp/metadata`
+* ACS URL : `https://{QueryPie Host}/saml/sp/acs` 
+* エンティティID : `https://{QueryPie Host}/saml/sp/metadata` 
 * 開始URL（選択事項） : `https://{QueryPie Host}/`
 
 
@@ -62,7 +65,8 @@ QueryPieではGoogleのユーザーをSAML 2.0を通じてユーザー連携を�
 </figure>
 
 
-7. 生成が正常に完了すると以下のようにリストに新規追加されたアプリが表示されます。使用設定のために該当アプリをクリックします。
+7. 生成が正常に完了すると以下のようにリストに新規追加されたアプリが表示されます。
+使用設定のために該当アプリをクリックします。
 
 <figure data-layout="center" data-align="center">
 ![screenshot-20240902-165202.png](/administrator-manual/general/user-management/authentication/integrating-with-google-saml/screenshot-20240902-165202.png)
@@ -91,9 +95,9 @@ QueryPieではGoogleのユーザーをSAML 2.0を通じてユーザー連携を�
 ![screenshot-20240902-170029.png](/administrator-manual/general/user-management/authentication/integrating-with-google-saml/screenshot-20240902-170029.png)
 </figure>
 
-* Type : SAMLを選択します。
-* Identity Provider Metadata : Google管理コンソールホームページでダウンロードしたファイル（GoogleIDPMetadata.xml）を開いて内容をコピー後ここに貼り付けます。
-* `Save Changes`ボタンを押すと設定が完了します。
+* Type : SAMLを選択します。 
+* Identity Provider Metadata : Google管理コンソールホームページでダウンロードしたファイル（GoogleIDPMetadata.xml）を開いて内容をコピー後ここに貼り付けます。 
+* `Save Changes`ボタンを押すと設定が完了します。 
 
 
 ### QueryPieでSAMLログイン

--- a/src/content/ja/administrator-manual/general/user-management/authentication/integrating-with-ldap.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/authentication/integrating-with-ldap.mdx
@@ -32,7 +32,9 @@ Administrator &gt; General &gt; User Management &gt; Authentication &gt; LDAP
 ![image-20250515-095143.png](/administrator-manual/general/user-management/authentication/integrating-with-ldap/image-20250515-095143.png)
 </figure>
 
-LDAP連携のための基本的な認証情報および属性情報を入力します。Attributeマッピングのための属性情報の場合、フィールド名はQueryPie Userの属性名で、フィールドにはLDAPで参照するAttribute名を入力します。詳細説明は下部項目を参照してください。
+LDAP連携のための基本的な認証情報および属性情報を入力します。
+Attributeマッピングのための属性情報の場合、フィールド名はQueryPie Userの属性名であり、フィールドにはLDAPで参照するAttribute名を入力します。
+詳細説明は下部項目を参照してください。
 
 #### グループ連携設定
 
@@ -225,7 +227,7 @@ QueryPie Attribute
 * `Save Changes`をクリックすると入力された設定情報をQueryPieに保存します。
 * `Synchronize`ボタンをクリックすると現在入力された設定情報を基盤に同期を実行します。（現在入力した設定情報を保存した後にのみ有効化される）
     * ![image-20241209-124345.png](/administrator-manual/general/user-management/authentication/integrating-with-ldap/image-20241209-124345.png)ボタンをクリックすると直前の同期履歴を照会できます。
-    * 個別同期中失敗件がある場合、Progress Bar色が黄色で表示されます。
+    * 個別同期中失敗件がある場合、Progress Bar色が黄色で表示されます。 
     * 失敗ログは：cross_mark:アイコンで表示されます。ログをクリックすると詳細なエラーメッセージを確認できます。
 
 
@@ -238,7 +240,7 @@ QueryPie Attribute
 
 ### QueryPieでLDAP認証してログイン
 
-1. Administrator &gt; General &gt; User Management &gt; UsersまたはGroupsメニューで同期されたユーザーおよびグループを確認できます。 <br/>  
+1. Administrator &gt; General &gt; User Management &gt; UsersまたはGroupsメニューで同期されたユーザーおよびグループを確認できます。 <br/>
   <figure data-layout="center" data-align="center">
   ![Admin &gt; General &gt; User Management &gt; Users](/administrator-manual/general/user-management/authentication/integrating-with-ldap/screenshot-20241209-215940.png)
   <figcaption>

--- a/src/content/ja/administrator-manual/general/user-management/authentication/integrating-with-okta.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/authentication/integrating-with-okta.mdx
@@ -13,7 +13,7 @@ Oktaのユーザーおよびグループを同期してアクセス権限を付�
 QueryPieとOktaの統合はデータベースおよびシステム管理エコシステムのセキュリティと運営効率性およびユーザー経験が向上させることができます。
 
 <Callout type="info">
-SCIMプロビジョニング連携まで実装したい場合、[[Okta]プロビジョニング連携ガイド](../provisioning/okta-provisioning-integration-guide) 内手順通り代わりに進行してください。下部のOkta APIを活用したアウトバウンドユーザー同期設定を同時に活用する場合、ユーザー同期に影響を受ける可能性がある点ご注意ください。
+SCIMプロビジョニング連携まで実装したい場合、[[Okta]プロビジョニング連携ガイド](../provisioning/okta-provisioning-integration-guide)  内手順通り代わりに進行してください。下部のOkta APIを活用したアウトバウンドユーザー同期設定を同時に活用する場合、ユーザー同期に影響を受ける可能性がある点ご注意ください。
 </Callout>
 
 
@@ -44,12 +44,12 @@ Okta Admin &gt; Directory &gt; Profile Editor &gt; QueryPie User &gt; Add Attrib
 </figure>
 
 1. Okta管理者ページの左側パネルでDirectory &gt; Profile Editorメニューに移動します。
-2. Profileリスト中'QueryPie User'をクリックします。
+2. Profileリスト中'QueryPie User'をクリックします。 
 3. Attributes設定で`Add Attribute`ボタンをクリックします。
 4. Attribute追加画面で以下4つの項目を順番に入力後保存します。
-    1. Display name : firstName / Variable name : firstName項目入力後`Save and Add Another`
+    1. Display name : firstName / Variable name : firstName項目入力後`Save and Add Another` 
     2. Display name : lastName / Variable name : lastName項目入力後`Save and Add Another`
-    3. Display name : email / Variable name : email項目入力後`Save and Add Another`
+    3. Display name : email / Variable name : email項目入力後`Save and Add Another` 
     4. Display name : loginId / Variable name : loginId項目入力後`Save`クリック
 
 <figure data-layout="center" data-align="center">
@@ -118,34 +118,34 @@ Okta Admin Console &gt; Security &gt; Administrators &gt; Roles &gt; Create new 
 </figcaption>
 </figure>
 
-1. Okta管理者ページ左側パネルでDirectory &gt; Peopleメニューに移動してAdd Personを押して専用システム連携用アカウントを生成します。
-    * 既にクエリパイ連携用で使用可能なアカウントがあれば本段階をスキップします。
-2. Okta管理者ページ左側パネルでSecurity &gt; Administratorsメニューに移動してRolesタブに移動します。
-3. Create new roleを選択します。
-4. Role name（例：MinimumAdminRole）およびRole descriptionを定義した後、Select Permisionsで以下の権限のみチェックします。
-    1.  **User**
+1. Okta管理者ページ左側パネルでDirectory &gt; Peopleメニューに移動してAdd Personを押して専用システム連携用アカウントを生成します。 
+    * 既にクエリパイ連携用で使用可能なアカウントがあれば本段階をスキップします。 
+2. Okta管理者ページ左側パネルでSecurity &gt; Administratorsメニューに移動してRolesタブに移動します。 
+3. Create new roleを選択します。 
+4. Role name（例：MinimumAdminRole）およびRole descriptionを定義した後、Select Permisionsで以下の権限のみチェックします。 
+    1.  **User** 
         * View users and their details
-    2.  **Group**
+    2.  **Group** 
         * View groups and their details
-    3.  **Application**
+    3.  **Application** 
         * View application and their details
-5. Save roleを押してカスタムロールを保存します。
-6. Resourcesタブに移動します。
+5. Save roleを押してカスタムロールを保存します。 
+6. Resourcesタブに移動します。 
 7. Create new resource setを選択します。
-    * 既に割り当てる権限範囲指定のために作っておいたresource setがあれば本段階をスキップして10番段階を進行します。
-8. Name（例：MinimumResources）およびDescriptionを定義した後以下の範囲を検索して指定します。
-    1. User : クエリパイユーザー全部選択
-    2. Group : クエリパイ使用グループ全部選択
+    * 既に割り当てる権限範囲指定のために作っておいたresource setがあれば本段階をスキップして10番段階を進行します。 
+8. Name（例：MinimumResources）およびDescriptionを定義した後以下の範囲を検索して指定します。 
+    1. User : クエリパイユーザー全部選択 
+    2. Group : クエリパイ使用グループ全部選択 
     3. Application : クエリパイアプリに限定
-9. Createを選択して生成します。
+9. Createを選択して生成します。 
 10. Adminsタブに移動してクエリパイ連携用アカウントに以下の権限を割り当てます。
     1. Role: MinimumAdminRole | Resource: MinimumResources
-    2. Role: Read-Only Administrator
-        * APIトークン生成メニューアクセスのための一時付与
-11. クエリパイ連携用アカウントでオクタ管理者コンソールページに認証後アクセスします。
+    2. Role: Read-Only Administrator 
+        * APIトークン生成メニューアクセスのための一時付与 
+11. クエリパイ連携用アカウントでオクタ管理者コンソールページに認証後アクセスします。 
 12. Security &gt; APIメニューでTokensタブに移動します。
-13. Create Tokenボタンをクリックして認証トークンを生成してこれを保管します。
-14. その後再び初期作業した管理者アカウントでアクセスしてSecurity &gt; Administrators &gt; Adminsタブで連携用アカウントを編集してRead-Only Adminstrator権限を回収します。
+13. Create Tokenボタンをクリックして認証トークンを生成してこれを保管します。 
+14. その後再び初期作業した管理者アカウントでアクセスしてSecurity &gt; Administrators &gt; Adminsタブで連携用アカウントを編集してRead-Only Adminstrator権限を回収します。 
 
 
 ### QueryPieでOkta連携および同期設定
@@ -162,8 +162,8 @@ Administrator &gt; General &gt; User Management &gt; Authentication
 3. コピーしたXML情報をIdentity Provider Metadata項目に貼り付けます。
 4. 自動同期を設定したい場合、"Use Synchronization with the Authentication System"をチェックします。
     1. API URL: Okta管理者ページ右上のプロフィールをクリックすると`{domain}`.okta.com形式のURLを確認できます。
-    2. API Token: Okta管理者APIトークンを記入します。
-    3. Application ID: Okta内で2つ以上のQueryPie Appを使用する場合入力します。
+    2. API Token: Okta管理者APIトークンを記入します。 
+    3. Application ID: Okta内で2つ以上のQueryPie Appを使用する場合入力します。 
 5. 自動同期機能を使用したい場合Replication Frequency項目でSchedulingを設定します。
 6. `Dry Run`ボタンをクリックして連携情報が正常に入力されたか確認します。
 7. `Save Changes`で保存します。
@@ -194,5 +194,5 @@ Okta Admin &gt; Applications &gt; QueryPie App上部URL
 
 <Callout type="info">
 該当連携方式ではユーザーおよびグループはOkta → QueryPieへの単方向同期をサポートします。
-SCIMプロビジョニング連携まで実装したい場合、[[Okta]プロビジョニング連携ガイド](../provisioning/okta-provisioning-integration-guide) 内手順通り代わりに進行してください。
+SCIMプロビジョニング連携まで実装したい場合、[[Okta]プロビジョニング連携ガイド](../provisioning/okta-provisioning-integration-guide)  内手順通り代わりに進行してください。
 </Callout>

--- a/src/content/ja/administrator-manual/general/user-management/authentication/setting-up-multi-factor-authentication.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/authentication/setting-up-multi-factor-authentication.mdx
@@ -21,8 +21,20 @@ MFA手段を指定するにはAuthentication TypeがInternal databaseまたはLD
 </Callout>
 
 * Admin &gt; General &gt; User Management &gt; Authenticationに移動します。
-* Authentication TypeがInternal databaseの場合<br/>
-* Authentication TypeがLDAPの場合<br/>
+* Authentication TypeがInternal databaseの場合<br/>  <br/>  
+  <figure data-layout="center" data-align="center">
+  ![Authentication Type - Internal Databaseの場合MFA設定](/administrator-manual/general/user-management/authentication/setting-up-multi-factor-authentication/image-20241219-015811.png)
+  <figcaption>
+  Authentication Type - Internal Databaseの場合MFA設定
+  </figcaption>
+  </figure>
+* Authentication TypeがLDAPの場合<br/> <br/>   <br/>  
+  <figure data-layout="center" data-align="center">
+  ![Authentication Type - LDAPの場合MFA設定](/administrator-manual/general/user-management/authentication/setting-up-multi-factor-authentication/image-20241219-020050.png)
+  <figcaption>
+  Authentication Type - LDAPの場合MFA設定
+  </figcaption>
+  </figure>
 
 ### サーバー接続時MFA使用
 
@@ -31,6 +43,9 @@ MFA手段を指定するにはAuthentication TypeがInternal databaseまたはLD
 </Callout>
 
 * Admin &gt; General &gt; Company Management &gt; Securityに移動します。
-* Server Connection Security項目下のAccess Server with MFAを"Enable"に設定しMFA TypeをGoogle OTPまたはEmailを選択します。（Access Server with MFAはデフォルト値がDisableです。<br/>
+* Server Connection Security項目下のAccess Server with MFAを"Enable"に設定しMFA TypeをGoogle OTPまたはEmailを選択します。（Access Server with MFAはデフォルト値がDisableです。<br/> <br/>  
+  <figure data-layout="center" data-align="center">
+  ![image-20241219-021137.png](/administrator-manual/general/user-management/authentication/setting-up-multi-factor-authentication/image-20241219-021137.png)
+  </figure>
 
 


### PR DESCRIPTION
## 변경 내용

- 들여쓰기 스타일을 한국어 원문과 일치시킴 (3칸 → 4칸)
- 리스트 항목의 중첩 들여쓰기를 수정
- 줄 끝 공백 패턴을 한국어 원문과 동기화
- 한국어 원문과의 구조적 차이를 수정하여 문서 일관성 개선
