### PR TITLE
mdx: 일본어 문서 불일치 수정 22

### DIFF
--- a/src/content/ja/administrator-manual/general/workflow-management/all-requests.mdx
+++ b/src/content/ja/administrator-manual/general/workflow-management/all-requests.mdx
@@ -45,9 +45,9 @@ Administrator &gt; General &gt; Workflow Management &gt; All Requests
 ボックス上にマウスをホバーすると詳細内容を確認できます。
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; General &gt; Workflow Management &gt; All Requests > List Detail > Current Status](/administrator-manual/general/workflow-management/all-requests/screenshot-20240725-181602.png)
+![Administrator &gt; General &gt; Workflow Management &gt; All Requests &gt; List Detail &gt; Current Status](/administrator-manual/general/workflow-management/all-requests/screenshot-20240725-181602.png)
 <figcaption>
-Administrator &gt; General &gt; Workflow Management &gt; All Requests > List Detail > Current Status
+Administrator &gt; General &gt; Workflow Management &gt; All Requests &gt; List Detail &gt; Current Status
 </figcaption>
 </figure>
 
@@ -77,4 +77,5 @@ Administrator &gt; General &gt; Workflow Management &gt; All Requests > List Det
 * [Access Role Request要求](../../../user-manual/workflow/requesting-access-role)
 * [IP Registration Request要求](../../../user-manual/workflow/requesting-ip-registration)
 * [DB Policy Exception Request要求](../../../user-manual/workflow/requesting-db-policy-exception)
+
 

--- a/src/content/ja/administrator-manual/general/workflow-management/approval-rules.mdx
+++ b/src/content/ja/administrator-manual/general/workflow-management/approval-rules.mdx
@@ -8,7 +8,9 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-決裁規則（Approval Rules）とは、管理者が事前に設定しておいたWorkflow承認プロセスを意味します。決裁規則は要求タイプ別にそれぞれ生成し、承認段階を1～4段階で設定し、各段階別に承認者選択方式を設定できます。Approval Rulesページで提供する機能は以下の通りです。
+決裁規則（Approval Rules）とは、管理者が事前に設定しておいたWorkflow承認プロセスを意味します。
+決裁規則は要求タイプ別にそれぞれ生成し、承認段階を1～4段階で設定し、各段階別に承認者選択方式を設定できます。
+Approval Rulesページで提供する機能は以下の通りです。
 
 1.  **決裁規則リスト照会**  ：登録された決裁規則リストを照会できます。（最近生成順）
 2.  **決裁設定**  ：決裁上申および承認プロセスを設定します。
@@ -37,9 +39,9 @@ Administrator &gt; General &gt; Workflow Management &gt; Approval Rules
 Approval Rulesページ右上の`Add Approval Rule`ボタンをクリックするとモーダルが露出されます。
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; General &gt; Workflow Management &gt; Approval Rules > Add Approval Rule](/administrator-manual/general/workflow-management/approval-rules/Screenshot-2025-08-26-at-4.42.57-PM.png)
+![Administrator &gt; General &gt; Workflow Management &gt; Approval Rules &gt; Add Approval Rule](/administrator-manual/general/workflow-management/approval-rules/Screenshot-2025-08-26-at-4.42.57-PM.png)
 <figcaption>
-Administrator &gt; General &gt; Workflow Management &gt; Approval Rules > Add Approval Rule
+Administrator &gt; General &gt; Workflow Management &gt; Approval Rules &gt; Add Approval Rule
 </figcaption>
 </figure>
 
@@ -73,6 +75,7 @@ Administrator &gt; General &gt; Workflow Management &gt; Approval Rules > Add Ap
 <Callout type="info">
 11.3.0でDefaultで提供される「Web App Just In Time Access Request」Approval Ruleで参照者を指定できるよう変更されました。
 </Callout>
+
 *  **Urgent Mode**  ：該当決裁規則下で事後承認（Urgent Mode）を許可するか決定します。
     * 基本値は非許可（Off）で、今後Approval Rule修正を通じてOn/Off可能です。
     * Workflow Configurationsで事後承認が許可されていなければならないこのオプションが表示されます。
@@ -80,23 +83,23 @@ Administrator &gt; General &gt; Workflow Management &gt; Approval Rules > Add Ap
     1.  **ワークフロー上申ページ**
         1.  **注意：**
             * 特定要求上申後に自己承認規則が変更されても、既に上申された要求には遡及して適用されません。
-        2.  **Allow Assignee selection (Admin-Only)** ：
+        2.  **Allow Assignee selection (Admin-Only)** :
             * 有効化時：ワークフロー上申ページで要求者本人を承認者として指定できます。
             * 無効化時：ワークフロー上申ページで承認者選択目録から要求者本人が除外されます。
-        3.  **Allow Assignee selection (All Users)**  ：
+        3.  **Allow Assignee selection (All Users)**  :
             * 有効化時：ワークフロー上申ページで要求者本人を承認者として指定できます。
             * 無効化時：ワークフロー上申ページで承認者選択目録から要求者本人が除外されます。
-        4.  **Select Assignees**  ：
+        4.  **Select Assignees**  :
             1. 承認規則に要求者自身のみApproverとして設定された場合：
                 * 有効化時：ワークフロー上申ページで要求者本人を承認者として指定できます。
                 * 無効化時：該当Approval Ruleは上申者ページ画面に表示されますが、選択して上申時エラーが発生します。
             2. 承認規則に要求者本人が含まれたグループがApproverとして設定された場合：
                 * 有効化時：ワークフロー上申ページで要求者本人を承認者として指定できます。
                 * 無効化時：要求者は承認者目録に含まれて表示されます。上申は可能ですが、実際の承認者画面では要求者本人の名前が除外され、残りのグループ構成員のみApproverとして登録されます。
-        5.  **Assign Connection Owner** ：
+        5.  **Assign Connection Owner** :
             * 有効化時：本人が含まれた場合自動的に本人が承認者として指定されます。
             * 無効化時：Ownerに要求者本人が含まれていても要求上申ページの承認者目録に表示されません。
-        6.  **Assign Server Group Owners ：**
+        6.  **Assign Server Group Owners :**
             * 有効化時：本人が含まれた場合自動的に本人が承認者として指定されます。
             * 無効化時：Ownerに要求者本人が含まれていても要求上申ページの承認者目録に表示されません。
     2.  **ワークフロー承認ページ**
@@ -115,9 +118,9 @@ Administrator &gt; General &gt; Workflow Management &gt; Approval Rules > Add Ap
 Administrator &gt; General &gt; Workflow Management &gt; Approval Rules内決裁規則リスト中詳細内容を確認および修正しようとするアイテムをクリックして、モーダルを開きます。
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; General &gt; Workflow Management &gt; Approval Rules > Update Approval Rule](/administrator-manual/general/workflow-management/approval-rules/image-20250512-121540.png)
+![Administrator &gt; General &gt; Workflow Management &gt; Approval Rules &gt; Update Approval Rule](/administrator-manual/general/workflow-management/approval-rules/image-20250512-121540.png)
 <figcaption>
-Administrator &gt; General &gt; Workflow Management &gt; Approval Rules > Update Approval Rule
+Administrator &gt; General &gt; Workflow Management &gt; Approval Rules &gt; Update Approval Rule
 </figcaption>
 </figure>
 

--- a/src/content/ja/administrator-manual/general/workflow-management/workflow-configurations.mdx
+++ b/src/content/ja/administrator-manual/general/workflow-management/workflow-configurations.mdx
@@ -11,7 +11,8 @@ import { Callout } from 'nextra/components'
 Workflow Configurationsでは、以下のような決裁上申および承認関連設定を変更します。
 
 <Callout type="info">
-10.2.6バージョンからSlack DM通知関連設定位置がIntegrationsに移動しました。使用方法は[Slack DM連動](../system/integrations/integrating-with-slack-dm)文書を参照してください。
+10.2.6バージョンからSlack DM通知関連設定位置がIntegrationsに移動しました。
+使用方法は[Slack DM連動](../system/integrations/integrating-with-slack-dm)文書を参照してください。
 10.2.5以下バージョンでのSlack DM設定方法は[10.1.0バージョンマニュアル文書](https://docs.querypie.com/ko/querypie-manual/10.1.0/workflow-configurations)を参照してください。
 </Callout>
 
@@ -48,7 +49,8 @@ Allow users to submit requests in Urgent modeトグルで有効化します。
 
 トグルをオンにするとWorkflowで上申されたSQL要求実行時スロットリングを適用します。
 
-このオプションを有効化する場合、明示された個数だけクエリを連続的に実行した後、明示された間隔（ms）だけ待機します。これを通じて大容量クエリ実行に伴うDB負荷を防止できます。
+このオプションを有効化する場合、明示された個数だけクエリを連続的に実行した後、明示された間隔（ms）だけ待機します。
+これを通じて大容量クエリ実行に伴うDB負荷を防止できます。
 
 *  **Maximum concurrent queries**  ：連続実行可能なクエリの最大個数（1～999,999）
 *  **Query throttle interval** ：連続クエリ実行後、次の連続クエリ実行間の間隔（1～9,999 ms）
@@ -60,3 +62,9 @@ Tag Display and Filtering in DAC Workflow Requestsトグルスイッチで有効
 このオプションを有効化する場合、以下の要求様式でタグで対象をフィルタリングできます。
 
 * DB Access Request：DB Connectionに付与されたタグを目録で見ることができ、フィルターを通じて特定タグがあるコネクションのみフィルタリングできます。
+  <figure data-layout="center" data-align="center">
+  ![DB Access Reqeust様式でタグ表示およびフィルタリング](/administrator-manual/general/workflow-management/workflow-configurations/image-20250629-180040.png)
+  <figcaption>
+  DB Access Reqeust様式でタグ表示およびフィルタリング
+  </figcaption>
+  </figure>

--- a/src/content/ja/administrator-manual/kubernetes/connection-management/cloud-providers.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/connection-management/cloud-providers.mdx
@@ -8,7 +8,8 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-Kubernetes同期用Cloud Providerの照会、作成、修正、削除をサポートします。Cloud Providerを通じて、クラウドプラットフォーム内のKubernetesリソースを同期し、QueryPieで管理するクラスターに一括登録することが可能です。
+Kubernetes同期用Cloud Providerの照会、作成、修正、削除をサポートします。
+Cloud Providerを通じて、クラウドプラットフォーム内のKubernetesリソースを同期し、QueryPieで管理するクラスターに一括登録することが可能です。
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Kubernetes &gt; Connection Management &gt; Cloud Providers](/administrator-manual/kubernetes/connection-management/cloud-providers/image-20240721-053703.png)
@@ -50,7 +51,7 @@ Administrator &gt; Kubernetes &gt; Connection Management &gt; Cloud Providers
 1. Administrator &gt; Kubernetes &gt; Connection Management &gt; Cloud Providersメニューに移動します。
 2. テーブル内の削除対象クラウドプロバイダー左側のチェックボックスをチェックします。
 3. テーブルカラムラインに表示された`Delete`ボタンをクリックします。
-4. ポップアップが表示されたら、*DELETE*文句を入力し、`Delete`ボタンをクリックして削除を進行します。
+4. ポップアップが表示されたら、*DELETE*文句を記入し、`Delete`ボタンをクリックして削除を進行します。
 
 <Callout type="important">
 Cloud Provider削除時、該当クラウドプロバイダーを通じて同期してきたすべてのリソースが一緒に一括削除されるため、この点にご注意ください。

--- a/src/content/ja/administrator-manual/kubernetes/connection-management/cloud-providers/synchronizing-kubernetes-resources-from-aws.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/connection-management/cloud-providers/synchronizing-kubernetes-resources-from-aws.mdx
@@ -8,12 +8,14 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-QueryPieでは、Kubernetesクラスター登録および管理のためのAWS連携をサポートします。AWS内のリソースを同期し、QueryPieで管理するクラスターに登録し、ユーザーおよびグループに同期してきたクラスターに対するKubernetes APIアクセス権限を付与し、ポリシーを設定することができます。
+QueryPieでは、Kubernetesクラスター登録および管理のためのAWS連携をサポートします。
+AWS内のリソースを同期してQueryPieで管理するクラスターに登録し、ユーザーおよびグループに同期してきたクラスターに対するKubernetes APIアクセス権限を付与し、ポリシーを設定することができます。
 
 <Callout type="info">
 #### 事前準備事項
 
-1. AWSリソースとの同期のために、QueryPieインスタンスに割り当てられたAWS IAMロールに必要なポリシー作業を添付したか確認してください。ポリシーには以下の作業をすべて含める必要があります：
+1. AWSリソースとの同期のために、QueryPieインスタンスに割り当てられたAWS IAMロールに必要なポリシー作業を添付したか確認してください。
+ポリシーには以下の作業をすべて含める必要があります：
 
 * eks:ListClusters
 * eks:DescribeCluster
@@ -27,7 +29,8 @@ QueryPieでは、Kubernetesクラスター登録および管理のためのAWS�
 
 ### AWS EKS認証モード修正
 
-QueryPieは、AWS EKS Kubernetesクラスター接続のために、同期時にEKS access entry APIを活用します。したがって、クラスター認証モードがConfigMapでのみ設定されている場合、接続が困難な部分があり、円滑な同期のためにAWSコンソールでモード変更を事前に作業しておくことをお勧めします。
+QueryPieは、AWS EKS Kubernetesクラスター接続のために、同期時にEKS access entry APIを活用します。
+したがって、クラスター認証モードがConfigMapでのみ設定されている場合、接続が困難な部分があり、円滑な同期のためにAWSコンソールでモード変更を事前に作業しておくことをお勧めします。
 
 <figure data-layout="center" data-align="center">
 ![AWS Console &gt; EKS &gt; Clusters &gt; `{cluster}` &gt; Access &gt; Access configuration &gt; Manage access](/administrator-manual/kubernetes/connection-management/cloud-providers/synchronizing-kubernetes-resources-from-aws/image-20240512-134234.png)
@@ -62,6 +65,9 @@ Administrator &gt; Kubernetes &gt; Connection Management &gt; Cloud Providers &g
 4.  **Cloud Provider**  項目でAmazon Web Servicesを選択します。
 5.  **Region**  項目で同期したいリソースのリージョンを選択します。
 6. リソースを同期するために必要な  **Credential**  情報を入力します。
+  <figure data-layout="center" data-align="center">
+  ![image-20240721-054206.png](/administrator-manual/kubernetes/connection-management/cloud-providers/synchronizing-kubernetes-resources-from-aws/image-20240721-054206.png)
+  </figure>
     1.  **Default Credentials**  : QueryPieサーバーが同じAWSアカウントにインストールされている場合、QueryPieがインストールされたEC2インスタンスにIAMロールを割り当てて同じAWS内のリソースを同期することができます。
     2.  **Cross Account Role**  : IAMロールを作成して他のAWSアカウントのリソースを同期することができます。画面に表示されたステップに従って同期のための権限を作成し、ポリシーを割り当ててください。
 7.  **Search Filter** を使用して同期したい一部のタイプのリソースリストを取得することができます。
@@ -76,7 +82,8 @@ Administrator &gt; Kubernetes &gt; Connection Management &gt; Cloud Providers &g
 
 <Callout type="important">
 **Q. Saveボタンをクリックしたのに「Already exists cloud provider.」というエラーが表示されます。**
-A. すでに  **Credential** が`Default Credentials`でありながら同じ`Region`で登録されたCloud Providerがある場合、重複登録ができません。この場合、他の`Region`を選択して登録を試みると正常に保存されます。
+A. すでに  **Credential** が`Default Credentials`でありながら同じ`Region`で登録されたCloud Providerがある場合、重複登録ができません。
+この場合、他の`Region`を選択して登録を試みると正常に保存されます。
 </Callout>
 
 

--- a/src/content/ja/administrator-manual/kubernetes/connection-management/clusters.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/connection-management/clusters.mdx
@@ -8,7 +8,8 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-QueryPieでKubernetesクラスター資産の照会、作成、修正、削除をサポートします。Cloud Providerを通じて同期してきたKubernetesクラスターおよび手動で登録したKubernetesクラスターすべて同じページで管理します。
+QueryPieでKubernetesクラスター資産の照会、作成、修正、削除をサポートします。
+Cloud Providerを通じて同期してきたKubernetesクラスターおよび手動で登録したKubernetesクラスターすべて同じページで管理します。
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Kubernetes &gt; Connection Management &gt; Clusters](/administrator-manual/kubernetes/connection-management/clusters/image-20240721-054705.png)

--- a/src/content/ja/administrator-manual/kubernetes/connection-management/clusters/manually-registering-kubernetes-clusters.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/connection-management/clusters/manually-registering-kubernetes-clusters.mdx
@@ -69,7 +69,7 @@ QueryPieでは、アクセス制御を適用するオンプレミスなどに位
 * 管理者は事前に該当対象Kubernetesクラスターにアクセスが可能でなければなりません。
 * 管理者はAdministrator &gt; Kubernetes &gt; Connection Management &gt; Clusters &gt; Create Cluster &gt; Credential案内ボックス内の「download and run this script」のリンクをクリックしてスクリプトをダウンロードできます。
 <details>
-<summary>generate_kubepie_sa.shスクリプトコンテンツ</summary>
+<summary>generate_kubepie_sa.shスクリプトコンテンツ </summary>
 ```
 #!/bin/bash
 

--- a/src/content/ja/administrator-manual/kubernetes/k8s-access-control/access-control.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/k8s-access-control/access-control.mdx
@@ -8,7 +8,8 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-QueryPieユーザーおよびグループに組織で管理するKubernetesクラスターのアクセス権限に対する付与および回収管理をサポートします。Access ControlはKubernetesアクセス権限を実装および適用するための最終段階を意味します。
+QueryPieユーザーおよびグループに組織で管理するKubernetesクラスターのアクセス権限に対する付与および回収管理をサポートします。
+Access ControlはKubernetesアクセス権限を実装および適用するための最終段階を意味します。
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Access Control](/administrator-manual/kubernetes/k8s-access-control/access-control/image-20240721-065226.png)
@@ -38,6 +39,9 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Access Control &gt; L
     5.  **Roles**  : 付与されたRoleの数
 5. Access Controlリストで行をクリックすると、対象ユーザー/グループに対する詳細ページに移動します。
     1.   **Roles**
+      <figure data-layout="center" data-align="center">
+      ![image-20240721-065530.png](/administrator-manual/kubernetes/k8s-access-control/access-control/image-20240721-065530.png)
+      </figure>
         1. デフォルトで指定されるタブで付与されたRoleリストを照会できます。
         2. Role名で検索可能です。
         3. リストは各Roleごとに以下の情報を露出します：
@@ -48,6 +52,9 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Access Control &gt; L
             5.  **Granted At**  : Roleが該当ユーザー/グループに付与された日時
             6.  **Granted By**  : 該当Roleをユーザー/グループに付与した管理者名
         4. 各Role行をクリックすると該当Roleの詳細情報をドロワー形態で提供します。
+          <figure data-layout="center" data-align="center">
+          ![image-20240721-065559.png](/administrator-manual/kubernetes/k8s-access-control/access-control/image-20240721-065559.png)
+          </figure>
             1. 上段には基本情報が以下のように露出されます：
                 1.  **Name**  : Role名
                     * (Role詳細ページリンクを新しいウィンドウで開けます。)
@@ -59,11 +66,17 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Access Control &gt; L
             2. 下段には該当ロールに割り当てられているポリシーがリストで露出されます。
                 1.  **Name**  : Policy名
                     * (ポリシー情報を照会できるリンクを提供します。)
+                      <figure data-layout="center" data-align="center">
+                      ![image-20240721-065637.png](/administrator-manual/kubernetes/k8s-access-control/access-control/image-20240721-065637.png)
+                      </figure>
                 2.  **Description**  : Policy詳細説明
                 3.  **Version**  : Policy版
                 4.  **Assigned At**  : 割り当て日時
                 5.  **Assigned By**  : 該当ポリシーを割り当てた管理者名
     2.  **Clusters**
+      <figure data-layout="center" data-align="center">
+      ![image-20240721-065710.png](/administrator-manual/kubernetes/k8s-access-control/access-control/image-20240721-065710.png)
+      </figure>
         1. 付与されたRoleによってアクセス可能なKubernetesクラスターリストを列挙します。
         2. Cluster名、Role名で検索可能です。
         3. リストは各クラスターごとに以下の情報を露出します：

--- a/src/content/ja/administrator-manual/kubernetes/k8s-access-control/access-control/granting-and-revoking-kubernetes-roles.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/k8s-access-control/access-control/granting-and-revoking-kubernetes-roles.mdx
@@ -21,7 +21,16 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Access Control
 
 1. Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Access Controlメニューに移動します。
 2. 権限を付与するユーザーまたはユーザーグループを選択して詳細ページに移動します。
+  <figure data-layout="center" data-align="center">
+  ![Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Access Control &gt; List Details](/administrator-manual/kubernetes/k8s-access-control/access-control/granting-and-revoking-kubernetes-roles/image-20240721-065443.png)
+  <figcaption>
+  Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Access Control &gt; List Details
+  </figcaption>
+  </figure>
 3. Rolesタブ右側の`+ Grant Roles`ボタンをクリックして付与するRole左側チェックボックスをチェックし、満了日を指定します。
+  <figure data-layout="center" data-align="center">
+  ![image-20240721-070449.png](/administrator-manual/kubernetes/k8s-access-control/access-control/granting-and-revoking-kubernetes-roles/image-20240721-070449.png)
+  </figure>
     1. Role名で検索可能です。
     2. 既存にすでに割り当てられている役割はチェックボックスが非活性化されます。
     3. リストリストには各ポリシー別に以下の情報を露出します：
@@ -43,6 +52,9 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Access Control
 1. Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Access Controlメニューに移動します。
 2. 権限を回収するユーザーまたはユーザーグループを選択して詳細ページに移動します。
 3. Rolesタブで全体選択または個別選択ボックスにチェックするとカラムバーに露出された`Revoke`ボタンをクリックします。
+  <figure data-layout="center" data-align="center">
+  ![image-20240721-070637.png](/administrator-manual/kubernetes/k8s-access-control/access-control/granting-and-revoking-kubernetes-roles/image-20240721-070637.png)
+  </figure>
 4. 確認ウィンドウで`Revoke`ボタンクリック時、選択した役割権限がユーザー/グループから回収されてリストから消えます。
 5. (`Cancel`ボタンクリック時は確認ウィンドウのみ閉じます。)
 

--- a/src/content/ja/administrator-manual/kubernetes/k8s-access-control/policies.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/k8s-access-control/policies.mdx
@@ -8,7 +8,8 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-組織で管理するKubernetesクラスターのアクセスポリシー(Policy)に対する照会、作成、修正、削除をサポートします。PolicyはKubernetesアクセス権限を実装および適用するための最も最初の段階です。
+組織で管理するKubernetesクラスターのアクセスポリシー(Policy)に対する照会、作成、修正、削除をサポートします。
+PolicyはKubernetesアクセス権限を実装および適用するための最も最初の段階です。
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Policies](/administrator-manual/kubernetes/k8s-access-control/policies/image-20240721-072128.png)
@@ -38,9 +39,15 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Policies &gt; List De
     5.  **Updated By**  : 最終アップデートを実行した管理者名
 5. 各行をクリックするとポリシー詳細情報照会が可能です。
     1.   **Detail**
+      <figure data-layout="center" data-align="center">
+      ![image-20240721-072345.png](/administrator-manual/kubernetes/k8s-access-control/policies/image-20240721-072345.png)
+      </figure>
         1. デフォルトで指定されるタブでポリシーで定義されたコードを照会できます。
         2. Detailタブに位置する時、右側に`Go to Editor Mode`ボタンがあり、これをクリックすると該当Code Editorページ画面に切り替わります。
     2.  **Roles**
+      <figure data-layout="center" data-align="center">
+      ![image-20240721-072412.png](/administrator-manual/kubernetes/k8s-access-control/policies/image-20240721-072412.png)
+      </figure>
         1. 該当ポリシーが割り当てられているRoleリストを列挙します。
         2. リストは各Roleごとに以下の情報を露出します：
             1.  **Name**  : Role名
@@ -48,6 +55,9 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Policies &gt; List De
             3.  **Assigned At**  : Roleに該当ポリシーが割り当てられた日時
             4.  **Assigned By** : 該当ポリシーをRoleに割り当てた管理者名
         3. 各行をクリックするとRoleに対する詳細情報をドロワー形態で提供します。
+          <figure data-layout="center" data-align="center">
+          ![image-20240721-072435.png](/administrator-manual/kubernetes/k8s-access-control/policies/image-20240721-072435.png)
+          </figure>
             1.  **Name**  : Role名
                 * 該当ロール詳細ページリンクを提供します。
             2.  **Description**  : Role詳細説明
@@ -57,6 +67,9 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Policies &gt; List De
             6.  **Updated At**  : Roleアップデート日時
             7.  **Updated By**  : 最終Role修正者名
     3.  **Versions**
+      <figure data-layout="center" data-align="center">
+      ![image-20240721-072503.png](/administrator-manual/kubernetes/k8s-access-control/policies/image-20240721-072503.png)
+      </figure>
         1. 該当ポリシーの各版に対する履歴を列挙します。
             * ポリシー版はCodeが修正されて保存されるとアップデートされます。
         2. リストは各versionごとに以下の情報を露出します：
@@ -65,6 +78,9 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Policies &gt; List De
             3.  **Updated At**  : 該当版作成日時
             4.  **Updated By**  : 該当版修正者名
         3. 各行をクリックすると版に対する詳細情報をドロワー形態で提供します。
+          <figure data-layout="center" data-align="center">
+          ![image-20240721-072547.png](/administrator-manual/kubernetes/k8s-access-control/policies/image-20240721-072547.png)
+          </figure>
             1.  **(Title)**  : ポリシー名
             2.  **Version**  : ポリシー版
             3.  **Justification**  : ポリシーアップデート入力事由


### PR DESCRIPTION
## Description
- Overview 섹션의 줄바꿈 추가 (가독성 향상)
- 누락된 figure 이미지 추가
- figcaption에서 잘못된 > 기호를 `&gt;`로 수정
- Callout 이후 누락된 빈 줄 추가
- 콜론 기호 통일 (：→:)
- summary 태그의 스페이스 추가
- 문장 구조 개선 (한국어 원문과 동기화)

수정된 파일:
- administrator-manual/general/workflow-management/all-requests.mdx
- administrator-manual/general/workflow-management/approval-rules.mdx
- administrator-manual/general/workflow-management/workflow-configurations.mdx
- administrator-manual/kubernetes/connection-management/cloud-providers.mdx
- administrator-manual/kubernetes/connection-management/cloud-providers/synchronizing-kubernetes-resources-from-aws.mdx
- administrator-manual/kubernetes/connection-management/clusters.mdx
- administrator-manual/kubernetes/connection-management/clusters/manually-registering-kubernetes-clusters.mdx
- administrator-manual/kubernetes/k8s-access-control/access-control.mdx
- administrator-manual/kubernetes/k8s-access-control/access-control/granting-and-revoking-kubernetes-roles.mdx
- administrator-manual/kubernetes/k8s-access-control/policies.mdx

