### PR TITLE
mdx: 영어 문서 불일치 수정 21

### DIFF
--- a/src/content/en/administrator-manual/kubernetes/k8s-access-control/policies/setting-kubernetes-policies.mdx
+++ b/src/content/en/administrator-manual/kubernetes/k8s-access-control/policies/setting-kubernetes-policies.mdx
@@ -6,7 +6,9 @@ title: 'Setting Kubernetes Policies'
 
 ### Overview
 
-You can manage access policies (Policy) for Kubernetes clusters managed by the organization. Kubernetes policies are operated as Policy as a Code (PaC) and work based on YAML format. You can not only set cluster resources and API scope to allow access, but also apply detailed policy application scope based on resource tags and user attributes (Attribute) and set accessible IP addresses together.
+You can manage access policies (Policy) for Kubernetes clusters managed by the organization.
+Kubernetes policies are operated as Policy as a Code (PaC) and work based on YAML format.
+You can not only set cluster resources and API scope to allow access, but also apply detailed policy application scope based on resource tags and user attributes (Attribute) and set accessible IP addresses together.
 
 
 ### Editing Policy Code

--- a/src/content/en/administrator-manual/kubernetes/k8s-access-control/roles.mdx
+++ b/src/content/en/administrator-manual/kubernetes/k8s-access-control/roles.mdx
@@ -8,7 +8,8 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-Supports viewing, creating, modifying, and deleting roles (Role) according to access permissions for Kubernetes clusters managed by the organization. Role is the step after Policy for implementing and applying Kubernetes access permissions, meaning a collection of Policies and permissions that serve as a link between users/groups and policies.
+Supports viewing, creating, modifying, and deleting roles (Role) according to access permissions for Kubernetes clusters managed by the organization.
+Role is the step after Policy for implementing and applying Kubernetes access permissions, meaning a collection of Policies and permissions that serve as a link between users/groups and policies.
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Kubernetes &gt; K8s Access Control &gt; Roles](/administrator-manual/kubernetes/k8s-access-control/roles/image-20240721-070743.png)

--- a/src/content/en/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles.mdx
+++ b/src/content/en/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles.mdx
@@ -8,7 +8,9 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-Apply role-based access control (Role-Based Access Control, RBAC) based on Kubernetes roles within the organization to allow or restrict user access to Kubernetes. You can grant set Roles to users or user groups. Roles are used to define multiple policies as a single role.
+Apply role-based access control (Role-Based Access Control, RBAC) based on Kubernetes roles within the organization to allow or restrict user access to Kubernetes.
+You can grant set Roles to users or user groups.
+Roles are used to define multiple policies as a single role.
 
 
 ### Assigning Role Policies

--- a/src/content/en/administrator-manual/kubernetes/kac-general-configurations.mdx
+++ b/src/content/en/administrator-manual/kubernetes/kac-general-configurations.mdx
@@ -7,7 +7,7 @@ import { Callout } from 'nextra/components'
 # KAC General Configurations
 
 <Callout type="info">
-Starting from 10.3.0, KAC-related settings previously under Administrator > General > Security have been moved to each service menu under General > Configurations.
+Starting from 10.3.0, KAC-related settings previously under Administrator &gt; General &gt; Security have been moved to each service menu under General &gt; Configurations.
 Starting from 11.4.0, the Maximum Access Duration option has been added to specify the maximum period for user privilege requests and administrator privilege grants.
 </Callout>
 
@@ -22,6 +22,7 @@ Provides settings for security in container-based environments, such as Kubernet
 Kubernetes Configurations options
 </figcaption>
 </figure>
+
 
 * Idle Session Timeout (Minutes): Pod session timeout (Default: 15)
     * Specify idle time when connecting sessions via exec, port-forward, or attach

--- a/src/content/en/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-aws.mdx
+++ b/src/content/en/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-aws.mdx
@@ -45,7 +45,8 @@ Administrator &gt; Servers &gt; Connection Management &gt; Cloud Providers &gt; 
 
 <Callout type="info">
 **Q. I clicked the Save button but got an error saying "Already exists cloud provider." Why is that?**
-A. If there is already a Cloud Provider registered with `Default Credentials` as **Credential** and the same `Region`, duplicate registration is not possible. In this case, you must select a different `Region` to register.
+A. If there is already a Cloud Provider registered with `Default Credentials` as **Credential** and the same `Region`, duplicate registration is not possible.
+In this case, you must select a different `Region` to register.
 </Callout>
 
 
@@ -104,5 +105,6 @@ Administrator &gt; Servers &gt; Connection Management &gt; Cloud Providers &gt; 
     7.  **Replication**   **Frequency** : Can be changed (however, cannot be changed if Credential is Access Key)
 
 <Callout type="important">
-Synchronization settings saved with the "Save Credential for Synchronization" option disabled can enable the option by checking the checkbox on the detailed page. Like when creating new ones, **this setting cannot be disabled again after being enabled**, so you must choose carefully.
+Synchronization settings saved with the "Save Credential for Synchronization" option disabled can enable the option by checking the checkbox on the detailed page.
+Like when creating new ones, **this setting cannot be disabled again after being enabled**, so you must choose carefully.
 </Callout>

--- a/src/content/en/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-azure.mdx
+++ b/src/content/en/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-azure.mdx
@@ -85,7 +85,8 @@ Administrator &gt; Servers &gt; Connection Management &gt; Cloud Providers &gt; 
     8.  **Replication**   **Frequency** : Cannot be changed
 
 <Callout type="important">
-Synchronization settings saved with the "Save Credential for Synchronization" option disabled can enable the option by checking the checkbox on the detailed page. Like when creating new ones, **this setting cannot be disabled again after being enabled**, so you must choose carefully.
+Synchronization settings saved with the "Save Credential for Synchronization" option disabled can enable the option by checking the checkbox on the detailed page.
+Like when creating new ones, **this setting cannot be disabled again after being enabled**, so you must choose carefully.
 </Callout>
 
 <Callout type="info">

--- a/src/content/en/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-gcp.mdx
+++ b/src/content/en/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-gcp.mdx
@@ -83,7 +83,8 @@ Administrator &gt; Servers &gt; Connection Management &gt; Cloud Providers &gt; 
     7.  **Replication**   **Frequency** : Cannot be changed
 
 <Callout type="important">
-Synchronization settings saved with the "Save Credential for Synchronization" option disabled can enable the option by checking the checkbox on the detailed page. Like when creating new ones, **this setting cannot be disabled again after being enabled**, so you must choose carefully.
+Synchronization settings saved with the "Save Credential for Synchronization" option disabled can enable the option by checking the checkbox on the detailed page.
+Like when creating new ones, **this setting cannot be disabled again after being enabled**, so you must choose carefully.
 </Callout>
 
 

--- a/src/content/en/administrator-manual/servers/connection-management/proxyjump-configurations.mdx
+++ b/src/content/en/administrator-manual/servers/connection-management/proxyjump-configurations.mdx
@@ -6,7 +6,10 @@ title: 'ProxyJump Configurations'
 
 ### Overview
 
-Supports access control for servers in different Network Zones from QueryPie or when CIDR overlaps. Through ProxyJump settings, you can connect to target servers through Jump Hosts installed in other Network Zones or VPCs. When users attempt to connect to servers displayed in QueryPie, they can connect in the same way as servers that do not go through Jump Hosts. This allows you to control unnecessary user access to Jump Hosts.
+Supports access control for servers in different Network Zones from QueryPie or when CIDR overlaps.
+Through ProxyJump settings, you can connect to target servers through Jump Hosts installed in other Network Zones or VPCs.
+When users attempt to connect to servers displayed in QueryPie, they can connect in the same way as servers that do not go through Jump Hosts.
+This allows you to control unnecessary user access to Jump Hosts.
 
 
 ### Viewing ProxyJump


### PR DESCRIPTION
## 변경 사항

한국어 원문과 영어 번역문의 구조적 불일치를 수정했습니다.

### 주요 수정 내용

1. **문장 분리 불일치 수정**
   - 한국어 원문이 여러 문장으로 구성된 경우, 영어 번역도 동일하게 여러 문장으로 분리
   - 주로 Overview 섹션과 Callout 컴포넌트 내부의 긴 문장들

2. **HTML 엔티티 수정**
   - `>` 기호를 `&gt;`로 변환하여 skeleton 비교 일관성 확보

### 수정된 파일 (8개)

#### Kubernetes 관련 (4개)
- `administrator-manual/kubernetes/k8s-access-control/policies/setting-kubernetes-policies.mdx`
- `administrator-manual/kubernetes/k8s-access-control/roles.mdx`
- `administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles.mdx`
- `administrator-manual/kubernetes/kac-general-configurations.mdx`

#### Servers 관련 (4개)
- `administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-aws.mdx`
- `administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-azure.mdx`
- `administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-gcp.mdx`
- `administrator-manual/servers/connection-management/proxyjump-configurations.mdx`

### 검증

모든 수정 파일에 대해 `mdx_to_skeleton.py`로 skeleton 비교를 수행하여 한국어 원문과의 구조적 일치를 확인했습니다.

### 참고

- todo-en.06.txt 파일의 20개 파일 중 8개 파일에서 실제 수정이 필요했습니다
- 나머지 12개 파일은 이미 한국어 원문과 구조가 일치하거나, inline code/bold 위치 차이만 있었습니다 (영어 어순상 자연스러운 차이)
