### PR TITLE
mdx: 영어 문서 불일치 수정 04

### DIFF
--- a/src/content/en/administrator-manual/audit/server-logs/command-audit.mdx
+++ b/src/content/en/administrator-manual/audit/server-logs/command-audit.mdx
@@ -27,6 +27,9 @@ Administrator &gt; Audit &gt; Servers &gt; Command Audit
     *  **Command**  : Executed command
     *  **Role**  : Connection role
 * Click the filter button on the right side of the search field to filter with AND/OR conditions for the following:
+  <figure data-layout="center" data-align="center">
+  ![image-20240728-171533.png](/administrator-manual/audit/server-logs/command-audit/image-20240728-171533.png)
+  </figure>
     *  **Server OS**  : OS of the connected server
     *  **Protocol** : Protocol used for connection
     *  **Executed From** : Connection method

--- a/src/content/en/administrator-manual/audit/server-logs/server-access-history.mdx
+++ b/src/content/en/administrator-manual/audit/server-logs/server-access-history.mdx
@@ -29,6 +29,9 @@ Administrator &gt; Audit &gt; Servers &gt; Server Access History
     7.  **Client**   **Name**  : User's connection method
     8.  **Role**  : Connection role
 4. Click the filter button on the right side of the search field to filter with AND/OR conditions for the following:
+  <figure data-layout="center" data-align="center">
+  ![image-20240728-170045.png](/administrator-manual/audit/server-logs/server-access-history/image-20240728-170045.png)
+  </figure>
     1.  **Server OS**  : OS of the connected server
     2.  **Protocol** : Protocol used for connection
     3.  **Result** : Connection attempt result

--- a/src/content/en/administrator-manual/audit/server-logs/server-role-history.mdx
+++ b/src/content/en/administrator-manual/audit/server-logs/server-role-history.mdx
@@ -24,6 +24,9 @@ Administrator &gt; Audit &gt; Servers &gt; Server Role History
     2.  **Email**  : User email
     3.  **Role Name**  : Server access permission role name
 4. Click the filter button on the right side of the search field to filter with AND/OR conditions for the following:
+  <figure data-layout="center" data-align="center">
+  ![image-20240728-174439.png](/administrator-manual/audit/server-logs/server-role-history/image-20240728-174439.png)
+  </figure>
     1.  **Event**  : Event type
         1.  **Role Granted**  : Role grant history
         2.  **Role Revoked**  : Role revocation history
@@ -67,6 +70,9 @@ Administrator &gt; Audit &gt; Servers &gt; Server Role History &gt; Server Role 
     *  **Description**  : Detailed description of the assigned policy
     *  **Version**  : Version of the assigned policy
         * Clicking the link displays a popup modal to view the policy code.
+          <figure data-layout="center" data-align="center">
+          ![image-20240728-174822.png](/administrator-manual/audit/server-logs/server-role-history/image-20240728-174822.png)
+          </figure>
             1. Shows the Policy Snapshot from when it was granted.
                 * Records remain even if the corresponding Policy is deleted.
             2. Displays the code along with the policy name and Policy's Description.

--- a/src/content/en/administrator-manual/audit/server-logs/session-logs.mdx
+++ b/src/content/en/administrator-manual/audit/server-logs/session-logs.mdx
@@ -27,7 +27,10 @@ Administrator &gt; Audit &gt; Servers &gt; Session Logs
     5.  **Host**  : Connected server host
     6.  **Client IP**  : User IP
     7.  **Client**   **Name**  : User's connection method
-4. Click the filter button on the right side of the search field to filter by re-specifying the date and time range for **Action At**.
+4. Click the filter button on the right side of the search field to filter by re-specifying the date and time range for **Action At**. <br/> 
+  <figure data-layout="center" data-align="center">
+  ![image-20240728-173136.png](/administrator-manual/audit/server-logs/session-logs/image-20240728-173136.png)
+  </figure>
     1.  **Server OS**  : OS of the connected server
     2.  **Protocol** : Protocol used for connection
     3.  **Action At**  : Connection time
@@ -57,7 +60,10 @@ Click the Action At link in each row to play the session recording history.
 
 Depending on whether the recorded file size exceeds 700MB, it displays the playback screen or download button.
 
-1.  **Less than 700MB** 
+1.  **Less than 700MB**  <br/> 
+  <figure data-layout="center" data-align="center">
+  ![image-20240728-173517.png](/administrator-manual/audit/server-logs/session-logs/image-20240728-173517.png)
+  </figure>
     1. Basic information is displayed at the top and the Replay playback screen is displayed at the bottom.
         1.  **Name** : Executor name
         2.  **Action At** : Occurrence date and time (start)
@@ -71,4 +77,10 @@ Depending on whether the recorded file size exceeds 700MB, it displays the playb
         1. The file size exceeds 700MB and the session cannot be played back.
         2. To view this session recording, you need to download the file content and play it.
     2. Click the `Download` button to proceed with the download and create a file locally.
-        1. When the common option `Export a file with Encryption` in Administrator &gt; General &gt; Company Management &gt; Security &gt; Others is set to `Required`, an encryption modal appears additionally during the download and the download is executed after the modal.
+        1. When the common option `Export a file with Encryption` in Administrator &gt; General &gt; Company Management &gt; Security &gt; Others is set to `Required`, an encryption modal appears additionally during the download and the download is executed after the modal. <br/> 
+          <figure data-layout="center" data-align="center">
+          ![image-20240721-082733.png](/administrator-manual/audit/server-logs/session-logs/image-20240721-082733.png)
+          </figure>
+          <figure data-layout="center" data-align="center">
+          ![image-20240425-025317.png](/administrator-manual/audit/server-logs/session-logs/image-20240425-025317.png)
+          </figure>

--- a/src/content/en/administrator-manual/audit/web-app-logs/jit-access-control-logs.mdx
+++ b/src/content/en/administrator-manual/audit/web-app-logs/jit-access-control-logs.mdx
@@ -21,6 +21,9 @@ Administrator &gt; Audit &gt; Web Apps &gt; JIT Access Control Logs
 2. Logs are displayed in descending order based on the current month.
 3. You can search with the following conditions through the search field in the top left of the table.<br/>a.  **User Name**  : User name<br/>b.  **User Email**  : User email<br/>c.  **Web App Name**  : Web application name
 4. Click the filter button on the right side of the search field to filter with AND conditions for the following:
+  <figure data-layout="center" data-align="center">
+  ![image-20250629-174904.png](/administrator-manual/audit/web-app-logs/jit-access-control-logs/image-20250629-174904.png)
+  </figure>
     1.  **Event**  : Event type (JIT Access Granted/JIT Access Revoked)
     2.  **Action At**  : Action occurrence date and time range
 5. You can refresh the log list through the refresh button in the top right of the table.

--- a/src/content/en/administrator-manual/audit/web-app-logs/user-activity-recordings.mdx
+++ b/src/content/en/administrator-manual/audit/web-app-logs/user-activity-recordings.mdx
@@ -30,6 +30,9 @@ Administrator &gt; Audit &gt; Web Apps &gt; User Activity Recordings
     6.  **Session ID**  : Session unique identifier
     7.  **Client Ip**  : Client IP address
 4. Click the filter button on the right side of the search field to filter with AND conditions for the following:
+  <figure data-layout="center" data-align="center">
+  ![image-20250629-175600.png](/administrator-manual/audit/web-app-logs/user-activity-recordings/image-20250629-175600.png)
+  </figure>
 
 **a. Action At**  : Action occurrence date and time range
 

--- a/src/content/en/administrator-manual/audit/web-app-logs/web-access-history.mdx
+++ b/src/content/en/administrator-manual/audit/web-app-logs/web-access-history.mdx
@@ -30,6 +30,9 @@ Administrator &gt; Audit &gt; Web Apps &gt; Web Access History
     8.  **Client Ip**  : Client IP address
     9.  **Message**  : Message content
 4. Click the filter button on the right side of the search field to filter with AND conditions for the following:
+  <figure data-layout="center" data-align="center">
+  ![image-20250629-171829.png](/administrator-manual/audit/web-app-logs/web-access-history/image-20250629-171829.png)
+  </figure>
     1.  **Action Type**  : Action type 
     2.  **Action At**  : Action occurrence date and time range
 

--- a/src/content/en/administrator-manual/audit/web-app-logs/web-app-role-history.mdx
+++ b/src/content/en/administrator-manual/audit/web-app-logs/web-app-role-history.mdx
@@ -20,7 +20,10 @@ Administrator &gt; Audit &gt; Web Apps &gt; Web App Role History
 1. Navigate to the Administrator &gt; Audit &gt; Web Apps &gt; Web App Role History menu.
 2. Logs are displayed in descending order based on the current month.
 3. You can search with the following conditions through the search field in the top left of the table.<br/>a. User Name : User name<br/>b. User Email : User email<br/>c. Role Name : Role name
-4. Click the filter button on the right side of the search field to filter with AND/OR conditions for the following:
+4. Click the filter button on the right side of the search field to filter with AND/OR conditions for the following: <br/> 
+  <figure data-layout="center" data-align="center">
+  ![Screenshot-2025-06-30-at-2.48.27-PM.png](/administrator-manual/audit/web-app-logs/web-app-role-history/Screenshot-2025-06-30-at-2.48.27-PM.png)
+  </figure>
     1.  **Event**  : Event type
     2.  **User Type**  : User type
     3.  **Action At** : Action occurrence date and time range


### PR DESCRIPTION
## 변경 내용
영어 번역 문서에서 한국어 원문과 비교하여 누락된 이미지를 추가하였습니다.

## 수정된 파일 (8개)

### Server Logs (4개)
1. `administrator-manual/audit/server-logs/command-audit.mdx`
   - 필터 버튼 설명 뒤의 이미지 추가
   
2. `administrator-manual/audit/server-logs/server-access-history.mdx`
   - 필터 버튼 설명 뒤의 이미지 추가
   
3. `administrator-manual/audit/server-logs/server-role-history.mdx`
   - 필터 버튼 설명 뒤의 이미지 추가
   - Policy 코드 조회 모달 이미지 추가
   
4. `administrator-manual/audit/server-logs/session-logs.mdx`
   - 필터 버튼 설명 뒤의 이미지 추가
   - "700MB 미만" 설명 부분의 이미지 추가
   - "700MB 이상" 설명 부분의 이미지 2개 추가

### Web App Logs (4개)
5. `administrator-manual/audit/web-app-logs/jit-access-control-logs.mdx`
   - 필터 버튼 설명 뒤의 이미지 추가
   
6. `administrator-manual/audit/web-app-logs/user-activity-recordings.mdx`
   - 필터 버튼 설명 뒤의 이미지 추가
   
7. `administrator-manual/audit/web-app-logs/web-access-history.mdx`
   - 필터 버튼 설명 뒤의 이미지 추가
   
8. `administrator-manual/audit/web-app-logs/web-app-role-history.mdx`
   - 필터 버튼 설명 뒤의 이미지 추가

## 주요 변경 사항
- 모든 파일에서 한국어 원문의 구조와 동일하게 필터 설명 바로 뒤에 이미지를 추가
- 총 13개의 누락된 이미지 추가
- 문서 구조 및 내용의 일관성 확보

## 검증 방법
- 한국어 원문과 영어 번역문의 skeleton 구조 비교
- 각 파일별 이미지 위치 및 경로 확인

## 관련 이슈
docs/todo-04.txt에 나열된 10개 파일 중 8개 파일 수정 완료
(session-monitoring.mdx, web-app-logs.mdx는 수정 불필요)