### PR TITLE
mdx: 영어 문서 불일치 재수정 01

### DIFF
--- a/src/content/en/administrator-manual/audit/general-logs/activity-logs.mdx
+++ b/src/content/en/administrator-manual/audit/general-logs/activity-logs.mdx
@@ -22,7 +22,7 @@ Administrator &gt; Audit &gt; General &gt; Activity Logs
 
 1. Access the Administrator &gt; Audit &gt; General &gt; Activity Logs menu.
 2.  **Query Period**  : By default, the log list for this month is displayed in the latest order.
-    1. To change the query period, open the filter panel and change the query reference date in **Action At**. Filtering is possible.
+    1. To change the query period, open the filter panel and change the query reference date in **Action At**.
 3.  **Action Type**  : You can briefly check the resource change content. The format is as follows:
     1. `{Resource type that was changed}` `{Created | Updated | Deleted…}` : When a specific resource was created, modified, or deleted
         * Example: `DB Connection Created`, `Server Updated`, `Kubernetes Policy Deleted`

--- a/src/content/en/administrator-manual/audit/general-logs/reverse-tunnels.mdx
+++ b/src/content/en/administrator-manual/audit/general-logs/reverse-tunnels.mdx
@@ -10,7 +10,8 @@ import { Callout } from 'nextra/components'
 
 This is a page for monitoring Reverse Tunnels sessions connected to QueryPie.
 
-When the Reverse Tunnel Agent installed by users within the infrastructure communicates normally with QueryPie, you can check the sessions created between QueryPie and Reverse Tunnels. You can set whether to access resources (servers, clusters) through Reverse Tunnels by adding Tags to the resources.<br/>
+When the Reverse Tunnel Agent installed by users within the infrastructure communicates normally with QueryPie, you can check the sessions created between QueryPie and Reverse Tunnels.
+You can set whether to access resources (servers, clusters) through Reverse Tunnels by adding Tags to the resources.<br/>
 
 <Callout type="info">
 In 11.4.0, the Reverse Tunnels page that displayed Reverse Tunnel status information has been moved from Admin &gt; Audit &gt; General &gt; Reverse Tunnels → Admin &gt; General &gt; System &gt; Reverse Tunnels.<br/>The "General Setting Full Access" Admin Role is required to access this menu.
@@ -37,4 +38,5 @@ Admin Page &gt; Audit &gt; General &gt; Reverse Tunnels
     2.  **Host**  : Host information of the Reverse Tunnel Agent
 4. Supported filter conditions are as follows.
     1.  **Tag** : Tags set on the Reverse Tunnel Agent
+
 

--- a/src/content/en/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-clusters-through-reverse-tunnel.mdx
+++ b/src/content/en/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-clusters-through-reverse-tunnel.mdx
@@ -6,7 +6,8 @@ title: 'Communicating with Clusters through Reverse Tunnel'
 
 ### Communicating with Clusters through Reverse Tunnel
 
-QueryPie supports Reverse Tunneling as a means to communicate with resources in different Network Zones. When you install a Reverse Tunnel Agent in the Network Zone you want to communicate with, the Reverse Tunnel Agent establishes a connection toward QueryPie (Outbound).
+QueryPie supports Reverse Tunneling as a means to communicate with resources in different Network Zones.
+When you install a Reverse Tunnel Agent in the Network Zone you want to communicate with, the Reverse Tunnel Agent establishes a connection toward QueryPie (Outbound).
 
 You can communicate from QueryPie to resources in different Network Zones through Reverse Tunnels by adding Tags to resources (clusters).
 
@@ -20,7 +21,7 @@ Administrator &gt; Kubernetes &gt; Connection Management &gt; Clusters &gt; List
 </figure>
 
 1. Navigate to Administrator &gt; Kubernetes &gt; Connection Management &gt; Clusters menu.
-2. Select a cluster from the list. For new cluster registration, please refer to [Manually Registering Kubernetes Clusters](../../../kubernetes/connection-management/clusters/manually-registering-kubernetes-clusters).
+2. Select a cluster from the list. For new cluster registration, refer to [Manually Registering Kubernetes Clusters](../../../kubernetes/connection-management/clusters/manually-registering-kubernetes-clusters).
 3. Add the following Tag to the Tags section in the Clusters List Detail page.
     1. `RTS = TRUE` : Clusters with this Tag will attempt to communicate through Reverse Tunnels.
     2. Reverse Tunnel Agent Tag : Communicates with the cluster through a Reverse Tunnel Agent with the same Tag. If there is no Reverse Tunnel Agent with the same Tag, communication will fail.

--- a/src/content/en/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-db-through-reverse-tunnel.mdx
+++ b/src/content/en/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-db-through-reverse-tunnel.mdx
@@ -6,7 +6,8 @@ title: 'Communicating with DB through Reverse Tunnel'
 
 ### Communicating with DB through Reverse Tunnel
 
-QueryPie supports Reverse Tunneling as a means to communicate with resources in different Network Zones. When you install a Reverse Tunnel Agent in the Network Zone you want to access, the Reverse Tunnel Agent establishes a connection toward QueryPie (Outbound).
+QueryPie supports Reverse Tunneling as a means to communicate with resources in different Network Zones.
+When you install a Reverse Tunnel Agent in the Network Zone you want to access, the Reverse Tunnel Agent establishes a connection toward QueryPie (Outbound).
 
 You can communicate from QueryPie to resources in different Network Zones through Reverse Tunnels by adding Tags to resources (DB Connection).
 
@@ -20,7 +21,7 @@ Admin Page &gt; Servers &gt; Connection Management &gt; DB Connections
 </figure>
 
 1. Navigate to Administrator &gt; Databases &gt; Connection Management &gt; DB Connections menu.
-2. Select a DB Connection from the list. For new DB registration, please refer to [Manually Registering DB Connections](../../../databases/connection-management/db-connections).
+2. Select a DB Connection from the list. For new DB registration, refer to [Manually Registering DB Connections](../../../databases/connection-management/db-connections).
 3. Add the following Tag to the Tags section in the DB Connection List Detail page.
     1. `RTS = TRUE` : DB Connections with this Tag will attempt to connect through Reverse Tunnels.
     2. Reverse Tunnel Agent Tag : Connects to the DB through a Reverse Tunnel Agent with the same Tag. If there is no Reverse Tunnel Agent with the same Tag, connection will fail.

--- a/src/content/en/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-servers-through-reverse-tunnel.mdx
+++ b/src/content/en/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-servers-through-reverse-tunnel.mdx
@@ -6,7 +6,8 @@ title: 'Communicating with Servers through Reverse Tunnel'
 
 ### Communicating with Servers through Reverse Tunnel
 
-QueryPie supports Reverse Tunneling as a means to communicate with resources in different Network Zones. When you install a Reverse Tunnel Agent in the Network Zone you want to access, the Reverse Tunnel Agent establishes a connection toward QueryPie (Outbound).
+QueryPie supports Reverse Tunneling as a means to communicate with resources in different Network Zones.
+When you install a Reverse Tunnel Agent in the Network Zone you want to access, the Reverse Tunnel Agent establishes a connection toward QueryPie (Outbound).
 
 You can communicate from QueryPie to resources in different Network Zones through Reverse Tunnels by adding Tags to resources (servers).
 
@@ -20,7 +21,7 @@ Admin Page &gt; Servers &gt; Connection Management &gt; Servers
 </figure>
 
 1. Navigate to Administrator &gt; Servers &gt; Connection Management &gt; Servers menu.
-2. Select a server from the list. For new server registration, please refer to [Manually Registering Individual Servers](../../../servers/connection-management/servers/manually-registering-individual-servers).
+2. Select a server from the list. For new server registration, refer to [Manually Registering Individual Servers](../../../servers/connection-management/servers/manually-registering-individual-servers).
 3. Add the following Tag to the Tags section in the Server List Detail page.
     1. `RTS = TRUE` : Servers with this Tag will attempt to connect through Reverse Tunnels.
     2. Reverse Tunnel Agent Tag : Connects to the server through a Reverse Tunnel Agent with the same Tag. If there is no Reverse Tunnel Agent with the same Tag, connection will fail.

--- a/src/content/en/administrator-manual/audit/kubernetes-logs.mdx
+++ b/src/content/en/administrator-manual/audit/kubernetes-logs.mdx
@@ -6,7 +6,9 @@ title: 'Kubernetes Logs'
 
 ### Overview
 
-All activities in QueryPie are recorded in audit logs. User and administrator login/logout, permission grants and revocations, API execution history for Kubernetes, resource or security configuration changes, and all activity history occurring in QueryPie and access-controlled target resources are subject to logging. Real-time recorded logs can be searched and filtered with various conditions.
+All activities in QueryPie are recorded in audit logs.
+User and administrator login/logout, permission grants and revocations, API execution history for Kubernetes, resource or security configuration changes, and all activity history occurring in QueryPie and access-controlled target resources are subject to logging.
+Real-time recorded logs can be searched and filtered with various conditions.
 
 ### Related Audit Log Types
 

--- a/src/content/en/administrator-manual/audit/kubernetes-logs/pod-session-recordings.mdx
+++ b/src/content/en/administrator-manual/audit/kubernetes-logs/pod-session-recordings.mdx
@@ -6,7 +6,8 @@ title: 'Pod Session Recordings'
 
 ### Overview
 
-Records actions within connection sessions such as Pod Exec among API server calls to Kubernetes clusters managed by the organization. Administrators can monitor users' execution history in operating container shells through video playback.
+Records actions within connection sessions such as Pod Exec among API server calls to Kubernetes clusters managed by the organization.
+Administrators can monitor users' execution history in operating container shells through video playback.
 
 ### Viewing Pod Session Recordings
 

--- a/src/content/en/administrator-manual/audit/reports.mdx
+++ b/src/content/en/administrator-manual/audit/reports.mdx
@@ -8,5 +8,6 @@ title: 'Reports'
 
 The Reports menu allows you to extract original audit log files and generate reports for audit compliance.
 
+
 * [Reports](reports/reports) **[beta]** : Generate one-time/regular reports on QueryPie system internal data status
 * [Audit Log Export](reports/audit-log-export) : Extract various audit log files provided in the Audit menu

--- a/src/content/en/administrator-manual/audit/reports/audit-log-export.mdx
+++ b/src/content/en/administrator-manual/audit/reports/audit-log-export.mdx
@@ -8,7 +8,10 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-This is a feature that allows you to extract various audit logs generated in QueryPie and download them as CSV files. It enables stable extraction and download even for large files such as logs spanning long periods. Once generated, log extraction files can be downloaded for 30 days. The supported extraction logs include Query Audit, Workflow SQL Request, and 21 other types.
+This is a feature that allows you to extract various audit logs generated in QueryPie and download them as CSV files.
+It enables stable extraction and download even for large files such as logs spanning long periods.
+Once generated, log extraction files can be downloaded for 30 days.
+The supported extraction logs include Query Audit, Workflow SQL Request, and 21 other types.
 
 <Callout type="important">
 With the addition of the Audit Log Export feature, the 'Excel File Download' button that was provided on each log screen has been discontinued from QueryPie v9.15.0.

--- a/src/content/en/administrator-manual/audit/reports/reports.mdx
+++ b/src/content/en/administrator-manual/audit/reports/reports.mdx
@@ -504,7 +504,7 @@ O
 *O*
 </td>
 <td>
-*-
+*-*
 </td>
 </tr>
 <tr>
@@ -677,11 +677,12 @@ O
 
 ### Viewing Report List
 
-You can check the report generation task list by entering the Audit menu &gt; Reports &gt; Reports menu.
+From the Audit menu, you can check the report generation task list by entering Reports &gt; Reports menu.
 
 <Callout type="info">
 To access the Reports menu, the Report Audit Full Access administrator permission must be granted to the account.
 </Callout>
+
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Audit &gt; Reports &gt; Reports](/administrator-manual/audit/reports/reports/screenshot-20241223-112238.png)

--- a/src/content/en/administrator-manual/audit/server-logs.mdx
+++ b/src/content/en/administrator-manual/audit/server-logs.mdx
@@ -6,7 +6,9 @@ title: 'Server Logs'
 
 ### Overview
 
-You can view logs generated from QueryPie's System Access Control in Server Logs. You can check information such as server access permission grants and revocations, server login/logout, and executed command history. Additionally, you can view the list of sessions connected through QueryPie or force terminate sessions.
+You can view logs generated from QueryPie's System Access Control in Server Logs.
+You can check information such as server access permission grants and revocations, server login/logout, and executed command history.
+Additionally, you can view the list of sessions connected through QueryPie or force terminate sessions.
 
 ### Related Audit Log Types
 

--- a/src/content/en/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-ms-azure.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-ms-azure.mdx
@@ -48,6 +48,7 @@ Administrator &gt; Databases &gt; Connection Management &gt; Cloud Providers &gt
         * Example: If you set the tag Key to "Network" and enter Value as `{vpcid}`, when the DB is in "vpc-1a2b3c4d" VPC, the "Network: vpc-1a2b3c4d" tag will be automatically created.
 12. Click the `Save` button to save the Cloud Provider.
 
+
 <Callout type="important">
 **Save Credential for Synchronization Option**
 

--- a/src/content/en/administrator-manual/databases/connection-management/db-connections.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/db-connections.mdx
@@ -87,7 +87,7 @@ Administrator &gt; Databases &gt; Connection Management &gt; DB Connections &gt;
 **What is Cluster Mode?**
 Generally, when synchronizing through Cloud Provider, it is registered in cluster structure for Primary and Secondary cluster and endpoint management.
 Even when manually registering connections, you can register connections in cluster structure through the Cluster toggle button.
-When using Cluster mode, you can manage access permissions in cluster and instance endpoint structure, and  **for purposes such as load balancing and permission management, you can grant permissions only to specific instance endpoints to certain users** .
+When using Cluster mode, you can manage access permissions in cluster and instance endpoint structure, and **for purposes such as load balancing and permission management, you can grant permissions only to specific instance endpoints to certain users**.
 </Callout>
 
 


### PR DESCRIPTION
## 개요
영어 번역 파일 13개의 한국어 원문과의 불일치를 수정했습니다.

## 수정 내용

### 1. 줄바꿈 통일
- 한국어 원문에서 한 줄에 한 문장씩 위치한 경우, 영어 번역에도 동일하게 적용
- 여러 문장이 한 줄로 합쳐진 경우를 분리하여 가독성 향상

### 2. 불필요한 텍스트 제거
- 번역 과정에서 추가된 불필요한 문구 삭제
  - 예: "please refer to" → "refer to"
  - 예: "Filtering is possible." 문장 제거

### 3. 포맷 통일
- 빈 줄 개수 일치
- 마크다운 이탤릭체 포맷 통일 (`*-*` vs `*-`)
- 불필요한 공백 및 마침표 제거

## 수정된 파일 (13개)

### Audit - General Logs
- `administrator-manual/audit/general-logs/activity-logs.mdx`
- `administrator-manual/audit/general-logs/reverse-tunnels.mdx`
- `administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-clusters-through-reverse-tunnel.mdx`
- `administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-db-through-reverse-tunnel.mdx`
- `administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-servers-through-reverse-tunnel.mdx`

### Audit - Kubernetes Logs
- `administrator-manual/audit/kubernetes-logs.mdx`
- `administrator-manual/audit/kubernetes-logs/pod-session-recordings.mdx`

### Audit - Reports
- `administrator-manual/audit/reports.mdx`
- `administrator-manual/audit/reports/audit-log-export.mdx`
- `administrator-manual/audit/reports/reports.mdx`

### Audit - Server Logs
- `administrator-manual/audit/server-logs.mdx`

### Databases
- `administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-ms-azure.mdx`
- `administrator-manual/databases/connection-management/db-connections.mdx`

## 검증 방법
각 파일에 대해 `bin/mdx_to_skeleton.py` 스크립트로 skeleton 비교를 수행하여 한국어 원문과 영어 번역의 구조적 일치를 확인했습니다.

남은 skeleton diff는 다음과 같은 자연스러운 차이만 존재합니다:
- inline code 위치 차이 (영어와 한국어의 어순 차이로 인한 자연스러운 변형)
- 언어별 텍스트 내용 차이 (번역된 내용 자체)

## 체크리스트
- [x] 한국어 원문과 줄바꿈 구조 일치
- [x] skeleton 비교로 구조적 일치 확인
- [x] 불필요한 텍스트 및 공백 제거
- [x] 마크다운 포맷 통일