### PR TITLE
mdx: 일본어 문서 불일치 수정 41

### DIFF
--- a/src/content/ja/administrator-manual/web-apps/wac-quickstart/1030-wac-jit-permission-acquisition-guide.mdx
+++ b/src/content/ja/administrator-manual/web-apps/wac-quickstart/1030-wac-jit-permission-acquisition-guide.mdx
@@ -136,6 +136,6 @@ JIT（Just-in-Time）権限申請時、以下のような制約事項があり�
 1. QueryPie Web Appsに移動します。
 2. 左上のRoleをクリックしてJust In Time Roleに変更します。
 3. Web App Dashboard内のMy Appsに先ほど申請したQueryPie Web Siteアプリケーションアイコンに「JIT Active」が表示されるはずです。アイコンをクリックするとウェブサイトにアクセスします。
-4. 申請した時間が満了するとアクセス権限は自動的に回収されます。
+4. 申請した時間が満了するとアクセス権限は自動的に回収されます。 <br/>
 
 

--- a/src/content/ja/administrator-manual/web-apps/wac-quickstart/root-ca-certificate-installation-guide.mdx
+++ b/src/content/ja/administrator-manual/web-apps/wac-quickstart/root-ca-certificate-installation-guide.mdx
@@ -77,7 +77,7 @@ sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keyc
 
 証明書が正常に設定されたかどうかを確認する方法は以下の通りです。
 
-1. Chromeブラウザで `chrome://certificate-manager/localcerts` を開きます。
+1. Chromeブラウザで chrome://certificate-manager/localcerts を開きます。
 2.  **macOSからインポートした証明書表示またはWindowsからインポートした証明書表示** をクリックします。
 3. 信頼できる証明書リストでquerypie証明書を確認します。
 

--- a/src/content/ja/administrator-manual/web-apps/web-app-access-control/policies.mdx
+++ b/src/content/ja/administrator-manual/web-apps/web-app-access-control/policies.mdx
@@ -8,7 +8,8 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-組織で管理するウェブアプリケーションのアクセスポリシー（Policy）に対する照会、生成、修正、削除をサポートします。Policyは、ウェブアプリケーションアクセス権限を実装し適用するための基盤となる核心段階です。
+組織で管理するウェブアプリケーションのアクセスポリシー（Policy）に対する照会、生成、修正、削除をサポートします。
+Policyは、ウェブアプリケーションアクセス権限を実装し適用するための基盤となる核心段階です。
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Web Apps &gt; Web App Access Control &gt; Policies](/administrator-manual/web-apps/web-app-access-control/policies/image-20250629-164449.png)

--- a/src/content/ja/administrator-manual/web-apps/web-app-access-control/roles.mdx
+++ b/src/content/ja/administrator-manual/web-apps/web-app-access-control/roles.mdx
@@ -8,7 +8,8 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-組織で管理するウェブアプリケーションのアクセス権限に応じた役割（Role）に対する照会、生成、修正、削除をサポートします。Roleは、ウェブアプリアクセス権限を実装し適用するためのPolicy以降の段階として、Policyの集合であり、ユーザー/グループとポリシーの接続点となる権限を意味します。
+組織で管理するウェブアプリケーションのアクセス権限に応じた役割（Role）に対する照会、生成、修正、削除をサポートします。
+Roleは、ウェブアプリアクセス権限を実装し適用するためのPolicy以降の段階として、Policyの集合であり、ユーザー/グループとポリシーの接続点となる権限を意味します。
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Web Apps &gt; Web App Access Control &gt; Roles](/administrator-manual/web-apps/web-app-access-control/roles/image-20250629-161837.png)

--- a/src/content/ja/release-notes/9100-9104.mdx
+++ b/src/content/ja/release-notes/9100-9104.mdx
@@ -36,7 +36,7 @@ External API変更事項は以下のリンクをご参照ください。
 
 **Bug Fix**
 
-* [Migration] 1MB以上のSQLが含まれたSQL Requestのマイグレーション時の「Data Tool long」発生エラーを解決
+* [Migration] 1MB以上のSQLが含まれたSQL Requestのマイグレーション時の `Data Tool long` 発生エラーを解決
 ---
 
 ### QueryPie 9.10.1 Release


### PR DESCRIPTION
## 변경 사항 요약

한국어 원문과 일본어 번역문 간의 구조적 차이 및 마크다운 형식 불일치를 해소했습니다.

## 수정된 파일 목록 (5개)

### 1. `1030-wac-jit-permission-acquisition-guide.mdx`
- **변경 내용**: 마지막 항목에 `<br/>` 태그 추가
- **이유**: 한국어 원문에 존재하는 `<br/>` 태그가 일본어 번역문에서 누락되어 있었음

### 2. `root-ca-certificate-installation-guide.mdx`
- **변경 내용**: `chrome://certificate-manager/localcerts` URL에서 백틱(`) 제거
- **이유**: 한국어 원문에는 URL이 백틱으로 감싸져 있지 않으나, 일본어 번역문에는 백틱이 추가되어 있었음

### 3. `policies.mdx`
- **변경 내용**: Overview 섹션의 설명을 두 줄로 분리
- **이유**: 한국어 원문은 두 문장이 별도의 줄로 구분되어 있으나, 일본어 번역문은 한 줄로 결합되어 있었음

### 4. `roles.mdx`
- **변경 내용**: Overview 섹션의 설명을 두 줄로 분리
- **이유**: 한국어 원문은 두 문장이 별도의 줄로 구분되어 있으나, 일본어 번역문은 한 줄로 결합되어 있었음

### 5. `9100-9104.mdx`
- **변경 내용**: `Data Tool long` 용어를 백틱(`)으로 감싸도록 수정
- **이유**: 한국어 원문에는 백틱으로 감싸져 있으나, 일본어 번역문에는 일본어 따옴표「」로 감싸져 있었음

## 검증 방법

각 파일에 대해 mdx_to_skeleton.py 스크립트를 실행하여 한국어 원문과 일본어 번역문의 skeleton 구조가 일치함을 확인했습니다.

## 관련 작업

- 작업 브랜치: `jk/ja` → `jk/ja-41`
- 대상 브랜치: `main`
- 수정 파일 수: 5개
- 추가된 줄: 7줄
- 삭제된 줄: 5줄