### PR TITLE
mdx: 일본어 문서 불일치 수정 27

### DIFF
--- a/src/content/ja/administrator-manual/web-apps/web-app-access-control/access-control/granting-and-revoking-roles.mdx
+++ b/src/content/ja/administrator-manual/web-apps/web-app-access-control/access-control/granting-and-revoking-roles.mdx
@@ -33,6 +33,9 @@ Administrator > Servers > Server Access Control > Access Control
 
 1. 画面左側のRolesタブを選択します。
 2. 右側中央で `+ Grant Roles` ボタンをクリックします。
+  <figure data-layout="center" data-align="center">
+  ![image-20250629-161407.png](/administrator-manual/web-apps/web-app-access-control/access-control/granting-and-revoking-roles/image-20250629-161407.png)
+  </figure>
 3. 付与するRole左側のチェックボックスをチェックします。
 4. Expiration Dateを入力します。基本値は1年です。
 5. `Grant` ボタンをクリックします。

--- a/src/content/ja/administrator-manual/web-apps/web-app-access-control/policies.mdx
+++ b/src/content/ja/administrator-manual/web-apps/web-app-access-control/policies.mdx
@@ -33,9 +33,15 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Policies &gt; List 
 5. テーブルで以下のような情報を提供します：<br/>a. Name：Policy名<br/>b. Description：Policy詳細説明<br/>c. Created At：ポリシー最初生成日時<br/>d. Updated At：ポリシー最後修正日時<br/>e. Updated By：最後更新を実行した管理者名
 6. 各行をクリックするとポリシー詳細情報照会が可能です。
     1. Detail
+      <figure data-layout="center" data-align="center">
+      ![image-20250629-164600.png](/administrator-manual/web-apps/web-app-access-control/policies/image-20250629-164600.png)
+      </figure>
         1. デフォルトで指定されるタブでポリシーで定義されたコードを照会できます。
         2. Detailタブの右側にある、右側の`Go to Editor Mode`ボタンがあり、これをクリックすると該当Code Editorページ画面に切り替わります。
     2. Roles<br/>
+      <figure data-layout="center" data-align="center">
+      ![image-20250629-164733.png](/administrator-manual/web-apps/web-app-access-control/policies/image-20250629-164733.png)
+      </figure>
         1. 該当ポリシーが割り当てられているRoleリストを列挙します。
         2. リストは各Roleごとに以下の情報を表示します：
             1. Name：Role名
@@ -44,6 +50,9 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Policies &gt; List 
             4. Assigned By：該当ポリシーをRoleに割り当てた管理者名
         3. 各行をクリックするとRoleに対する詳細情報をドロワー形式で提供します。
     3. Versions
+      <figure data-layout="center" data-align="center">
+      ![image-20250629-164755.png](/administrator-manual/web-apps/web-app-access-control/policies/image-20250629-164755.png)
+      </figure>
         1. 該当ポリシーの各バージョンに対する履歴を列挙します。
             1. ポリシーバージョンはCodeが修正されて保存されると更新されます。
         2.  リストは各versionごとに以下の情報を表示します：

--- a/src/content/ja/administrator-manual/web-apps/web-app-access-control/roles.mdx
+++ b/src/content/ja/administrator-manual/web-apps/web-app-access-control/roles.mdx
@@ -33,6 +33,9 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Roles &gt; List Det
 4. テーブルで以下のような情報を提供します：<br/>a.  **Name**  : Role名<br/>b.  **Description**  : Role詳細説明<br/>c.  **Last Access At** : 該当役割の最後呼び出し日時<br/>d.  **Created At** : 役割最初生成日時<br/>e.  **Updated At**  : 役割最後修正日時<br/>f.  **Updated By**  : 最後更新を実行した管理者名
 5. 各行をクリックすると役割詳細情報照会が可能です。
     1.   **Policies** 
+      <figure data-layout="center" data-align="center">
+      ![image-20250629-163153.png](/administrator-manual/web-apps/web-app-access-control/roles/image-20250629-163153.png)
+      </figure>
         1. デフォルトで指定されるタブで割り当てられたポリシーリストを照会できます。
         2. テーブルリストには各ポリシー別以下の情報を表示します：
             1. Name：Policy名
@@ -41,6 +44,9 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Roles &gt; List Det
             4. Assigned At：割り当て日時
             5. Assigned By：該当ポリシーを割り当てた管理者名
         3. 各ポリシー行の左側ポリシーの詳細情報をドロワー形式で提供します。
+          <figure data-layout="center" data-align="center">
+          ![image-20250629-163327.png](/administrator-manual/web-apps/web-app-access-control/roles/image-20250629-163327.png)
+          </figure>
             1. 上部には基本情報が以下のように表示されます：
                 1.  **Name**  : Policy名
                     * ポリシー詳細ページリンクを新しいウィンドウで開けます。
@@ -50,6 +56,9 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Roles &gt; List Det
                 5.  **Assigned By**  : 該当ポリシーを割り当てた管理者名
             2. 下部にはポリシーがコードで表示されます。
     2.  **Users/Groups** 
+      <figure data-layout="center" data-align="center">
+      ![image-20250629-163722.png](/administrator-manual/web-apps/web-app-access-control/roles/image-20250629-163722.png)
+      </figure>
         1. 該当Roleが付与されているユーザー/グループリストを列挙します。
         2. ユーザー/グループ名で検索可能です。
         3. リストは各ユーザー/グループごとに以下の情報を表示します：
@@ -59,6 +68,9 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Roles &gt; List Det
             4. Expiration Date：期限満了日
             5. Granted At：ユーザー/グループに該当Roleが付与された日時
     3.  **Web Apps** 
+      <figure data-layout="center" data-align="center">
+      ![image-20250629-163658.png](/administrator-manual/web-apps/web-app-access-control/roles/image-20250629-163658.png)
+      </figure>
         1. 該当Roleによってアクセス可能なウェブアプリケーションリストを列挙します。
         2. ウェブアプリケーション名で検索可能です。
         3. リストは各ウェブアプリケーションごとに以下の情報を表示します：


### PR DESCRIPTION
## 변경 사항

일본어 번역문에서 한국어 원문과 비교하여 누락된 figure 요소들을 추가하였습니다.

### 수정된 파일 (3개)

1. **granting-and-revoking-roles.mdx**
   - Role 부여하기 섹션에 누락된 figure 1개 추가
   - 위치: "2. 권한을 부여할 Role을 선택합니다." 항목의 2번 단계 후

2. **policies.mdx**
   - Policy 조회하기 섹션에 누락된 figure 3개 추가
   - Detail 서브섹션: figure 1개
   - Roles 서브섹션: figure 1개
   - Versions 서브섹션: figure 1개

3. **roles.mdx**
   - Role 조회하기 섹션에 누락된 figure 4개 추가
   - Policies 서브섹션: figure 2개
   - Users/Groups 서브섹션: figure 1개
   - Web Apps 서브섹션: figure 1개

### 변경 사유

한국어 원문에는 포함되어 있으나 일본어 번역문에서 누락된 이미지(figure) 요소들을 추가하여 문서 구조의 일관성을 확보하였습니다.

### 검증 방법

- ✅ 한국어 원문 파일과 일본어 번역 파일의 구조 비교 완료
- ✅ 모든 figure 요소의 경로 및 속성 확인 완료
- ✅ MDX 문법 검증 완료