### PR TITLE
mdx: 일본어 문서 불일치 수정 37

### DIFF
--- a/src/content/ja/administrator-manual/web-apps/web-app-access-control/access-control/granting-and-revoking-roles.mdx
+++ b/src/content/ja/administrator-manual/web-apps/web-app-access-control/access-control/granting-and-revoking-roles.mdx
@@ -4,13 +4,13 @@ title: 'Role付与および回収'
 
 import { Callout } from 'nextra/components'
 
-# Role付与および回収
+# Roleの付与および回収
 
 ### Overview
 
 管理者はユーザーまたはユーザーグループにサーバーアクセス権限がある役割（Role）を付与または回収できます。
 
-### Role付与
+### Roleの付与
 
 #### 1. 権限を付与する対象を選択します。
 
@@ -36,12 +36,12 @@ Administrator > Servers > Server Access Control > Access Control
   <figure data-layout="center" data-align="center">
   ![image-20250629-161407.png](/administrator-manual/web-apps/web-app-access-control/access-control/granting-and-revoking-roles/image-20250629-161407.png)
   </figure>
-3. 付与するRole左側のチェックボックスをチェックします。
+3. 付与するRoleの左側のチェックボックスをチェックします。
 4. Expiration Dateを入力します。基本値は1年です。
 5. `Grant` ボタンをクリックします。
 
 
-### Role回収
+### Roleの回収
 
 <figure data-layout="center" data-align="center">
 ![image-20250629-161437.png](/administrator-manual/web-apps/web-app-access-control/access-control/granting-and-revoking-roles/image-20250629-161437.png)

--- a/src/content/ja/administrator-manual/web-apps/web-app-access-control/policies.mdx
+++ b/src/content/ja/administrator-manual/web-apps/web-app-access-control/policies.mdx
@@ -17,7 +17,7 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Policies
 </figcaption>
 </figure>
 
-### Policy照会
+### Policyの照会
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Web Apps &gt; Web App Access Control &gt; Policies &gt; List Details](/administrator-manual/web-apps/web-app-access-control/policies/image-20250629-164509.png)
@@ -68,7 +68,7 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Policies &gt; List 
             5. **Updated By**: 該当バージョン修正者名
             6. 下部に当時のポリシーコードスナップショットが表示されます。
 
-### Policy生成
+### Policyの生成
 
 <figure data-layout="center" data-align="center">
 ![image-20250629-164901.png](/administrator-manual/web-apps/web-app-access-control/policies/image-20250629-164901.png)
@@ -81,7 +81,7 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Policies &gt; List 
 5. ポリシーリスト最上部に新規生成されたポリシーをクリックします。
 6. ウェブアプリケーションポリシー設定ガイドを参照してポリシーを設定します。
 
-### Policy修正
+### Policyの修正
 
 <figure data-layout="center" data-align="center">
 ![image-20250629-164928.png](/administrator-manual/web-apps/web-app-access-control/policies/image-20250629-164928.png)
@@ -93,7 +93,7 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Policies &gt; List 
 3. 画面右上のEditボタンをクリックして以下の情報を修正できます。<br/>a. Name：識別可能なポリシー名（必須）<br/>b. Description：該当ポリシーに対する付加的な説明
 4. OKボタンをクリックして修正を反映します。
 
-### Policy複製
+### Policyの複製
 
 <figure data-layout="center" data-align="center">
 ![image-20250629-164941.png](/administrator-manual/web-apps/web-app-access-control/policies/image-20250629-164941.png)
@@ -105,7 +105,7 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Policies &gt; List 
 4. OKボタンをクリックして修正を反映します。
 5. ポリシーリスト最上部に新規複製されたポリシーをクリックして照会/修正します。
 
-### Policy削除
+### Policyの削除
 
 <figure data-layout="center" data-align="center">
 ![image-20250629-164955.png](/administrator-manual/web-apps/web-app-access-control/policies/image-20250629-164955.png)
@@ -119,7 +119,7 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Policies &gt; List 
 Policy削除時、該当ポリシーが付与されていたウェブアプリケーションリソースと役割から自動分離されます。
 </Callout>
 
-### Policyコード編集
+### Policyコードの編集
 
 <figure data-layout="center" data-align="center">
 ![image-20250629-165051.png](/administrator-manual/web-apps/web-app-access-control/policies/image-20250629-165051.png)

--- a/src/content/ja/administrator-manual/web-apps/web-app-access-control/roles.mdx
+++ b/src/content/ja/administrator-manual/web-apps/web-app-access-control/roles.mdx
@@ -18,7 +18,7 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Roles
 </figure>
 
 
-### Role照会
+### Roleの照会
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Web Apps &gt; Web App Access Control &gt; Roles &gt; List Details](/administrator-manual/web-apps/web-app-access-control/roles/image-20250629-161857.png)
@@ -83,7 +83,7 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Roles &gt; List Det
             7. Updated At：ウェブアプリケーション最後修正日時
 
 
-### Role生成
+### Roleの生成
 
 1. Administrator &gt; Web Apps &gt; Access Control &gt; Rolesメニューへ移動します。
 2. 右上の+ Create Roleボタンをクリックします。
@@ -92,7 +92,7 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Roles &gt; List Det
 5. 役割リスト最上部に新規生成された役割をクリックします。
 6. クーバネティス役割設定ガイドを参照してポリシーを設定します。
 
-### Role修正
+### Roleの修正
 
 <figure data-layout="center" data-align="center">
 ![image-20250629-163924.png](/administrator-manual/web-apps/web-app-access-control/roles/image-20250629-163924.png)
@@ -103,7 +103,7 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Roles &gt; List Det
 3. 画面右上のEditボタンをクリックして以下の情報を修正できます。<br/>a. Name：識別可能な役割名（必須）<br/>b. Description：該当役割に対する付加的な説明
 4. Saveボタンをクリックして修正を反映します。
 
-### Role削除
+### Roleの削除
 
 <figure data-layout="center" data-align="center">
 ![image-20250629-163949.png](/administrator-manual/web-apps/web-app-access-control/roles/image-20250629-163949.png)


### PR DESCRIPTION
## 변경 사항

Web Apps Access Control 관련 일본어 문서의 표현을 개선하여 한국어 원문과의 일관성을 높였습니다.

### 수정된 파일

1. **granting-and-revoking-roles.mdx**
   - `Role付与` → `Roleの付与`
   - `Role回収` → `Roleの回収`
   - `付与するRole左側` → `付与するRoleの左側`

2. **policies.mdx**
   - `Policy照会` → `Policyの照会`
   - `Policy生成` → `Policyの生成`
   - `Policy修正` → `Policyの修正`
   - `Policy複製` → `Policyの複製`
   - `Policy削除` → `Policyの削除`
   - `Policyコード編集` → `Policyコードの編集`

3. **roles.mdx**
   - `Role照会` → `Roleの照会`
   - `Role生成` → `Roleの生成`
   - `Role修正` → `Roleの修正`
   - `Role削除` → `Roleの削除`

### 개선 내용

- 명사와 동사 사이에 조사 "の"를 추가하여 더 자연스러운 일본어 표현으로 개선
- 문서 전반에 걸쳐 일관된 표현 스타일 유지
- 한국어 원문의 의미를 정확히 반영

### 검증 방법

- 한국어 원문과 비교하여 의미 전달이 정확한지 확인
- 일본어 문법 및 표현의 자연스러움 검토
- 기존 번역 스타일과의 일관성 확인

## 참고 사항

- todo-ja.03.txt 파일의 첫 3개 파일에 대한 수정 사항
- Release Notes 관련 파일(9100-9104.mdx, external-api-changes-9810-version-994-version.mdx)은 현재 번역 품질이 양호하여 수정 불필요