### PR TITLE
mdx: 일본어 문서 불일치 수정 35

### DIFF
--- a/src/content/ja/administrator-manual/general/system/integrations/integrating-with-slack-dm/slack-dm-workflow-notification-types.mdx
+++ b/src/content/ja/administrator-manual/general/system/integrations/integrating-with-slack-dm/slack-dm-workflow-notification-types.mdx
@@ -32,10 +32,10 @@ Workflowの5つのタイプ（SQL Request、SQL Export Request、DB Access Reque
 
 各段階の承認者が複数名の場合には該当承認者すべてにメッセージが送信されます。
 この時承認者中代理決裁を設定したユーザーがいれば、該当代理決裁者にもメッセージが送信されます。
-代理決裁関連詳細設定方法は[リクエスト付加機能](../../../../../user-manual/workflow/approval-additional-features-proxy-approval-resubmission-etc)内  **代理決裁使用**  ドキュメントを参照してください。
+代理決裁関連詳細設定方法は[リクエスト付加機能](../../../../../user-manual/workflow/approval-additional-features-proxy-approval-resubmission-etc)内  **代理決裁の使用方法**  ドキュメントを参照してください。
 
 QueryPie管理者の事前設定により、メッセージを受信した承認者はSlackで承認/却下をすることもできます。
-必要な設定は上部の'Slack DM設定'を確認してください。
+必要な設定は上部の「Slack DM設定」を確認してください。
 アクションボタンがなくても`Details`ボタンは常に含まれます。
 該当ボタンクリック時、ウェブブラウザが実行されQueryPieログイン画面が表示されます。
 ログイン成功時Workflow詳細ページに移動します。
@@ -112,7 +112,7 @@ Urgent Modeで提出された起案が1日以上未承認状態であること�
 
 各段階の承認者が複数名の場合には該当承認者すべてにメッセージが送信されます。
 この時承認者中代理決裁を設定したユーザーがいれば、該当代理決裁者にもメッセージが送信されます。
-代理決裁関連詳細設定方法は[リクエスト付加機能](../../../../../user-manual/workflow/approval-additional-features-proxy-approval-resubmission-etc)内  **代理決裁使用**  ドキュメントを参照してください。
+代理決裁関連詳細設定方法は[リクエスト付加機能](../../../../../user-manual/workflow/approval-additional-features-proxy-approval-resubmission-etc)内  **代理決裁の使用方法**  ドキュメントを参照してください。
 
 未承認起案1件ごとにメッセージが1件であるため、未承認起案が複数件であればメッセージも複数件送信されます。
 送信時刻は毎朝10時で、営業日と休日を区別しません。

--- a/src/content/ja/administrator-manual/general/user-management/authentication/integrating-with-okta.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/authentication/integrating-with-okta.mdx
@@ -10,7 +10,7 @@ import { Callout } from 'nextra/components'
 
 QueryPieではOkta連携をサポートします。
 Oktaのユーザーおよびグループを同期してアクセス権限を付与しポリシーを適用でき、この過程でユーザーに簡素化され便利な環境を提供しながらも厳格なセキュリティポリシーを運営できます。
-QueryPieとOktaの統合はデータベースおよびシステム管理エコシステムのセキュリティと運営効率性およびユーザー経験が向上させることができます。
+QueryPieとOktaの統合はデータベースおよびシステム管理エコシステムのセキュリティと運営効率性およびユーザーエクスペリエンスが向上します。
 
 <Callout type="info">
 SCIMプロビジョニング連携まで実装したい場合、[[Okta]プロビジョニング連携ガイド](../provisioning/okta-provisioning-integration-guide) 内手順通り代わりに進行してください。下部のOkta APIを活用したアウトバウンドユーザー同期設定を同時に活用する場合、ユーザー同期に影響を受ける可能性がある点ご注意ください。
@@ -81,7 +81,7 @@ Okta Admin &gt; Applications &gt; Applications &gt; QueryPie App
 2. リストでQueryPieアプリケーションをクリックします。
 3. Assignmentsタブに移動した後`Assign`ボタンをクリックして`Assign to People`または`Assign to Group`を選択します。
 4. OktaアカウントでQueryPieアクセスを許可するユーザーまたはグループを割り当てた後Doneボタンをクリックします。
-    1. People割り当て時ユーザー情報確認後`Sava and Go Back`ボタンをクリックします。
+    1. People割り当て時ユーザー情報確認後`Save and Go Back`ボタンをクリックします。
     2. Group割り当て時loginId項目を空白にして`Save and Go Back`ボタンをクリックします。
 5. ユーザーまたはグループがQueryPieアプリケーションに割り当てられ追加された履歴を確認できます。
 
@@ -119,7 +119,7 @@ Okta Admin Console &gt; Security &gt; Administrators &gt; Roles &gt; Create new 
 </figure>
 
 1. Okta管理者ページ左側パネルでDirectory &gt; Peopleメニューに移動してAdd Personを押して専用システム連携用アカウントを生成します。 
-    * 既にクエリパイ連携用で使用可能なアカウントがあれば本段階をスキップします。 
+    * 既にQueryPie連携用で使用可能なアカウントがあれば本段階をスキップします。 
 2. Okta管理者ページ左側パネルでSecurity &gt; Administratorsメニューに移動してRolesタブに移動します。 
 3. Create new roleを選択します。 
 4. Role name（例：MinimumAdminRole）およびRole descriptionを定義した後、Select Permisionsで以下の権限のみチェックします。 
@@ -134,15 +134,15 @@ Okta Admin Console &gt; Security &gt; Administrators &gt; Roles &gt; Create new 
 7. Create new resource setを選択します。
     * 既に割り当てる権限範囲指定のために作っておいたresource setがあれば本段階をスキップして10番段階を進行します。 
 8. Name（例：MinimumResources）およびDescriptionを定義した後以下の範囲を検索して指定します。 
-    1. User : クエリパイユーザー全部選択 
-    2. Group : クエリパイ使用グループ全部選択 
-    3. Application : クエリパイアプリに限定
+    1. User : QueryPieユーザー全部選択 
+    2. Group : QueryPie使用グループ全部選択 
+    3. Application : QueryPieアプリに限定
 9. Createを選択して生成します。 
-10. Adminsタブに移動してクエリパイ連携用アカウントに以下の権限を割り当てます。
+10. Adminsタブに移動してQueryPie連携用アカウントに以下の権限を割り当てます。
     1. Role: MinimumAdminRole | Resource: MinimumResources
     2. Role: Read-Only Administrator 
         * APIトークン生成メニューアクセスのための一時付与 
-11. クエリパイ連携用アカウントでオクタ管理者コンソールページに認証後アクセスします。 
+11. QueryPie連携用アカウントでOkta管理者コンソールページに認証後アクセスします。 
 12. Security &gt; APIメニューでTokensタブに移動します。
 13. Create Tokenボタンをクリックして認証トークンを生成してこれを保管します。 
 14. その後再び初期作業した管理者アカウントでアクセスしてSecurity &gt; Administrators &gt; Adminsタブで連携用アカウントを編集してRead-Only Adminstrator権限を回収します。 

--- a/src/content/ja/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-action-configuration-reference-guide.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-action-configuration-reference-guide.mdx
@@ -7,14 +7,14 @@ title: 'KubernetesポリシーAction設定参考ガイド'
 ### Overview
 
 QueryPie KACではYaml形態のPolicyを通じてk8sに対するアクセス制御ポリシーを設定します。
-この時、Actionに対するガイドを提供して、間違ったポリシー設定によるkubectl、lens、k9sのようなclient tool使用の困難を経験しないようにしようとします。
+この時、Actionに対するガイドを提供して、間違ったポリシー設定によるkubectl、lens、k9sのようなclient tool使用の困難が発生しないようにします。
 
 
 ### API Groups関連設定ガイド
 
-よく使用されるpodsのような場合はapiGroupsがcoreグループなので`""`空文字列ですが、deploymentsやreplicasetsは`"apps"`、ingressesのような場合は`"networking.k8s.io"`で管理者が一つ一つ知って設定するのが困難です。
+よく使用されるpodsのような場合はapiGroupsがcoreグループなので`""`空文字列ですが、deploymentsやreplicasetsは`"apps"`、ingressesのような場合は`"networking.k8s.io"`で管理者が個別に設定を行うのは困難です。
 
-もちろん同じresource nameを持つ場合、apiGroupsを通じて分離する必要があるかもしれませんが、よくある状況ではありません。
+もちろん同じresource nameを持つ場合、apiGroupsを通じて分離する必要があるかもしれませんが、一般的な状況ではありません。
 
 したがって、Kubernetes API Group管理のミッションがない限り、一般的には`"*"`で設定し、resourcesでアクセス権限を制御する方向で設定することをお勧めします。
 
@@ -48,7 +48,7 @@ allow:
 *  **Eventsパート**
     * 下のevents項目は`events`リソースに対する権限によって表示されますが、上のresources項目と同様にnamespace、nameによってフィルタリングされて表示されます。
     * ただし`pods`に対する権限があるからといって`pods`関連`events`が見えるわけではないので、該当画面を見るには明示的に`events`リソースに対する権限を与える必要があります。
-    * `events`リソースと`pods`リソースは互いに分離されたリソースです。したがって、`events`リソース権限がある状態で`pods`に対する権限だけを与えたからといって`events`中`pods`に対する履歴だけ照会されないことをお知らせします。
+    * `events`リソースと`pods`リソースは互いに分離されたリソースです。したがって、`events`リソース権限がある状態で`pods`に対する権限だけを与えたとしても`events`中`pods`に対する内容だけが照会されるわけではないことをご案内します。
     * 推奨スペック
       ```
 allow:
@@ -81,7 +81,7 @@ allow:
       verbs: ["get", "list", "watch"]
       ```
 *  **Edit権限**
-    * Edit権限まで得るユーザーの場合はView権限(最小`get`、`list`)も一緒に付与してあげる必要があります。kubectlでも特定リソースに対する修正要求をするとまず照会要求をするためです。
+    * Edit権限まで得るユーザーの場合はView権限(最小`get`、`list`)も一緒に付与する必要があります。kubectlでも特定リソースに対する修正要求をするとまず照会要求をするためです。
     * lensのようなツールではView権限がないとEdit画面に行く方法がありません。
     * Edit中でも作成(`create`)、修正(`patch`、`update`)、削除(`delete`、`deletecollection`)このように各役割に合わせて束にして与えられる必要があります。
     * `deletecollection`はよく使用されるわけではありませんが、KACでは`deletecollection`で要求が来てもユーザーに権限があるリソースだけを選んで削除処理するため、有用に使用できます。

--- a/src/content/ja/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-ui-code-helper-guide.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-ui-code-helper-guide.mdx
@@ -8,12 +8,13 @@ title: 'KubernetesポリシーUIコードヘルパー案内'
 
 組織で管理するKubernetesクラスターのアクセスポリシー(Policy)を管理できます。
 KubernetesポリシーはPolicy as a Code(PaC)で運営され、YAML形態をベースに動作します。
-右側にはPolicy UI便宜機能としてコードエディタに挿入する内容をユーザーがUIで作業できるように助けるモーダルを提供します。KubernetesポリシーはPolicy as a Code(PaC)で運営され、YAML形態をベースに動作します。右側にはPolicy UI便利機能としてコードエディターに挿入する内容をユーザーがUIで作業できるように助けるモーダルを提供します。
+右側にはPolicy UI便利機能としてコードエディターに挿入する内容をユーザーがUIで作業できるように助けるモーダルを提供します。
 
 
-### UIコードヘルパー利用
+### UIコードヘルパーの使用
 
-コードエディター画面右側に各フィールド別コードサポートモーダルを提供します。モーダルはコード編集を助ける役割で、全体モーダルによって挿入された内容はコードエディター上で削除が可能です。
+コードエディター画面右側に各フィールド別コード支援モーダルを提供します。
+モーダルはコード編集を助ける役割で、全体モーダルによって挿入された内容はコードエディター上で削除が可能です。
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Policies &gt; List Details &gt; Go to Editor Mode](/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-ui-code-helper-guide/image-20240721-073114.png)
@@ -34,10 +35,10 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Policies &gt; List De
   ![image-20240721-073434.png](/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-ui-code-helper-guide/image-20240721-073434.png)
   </figure>
     1. Spec: Allowでのみ動作します。
-    2.  **Kubernetes Groups**  : (Required) 該当フィールドを通じてKubePie ProxyがAPI呼び出し実行のためにimpersonateするKubernetesグループを明示します。
-    3.  **Permitted Impersonation**  : (Optional) 該当フィールドを通じてユーザーがクライアントを通じて実際の--as、--as-groupを通じたimpersonationを試みる時に適用可能なKubernetesユーザー/グループを列挙します。
-        1.  **Allowed Kubernetes Users** : --asパラメータでQueryPieで許可するkubenetes usersを入力します。
-        2.  **Allowed Kubernetes Groups** : --as-groupパラメータでQueryPieで許可するkubernetes groupsを入力します。
+    2.  **Kubernetes Groups**  : (Required) 該当フィールドを通じてKubePie ProxyがAPI呼び出し実行のためにimpersonateするKubernetesグループを指定します。
+    3.  **Permitted Impersonation**  : (Optional) このフィールドでは、ユーザーがクライアント経由で実際に--as、--as-groupによるimpersonationを試行する際に適用可能なKubernetesユーザー/グループをリストアップします。
+        1.  **Allowed Kubernetes Users** : --asパラメータでQueryPieで許可するkubenetes usersを指定します。
+        2.  **Allowed Kubernetes Groups** : --as-groupパラメータでQueryPieで許可するkubernetes groupsを指定します。
         3. ','を通じて多重で登録可能です。
     4. エディターにある内容を基にモーダルが既存の情報を一緒に表記し、`Set`ボタンを押すと変更事項をエディターで上書きします。
 3.  **Add Actions**  モーダル
@@ -45,25 +46,25 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Policies &gt; List De
   ![image-20240721-073515.png](/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-ui-code-helper-guide/image-20240721-073515.png)
   </figure>
     1. Spec: Allow、Spec: Deny二箇所で同じように動作します。
-    2.  **API Groups** : デフォルトで"*"提供；管理者が修正可能で、','で多重入力可能です。
+    2.  **API Groups** : デフォルトで"*"が提供され、管理者が修正可能で、「,」区切りで複数入力可能です。
     3.  **Resources** : Kubernetesリソースを明示します。
         1. デフォルトで"*"提供；管理者が修正可能で、多重入力可能です。
-        2. 一般的に多く使われるリソースは以下と同じで、フィールドにカーソルを置くと以下のリストで便利にリソースを選択できます：
+        2. 一般的に多く使われるリソースは以下の通りで、フィールドにカーソルを置くと、リストからリソースを簡単に選択できます：
             * `pods`, `pods/exec`, `pods/log`, `pods/portforward`, `services`, `ingresses`, `deployments`, `replicasets`, `statefulsets`, `daemonsets`, `configmaps`, `secrets`, `namespaces`, `nodes`, `persistentvolumes`, `persistentvolumeclaims`, `jobs`, `cronjobs`, `serviceaccounts`, `endpoints`, `roles`, `rolebindings`, `clusterroles`, `clusterrolebindings`
-        3. 上に表記されていないリソースは直接タイピングしてリスト外リソース(カスタムリソース対応のため)明示が可能です。
+        3. ここに記載されていないリソースは、直接入力してリスト外のリソース（カスタムリソース対応のため）を明記することが可能です。
         4. 指定されるとItemブロックのように表記され、Xを押すと削除されます。
     4.  **Namespace** : ネームスペースを指定してKubernetesリソース範囲を制限します。
-        1. デフォルトで"*"提供；管理者が修正可能で、ワイルドカードおよび正規表現受容が可能です。
+        1. デフォルトで"*"提供；管理者が修正可能で、ワイルドカードおよび正規表現が利用可能です。
         2. Namespace範囲外のResourcesの場合、該当フィールドの値はどのような値が入っても影響を受けません。
             * 範囲外リソース: `persistentvolumes`, `persistentvolumeclaims`, `serviceaccounts`, `customresourcedefinitions`, `endpoints`, `nodes`, `clusterroles`, `clusterrolebindings`
-    5.  **Name** : Kubernetesリソース中対象にするリソース名を入力します。
+    5.  **Name** : Kubernetesリソースのうち対象とするリソース名を指定します。
         1. デフォルトで"*"提供；管理者が修正可能で、ワイルドカードおよび正規表現受容が可能です。
     6.  **Verbs** : Kubernetes APIメソッドを多重設定できます。
         1. デフォルトで"*"提供；指定されるとItemブロックのように表記され、Xを押すと削除されます。
         2. 一般的に呼び出されるVerbは以下と同じで、フィールドにカーソルを置くと以下のリストで便利にVerbを選択できます：
             * `get`, `list`, `watch`, `create`, `update`, `patch`, `delete`, `deletecollection`
-        3. ユーザーは直接タイピングしてリスト外カスタムリソース専用他のverb明示が可能です。
-    7. `Add`ボタンをクリックしてactionsリスト中一つのアクションセットを定義できます。
+        3. ユーザーは直接入力してリスト外のカスタムリソース専用の他のverbを明記することが可能です。
+    7. `Add`ボタンをクリックしてactionsリストに一つのアクションセットを定義できます。
     8. コード上でappendに該当する部分で既存の追加されたアクションを初期化せずに新しく追加が可能です。
 4.  **Set Conditions**  モーダル
   <figure data-layout="center" data-align="center">
@@ -73,18 +74,18 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Policies &gt; List De
     2. エディターにある内容を基にモーダルが既存の情報を一緒に表記し、`Set`ボタンを押すと変更事項をエディターで上書きします。
     3.  **Resource Tags**  (Optional)
         1. QueryPieリソースに付いたタグを基にポリシー適用範囲縮小が可能です。
-        2. 各行ごとにAND条件で動作し；Valueで','でOR動作します。
+        2. 各行ごとにAND条件で動作し、Valueで「,」区切りでOR動作します。
         3. Insertボタンを押して新しく行を生成できます。
         4. 指定されるとtagブロックのように表記され、Xを押すと削除されます。
         5. 入力項目：
             1.  **Key** : タグキー (正規式、glob未サポート)
-            2.  **Value** : タグバリュー入力 (正規式、globすべてサポート、多重入力サポート)
+            2.  **Value** : タグバリュー入力 (正規式、globすべてサポート、複数入力サポート)
     4.  **User Attributes**  (Optional)
         1. QueryPieユーザー属性を基にポリシー適用対象範囲縮小可能です。
-        2. 該当属性値にすべてマッチングされなければ該当ユーザーは属性値がマッチングされるまでポリシーを割り当てられても使用ができません。
+        2. 該当属性値とすべてマッチしない場合、そのユーザーは属性値がマッチするまでポリシーが割り当てられていても使用できません。
         3. 各行ごとにAND条件で動作し；Valueで','でOR動作します。
         4. Variable Nameで現在サポートするAttributeをドロップダウンリストで提案します。
             * loginId, firstName, lastName, middleName, honorificPrefix, honorificSuffix, email, title, displayName, nickName, profileUrl, secondEmail, mobilePhone, primaryPhone, streetAddress, city, state, zipCode, countryCode, postalAddress, preferredLanguage, locale<br/>timezone, userType, employeeNumber, costCenter, organization, division, department, managerId, manager, endpoints, staticIp, macAddress
     5.  **IP Addresses**  (Optional)
         1. 該当リソースにアクセス可能または不可能なIP帯域を管理者が指定します。
-        2. ','を区分で単一IP、CIDRすべて受容します。
+        2. 「,」区切りで単一IP、CIDRすべてに対応します。

--- a/src/content/ja/administrator-manual/kubernetes/k8s-access-control/roles.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/k8s-access-control/roles.mdx
@@ -8,7 +8,7 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-組織で管理するKubernetesクラスターのアクセス権限に応じた役割(Role)に対する照会、作成、修正、削除をサポートします。RoleはKubernetesアクセス権限を実装および適用するためのPolicy以降の段階として、Policyの集合であり、ユーザー/グループとポリシーの連結点になってくれる権限を意味します。
+組織で管理するKubernetesクラスターのアクセス権限に応じた役割(Role)に対する照会、作成、修正、削除をサポートします。RoleはKubernetesアクセス権限を実装および適用するためのPolicy以降の段階として、Policyの集合であり、ユーザー/グループとポリシーの連携を担う権限を意味します。
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles](/administrator-manual/kubernetes/k8s-access-control/roles/image-20240721-070743.png)
@@ -18,7 +18,7 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles
 </figure>
 
 
-### Role照会
+### Roleを照会する
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles &gt; List Details](/administrator-manual/kubernetes/k8s-access-control/roles/image-20240721-070912.png)
@@ -30,7 +30,7 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles &gt; List Detai
 1. Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Rolesメニューに移動します。
 2. テーブル左上の検索欄を通じて、役割名を条件に検索が可能です。
 3. テーブル右上の更新ボタンを通じて、Roleリストを最新化できます。
-4. テーブルでは以下のカラム情報を提供します：
+4. テーブルでは以下の項目情報を提供します：
     1.  **Name**  : Role名
     2.  **Description**  : Role詳細説明
     3.  **Last Access At**  : 該当役割の最終呼び出し日時
@@ -46,8 +46,8 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles &gt; List Detai
         2. テーブルリストには各ポリシー別に以下の情報を露出します：
             1.  **Name**  : Policy名
             2.  **Description**  : Policy詳細説明
-            3.  **Version**  : Policy版
-            4.  **Assigned At**  : 割り当て日時
+            3.  **Version**  : ポリシーバージョン
+            4.  **Assigned At**  : 割り当て日
             5.  **Assigned By**  : 該当ポリシーを割り当てた管理者名
         3. 各ポリシー行をクリックすると該当ポリシーの詳細情報をドロワー形態で提供します。
           <figure data-layout="center" data-align="center">
@@ -55,10 +55,10 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles &gt; List Detai
           </figure>
             1. 上段には基本情報が以下のように露出されます：
                 1.  **Name**  : Policy名
-                    * ポリシー詳細ページリンクを新しいウィンドウで開けます。
+                    * ポリシー詳細ページリンクを新しいウィンドウで開くことができます。
                 2.  **Description**  : Policy詳細説明
-                3.  **Version**  : Policy版
-                4.  **Assigned**   **At**  : 割り当て日時
+                3.  **Version**  : ポリシーバージョン
+                4.  **Assigned**   **At**  : 割り当て日
                 5.  **Assigned By**  : 該当ポリシーを割り当てた管理者名
             2. 下段にはポリシーがコードで露出されます。
     2.  **Users/Groups**
@@ -68,7 +68,7 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles &gt; List Detai
         1. 該当Roleが付与されているユーザー/グループリストを列挙します。
         2. ユーザー/グループ名で検索可能です。
         3. リストは各ユーザー/グループごとに以下の情報を露出します：
-            1.  **User Type**  : ユーザー/グループタイプ
+            1.  **User Type**  : ユーザー/グループ種別
             2.  **Name**  : ユーザー/グループ名
             3.  **Last Access At**  : ユーザー/グループの最終呼び出し日時
             4.  **Expiration Date**  : 期限満了日
@@ -81,7 +81,7 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles &gt; List Detai
         2. Cluster名で検索可能です。
         3. リストは各クラスターごとに以下の情報を露出します：
             1.  **Name**  : クラスター名
-            2.  **Version**  : Kubernetes版
+            2.  **Version**  : Kubernetesバージョン
             3.  **API URL**  : クラスターAPI URL
             4.  **Cloud Provider**  : 接続プラットフォーム (手動クラスターの場合、ハイフンで表記)
             5.  **Tags**  : クラスターに付いたタグリスト
@@ -89,7 +89,7 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles &gt; List Detai
             7.  **Updated At**  : クラスター最終修正日時
 
 
-### Role作成
+### Roleを作成する
 
 <figure data-layout="left" data-align="left">
 ![image-20240721-071306.png](/administrator-manual/kubernetes/k8s-access-control/roles/image-20240721-071306.png)
@@ -105,7 +105,7 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles &gt; List Detai
 6. Kubernetes役割設定ガイドを参考にしてポリシーを設定します。
 
 
-### Role修正
+### Roleを修正する
 
 <figure data-layout="left" data-align="left">
 ![image-20240721-071337.png](/administrator-manual/kubernetes/k8s-access-control/roles/image-20240721-071337.png)
@@ -119,7 +119,7 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles &gt; List Detai
 4. `Save`ボタンをクリックして修正を反映します。
 
 
-### Role削除
+### Roleを削除する
 
 <figure data-layout="left" data-align="left">
 ![image-20240721-071429.png](/administrator-manual/kubernetes/k8s-access-control/roles/image-20240721-071429.png)
@@ -135,5 +135,5 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles &gt; List Detai
 3. ポップアップが表示されたら`Delete`ボタンをクリックして削除を進行します。
 
 <Callout type="important">
-Role削除時、該当役割が付与されていたユーザーおよびグループから権限が回収されます。
+Role削除時、該当役割が付与されていたユーザーおよびグループから権限が解除されます。
 </Callout>

--- a/src/content/ja/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles.mdx
@@ -1,17 +1,17 @@
 ---
-title: 'Kubernetes役割設定'
+title: 'Kubernetes役割設定方法'
 ---
 
 import { Callout } from 'nextra/components'
 
-# Kubernetes役割設定
+# Kubernetes役割設定方法
 
 ### Overview
 
 Kubernetesに対するユーザーアクセスを許可または制限するために、組織内でのKubernetes役割をベースにする役割ベースアクセス制御(Role-Based Access Control, RBAC)を適用します。ユーザーまたはユーザーグループに設定したRoleを付与できます。Roleは複数のポリシーを総合して単一役割で定義するのに使用されます。
 
 
-### Roleポリシー割り当て
+### Roleポリシーを割り当てる
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles &gt; List Details](/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles/image-20240721-071540.png)
@@ -27,10 +27,10 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles &gt; List Detai
   <figure data-layout="center" data-align="center">
   ![image-20240721-071758.png](/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles/image-20240721-071758.png)
   </figure>
-    1. Policy名で検索可能です。
-    2. 既存にすでに割り当てられているポリシーはチェックボックスが非活性化されます。
-    3. リストリストには各ポリシー別に以下の情報を露出します：
-        *  **Name**  : Policy名
+    1. ポリシー名で検索可能です。
+    2. 既に割り当てられているポリシーはチェックボックスが選択できません。
+    3. リスト目録には各ポリシー別に以下の情報を露出します：
+        *  **Name**  : ポリシー名
             * ポリシー情報を照会できるモーダルリンクを提供します。
               <figure data-layout="center" data-align="center">
               ![image-20240721-071822.png](/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles/image-20240721-071822.png)
@@ -47,7 +47,7 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles &gt; List Detai
 
 1. Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Rolesメニューに移動します。
 2. Rolesリストで対象Role行をクリックして詳細ページに移動します。
-3. Policiesタブで全体選択または個別選択ボックスにチェックするとカラムバーに露出された`Unassign`ボタンをクリックします。
+3. Policiesタブで全体選択または個別選択ボックスにチェックするとカラムバーに表示される`Unassign`ボタンをクリックします。
   <figure data-layout="center" data-align="center">
   ![image-20240721-071940.png](/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles/image-20240721-071940.png)
   </figure>
@@ -55,5 +55,5 @@ Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles &gt; List Detai
 5. (`Cancel`ボタンクリック時は確認ウィンドウのみ閉じます。)
 
 <Callout type="important">
-Policy割り当て解除時、該当ポリシーでユーザーおよびグループに付与されていたすべてのアクセス権限が回収されます。
+ポリシー割り当て解除時、該当ポリシーでユーザーおよびグループに付与されていたすべてのアクセス権限が解除されます。
 </Callout>

--- a/src/content/ja/administrator-manual/servers/connection-management/server-agents-for-rdp/installing-and-removing-server-agent.mdx
+++ b/src/content/ja/administrator-manual/servers/connection-management/server-agents-for-rdp/installing-and-removing-server-agent.mdx
@@ -46,7 +46,7 @@ RDP Server Agentダウンロードボタン提供
 
 RDP Server Agentが接続されるQueryPieのアドレスを持っています。
 
-10.2.8版からはRDP接続に使用するPortをCONFIGファイルで指定できます。
+10.2.8バージョンからはRDP接続に使用するPortをCONFIGファイルで指定できます。
 </Callout>
 
 <Callout type="important">

--- a/src/content/ja/administrator-manual/servers/server-access-control/access-control/granting-server-privilege.mdx
+++ b/src/content/ja/administrator-manual/servers/server-access-control/access-control/granting-server-privilege.mdx
@@ -34,10 +34,22 @@ Administrator &gt; Servers &gt; Server Access Control &gt; Access Control &gt; U
     3.  **Privilege Duration**  : Server Privilege適用時間を設定します。分単位で時間を入力できます。Privilege Start Triggerに応じて開始する時点が異なります。
     4.  **Privilege Expiration Date**  : 上記コマンドに対する別途例外処理有効期限日を指定します。
 6. モーダルの項目はサーバーのOSとRequire Privilegeオプション状態に応じて表示される項目が異なります。
-    1. サーバーのOSがLinuxでRequire Privilegeオプションが有効化された場合
-    2. サーバーのOSがLinuxでRequire Privilegeオプションが無効化された場合
-    3. サーバーのOSがLinuxでなくRequire Privilegeオプションが有効化された場合
-    4. サーバーのOSがLinuxでなくRequire Privilegeオプションが無効化された場合
+    1. サーバーのOSがLinuxでRequire Privilegeオプションが有効化された場合 <br/> 
+      <figure data-layout="center" data-align="center">
+      ![Screenshot-2025-07-02-at-5.14.50-PM.png](/administrator-manual/servers/server-access-control/access-control/granting-server-privilege/Screenshot-2025-07-02-at-5.14.50-PM.png)
+      </figure>
+    2. サーバーのOSがLinuxでRequire Privilegeオプションが無効化された場合 <br/> 
+      <figure data-layout="center" data-align="center">
+      ![Screenshot-2025-07-01-at-5.58.34-PM.png](/administrator-manual/servers/server-access-control/access-control/granting-server-privilege/Screenshot-2025-07-01-at-5.58.34-PM.png)
+      </figure>
+    3. サーバーのOSがLinuxでなくRequire Privilegeオプションが有効化された場合 <br/> 
+      <figure data-layout="center" data-align="center">
+      ![Screenshot-2025-07-01-at-6.02.23-PM.png](/administrator-manual/servers/server-access-control/access-control/granting-server-privilege/Screenshot-2025-07-01-at-6.02.23-PM.png)
+      </figure>
+    4. サーバーのOSがLinuxでなくRequire Privilegeオプションが無効化された場合 <br/> 
+      <figure data-layout="center" data-align="center">
+      ![Screenshot-2025-07-02-at-5.10.49-PM.png](/administrator-manual/servers/server-access-control/access-control/granting-server-privilege/Screenshot-2025-07-02-at-5.10.49-PM.png)
+      </figure>
 
 <Callout type="info">
 **Q. 権限が付与されたり回収された履歴を確認できる場所がありますか？**


### PR DESCRIPTION
## 개요
todo-ja.01.txt에 나열된 10개 일본어 번역 파일의 오류 및 한국어 원문과의 차이를 수정했습니다.

## 수정된 파일 (8개)

1. **slack-dm-workflow-notification-types.mdx**
   - "代理決裁使用" → "代理決裁の使用方法"로 수정

2. **integrating-with-okta.mdx**
   - "クエリパイ連携用アカウント" → "QueryPie連携用アカウント"로 일관성 유지
   - 여러 곳의 "クエリパイ" → "QueryPie"로 통일

3. **kubernetes-policy-action-configuration-reference-guide.mdx**
   - Events 파트 설명 개선 (한국어 원문 의미 정확히 반영)

4. **kubernetes-policy-ui-code-helper-guide.mdx**
   - 제목 "UIコードヘルパー利用方法" → "UIコードヘルパーの使用"으로 수정
   - 본문 내용 한국어 원문과 정확히 일치하도록 수정

5. **roles.mdx**
   - "Kubernetes版" → "Kubernetesバージョン"로 용어 통일

6. **setting-kubernetes-roles.mdx**
   - "リストリスト" → "リスト目録"로 수정

7. **installing-and-removing-server-agent.mdx**
   - "10.2.8版" → "10.2.8バージョン"로 용어 일관성 유지

8. **granting-server-privilege.mdx**
   - 누락된 4개 시나리오별 이미지 추가
   - 각 서버 OS 및 Require Privilege 옵션 조합에 대한 스크린샷 포함

## 수정 필요 없는 파일 (2개)
- blocked-accounts.mdx (변경 사항 없음)
- command-templates.mdx (변경 사항 없음)

## 검증
- 모든 수정 사항은 한국어 원문과 비교하여 정확성 확인
- 번역 가이드라인 준수 (translation.md)
- 이미지 경로 및 마크다운 형식 유효성 검증