### PR TITLE
mdx: 일본어 문서 불일치 수정 31

### DIFF
--- a/src/content/ja/administrator-manual/general/system/integrations/identity-providers.mdx
+++ b/src/content/ja/administrator-manual/general/system/integrations/identity-providers.mdx
@@ -151,7 +151,7 @@ Membership Type
 </td>
 <td data-highlight-colour="#ffffff">
 ユーザーにグループ情報が含まれている場合、`Include group information in user entries`を選択し、下位フィールドに参照するAttributeを入力します。
-* 例: `member`, `uniqueMember`, `memberUid` 등
+* 例：`member`、`uniqueMember`、`memberUid`等
 </td>
 </tr>
 <tr>

--- a/src/content/ja/administrator-manual/general/system/integrations/integrating-with-slack-dm.mdx
+++ b/src/content/ja/administrator-manual/general/system/integrations/integrating-with-slack-dm.mdx
@@ -25,9 +25,18 @@ Slack AppをQueryPieに連携し、QueryPieからDirect Message通知を受信�
 App Manifestを利用してQueryPie DM連携専用Slack Appを生成します。
 
 
-1. [https://api.slack.com/apps](https://api.slack.com/apps)に移動して`Create an App`をクリックします。<br/> 
-2. Create an appモーダルで、App生成方式を選択します。`From a manifest`をクリックします。<br/>
-3. Pick a workspaceモーダルでQueryPieと連携するSlack Workspaceを選択した後次の段階に進行します。<br/>
+1. [https://api.slack.com/apps](https://api.slack.com/apps)に移動して`Create an App`をクリックします。<br/> <br/> 
+  <figure data-layout="center" data-align="center">
+  ![image-20231227-065658.png](/administrator-manual/general/system/integrations/integrating-with-slack-dm/image-20231227-065658.png)
+  </figure>
+2. Create an appモーダルで、App生成方式を選択します。`From a manifest`をクリックします。<br/> <br/> 
+  <figure data-layout="center" data-align="center">
+  ![screenshot-20250218-131725.png](/administrator-manual/general/system/integrations/integrating-with-slack-dm/screenshot-20250218-131725.png)
+  </figure>
+3. Pick a workspaceモーダルでQueryPieと連携するSlack Workspaceを選択した後次の段階に進行します。<br/> <br/> 
+  <figure data-layout="center" data-align="center">
+  ![image-20231227-065951.png](/administrator-manual/general/system/integrations/integrating-with-slack-dm/image-20231227-065951.png)
+  </figure>
 4. Create app from manifestモーダルでJSON形式のApp Manifestを入力します。<br/>事前に埋められている内容を削除し以下のApp Manifestを貼り付けた後次の段階に進行します。<br/>:light_bulb_on: `{{..}}`内の値は希望する値に変更してください。 <br/>
   ```
 {
@@ -59,13 +68,22 @@ App Manifestを利用してQueryPie DM連携専用Slack Appを生成します。
     }
 }
   ```
-5. 設定内容を検討し`Create`ボタンをクリックしてApp生成を完了します。<br/> <br/>
+5. 設定内容を検討し`Create`ボタンをクリックしてApp生成を完了します。<br/> <br/> 
+  <figure data-layout="center" data-align="center">
+  ![image-20240115-220447.png](/administrator-manual/general/system/integrations/integrating-with-slack-dm/image-20240115-220447.png)
+  </figure>
 
 ### Slack WorkspaceにSlack Appインストール
 
-1. Settings &gt; Install Appで`Install to Workspace`ボタンをクリックして生成されたアプリをSlack Workspaceにインストールします。
-2. 権限リクエストページで、`許可`をクリックします。
+1. Settings &gt; Install Appで`Install to Workspace`ボタンをクリックして生成されたアプリをSlack Workspaceにインストールします。 
+2. 権限リクエストページで、`許可`をクリックします。 <br/> 
+  <figure data-layout="center" data-align="center">
+  ![image-20240115-221520.png](/administrator-manual/general/system/integrations/integrating-with-slack-dm/image-20240115-221520.png)
+  </figure>
 3. 設定したSlack WorkspaceでSlack DM専用Appが生成されたことを確認できます。
+  <figure data-layout="center" data-align="center">
+  ![image-20240115-221618.png](/administrator-manual/general/system/integrations/integrating-with-slack-dm/image-20240115-221618.png)
+  </figure>
 
 ### Bot User OAuth Token取得
 
@@ -86,29 +104,68 @@ App manifestでSlack appを生成する時Socket Modeと関連権限を有効化
 
 以下の段階を実行してApp-Level Tokenを手動で生成します。
 
-1. アプリ設定ページのSettings &gt; Basic InformationメニューのApp-Level Tokensセクションに移動し、`Generate Token and Scope`ボタンをクリックします。<br/>
-2. Generate an app-level tokenモーダルで、Add Scopeボタンをクリックした後`connections:write`を追加します。<br/>
+1. アプリ設定ページのSettings &gt; Basic InformationメニューのApp-Level Tokensセクションに移動し、`Generate Token and Scope`ボタンをクリックします。<br/> <br/> 
+  <figure data-layout="center" data-align="center">
+  ![screenshot-20250218-140951.png](/administrator-manual/general/system/integrations/integrating-with-slack-dm/screenshot-20250218-140951.png)
+  </figure>
+2. Generate an app-level tokenモーダルで、Add Scopeボタンをクリックした後`connections:write`を追加します。<br/> <br/> 
+  <figure data-layout="center" data-align="center">
+  ![screenshot-20250218-141555.png](/administrator-manual/general/system/integrations/integrating-with-slack-dm/screenshot-20250218-141555.png)
+  </figure>
 3. 生成されたApp-Level Tokenモーダルで、アプリトークンをコピーして別途記録しておきます。App-Level Tokenは`xapp-`で始まります。
 
 ### QueryPieでSlack DM設定
 
-1. Admin &gt; General &gt; System &gt; Integrations &gt; Slackメニューに進入した後、`Configure`ボタンをクリックして設定モーダルを開きます。<br/>
+1. Admin &gt; General &gt; System &gt; Integrations &gt; Slackメニューに進入した後、`Configure`ボタンをクリックして設定モーダルを開きます。<br/> <br/> 
+  <figure data-layout="center" data-align="center">
+  ![Administrator &gt; General &gt; System &gt; Integrations &gt; Slack &gt; Create a New Slack Configuration](/administrator-manual/general/system/integrations/integrating-with-slack-dm/screenshot-20250310-113509.png)
+  <figcaption>
+  Administrator &gt; General &gt; System &gt; Integrations &gt; Slack &gt; Create a New Slack Configuration
+  </figcaption>
+  </figure>
 2. 設定モーダルに先ほど記録しておいたApp TokenとBot User OAuth Tokenを入力します。
 3. 追加設定値は以下の通りです。DMでWorkflow通知を受けメッセージ内で承認/拒否を実行するにはすべての設定トグルを有効化します。
     *  **Send Workflow Notification via Slack DM**  : ワークフローリクエストに対するSlack DM送信有効化
-    *  **Allow Users to approve or reject on Slack DM**  : Slack DM内で承認または拒否機能有効化<br/>
+    *  **Allow Users to approve or reject on Slack DM**  : Slack DM内で承認または拒否機能有効化<br/> <br/> 
+      <figure data-layout="center" data-align="center">
+      ![アクション許容タイプ例（左）/ アクション非許容タイプ例（右）](/administrator-manual/general/system/integrations/integrating-with-slack-dm/image-20231003-054240.png)
+      <figcaption>
+      アクション許容タイプ例（左）/ アクション非許容タイプ例（右）
+      </figcaption>
+      </figure>
 4. `Save`ボタンを押して設定を完了します。
 
 ### Slack DM設定管理
 
-1. Slack Configurationを登録した後、現在の設定状態を画面で確認できます。<br/>
+1. Slack Configurationを登録した後、現在の設定状態を画面で確認できます。<br/> <br/> 
+  <figure data-layout="center" data-align="center">
+  ![Administrator &gt; General &gt; System &gt; Integrations &gt; Slack](/administrator-manual/general/system/integrations/integrating-with-slack-dm/screenshot-20250310-113950.png)
+  <figcaption>
+  Administrator &gt; General &gt; System &gt; Integrations &gt; Slack
+  </figcaption>
+  </figure>
 2. `Edit`ボタンをクリックして入力した設定を変更できます。<br/>
+  <figure data-layout="center" data-align="center">
+  ![Administrator &gt; General &gt; System &gt; Integrations &gt; Slack &gt; Edit the Slack Configuration](/administrator-manual/general/system/integrations/integrating-with-slack-dm/screenshot-20250218-152840.png)
+  <figcaption>
+  Administrator &gt; General &gt; System &gt; Integrations &gt; Slack &gt; Edit the Slack Configuration
+  </figcaption>
+  </figure>
 
 
 ### Workflowリクエスト時Slack DMテスト
 
 DB Access Requestを例に、Slack DM機能が正常に動作するかテストを実行します。
 
-1. QueryPie User &gt; WorkflowページでSubmit Requestボタンをクリックした後、DB Access Requestを選択してリクエスト作成画面に進入します。リクエスト作成画面で必要な情報を入力し、リクエストを提出します。
-2. 承認者は前に追加したSlack AppとのDMで承認すべきリクエスト通知を受信できます。<br/>**Allow Users to approve or reject on Slack DM**設定がオンになっているため、DMで直接理由を入力してリクエストを承認または拒否できます。<br/>
+1. QueryPie User &gt; WorkflowページでSubmit Requestボタンをクリックした後、DB Access Requestを選択してリクエスト作成画面に進入します。リクエスト作成画面で必要な情報を入力し、リクエストを提出します。 <br/> 
+  <figure data-layout="center" data-align="center">
+  ![screenshot-20250218-151504.png](/administrator-manual/general/system/integrations/integrating-with-slack-dm/screenshot-20250218-151504.png)
+  </figure>
+2. 承認者は前に追加したSlack AppとのDMで承認すべきリクエスト通知を受信できます。<br/>**Allow Users to approve or reject on Slack DM**設定がオンになっているため、DMで直接理由を入力してリクエストを承認または拒否できます。<br/> <br/> 
+  <figure data-layout="center" data-align="center">
+  ![screenshot-20250218-152238.png](/administrator-manual/general/system/integrations/integrating-with-slack-dm/screenshot-20250218-152238.png)
+  </figure>
 3. DMで`Details`ボタンをクリック時、QueryPie Adminで承認リクエストに対する詳細内容を確認し承認または拒否できます。<br/>
+  <figure data-layout="center" data-align="center">
+  ![screenshot-20250218-152527.png](/administrator-manual/general/system/integrations/integrating-with-slack-dm/screenshot-20250218-152527.png)
+  </figure>

--- a/src/content/ja/administrator-manual/general/system/integrations/integrating-with-slack-dm/slack-dm-workflow-notification-types.mdx
+++ b/src/content/ja/administrator-manual/general/system/integrations/integrating-with-slack-dm/slack-dm-workflow-notification-types.mdx
@@ -26,13 +26,22 @@ title: 'Slack DM - Workflow通知タイプ'
 
 Workflowの5つのタイプ（SQL Request、SQL Export Request、DB Access Request、Server Access Request、Access Role Request）すべてをサポートします。
 
-起案作成即座に1段階承認者に通知が送信されます。1段階承認が完了した場合には2段階承認者に通知が送信されます。同様に2段階承認が完了した場合3段階承認者に通知が送信されます。
+起案作成即座に1段階承認者に通知が送信されます。
+1段階承認が完了した場合には2段階承認者に通知が送信されます。
+同様に2段階承認が完了した場合3段階承認者に通知が送信されます。
 
-各段階の承認者が複数名の場合には該当承認者すべてにメッセージが送信されます。この時承認者中代理決裁を設定したユーザーがいれば、該当代理決裁者にもメッセージが送信されます。代理決裁関連詳細設定方法は[リクエスト付加機能](../../../../../user-manual/workflow/approval-additional-features-proxy-approval-resubmission-etc)内**代理決裁使用**ドキュメントを参照してください。
+各段階の承認者が複数名の場合には該当承認者すべてにメッセージが送信されます。
+この時承認者中代理決裁を設定したユーザーがいれば、該当代理決裁者にもメッセージが送信されます。
+代理決裁関連詳細設定方法は[リクエスト付加機能](../../../../../user-manual/workflow/approval-additional-features-proxy-approval-resubmission-etc)内  **代理決裁使用**  ドキュメントを参照してください。
 
-QueryPie管理者の事前設定により、メッセージを受信した承認者はSlackで承認/却下をすることもできます。必要な設定は上部の'Slack DM設定'を確認してください。アクションボタンがなくても`Details`ボタンは常に含まれます。該当ボタンクリック時、ウェブブラウザが実行されQueryPieログイン画面が表示されます。ログイン成功時Workflow詳細ページに移動します。
+QueryPie管理者の事前設定により、メッセージを受信した承認者はSlackで承認/却下をすることもできます。
+必要な設定は上部の'Slack DM設定'を確認してください。
+アクションボタンがなくても`Details`ボタンは常に含まれます。
+該当ボタンクリック時、ウェブブラウザが実行されQueryPieログイン画面が表示されます。
+ログイン成功時Workflow詳細ページに移動します。
 
-事後承認（Urgent Mode）起案の場合には以下のように該当事実がメッセージに一緒に案内されます。事後承認リクエスト件であるため、アクションボタンを使用中でも`Approve`ボタンのみ表示されます。
+事後承認（Urgent Mode）起案の場合には以下のように該当事実がメッセージに一緒に案内されます。
+事後承認リクエスト件であるため、アクションボタンを使用中でも`Approve`ボタンのみ表示されます。
 
 <figure data-layout="center" data-align="center">
 ![一般モード承認リクエスト例（左）/ 事後承認モード承認リクエスト例（右）](/administrator-manual/general/system/integrations/integrating-with-slack-dm/slack-dm-workflow-notification-types/image-20231003-062427.png)
@@ -47,11 +56,16 @@ QueryPie管理者の事前設定により、メッセージを受信した承認
 ![image-20231003-060544.png](/administrator-manual/general/system/integrations/integrating-with-slack-dm/slack-dm-workflow-notification-types/image-20231003-060544.png)
 </figure>
 
-Workflowの4つのタイプ（SQL Request、SQL Export Request、DB Access Request、Server Access Request）すべてをサポートします。どの段階でも該当起案を承認者が却下した場合、リクエスト者に即座にメッセージが送信されます。メッセージ内には却下理由コメントが一緒に伝達されます。
+Workflowの4つのタイプ（SQL Request、SQL Export Request、DB Access Request、Server Access Request）すべてをサポートします。
+どの段階でも該当起案を承認者が却下した場合、リクエスト者に即座にメッセージが送信されます。
+メッセージ内には却下理由コメントが一緒に伝達されます。
 
-別途のアクションボタンは含まれず、`Details`ボタンが含まれます。該当ボタンクリック時、ウェブブラウザが実行されQueryPieログイン画面が表示されます。ログイン成功時Workflow詳細ページに移動します。
+別途のアクションボタンは含まれず、`Details`ボタンが含まれます。
+該当ボタンクリック時、ウェブブラウザが実行されQueryPieログイン画面が表示されます。
+ログイン成功時Workflow詳細ページに移動します。
 
-事後承認（Urgent Mode）起案の場合には却下ケースが存在しません。したがって却下メッセージも存在しません。
+事後承認（Urgent Mode）起案の場合には却下ケースが存在しません。
+したがって却下メッセージも存在しません。
 
 ### 承認完了通知 - リクエスト者に
 
@@ -59,9 +73,12 @@ Workflowの4つのタイプ（SQL Request、SQL Export Request、DB Access Reque
 ![image-20231003-060552.png](/administrator-manual/general/system/integrations/integrating-with-slack-dm/slack-dm-workflow-notification-types/image-20231003-060552.png)
 </figure>
 
-Workflowの4つのタイプ（SQL Request、SQL Export Request、DB Access Request、Server Access Request）すべてをサポートします。承認が最終的に完了した時点でリクエスト者にメッセージが送信されます。
+Workflowの4つのタイプ（SQL Request、SQL Export Request、DB Access Request、Server Access Request）すべてをサポートします。
+承認が最終的に完了した時点でリクエスト者にメッセージが送信されます。
 
-別途のアクションボタンは含まれず、`Details`ボタンが含まれます。該当ボタンクリック時、ウェブブラウザが実行されQueryPieログイン画面が表示されます。ログイン成功時Workflow詳細ページに移動します。
+別途のアクションボタンは含まれず、`Details`ボタンが含まれます。
+該当ボタンクリック時、ウェブブラウザが実行されQueryPieログイン画面が表示されます。
+ログイン成功時Workflow詳細ページに移動します。
 
 事後承認（Urgent Mode）起案の場合にもすべての事後承認が完了してからリクエスト者に該当メッセージが送信されます。
 
@@ -71,7 +88,10 @@ WorkflowでExecute行動を含む2つのタイプ（SQL Request、SQL Export Req
 
 承認が最終的に完了した時点で実行者にメッセージが送信されます。
 
-別途のアクションボタンは含まれず、`Details`ボタンが含まれます。該当ボタンクリック時、ウェブブラウザが実行されQueryPieログイン画面が表示されます。ログイン成功時Workflow詳細ページに移動します。該当ページでSQL RequestおよびSQL Export Requestを実行できます。
+別途のアクションボタンは含まれず、`Details`ボタンが含まれます。
+該当ボタンクリック時、ウェブブラウザが実行されQueryPieログイン画面が表示されます。
+ログイン成功時Workflow詳細ページに移動します。
+該当ページでSQL RequestおよびSQL Export Requestを実行できます。
 
 事後承認（Urgent Mode）起案の場合には起案提出即座に実行者にメッセージが送信されます。
 
@@ -87,10 +107,15 @@ WorkflowでExecute行動を含む2つのタイプ（SQL Request、SQL Export Req
 
 Workflowで2つのタイプ（SQL Request、SQL Export Request）をサポートします。
 
-Urgent Modeで提出された起案が1日以上未承認状態であることを知らせるメッセージです。1日以上経過したすべての起案件に対して該当段階の承認者に毎朝1回送信されます。
+Urgent Modeで提出された起案が1日以上未承認状態であることを知らせるメッセージです。
+1日以上経過したすべての起案件に対して該当段階の承認者に毎朝1回送信されます。
 
-各段階の承認者が複数名の場合には該当承認者すべてにメッセージが送信されます。この時承認者中代理決裁を設定したユーザーがいれば、該当代理決裁者にもメッセージが送信されます。代理決裁関連詳細設定方法は[リクエスト付加機能](../../../../../user-manual/workflow/approval-additional-features-proxy-approval-resubmission-etc)内**代理決裁使用**ドキュメントを参照してください。
+各段階の承認者が複数名の場合には該当承認者すべてにメッセージが送信されます。
+この時承認者中代理決裁を設定したユーザーがいれば、該当代理決裁者にもメッセージが送信されます。
+代理決裁関連詳細設定方法は[リクエスト付加機能](../../../../../user-manual/workflow/approval-additional-features-proxy-approval-resubmission-etc)内  **代理決裁使用**  ドキュメントを参照してください。
 
-未承認起案1件ごとにメッセージが1件であるため、未承認起案が複数件であればメッセージも複数件送信されます。送信時刻は毎朝10時で、営業日と休日を区別しません。
+未承認起案1件ごとにメッセージが1件であるため、未承認起案が複数件であればメッセージも複数件送信されます。
+送信時刻は毎朝10時で、営業日と休日を区別しません。
+
 
 


### PR DESCRIPTION
## 변경 사항

이 PR은 일본어 번역 문서의 한국어 원문과의 불일치를 수정합니다.

### 수정된 파일 (3개)

#### 1. `identity-providers.mdx`
- **문제**: LDAP 연동 섹션의 Membership Type 테이블에서 한국어 "등"이 혼입됨
- **수정**: `등` → `等` (일본어로 올바르게 변경)
- **영향**: 1줄

#### 2. `integrating-with-slack-dm.mdx`  
- **문제**: 여러 섹션에서 figure 태그와 figcaption이 누락되어 이미지 설명 부재
- **수정**: 누락된 figure 및 figcaption 추가 (총 11개 이미지에 대한 마크업 복원)
- **영향**: 
  - Slack API에서 DM App 생성 섹션: 5개 figure 추가
  - App-Level Token 생성 섹션: 2개 figure 추가  
  - QueryPie에서 Slack DM 설정 섹션: 2개 figure 추가
  - Slack DM 설정 관리 섹션: 2개 figure 추가
  - Workflow 요청 시 Slack DM 테스트 섹션: 3개 figure 추가

#### 3. `slack-dm-workflow-notification-types.mdx`
- **문제**: 승인 요청, 실행 가능, 미승인 알림 섹션의 문단 구조가 한국어 원문과 달라 가독성 저하
- **수정**: 한국어 원문과 동일하게 문단을 적절히 분리하여 가독성 향상
- **영향**: 5개 섹션의 문단 구조 개선

## 검증

- [x] 한국어 원문과 일본어 번역문 비교 완료
- [x] 수정된 파일의 MDX 문법 검증
- [x] 이미지 경로 및 figcaption 정확성 확인
- [x] 문단 구조 개선으로 가독성 향상 확인

## 관련 이슈

todo-ja.01.txt 파일의 일본어 번역 보완 작업의 일환