### PR TITLE
mdx: 일본어 문서 불일치 수정 23

### DIFF
--- a/src/content/ja/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-ui-code-helper-guide.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-ui-code-helper-guide.mdx
@@ -21,10 +21,16 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Policies &gt; List De
 </figure>
 
 1.  **Add Resources**  モーダル
+  <figure data-layout="center" data-align="center">
+  ![image-20240721-073346.png](/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-ui-code-helper-guide/image-20240721-073346.png)
+  </figure>
     1. Spec: Allow、Spec: Deny二箇所で同じように動作します。
     2. Cluster名でリソース検索が可能です。
     3. チェックボックスにチェックしたリソースを`Add`ボタンをクリックしてコードに挿入します。
 2.  **Set Subjects**  モーダル
+  <figure data-layout="center" data-align="center">
+  ![image-20240721-073434.png](/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-ui-code-helper-guide/image-20240721-073434.png)
+  </figure>
     1. Spec: Allowでのみ動作します。
     2.  **Kubernetes Groups**  : (Required) 該当フィールドを通じてKubePie ProxyがAPI呼び出し実行のためにimpersonateするKubernetesグループを明示します。
     3.  **Permitted Impersonation**  : (Optional) 該当フィールドを通じてユーザーがクライアントを通じて実際の--as、--as-groupを通じたimpersonationを試みる時に適用可能なKubernetesユーザー/グループを列挙します。
@@ -33,6 +39,9 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Policies &gt; List De
         3. ','を通じて多重で登録可能です。
     4. エディターにある内容を基にモーダルが既存の情報を一緒に表記し、`Set`ボタンを押すと変更事項をエディターで上書きします。
 3.  **Add Actions**  モーダル
+  <figure data-layout="center" data-align="center">
+  ![image-20240721-073515.png](/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-ui-code-helper-guide/image-20240721-073515.png)
+  </figure>
     1. Spec: Allow、Spec: Deny二箇所で同じように動作します。
     2.  **API Groups** : デフォルトで"*"提供；管理者が修正可能で、','で多重入力可能です。
     3.  **Resources** : Kubernetesリソースを明示します。
@@ -55,6 +64,9 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Policies &gt; List De
     7. `Add`ボタンをクリックしてactionsリスト中一つのアクションセットを定義できます。
     8. コード上でappendに該当する部分で既存の追加されたアクションを初期化せずに新しく追加が可能です。
 4.  **Set Conditions**  モーダル
+  <figure data-layout="center" data-align="center">
+  ![image-20240721-073628.png](/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-ui-code-helper-guide/image-20240721-073628.png)
+  </figure>
     1. 該当項目はすべて選択事項です。
     2. エディターにある内容を基にモーダルが既存の情報を一緒に表記し、`Set`ボタンを押すと変更事項をエディターで上書きします。
     3.  **Resource Tags**  (Optional)

--- a/src/content/ja/administrator-manual/kubernetes/k8s-access-control/roles.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/k8s-access-control/roles.mdx
@@ -39,6 +39,9 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles &gt; List Detai
     6.  **Updated By**  : 最終アップデートを実行した管理者名
 5. 各行をクリックすると役割詳細情報照会が可能です。
     1.   **Policies**
+      <figure data-layout="center" data-align="center">
+      ![image-20240721-070945.png](/administrator-manual/kubernetes/k8s-access-control/roles/image-20240721-070945.png)
+      </figure>
         1. デフォルトで指定されるタブで割り当てられたポリシーリストを照会できます。
         2. テーブルリストには各ポリシー別に以下の情報を露出します：
             1.  **Name**  : Policy名
@@ -47,6 +50,9 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles &gt; List Detai
             4.  **Assigned At**  : 割り当て日時
             5.  **Assigned By**  : 該当ポリシーを割り当てた管理者名
         3. 各ポリシー行をクリックすると該当ポリシーの詳細情報をドロワー形態で提供します。
+          <figure data-layout="center" data-align="center">
+          ![image-20240721-071031.png](/administrator-manual/kubernetes/k8s-access-control/roles/image-20240721-071031.png)
+          </figure>
             1. 上段には基本情報が以下のように露出されます：
                 1.  **Name**  : Policy名
                     * ポリシー詳細ページリンクを新しいウィンドウで開けます。
@@ -56,6 +62,9 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles &gt; List Detai
                 5.  **Assigned By**  : 該当ポリシーを割り当てた管理者名
             2. 下段にはポリシーがコードで露出されます。
     2.  **Users/Groups**
+      <figure data-layout="center" data-align="center">
+      ![image-20240721-071134.png](/administrator-manual/kubernetes/k8s-access-control/roles/image-20240721-071134.png)
+      </figure>
         1. 該当Roleが付与されているユーザー/グループリストを列挙します。
         2. ユーザー/グループ名で検索可能です。
         3. リストは各ユーザー/グループごとに以下の情報を露出します：
@@ -65,6 +74,9 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles &gt; List Detai
             4.  **Expiration Date**  : 期限満了日
             5.  **Granted At**  : ユーザー/グループに該当Roleが付与された日時
     3.  **Clusters**
+      <figure data-layout="center" data-align="center">
+      ![image-20240721-071233.png](/administrator-manual/kubernetes/k8s-access-control/roles/image-20240721-071233.png)
+      </figure>
         1. 該当Roleによってアクセス可能なKubernetesクラスターリストを列挙します。
         2. Cluster名で検索可能です。
         3. リストは各クラスターごとに以下の情報を露出します：

--- a/src/content/ja/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles.mdx
@@ -24,11 +24,17 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles &gt; List Detai
 2. Rolesリストで対象Role行をクリックして詳細ページに移動します。
 3. Policiesタブ右側の`+ Assign Policies`ボタンをクリックします。
 4. 割り当てるポリシーを検討した後、左側のチェックボックスをチェックします。
+  <figure data-layout="center" data-align="center">
+  ![image-20240721-071758.png](/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles/image-20240721-071758.png)
+  </figure>
     1. Policy名で検索可能です。
     2. 既存にすでに割り当てられているポリシーはチェックボックスが非活性化されます。
     3. リストリストには各ポリシー別に以下の情報を露出します：
         *  **Name**  : Policy名
             * ポリシー情報を照会できるモーダルリンクを提供します。
+              <figure data-layout="center" data-align="center">
+              ![image-20240721-071822.png](/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles/image-20240721-071822.png)
+              </figure>
 5. `Assign`ボタンを押すとチェックボックスをチェックした対象ポリシーを割り当てます。
 6. (`Cancel`ボタンを押すと該当モーダルを変更事項なしで終了します。)
 
@@ -42,6 +48,9 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles &gt; List Detai
 1. Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Rolesメニューに移動します。
 2. Rolesリストで対象Role行をクリックして詳細ページに移動します。
 3. Policiesタブで全体選択または個別選択ボックスにチェックするとカラムバーに露出された`Unassign`ボタンをクリックします。
+  <figure data-layout="center" data-align="center">
+  ![image-20240721-071940.png](/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles/image-20240721-071940.png)
+  </figure>
 4. 確認ウィンドウで`Unassign`ボタンクリック時、選択したアイテムが割り当て解除されてリストから消えます。
 5. (`Cancel`ボタンクリック時は確認ウィンドウのみ閉じます。)
 


### PR DESCRIPTION
## 개요
`docs/todo-06.txt`에 나열된 일본어 번역문 10개 파일 중 불일치가 발견된 3개 파일을 수정했습니다.

## 수정 내용

### 1. kubernetes-policy-ui-code-helper-guide.mdx
- **Add Resources** 모달 섹션에 누락된 이미지 참조 추가
- **Set Subjects** 모달 섹션에 누락된 이미지 참조 추가
- **Add Actions** 모달 섹션에 누락된 이미지 참조 추가
- **Set Conditions** 모달 섹션에 누락된 이미지 참조 추가
- **총 4개의 figure 이미지 참조 추가**

### 2. roles.mdx
- **Policies** 탭 섹션에 누락된 이미지 참조 2개 추가
- **Users/Groups** 탭 섹션에 누락된 이미지 참조 추가
- **Clusters** 탭 섹션에 누락된 이미지 참조 추가
- **총 4개의 figure 이미지 참조 추가**

### 3. setting-kubernetes-roles.mdx
- Role 정책 할당 섹션에 누락된 이미지 참조 2개 추가
- Role 정책 할당 해제 섹션에 누락된 이미지 참조 추가
- **총 3개의 figure 이미지 참조 추가**

## 영향 범위
- 한국어 원문과 일본어 번역문 간의 구조적 불일치 해소
- 문서 가독성 및 사용자 경험 개선
- 총 **11개의 이미지 참조 추가**

## 검토 사항
나머지 7개 파일은 한국어 원문과 일본어 번역문이 일치하여 수정이 필요하지 않습니다:
- kubernetes-policy-action-configuration-reference-guide.mdx ✅
- kubernetes-policy-tips-guide.mdx ✅
- kubernetes-policy-yaml-code-syntax-guide.mdx ✅
- setting-kubernetes-policies.mdx ✅
- cloud-providers.mdx ✅
- synchronizing-server-resources-from-aws.mdx ✅
- synchronizing-server-resources-from-azure.mdx ✅