### PR TITLE
mdx: 영어 문서 불일치 수정 09

### DIFF
--- a/src/content/en/administrator-manual/general/company-management.mdx
+++ b/src/content/en/administrator-manual/general/company-management.mdx
@@ -16,11 +16,11 @@ Administrator &gt; General &gt; Company Management &gt; General
 </figure>
 
 
-### Menu Description
+### Menu Descriptions
 
-* [ **General** ](company-management/general) **:** Menu for applying basic system settings of QueryPie.
-* [ **Security** ](company-management/security) : Menu for applying security settings of QueryPie.
-* [ **Allowed Zones** ](company-management/allowed-zones) **** : Menu for configuring allowed network zone settings of QueryPie.
-* [ **Channels** ](company-management/channels) : Menu for configuring channels to receive QueryPie notifications.
-* [ **Alerts** ](company-management/alerts) : Menu for setting up QueryPie notifications.
-* [ **Licenses** ](company-management/licenses) : Menu where you can view the status of applied licenses for QueryPie.
+* [ **General** ](company-management/general) **:** This menu allows you to configure QueryPie's basic system settings. 
+* [ **Security** ](company-management/security) : This menu allows you to configure QueryPie's security settings. 
+* [ **Allowed Zones** ](company-management/allowed-zones) **** : This menu allows you to configure QueryPie's allowed network zone settings. 
+* [ **Channels** ](company-management/channels) : This menu allows you to configure channels to receive QueryPie notifications.
+* [ **Alerts** ](company-management/alerts) : This menu allows you to set up QueryPie notification settings. 
+* [ **Licenses** ](company-management/licenses) : This menu allows you to view the status of applied licenses for QueryPie. 

--- a/src/content/en/administrator-manual/general/company-management/alerts.mdx
+++ b/src/content/en/administrator-manual/general/company-management/alerts.mdx
@@ -8,7 +8,9 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-The Alerts page provides notification functionality related to resource access. By pre-setting trigger conditions for major anomalies, you can detect policy violations in real-time. This allows for rapid identification and resolution of potential security incidents, and protection of sensitive information such as queries or data leaks that exceed predefined thresholds.
+The Alerts page provides notification functionality related to resource access.
+By pre-setting trigger conditions for major anomalies, you can detect policy violations in real-time.
+This allows for rapid identification and resolution of potential security incidents, and protection of sensitive information such as queries or data leaks that exceed predefined thresholds.
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; General &gt; Company Management &gt; Alerts](/administrator-manual/general/company-management/alerts/screenshot-20240728-223320.png)
@@ -340,7 +342,8 @@ Sensitive data query notification for defined conditions
     * Can enter up to 1440.
 
 <Callout type="important">
-To use the Sensitive Data Access alert type, you must pre-define tables and columns containing personal information in sensitive data policies. For detailed information, please refer to the [Sensitive Data](../../databases/policies/sensitive-data) documentation.
+To use the Sensitive Data Access alert type, you must pre-define tables and columns containing personal information in sensitive data policies.
+For detailed information, please refer to the [Sensitive Data](../../databases/policies/sensitive-data) documentation.
 </Callout>
 
 <Callout type="info">
@@ -496,7 +499,9 @@ Data Access alerts can select four **policy types**: Column Data Masking, Table 
 
 ### Viewing and Modifying Alert Details
 
-Select the alert you want to view details for in the Alerts page. In the Details tab of the detail page, you can view and modify the alert conditions and messages entered when creating the alert. Click the `Save Changes` button in the top right corner to apply the modifications.
+Select the alert you want to view details for in the Alerts page.
+In the Details tab of the detail page, you can view and modify the alert conditions and messages entered when creating the alert.
+Click the `Save Changes` button in the top right corner to apply the modifications.
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; General &gt; Company Management &gt; Alerts &gt; List Details (Details)](/administrator-manual/general/company-management/alerts/screenshot-20240729-154217.png)
@@ -507,7 +512,8 @@ Administrator &gt; General &gt; Company Management &gt; Alerts &gt; List Details
 
 ### Viewing Alert Delivery History
 
-Select the alert you want to view delivery history for in the Alerts list. You can then view the history in the Log section of the detail page.
+Select the alert you want to view delivery history for in the Alerts list.
+You can then view the history in the Log section of the detail page.
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; General &gt; Company Management &gt; Alerts &gt; List Details (Logs)](/administrator-manual/general/company-management/alerts/screenshot-20240729-154223.png)


### PR DESCRIPTION
## 변경 사항

영어 문서 번역 품질 개선 및 한국어 원문과의 불일치 수정

### 수정된 파일 (2개)

1. **administrator-manual/general/company-management.mdx**
   - 번역 톤 개선: "Menu for applying" → "This menu allows you to" (formal but friendly 톤 적용)
   - 메뉴 설명 일관성 개선

2. **administrator-manual/general/company-management/alerts.mdx**
   - 문단 구조 수정: 한국어 원문의 3줄 구조를 반영
   - Overview 섹션의 줄 바꿈 적용
   - Callout 내부 텍스트 구조 정리
   - 주요 섹션 설명 문단 구조 개선

### 검토된 파일 (10개)

다음 파일들을 검토하였으며, 번역 품질이 양호함을 확인:
- ✅ administrator-manual/general/company-management/allowed-zones.mdx
- ✅ administrator-manual/general/company-management/channels.mdx  
- ✅ administrator-manual/general/company-management/general.mdx
- ✅ administrator-manual/general/company-management/licenses.mdx
- ✅ administrator-manual/general/company-management/security.mdx
- ✅ administrator-manual/general/system.mdx
- ✅ administrator-manual/general/system/api-token.mdx
- ⚠️ administrator-manual/general/company-management/alerts/new-request-template-variables-by-request-type.mdx (테이블 구조 차이 - 추가 조사 필요)

### 번역 가이드라인 준수

- ✅ Formal but friendly tone 적용
- ✅ 한국어 원문의 문단 구조 유지
- ✅ Markdown 포맷팅 일치
- ✅ 기술 용어 일관성 유지

### 관련 문서

- Translation Guidelines: `.claude/skills/translation.md`
- MDX Skeleton Comparison: `.claude/skills/mdx-skeleton-comparison.md`
