### PR TITLE
mdx: 일본어 문서 불일치 수정 34

### DIFF
--- a/src/content/ja/administrator-manual/servers/server-account-management/account-management.mdx
+++ b/src/content/ja/administrator-manual/servers/server-account-management/account-management.mdx
@@ -11,7 +11,7 @@ import { Callout } from 'nextra/components'
 Password Provisioningを通じてパスワードが変更されたサーバーのアカウントを照会し、パスワード変更履歴を確認し、個別サーバーアカウントのパスワードを手動で管理できます。
 
 <Callout type="info">
-このメニューはAdministrator &gt; Servers &gt; [SAC General Configurations](../sac-general-configurations)で  **Password Provisioning**  設定をOnに選択後保存する必要があります。
+このメニューはAdministrator &gt; Servers &gt; [SAC General Configurations](../sac-general-configurations)で  **Password Provisioning**  設定をOnに選択後保存すると表示されます。
 </Callout>
 
 ### Account照会
@@ -26,7 +26,7 @@ Administrator &gt; Servers &gt; Server Account Management &gt; Account Managemen
 1. Administrator &gt; Servers &gt; Server Account Management &gt; Account Managementメニューに移動します
 2. テーブル左上の検索欄を通じてサーバーまたはAccountの検索が可能です。
 3. テーブル右上のリフレッシュボタンを通じてアカウントリストを最新化できます。
-4. テーブルで以下のカラム情報を提供します。
+4. テーブルでは以下のカラム情報を提供します。
     1.  **Server** : 対象サーバー名
     2.  **Host**  : サーバーのIP
     3.  **Server OS**  : サーバーのOS
@@ -50,7 +50,7 @@ Administrator &gt; Servers &gt; Server Account Management &gt; Account Managemen
 1. Administrator &gt; Servers &gt; Server Account Management &gt; Account Management &gt; One Time Accountsタブに移動します
 2. テーブル左上の検索欄を通じてServer、HostまたはAccountの検索が可能です。
 3. テーブル右上のリフレッシュボタンを通じてアカウントリストを最新化できます。
-4. テーブルで以下のカラム情報を提供します。
+4. テーブルでは以下のカラム情報を提供します。
     1.  **Server** : 対象サーバー名
     2.  **Host**  : サーバーのIP
     3.  **Server OS**  : サーバーのOS
@@ -71,7 +71,7 @@ Administrator &gt; Servers &gt; Server Account Management &gt; Account Managemen
 1. Administrator &gt; Servers &gt; Server Account Management &gt; Account Management &gt; Active Directoryタブに移動します
 2. テーブル左上の検索欄を通じてUPNの検索が可能です。
 3. テーブル右上のリフレッシュボタンを通じてアカウントリストを最新化できます。
-4. テーブルで以下のカラム情報を提供します。
+4. テーブルでは以下のカラム情報を提供します。
     1.  **AD Name**  : QueryPieに連動されたAD名
     2.  **AD Domain**  : ADドメインアドレス
     3.  **UPN**  : 該当ドメインにログインする時に使用するユーザーアカウント

--- a/src/content/ja/administrator-manual/web-apps/wac-quickstart.mdx
+++ b/src/content/ja/administrator-manual/web-apps/wac-quickstart.mdx
@@ -44,8 +44,8 @@ QueryPieホームページ（`www.querypie.com`）内の `/ko/resources` 配下�
 ```
 
 
-1. Admin > Web Apps > Connection Management > Web Apps メニューに移動します。
-2. `Create a Web App` ボタンをクリックすると、Webアプリ登録ページに移動します。<br/>
+1. Admin > Web Apps > Connection Management > Web Apps メニューへ移動します。
+2. `Create a Web App` ボタンをクリックすると、Webアプリ登録ページへ移動します。<br/>
 
 <figure data-layout="center" data-align="center">
 ![Admin > Web Apps > Create a Web App](/administrator-manual/web-apps/wac-quickstart/screenshot-20250412-225620.png)
@@ -101,7 +101,7 @@ Admin > Web Apps > Web App Access Control > Policies > Edit Policy Code
 </figcaption>
 </figure>
 
-1. Admin > Web Apps > Web App Access Control > Policies メニューに移動します。
+1. Admin > Web Apps > Web App Access Control > Policies メニューへ移動します。
 2. `Create Policy` ボタンをクリックし、Create Policyモーダルに以下を入力します。
     1. **Name**: QP Web Test
 3. `Save` ボタンをクリックして保存します。
@@ -137,10 +137,10 @@ Admin > Web Apps > Web App Access Control > Roles > List Details
 </figcaption>
 </figure>
 
-1. Admin > Web Apps > Web App Access Control > Roles メニューに移動します。
+1. Admin > Web Apps > Web App Access Control > Roles メニューへ移動します。
 2. `Create Role` ボタンをクリックし、以下を入力します。
     1. **Name**: QP Web Test
-3. 今作成したロールをクリックして詳細ページ > Policiesタブに移動します。`Assign Policies` ボタンをクリックします。
+3. 今作成したロールをクリックして詳細ページ > Policiesタブへ移動します。`Assign Policies` ボタンをクリックします。
 4. Assign Policiesモーダルで先ほど作成したQP Web Testポリシーを選択し、`Assign` ボタンをクリックして保存し、モーダルを閉じます。
 
 ### 4. ロールをユーザー/グループに割り当て
@@ -154,7 +154,7 @@ Admin > Web Apps > Web App Access Control > Access Control > List Details
 </figcaption>
 </figure>
 
-1. Admin > Web Apps > Web App Access Control > Access Control メニューに移動します。
+1. Admin > Web Apps > Web App Access Control > Access Control メニューへ移動します。
 2. ロールを割り当てたいユーザーまたはグループを選択します。
     1. 今はテスト中の自分を選択してみます。
 3. ユーザー詳細ページ > Rolesタブで、`Grant Roles` ボタンをクリックします。
@@ -221,7 +221,7 @@ WAC拡張機能インストール前に開いていたタブについては管�
 
 1. `Go to Dashboard` ボタンをクリックすると新しいタブが開き、QueryPie Webコンソールが開きます。
     1. 現在QueryPieにログインされている状態であれば、Web App Dashboardが開きます。
-    2. ログインされていない状態であればログインページに移動します。ログインを完了し、上部メニューでWeb Appsをクリックしてダッシュボードにアクセスしてください。
+    2. ログインされていない状態であればログインページへ移動します。ログインを完了し、上部メニューでWeb Appsをクリックしてダッシュボードにアクセスしてください。
     3. ロール選択モーダルが表示されたら、QP Web Testを選択します。
 2. Web App Dashboard内のMy Appsに先ほど登録したQueryPie Web Siteアプリアイコンが表示されるはずです。アイコンをクリックするとウェブサイトにアクセスします。<br/> <br/> 
   <figure data-layout="center" data-align="center">
@@ -289,7 +289,7 @@ Admin > Audit > Web Apps > User Activity Recordings > Details
 
 
 1. Admin > Audit > Web Apps > User Activity Recording に移動します。
-2. 現在のユーザー名で残った記録をクリックすると、詳細ページに移動します。
+2. 現在のユーザー名で残った記録をクリックすると、詳細ページへ移動します。
 3. Event Timelineでユーザーの行動を時間順で確認できます。
     1. フィルターをクリックすると行動種類別で確認可能です。
     2. 検索可能な値は以下の通りです。

--- a/src/content/ja/administrator-manual/web-apps/wac-quickstart/1030-wac-jit-permission-acquisition-guide.mdx
+++ b/src/content/ja/administrator-manual/web-apps/wac-quickstart/1030-wac-jit-permission-acquisition-guide.mdx
@@ -28,8 +28,8 @@ JIT権限取得Guideは `10.3.0` バージョンを基準に説明します。
 
 ### 1. Webアプリの登録
 
-1. Admin > Web Apps > Connection Management > Web Apps メニューに移動します。
-2. `Create a Web App` ボタンをクリックすると、Webアプリ登録ページに移動します。
+1. Admin > Web Apps > Connection Management > Web Apps メニューへ移動します。
+2. `Create a Web App` ボタンをクリックすると、Webアプリ登録ページへ移動します。
 
 <figure data-layout="center" data-align="center">
 ![screenshot-20250412-225620.png](/administrator-manual/web-apps/wac-quickstart/1030-wac-jit-permission-acquisition-guide/screenshot-20250412-225620.png)
@@ -123,7 +123,7 @@ JIT（Just-in-Time）権限申請時、以下のような制約事項があり�
 
 1. （Web App Ownerに指定された）決裁権を持つユーザーがWorkflowにアクセスします。
 2. Received Requests > To Doに移動します。
-3. 申請内容をクリックしてDetailページに移動します。
+3. 申請内容をクリックしてDetailページへ移動します。
 4. 上部のApproveをクリックします。
 
 

--- a/src/content/ja/administrator-manual/web-apps/web-app-access-control/access-control/granting-and-revoking-roles.mdx
+++ b/src/content/ja/administrator-manual/web-apps/web-app-access-control/access-control/granting-and-revoking-roles.mdx
@@ -22,7 +22,7 @@ Administrator > Servers > Server Access Control > Access Control
 </figure>
 
 
-1. **Administrator > Web Apps > Web App Access Control > Access Control** メニューに移動します。
+1. **Administrator > Web Apps > Web App Access Control > Access Control** メニューへ移動します。
 2. 権限を付与するユーザーまたはユーザーグループを選択します。
 
 #### 2. 権限を付与するRoleを選択します。
@@ -47,9 +47,9 @@ Administrator > Servers > Server Access Control > Access Control
 ![image-20250629-161437.png](/administrator-manual/web-apps/web-app-access-control/access-control/granting-and-revoking-roles/image-20250629-161437.png)
 </figure>
 
-1. **Administrator > Web Apps > Web App Access Control > Access Control** メニューに移動します。
+1. **Administrator > Web Apps > Web App Access Control > Access Control** メニューへ移動します。
 2. 権限を付与するユーザーまたはユーザーグループを選択します。
-3. Rolesタブに移動します。
+3. Rolesタブへ移動します。
 4. Roleリストで権限を回収するRoleを選択します。（複数選択可能）
 5. リスト左側上部に表示される `Revoke` ボタンをクリックします。
 6. 確認ポップアップでRevoke入力後 `Revoke` ボタンを押すとRoleが正常に回収されます。

--- a/src/content/ja/administrator-manual/web-apps/web-app-access-control/policies.mdx
+++ b/src/content/ja/administrator-manual/web-apps/web-app-access-control/policies.mdx
@@ -26,28 +26,28 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Policies &gt; List 
 </figcaption>
 </figure>
 
-1. Administrator &gt; Web Apps &gt; Web App Access Control &gt; Policiesメニューに移動します。
-2. テーブル最左上部の検索欄を通じてポリシー名を条件に検索が可能です。
+1. Administrator &gt; Web Apps &gt; Web App Access Control &gt; Policiesメニューへ移動します。
+2. テーブル左上の検索欄を通じてポリシー名を条件に検索が可能です。
 3. 下部のErrorsタブを通じて直接修正したコードのエラーをデバッグします。コードにエラーがある場合、Errorsタブが赤色で表示されて即座に確認できます。
 4. テーブル右上のリフレッシュボタンを通じてPolicyリストを最新化できます。
-5. テーブルで以下のような情報を提供します：<br/>a. Name：Policy名<br/>b. Description：Policy詳細説明<br/>c. Created At：ポリシー最初生成日時<br/>d. Updated At：ポリシー最後修正日時<br/>e. Updated By：最後更新を実行した管理者名
+5. テーブルで以下のような情報を提供します：<br/>a. **Name**: Policy名<br/>b. **Description**: Policy詳細説明<br/>c. **Created At**: ポリシー最初生成日時<br/>d. **Updated At**: ポリシー最後修正日時<br/>e. **Updated By**: 最後更新を実行した管理者名
 6. 各行をクリックするとポリシー詳細情報照会が可能です。
     1. Detail
       <figure data-layout="center" data-align="center">
       ![image-20250629-164600.png](/administrator-manual/web-apps/web-app-access-control/policies/image-20250629-164600.png)
       </figure>
         1. デフォルトで指定されるタブでポリシーで定義されたコードを照会できます。
-        2. Detailタブの右側にある、右側の`Go to Editor Mode`ボタンがあり、これをクリックすると該当Code Editorページ画面に切り替わります。
+        2. Detailタブの右側にある`Go to Editor Mode`ボタンをクリックすると、該当Code Editorページ画面に切り替わります。
     2. Roles<br/>
       <figure data-layout="center" data-align="center">
       ![image-20250629-164733.png](/administrator-manual/web-apps/web-app-access-control/policies/image-20250629-164733.png)
       </figure>
         1. 該当ポリシーが割り当てられているRoleリストを列挙します。
         2. リストは各Roleごとに以下の情報を表示します：
-            1. Name：Role名
-            2. Description：Role詳細説明
-            3. Assigned At：Roleに該当ポリシーが割り当てられた日時
-            4. Assigned By：該当ポリシーをRoleに割り当てた管理者名
+            1. **Name**: Role名
+            2. **Description**: Role詳細説明
+            3. **Assigned At**: Roleに該当ポリシーが割り当てられた日時
+            4. **Assigned By**: 該当ポリシーをRoleに割り当てた管理者名
         3. 各行をクリックするとRoleに対する詳細情報をドロワー形式で提供します。
     3. Versions
       <figure data-layout="center" data-align="center">
@@ -56,16 +56,16 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Policies &gt; List 
         1. 該当ポリシーの各バージョンに対する履歴を列挙します。
             1. ポリシーバージョンはCodeが修正されて保存されると更新されます。
         2.  リストは各versionごとに以下の情報を表示します：
-            1. Version：バージョン名
-            2. Justification：ポリシー更新期間事由
-            3. Updated At：該当バージョン生成日時
-            4. Updated By：該当バージョン修正者名
+            1. **Version**: バージョン名
+            2. **Justification**: ポリシー更新期間事由
+            3. **Updated At**: 該当バージョン生成日時
+            4. **Updated By**: 該当バージョン修正者名
         3. 各行をクリックするとバージョンに対する詳細情報をドロワー形式で提供します。
-            1. (Title)：ポリシー名
-            2. Version：ポリシーバージョン
-            3. Justification：ポリシー更新期間事由
-            4. Updated At：該当バージョン生成日時
-            5. Updated By：該当バージョン修正者名
+            1. **(Title)**: ポリシー名
+            2. **Version**: ポリシーバージョン
+            3. **Justification**: ポリシー更新期間事由
+            4. **Updated At**: 該当バージョン生成日時
+            5. **Updated By**: 該当バージョン修正者名
             6. 下部に当時のポリシーコードスナップショットが表示されます。
 
 ### Policy生成
@@ -74,9 +74,9 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Policies &gt; List 
 ![image-20250629-164901.png](/administrator-manual/web-apps/web-app-access-control/policies/image-20250629-164901.png)
 </figure>
 
-1. Administrator &gt; Web Apps &gt; Web App Access Control &gt; Policiesメニューに移動します。
+1. Administrator &gt; Web Apps &gt; Web App Access Control &gt; Policiesメニューへ移動します。
 2. 右上の+ Create Policyボタンをクリックします。
-3. ポリシー生成のための以下の情報を入力します。（以下の情報はすべてユーザーに表示される情報です。）<br/>a. Name：識別可能なポリシー名（必須）<br/>b. Description：該当ポリシーに対する付加的な説明
+3. ポリシー生成のための以下の情報を入力します。（以下の情報はすべてユーザーに表示される情報です。）<br/>a. **Name**: 識別可能なポリシー名（必須）<br/>b. **Description**: 該当ポリシーに対する付加的な説明
 4. OKボタンをクリックして生成します。
 5. ポリシーリスト最上部に新規生成されたポリシーをクリックします。
 6. ウェブアプリケーションポリシー設定ガイドを参照してポリシーを設定します。

--- a/src/content/ja/administrator-manual/web-apps/web-app-access-control/roles.mdx
+++ b/src/content/ja/administrator-manual/web-apps/web-app-access-control/roles.mdx
@@ -27,7 +27,7 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Roles &gt; List Det
 </figcaption>
 </figure>
 
-1. Administrator &gt; Web Apps &gt; Access Control &gt; Rolesメニューに移動します。
+1. Administrator &gt; Web Apps &gt; Access Control &gt; Rolesメニューへ移動します。
 2. テーブル最左上部の検索欄を通じて役割名を条件に検索が可能です。
 3. テーブル右上のリフレッシュボタンを通じてRoleリストを最新化できます。
 4. テーブルで以下のような情報を提供します：<br/>a.  **Name**  : Role名<br/>b.  **Description**  : Role詳細説明<br/>c.  **Last Access At** : 該当役割の最後呼び出し日時<br/>d.  **Created At** : 役割最初生成日時<br/>e.  **Updated At**  : 役割最後修正日時<br/>f.  **Updated By**  : 最後更新を実行した管理者名
@@ -85,7 +85,7 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Roles &gt; List Det
 
 ### Role生成
 
-1. Administrator &gt; Web Apps &gt; Access Control &gt; Rolesメニューに移動します。
+1. Administrator &gt; Web Apps &gt; Access Control &gt; Rolesメニューへ移動します。
 2. 右上の+ Create Roleボタンをクリックします。
 3. 役割生成のための以下の情報を入力します。（以下の情報はすべてユーザーに表示される情報です。）<br/>a. Name：識別可能な役割名（必須）<br/>b. Description：該当役割に対する付加的な説明
 4. Saveボタンをクリックして生成します。
@@ -98,8 +98,8 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Roles &gt; List Det
 ![image-20250629-163924.png](/administrator-manual/web-apps/web-app-access-control/roles/image-20250629-163924.png)
 </figure>
 
-1. Administrator &gt; Web Apps &gt; Access Control &gt; Rolesメニューに移動します。
-2. リストで修正するRoleをクリックして詳細ページに移動します。
+1. Administrator &gt; Web Apps &gt; Access Control &gt; Rolesメニューへ移動します。
+2. リストで修正するRoleをクリックして詳細ページへ移動します。
 3. 画面右上のEditボタンをクリックして以下の情報を修正できます。<br/>a. Name：識別可能な役割名（必須）<br/>b. Description：該当役割に対する付加的な説明
 4. Saveボタンをクリックして修正を反映します。
 
@@ -109,7 +109,7 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Roles &gt; List Det
 ![image-20250629-163949.png](/administrator-manual/web-apps/web-app-access-control/roles/image-20250629-163949.png)
 </figure>
 
-1. Administrator &gt; Web Apps &gt; Access Control &gt; Rolesメニューに移動します。
+1. Administrator &gt; Web Apps &gt; Access Control &gt; Rolesメニューへ移動します。
 2. 二つの方式で削除段階を進行できます：<br/>a. リストから削除<br/> i. テーブル内削除対象ポリシーのチェックボックスをチェックします。<br/> ii. テーブルコンテンツラインに現れたDeleteボタンをクリックします。<br/>b. 詳細ページから削除<br/> i. 画面右上のDeleteボタンをクリックします。
 3. ポップアップが現れたらDeleteボタンをクリックして削除を進行します。
 


### PR DESCRIPTION
## 개요
일본어 문서 번역의 일관성을 개선하고, 한국어 원문과의 불일치를 수정했습니다.

## 수정 내용

### 수정된 파일 (6개)

1. **account-management.mdx**
   - "표시됩니다" 번역 추가
   - 테이블 표현 일관성 개선 ("で" → "では")

2. **wac-quickstart.mdx**
   - 메뉴 이동 표현 통일 ("に移動" → "へ移動")

3. **1030-wac-jit-permission-acquisition-guide.mdx**
   - 메뉴 이동 표현 통일

4. **granting-and-revoking-roles.mdx**
   - 메뉴 이동 표현 통일

5. **policies.mdx**
   - "최좌측" → "左上" (좌측 상단)
   - 볼드 마크업 일관성 개선 (`: ` → `: **Field**:`)
   - 메뉴 이동 표현 통일

6. **roles.mdx**
   - "최좌측" → "左上"
   - 메뉴 이동 표현 통일
   - 볼드 마크업 일관성 개선

## 변경 통계
- 6개 파일 수정
- 42 insertions(+), 42 deletions(-)

## 검증
- [x] 일본어 문법 및 자연스러운 표현 검토
- [x] 한국어 원문과의 일관성 확인
- [x] 마크다운 문법 정확성 검증

## 참고사항
- todo-ja.03.txt 파일에 나열된 11개 파일 중 6개를 이번 PR에서 처리
- 나머지 5개 파일은 추가 검토 필요 (별도 PR 예정)

## 관련 이슈
#N/A