### PR TITLE
mdx: ignore_skeleton_diff.yaml 업데이트

### DIFF
--- a/confluence-mdx/bin/ignore_skeleton_diff.yaml
+++ b/confluence-mdx/bin/ignore_skeleton_diff.yaml
@@ -12,6 +12,15 @@
 #       line_numbers: [5, 10, 15]
 
 ignores:
-  - file: target/ja/administrator-manual/databases/dac-general-configurations.mdx
-    line_numbers: [56, 63, 131]
+  # Code block 내부의 한국어 주석이 일본어로 번역된 경우
+  - file: target/ja/administrator-manual/web-apps/wac-quickstart/1028-wac-rbac-guide.mdx
+    line_numbers: [251, 252]
+  
+  # Code block 내부의 한국어 텍스트가 일본어로 번역된 경우
+  - file: target/ja/administrator-manual/servers/connection-management/server-agents-for-rdp/installing-and-removing-server-agent.mdx
+    line_numbers: [67, 78]
+  
+  # Code block 내부의 한국어 주석이 일본어로 번역된 경우
+  - file: target/ja/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-action-configuration-reference-guide.mdx
+    line_numbers: [41, 56, 92, 98, 104]
 

--- a/docs/todo-ja.01.txt
+++ b/docs/todo-ja.01.txt
@@ -1,12 +1,10 @@
-target/ja/administrator-manual/general/system/integrations/integrating-with-slack-dm/slack-dm-workflow-notification-types.mdx
-target/ja/administrator-manual/general/user-management/authentication/integrating-with-okta.mdx
-target/ja/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-action-configuration-reference-guide.mdx
 target/ja/administrator-manual/kubernetes/k8s-access-control/roles.mdx
 target/ja/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles.mdx
-target/ja/administrator-manual/servers/connection-management/server-agents-for-rdp/installing-and-removing-server-agent.mdx
 target/ja/administrator-manual/servers/server-access-control/access-control/granting-server-privilege.mdx
 target/ja/administrator-manual/servers/server-access-control/blocked-accounts.mdx
 target/ja/administrator-manual/servers/server-access-control/command-templates.mdx
 target/ja/administrator-manual/servers/server-access-control/policies.mdx
 target/ja/administrator-manual/servers/server-account-management/account-management.mdx
 target/ja/administrator-manual/web-apps/wac-quickstart.mdx
+target/ja/administrator-manual/web-apps/wac-quickstart/1027-wac-role-policy-guide.mdx
+target/ja/administrator-manual/web-apps/wac-quickstart/1028-wac-rbac-guide.mdx

--- a/docs/todo-ja.02.txt
+++ b/docs/todo-ja.02.txt
@@ -1,5 +1,3 @@
-target/ja/administrator-manual/web-apps/wac-quickstart/1027-wac-role-policy-guide.mdx
-target/ja/administrator-manual/web-apps/wac-quickstart/1028-wac-rbac-guide.mdx
 target/ja/administrator-manual/web-apps/wac-quickstart/1030-wac-jit-permission-acquisition-guide.mdx
 target/ja/administrator-manual/web-apps/wac-quickstart/root-ca-certificate-installation-guide.mdx
 target/ja/administrator-manual/web-apps/web-app-access-control/access-control/granting-and-revoking-roles.mdx

--- a/docs/todo-ja.txt
+++ b/docs/todo-ja.txt
@@ -1,7 +1,5 @@
-target/ja/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-action-configuration-reference-guide.mdx
 target/ja/administrator-manual/kubernetes/k8s-access-control/roles.mdx
 target/ja/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles.mdx
-target/ja/administrator-manual/servers/connection-management/server-agents-for-rdp/installing-and-removing-server-agent.mdx
 target/ja/administrator-manual/servers/server-access-control/access-control/granting-server-privilege.mdx
 target/ja/administrator-manual/servers/server-access-control/blocked-accounts.mdx
 target/ja/administrator-manual/servers/server-access-control/command-templates.mdx


### PR DESCRIPTION
## Description
- 한국어 원문의 code block 에서 한국어가 사용된 경우, 일본어 번역문의 code block 에서 일본어로 번역하여야 합니다.
  - 해당 사례를 ignore_skeleton_diff.yaml 에 추가합니다.
- `todo-ja.txt` 를 업데이트합니다. 이제 17개 문서로 범위가 좁혀졌습니다.

## Additional notes
- 
