### PR TITLE
mdx: 영어 문서 불일치 수정 15

### DIFF
--- a/src/content/en/administrator-manual/kubernetes/k8s-access-control/roles.mdx
+++ b/src/content/en/administrator-manual/kubernetes/k8s-access-control/roles.mdx
@@ -39,6 +39,9 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles &gt; List Detai
     6.  **Updated By**  : Administrator name who performed the last update
 5. Click on each row to view role detailed information.
     1.   **Policies** 
+      <figure data-layout="center" data-align="center">
+      ![image-20240721-070945.png](/administrator-manual/kubernetes/k8s-access-control/roles/image-20240721-070945.png)
+      </figure>
         1. This is the default tab where you can view the list of assigned policies.
         2. The table list exposes the following information for each policy:
             1.  **Name**  : Policy name
@@ -47,6 +50,9 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles &gt; List Detai
             4.  **Assigned At**  : Assignment date and time
             5.  **Assigned By**  : Administrator name who assigned the policy
         3. Click on each policy row to provide detailed information about the policy in drawer format.
+          <figure data-layout="center" data-align="center">
+          ![image-20240721-071031.png](/administrator-manual/kubernetes/k8s-access-control/roles/image-20240721-071031.png)
+          </figure>
             1. Basic information is exposed at the top as follows:
                 1.  **Name**  : Policy name 
                     * You can open the policy detailed page link in a new window.
@@ -56,6 +62,9 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles &gt; List Detai
                 5.  **Assigned By**  : Administrator name who assigned the policy
             2. The policy is exposed as code at the bottom.
     2.  **Users/Groups** 
+      <figure data-layout="center" data-align="center">
+      ![image-20240721-071134.png](/administrator-manual/kubernetes/k8s-access-control/roles/image-20240721-071134.png)
+      </figure>
         1. Lists the user/group list where the Role is granted.
         2. You can search by user/group name. 
         3. The list exposes the following information for each user/group:
@@ -65,6 +74,9 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles &gt; List Detai
             4.  **Expiration Date**  : Expiration date
             5.  **Granted At**  : Date and time when the Role was granted to the user/group
     3.  **Clusters** 
+      <figure data-layout="center" data-align="center">
+      ![image-20240721-071233.png](/administrator-manual/kubernetes/k8s-access-control/roles/image-20240721-071233.png)
+      </figure>
         1. Lists the Kubernetes cluster list accessible through the Role.
         2. You can search by cluster name.
         3. The list exposes the following information for each cluster:

--- a/src/content/en/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles.mdx
+++ b/src/content/en/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles.mdx
@@ -24,11 +24,17 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles &gt; List Detai
 2. Click on the target Role row from the Roles list to move to the detailed page.
 3. Click the `+ Assign Policies` button on the right of the Policies tab.
 4. Review the policies to assign, then check the checkbox on the left. 
+  <figure data-layout="center" data-align="center">
+  ![image-20240721-071758.png](/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles/image-20240721-071758.png)
+  </figure>
     1. You can search by policy name.
     2. Already assigned policies have disabled checkboxes.
     3. The list exposes the following information for each policy:
         *  **Name**  : Policy name 
             * Provides a modal link to view policy information.
+              <figure data-layout="center" data-align="center">
+              ![image-20240721-071822.png](/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles/image-20240721-071822.png)
+              </figure>
 5. Press the `Assign` button to assign the checked target policies.
 6. (Pressing the `Cancel` button closes the modal without changes.)
 
@@ -42,6 +48,9 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles &gt; List Detai
 1. Navigate to Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles menu.
 2. Click on the target Role row from the Roles list to move to the detailed page.
 3. In the Policies tab, click the `Unassign` button exposed in the column bar when checking the select all or individual selection box.
+  <figure data-layout="center" data-align="center">
+  ![image-20240721-071940.png](/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles/image-20240721-071940.png)
+  </figure>
 4. When clicking the `Unassign` button in the confirmation window, the selected items are unassigned and disappear from the list.
 5. (Clicking the `Cancel` button only closes the confirmation window.)
 

--- a/src/content/en/administrator-manual/kubernetes/kac-general-configurations.mdx
+++ b/src/content/en/administrator-manual/kubernetes/kac-general-configurations.mdx
@@ -11,7 +11,8 @@ Starting from 10.3.0, KAC-related settings previously under Administrator > Gene
 Starting from 11.4.0, the Maximum Access Duration option has been added to specify the maximum period for user privilege requests and administrator privilege grants.
 </Callout>
 
-### Kubernetes access control settings
+
+### Kubernetes Access Control Settings
 
 Provides settings for security in container-based environments, such as Kubernetes cluster access control, permission management, and session policies.
 

--- a/src/content/en/administrator-manual/servers/connection-management.mdx
+++ b/src/content/en/administrator-manual/servers/connection-management.mdx
@@ -6,7 +6,8 @@ title: 'Connection Management'
 
 ### Overview
 
-This document provides a guide to effectively manage servers in QueryPie. You can learn how to synchronize servers from Cloud Providers at once through cloud synchronization features, how to manually register servers, and server group management features for convenient management of numerous servers.
+This document provides a guide to effectively manage servers in QueryPie.
+You can learn how to synchronize servers from Cloud Providers at once through cloud synchronization features, how to manually register servers, and server group management features for convenient management of numerous servers.
 
 
 ### Server Management Guide Quick Links

--- a/src/content/en/administrator-manual/servers/connection-management/cloud-providers.mdx
+++ b/src/content/en/administrator-manual/servers/connection-management/cloud-providers.mdx
@@ -8,7 +8,8 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-QueryPie supports integration with Cloud Providers for server registration and management. You can synchronize resources within Cloud Providers, register them as servers managed by QueryPie, and grant access permissions and set policies for users and groups on the synchronized servers.
+QueryPie supports integration with Cloud Providers for server registration and management.
+You can synchronize resources within Cloud Providers, register them as servers managed by QueryPie, and grant access permissions and set policies for users and groups on the synchronized servers.
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Servers &gt; Connection Management &gt; Cloud Providers](/administrator-manual/servers/connection-management/cloud-providers/image-20240902-044659.png)

--- a/src/content/en/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-aws.mdx
+++ b/src/content/en/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-aws.mdx
@@ -8,7 +8,9 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-QueryPie supports AWS integration for server registration and management. You can synchronize resources within AWS, register them as servers managed by QueryPie, and grant access permissions and set policies for users and groups on the synchronized servers. Additionally, you can automatically add server groups to servers that have been scaled out and apply set access permissions.
+QueryPie supports AWS integration for server registration and management.
+You can synchronize resources within AWS, register them as servers managed by QueryPie, and grant access permissions and set policies for users and groups on the synchronized servers.
+Additionally, you can automatically add server groups to servers that have been scaled out and apply set access permissions.
 
 
 ### Registering AWS Integration Information in QueryPie

--- a/src/content/en/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-azure.mdx
+++ b/src/content/en/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-azure.mdx
@@ -8,7 +8,8 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-QueryPie supports Azure integration for server registration and management. You can synchronize resources within Azure, register them as servers managed by QueryPie, and grant access permissions and set policies for users and groups on the synchronized servers.
+QueryPie supports Azure integration for server registration and management.
+You can synchronize resources within Azure, register them as servers managed by QueryPie, and grant access permissions and set policies for users and groups on the synchronized servers.
 
 
 ### Registering Azure Integration Information in QueryPie

--- a/src/content/en/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-gcp.mdx
+++ b/src/content/en/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-gcp.mdx
@@ -8,7 +8,8 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-QueryPie supports GCP integration for server registration and management. You can synchronize resources within GCP, register them as servers managed by QueryPie, and grant access permissions and set policies for users and groups on the synchronized servers.
+QueryPie supports GCP integration for server registration and management.
+You can synchronize resources within GCP, register them as servers managed by QueryPie, and grant access permissions and set policies for users and groups on the synchronized servers.
 
 
 ### Registering GCP Integration Information in QueryPie


### PR DESCRIPTION
## 개요
이 PR은 영어 번역 문서와 한국어 원문 간의 불일치를 수정하기 위한 것입니다.

## 변경 사항
다음 10개의 영어 문서 파일을 한국어 원문과 일치하도록 수정했습니다:

### 수정된 파일 목록
1. `administrator-manual/kubernetes/k8s-access-control/roles.mdx`
   - 누락된 이미지 4개 추가 (Policies, Users/Groups, Clusters 탭 스크린샷)
   
2. `administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles.mdx`
   - 누락된 이미지 3개 추가 (정책 할당 및 해제 관련 스크린샷)
   
3. `administrator-manual/kubernetes/kac-general-configurations.mdx`
   - 헤딩 대소문자 수정 및 공백 라인 추가
   
4. `administrator-manual/multi-agent-limitations.mdx`
   - 수정 불필요 (이미 일치)
   
5. `administrator-manual/servers.mdx`
   - 수정 불필요 (이미 일치)
   
6. `administrator-manual/servers/connection-management.mdx`
   - Overview 섹션 문단 분리
   
7. `administrator-manual/servers/connection-management/cloud-providers.mdx`
   - Overview 섹션 문단 분리
   
8. `administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-aws.mdx`
   - Overview 섹션 문단 분리
   
9. `administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-azure.mdx`
   - Overview 섹션 문단 분리
   
10. `administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-gcp.mdx`
    - Overview 섹션 문단 분리

## 주요 수정 내용
- **이미지 추가**: 한국어 원문에는 있지만 영어 번역에 누락된 스크린샷 이미지 추가
- **문단 구조 조정**: Overview 섹션의 긴 문장을 여러 줄로 분리하여 한국어 원문과 구조 일치
- **헤딩 대소문자 정리**: 일관된 대소문자 사용

## 검증
- `mdx_to_skeleton.py` 스크립트를 사용하여 한국어 원문과 영어 번역의 skeleton 구조 비교
- 모든 수정된 파일에 대해 skeleton 재생성 및 검증 완료

## 참고
- 작업 브랜치: `jk/en-15`
- 베이스 브랜치: `main`
- 관련 문서: `docs/todo-15.txt`