### PR TITLE
mdx_to_skeleton: --recursive 실행결과 변경, ignore_skeleton_diff.yaml 경로 패턴 변경

### DIFF
--- a/confluence-mdx/bin/ignore_skeleton_diff.yaml
+++ b/confluence-mdx/bin/ignore_skeleton_diff.yaml
@@ -3,15 +3,15 @@
 #
 # Format:
 #   ignores:
-#     - file: /path/to/file.mdx  # Path relative to target/{lang} (e.g., /administrator-manual/databases/db-access-control.mdx)
+#     - file: target/{lang}/path/to/file.mdx  # Path including target/{lang}/ prefix (e.g., target/ja/administrator-manual/databases/db-access-control.mdx)
 #       line_numbers: [10, 20, 30]  # Line numbers in the original .mdx file to ignore
 #
 # Example:
 #   ignores:
-#     - file: /administrator-manual/databases/db-access-control.mdx
+#     - file: target/ja/administrator-manual/databases/db-access-control.mdx
 #       line_numbers: [5, 10, 15]
 
 ignores:
-  - file: /administrator-manual/databases/dac-general-configurations.mdx
+  - file: target/ja/administrator-manual/databases/dac-general-configurations.mdx
     line_numbers: [56, 63, 131]
 

--- a/docs/todo-ja.txt
+++ b/docs/todo-ja.txt
@@ -1,5 +1,3 @@
-target/ja/administrator-manual/general/system/integrations/integrating-with-slack-dm/slack-dm-workflow-notification-types.mdx
-target/ja/administrator-manual/general/user-management/authentication/integrating-with-okta.mdx
 target/ja/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-action-configuration-reference-guide.mdx
 target/ja/administrator-manual/kubernetes/k8s-access-control/roles.mdx
 target/ja/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles.mdx


### PR DESCRIPTION
## Description
- `mdx_to_skeleton`의 `--recursive` 실행 시 diff 로깅 최적화 (차이점이 있을 때만 출력)
- `ignore_skeleton_diff.yaml`의 파일 경로 패턴에 `target/{lang}/` 포함하도록 변경
    - `skeleton_diff.py`에서 새로운 패턴 형식 지원
- `todo-ja.txt` 업데이트
