### PR TITLE
mdx: 일본어 문서 불일치 수정 39

### DIFF
--- a/src/content/ja/administrator-manual/web-apps/wac-quickstart/1027-wac-role-policy-guide.mdx
+++ b/src/content/ja/administrator-manual/web-apps/wac-quickstart/1027-wac-role-policy-guide.mdx
@@ -92,7 +92,7 @@ WACのポリシーはYAML形式で記述され、その基本構造は以下の�
 </tr>
 <tr>
 <td>
-`spec:`<br/> `&lt;effect&gt;`
+`spec:`<br/>  `&lt;effect&gt;`
 </td>
 <td>
 -

--- a/src/content/ja/administrator-manual/web-apps/wac-quickstart/1030-wac-jit-permission-acquisition-guide.mdx
+++ b/src/content/ja/administrator-manual/web-apps/wac-quickstart/1030-wac-jit-permission-acquisition-guide.mdx
@@ -47,10 +47,10 @@ JIT権限取得Guideは `10.3.0` バージョンを基準に説明します。
 5. Watermark: Webアプリアクセス時にユーザーのブラウザ画面にウォーターマークを適用するかどうかを選択します。
     1. Webアプリアクセス時にブラウザにアクセス者、アクセス日時などの情報を表示することで画面流出を防止します。
     2. ガイドではOn状態を前提として案内します。
-6. **User Activity Recording**: ユーザー行動記録の有無
+6. User Activity Recording : ユーザー行動記録の有無
     1. Onで有効化後、すべてのオプションをオンにしてください。
     2. Excluded URL Pathsはユーザー行動記録を除外するパスを入力します。ここでは空にしておきます。
-7. **Tag**: Webアプリのタグです。ここでは空にしておきます。
+7. Tag : Webアプリのタグです。ここでは空にしておきます。
 8. `Save` ボタンを押して保存します。
 
 ### 2. Web App Owner / Memberの登録
@@ -99,12 +99,12 @@ QueryPieを通じてWeb Appアクセス時、Root CA証明書インストール�
 
 1. Web App Just-In-Time Access Requestにアクセスします。
 2. Step1を記述します。Web Appsで割り当てられた項目をクリックした場合、別途選択は必要ありません。
-    1. **Web App**: 利用者がMemberに指定された項目のみ選択可能です。
-    2. **Approvers**: Ownerに指定されたUserを表示します。
+    1. Web App : 利用者がMemberに指定された項目のみ選択可能です。
+    2. Approvers : Ownerに指定されたUserを表示します。
 3. Step2を記述します。
-    1. **Request Title**: 申請タイトルを入力します。
-    2. **Access Duration (Minutes)**: 使用時間を入力します。分単位で申請されます。
-    3. **Reason for Request**: 申請理由を入力します。
+    1. Request Title : 申請タイトルを入力します。
+    2. Access Duration (Minutes) : 使用時間を入力します。分単位で申請されます。
+    3. Reason for Request : 申請理由を入力します。
 4. Submitをクリックします。
 
 <Callout type="info">

--- a/src/content/ja/administrator-manual/web-apps/web-app-access-control/access-control/granting-and-revoking-roles.mdx
+++ b/src/content/ja/administrator-manual/web-apps/web-app-access-control/access-control/granting-and-revoking-roles.mdx
@@ -22,7 +22,7 @@ Administrator > Servers > Server Access Control > Access Control
 </figure>
 
 
-1. **Administrator > Web Apps > Web App Access Control > Access Control** メニューへ移動します。
+1. Administrator > Web Apps > Web App Access Control > Access Control メニューへ移動します。
 2. 権限を付与するユーザーまたはユーザーグループを選択します。
 
 #### 2. 権限を付与するRoleを選択します。
@@ -47,7 +47,7 @@ Administrator > Servers > Server Access Control > Access Control
 ![image-20250629-161437.png](/administrator-manual/web-apps/web-app-access-control/access-control/granting-and-revoking-roles/image-20250629-161437.png)
 </figure>
 
-1. **Administrator > Web Apps > Web App Access Control > Access Control** メニューへ移動します。
+1. Administrator > Web Apps > Web App Access Control > Access Control メニューへ移動します。
 2. 権限を付与するユーザーまたはユーザーグループを選択します。
 3. Rolesタブへ移動します。
 4. Roleリストで権限を回収するRoleを選択します。（複数選択可能）

--- a/src/content/ja/administrator-manual/web-apps/web-app-access-control/policies.mdx
+++ b/src/content/ja/administrator-manual/web-apps/web-app-access-control/policies.mdx
@@ -30,7 +30,7 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Policies &gt; List 
 2. テーブル左上の検索欄を通じてポリシー名を条件に検索が可能です。
 3. 下部のErrorsタブを通じて直接修正したコードのエラーをデバッグします。コードにエラーがある場合、Errorsタブが赤色で表示されて即座に確認できます。
 4. テーブル右上のリフレッシュボタンを通じてPolicyリストを最新化できます。
-5. テーブルで以下のような情報を提供します：<br/>a. **Name**: Policy名<br/>b. **Description**: Policy詳細説明<br/>c. **Created At**: ポリシー最初生成日時<br/>d. **Updated At**: ポリシー最後修正日時<br/>e. **Updated By**: 最後更新を実行した管理者名
+5. テーブルで以下のような情報を提供します：<br/>a. Name : Policy名<br/>b. Description : Policy詳細説明<br/>c. Created At : ポリシー最初生成日時<br/>d. Updated At : ポリシー最後修正日時<br/>e. Updated By : 最後更新を実行した管理者名
 6. 各行をクリックするとポリシー詳細情報照会が可能です。
     1. Detail
       <figure data-layout="center" data-align="center">
@@ -44,10 +44,10 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Policies &gt; List 
       </figure>
         1. 該当ポリシーが割り当てられているRoleリストを列挙します。
         2. リストは各Roleごとに以下の情報を表示します：
-            1. **Name**: Role名
-            2. **Description**: Role詳細説明
-            3. **Assigned At**: Roleに該当ポリシーが割り当てられた日時
-            4. **Assigned By**: 該当ポリシーをRoleに割り当てた管理者名
+            1. Name : Role名
+            2. Description : Role詳細説明
+            3. Assigned At : Roleに該当ポリシーが割り当てられた日時
+            4. Assigned By : 該当ポリシーをRoleに割り当てた管理者名
         3. 各行をクリックするとRoleに対する詳細情報をドロワー形式で提供します。
     3. Versions
       <figure data-layout="center" data-align="center">
@@ -56,16 +56,16 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Policies &gt; List 
         1. 該当ポリシーの各バージョンに対する履歴を列挙します。
             1. ポリシーバージョンはCodeが修正されて保存されると更新されます。
         2.  リストは各versionごとに以下の情報を表示します：
-            1. **Version**: バージョン名
-            2. **Justification**: ポリシー更新期間事由
-            3. **Updated At**: 該当バージョン生成日時
-            4. **Updated By**: 該当バージョン修正者名
+            1. Version : バージョン名
+            2. Justification : ポリシー更新期間事由
+            3. Updated At : 該当バージョン生成日時
+            4. Updated By : 該当バージョン修正者名
         3. 各行をクリックするとバージョンに対する詳細情報をドロワー形式で提供します。
-            1. **(Title)**: ポリシー名
-            2. **Version**: ポリシーバージョン
-            3. **Justification**: ポリシー更新期間事由
-            4. **Updated At**: 該当バージョン生成日時
-            5. **Updated By**: 該当バージョン修正者名
+            1. (Title) : ポリシー名
+            2. Version : ポリシーバージョン
+            3. Justification : ポリシー更新期間事由
+            4. Updated At : 該当バージョン生成日時
+            5. Updated By : 該当バージョン修正者名
             6. 下部に当時のポリシーコードスナップショットが表示されます。
 
 ### Policyの生成
@@ -76,7 +76,7 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Policies &gt; List 
 
 1. Administrator &gt; Web Apps &gt; Web App Access Control &gt; Policiesメニューへ移動します。
 2. 右上の+ Create Policyボタンをクリックします。
-3. ポリシー生成のための以下の情報を入力します。（以下の情報はすべてユーザーに表示される情報です。）<br/>a. **Name**: 識別可能なポリシー名（必須）<br/>b. **Description**: 該当ポリシーに対する付加的な説明
+3. ポリシー生成のための以下の情報を入力します。（以下の情報はすべてユーザーに表示される情報です。）<br/>a. Name : 識別可能なポリシー名（必須）<br/>b. Description : 該当ポリシーに対する付加的な説明
 4. OKボタンをクリックして生成します。
 5. ポリシーリスト最上部に新規生成されたポリシーをクリックします。
 6. ウェブアプリケーションポリシー設定ガイドを参照してポリシーを設定します。
@@ -90,7 +90,7 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Policies &gt; List 
 
 1. Administrator &gt; Web Apps &gt; Web App Access Control &gt; Policiesメニューに移動します。
 2. リストで修正するPolicyをクリックして詳細ページに移動します。
-3. 画面右上のEditボタンをクリックして以下の情報を修正できます。<br/>a. Name：識別可能なポリシー名（必須）<br/>b. Description：該当ポリシーに対する付加的な説明
+3. 画面右上のEditボタンをクリックして以下の情報を修正できます。<br/>a. Name : 識別可能なポリシー名（必須）<br/>b. Description : 該当ポリシーに対する付加的な説明
 4. OKボタンをクリックして修正を反映します。
 
 ### Policyの複製
@@ -101,7 +101,7 @@ Administrator &gt; Web Apps &gt; Web App Access Control &gt; Policies &gt; List 
 
 1. Administrator &gt; Web Apps &gt; Web App Access Control &gt; Policiesメニューに移動します。
 2. リストで複製するPolicyをクリックして詳細ページに移動します。
-3. 画面右上のDuplicateボタンをクリックして複製版の情報を修正できます。<br/>a. Name：識別可能なポリシー名（必須）<br/>b. Description：該当ポリシーに対する付加的な説明
+3. 画面右上のDuplicateボタンをクリックして複製版の情報を修正できます。<br/>a. Name : 識別可能なポリシー名（必須）<br/>b. Description : 該当ポリシーに対する付加的な説明
 4. OKボタンをクリックして修正を反映します。
 5. ポリシーリスト最上部に新規複製されたポリシーをクリックして照会/修正します。
 


### PR DESCRIPTION
## 개요
일본어 번역 문서의 포맷팅 불일치를 수정하여 한국어 원문과 일치하도록 수정했습니다.

## 수정 파일 (4개)
### WAC Quickstart 가이드
1. **1027-wac-role-policy-guide.mdx**
   - 테이블 내 `spec:` 행의 공백 수정 (`<br/> ` → `<br/>  `)

2. **1030-wac-jit-permission-acquisition-guide.mdx**
   - User Activity Recording, Tag 항목의 불필요한 볼드 제거
   - Step2의 Web App, Approvers, Request Title 등 항목 레이블 볼드 제거
   - 한국어 원문 포맷과 일치

### Web App Access Control
3. **access-control/granting-and-revoking-roles.mdx**
   - Administrator 메뉴 경로의 불필요한 볼드 제거 (2군데)
   - 한국어 원문에는 볼드가 없음

4. **policies.mdx**
   - Policy 조회 항목 (Name, Description, Created At 등) 볼드 제거
   - Roles 탭의 항목 레이블 볼드 제거
   - Versions 탭의 항목 레이블 볼드 제거
   - Policy 생성/수정/복제 시 항목 레이블 볼드 제거
   - 모든 항목이 한국어 원문과 동일한 포맷으로 수정됨

## 수정 사유
- 일본어 번역에서 일부 항목이 볼드 처리되어 있었으나, 한국어 원문에서는 볼드가 없음
- Markdown 포맷팅 일관성 유지를 위해 한국어 원문과 동일하게 수정
- Translation skill 가이드라인에 따라 "Preserve Formatting: Maintain exact markdown formatting"

## 검증
- [x] 한국어 원문과 일본어 번역문의 포맷팅 비교 완료
- [x] Markdown 문법 오류 없음
- [x] 내용 변경 없이 포맷팅만 수정

## 관련 이슈
- 일본어 문서 번역 품질 개선 작업의 일환