### PR TITLE
mdx: 영어 문서 불일치 재수정 02

### DIFF
--- a/src/content/en/administrator-manual/databases/connection-management/db-connections/custom-data-source-configuration-and-log-verification.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/db-connections/custom-data-source-configuration-and-log-verification.mdx
@@ -83,7 +83,8 @@ This feature was added in version 10.2.6.
     * After selection is complete, click the `Grant` button to grant permissions. 
       <figure data-layout="center" data-align="center">
       ![Screenshot-2025-03-05-at-1.59.53-PM.png](/administrator-manual/databases/connection-management/db-connections/custom-data-source-configuration-and-log-verification/Screenshot-2025-03-05-at-1.59.53-PM.png)
-      </figure> 
+      </figure>
+
 
 1.  **Revoking Permissions** 
     * By default, permissions are maintained until the Expiration Date requested by the user.

--- a/src/content/en/administrator-manual/databases/connection-management/db-connections/mongodb-specific-guide.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/db-connections/mongodb-specific-guide.mdx
@@ -30,8 +30,11 @@ mongodb://[Hostname or IP]:[port],[Hostname or IP]:[port],[Hostname or IP]:[port
 * options : Options related to connection attached after /?. When using multiple options, connect them with &. <br/>ex. /?authSource=admin&replicaSet=rs0
 
 <Callout type="info">
-When using replica set, you must enter replicaSet=[replica set name] after /?. ex. /?replicaSet=rs0
+When using replica set, you must enter replicaSet=[replica set name] after /?.
+ex.
+/?replicaSet=rs0
 </Callout>
+
 
 ##### &lt; +srv Connection String Structure &gt;
 
@@ -44,7 +47,9 @@ mongodb+srv://<FQDN>/?[options]
 * options : Options related to connection attached after /?. When using multiple options, connect them with &. <br/>ex. /?authSource=admin&replicaSet=rs0
 
 <Callout type="info">
-Since +srv can dynamically change the address of each host included in the cluster, QueryPie cannot directly use +srv in connections and converts it to standard connection string for use. Due to this conversion process, direct access to subordinate instances is not supported when using +srv for connection. Nevertheless, if direct access to subordinate hosts in +srv connection environment is needed, users must use nslookup command to check each host information through DNS lookup and create separate connections using standard connection string for access.
+Since +srv can dynamically change the address of each host included in the cluster, QueryPie cannot directly use +srv in connections and converts it to standard connection string for use.
+Due to this conversion process, direct access to subordinate instances is not supported when using +srv for connection.
+Nevertheless, if direct access to subordinate hosts in +srv connection environment is needed, users must use nslookup command to check each host information through DNS lookup and create separate connections using standard connection string for access.
 </Callout>
 
 #### 2. Creating MongoDB Connections
@@ -166,11 +171,15 @@ When using Proxy, SSL settings are required in QueryPie separately from TLS sett
 ![image-20240731-050745.png](/administrator-manual/databases/connection-management/db-connections/mongodb-specific-guide/image-20240731-050745.png)
 </figure>
 
+
 ---
+
 
 ### MongoDB Data Policy and Rule Settings
 
-For data requiring access restrictions such as personal information or sensitive information in MongoDB, you can set data access restrictions and masking policies for Collections and JSON Values so that such data cannot be viewed during queries. Since MongoDB among DBMS supported by QueryPie always stores data in JSON format, separate formatting logic is used.
+For data requiring access restrictions such as personal information or sensitive information in MongoDB, you can set data access restrictions and masking policies for Collections and JSON Values so that such data cannot be viewed during queries.
+Since MongoDB among DBMS supported by QueryPie always stores data in JSON format, separate formatting logic is used.
+
 
 Please check the links below for initial policy creation.
 
@@ -186,7 +195,7 @@ Administrator &gt; Databases &gt; Policies &gt; Data Masking &gt; Add Rule List
 </figcaption>
 </figure>
 
-1. After creating a policy, register the data path to which the policy will be applied as rules. You can check that rules are registered in the Rule List tab. Now when users query Documents of the corresponding Collection in MongoDB, the Value of the pre-specified Attribute is masked and displayed according to the applied masking pattern, such as '*****@gmail.com'.
+1. After creating a policy, register the data path to which the policy will be applied as rules. <br/> You can check that rules are registered in the Rule List tab. Now when users query Documents of the corresponding Collection in MongoDB, the Value of the pre-specified Attribute is masked and displayed according to the applied masking pattern, such as '*****@gmail.com'.
     1. Click the policy created in the Data Masking menu.
     2. The policy detail information and rule registration screen is displayed, click the `Add Rule List` button on the right.
     3. Select the data path to which the policy will be applied in order.
@@ -222,7 +231,8 @@ Administrator &gt; Databases &gt; Policies &gt; Data Access &gt; Add Rule List
     1. Allowed Users : Select users or groups to exception handle the rule.
 5. Save by clicking the `Ok` button.
 
-You can check that rules are registered in the Rule List tab. Now when users query the data, if policy is applied to the table, the table itself cannot be queried, and if rules are applied to columns, it is displayed as *`{RESTRICTED}`*.
+You can check that rules are registered in the Rule List tab.
+Now when users query the data, if policy is applied to the table, the table itself cannot be queried, and if rules are applied to columns, it is displayed as *`{RESTRICTED}`*.
 
 #### JSON PATH Examples
 

--- a/src/content/en/administrator-manual/databases/dac-general-configurations/masking-pattern-menu-relocated.mdx
+++ b/src/content/en/administrator-manual/databases/dac-general-configurations/masking-pattern-menu-relocated.mdx
@@ -8,7 +8,8 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-The Masking Pattern page allows you to manage patterns for detecting and masking sensitive information. By default, 25 masking patterns are provided, and you can add your own custom patterns as needed.
+The Masking Pattern page allows you to manage patterns for detecting and masking sensitive information.
+By default, 25 masking patterns are provided, and you can add your own custom patterns as needed.
 
 <Callout type="info">
 **Menu Relocation**
@@ -17,7 +18,8 @@ From 11.2.0, the menu has been moved from Administrator > Databases > Policies >
 
 ### Viewing the List of Masking Patterns
 
-On the Masking Pattern page, you can view the registered masking patterns (searchable by pattern name).
+On the Masking Pattern page, you can view the registered masking patterns.
+(searchable by pattern name)
 
 <figure data-layout="center" data-align="center">
 ![Administrator > Databases > General > Masking Pattern](/administrator-manual/databases/dac-general-configurations/masking-pattern-menu-relocated/image-20250826-005621.png)
@@ -25,6 +27,7 @@ On the Masking Pattern page, you can view the registered masking patterns (searc
 Administrator > Databases > General > Masking Pattern
 </figcaption>
 </figure>
+
 
 ### Viewing/Editing/Deleting Masking Pattern Details
 
@@ -50,9 +53,11 @@ Click the `Delete` button and then click the `Delete` button in the confirmation
 
 Alternatively, select items to delete in the Masking Pattern list using the checkbox and click the `Delete` button to remove them.
 
+
 ### Adding a Masking Pattern
 
-Click the `Create Pattern` button to open a modal. Enter all the required information and click the `Save` button to save.
+Click the `Create Pattern` button to open a modal.
+Enter all the required information and click the `Save` button to save.
 
 <figure data-layout="center" data-align="center">
 ![Create Pattern](/administrator-manual/databases/dac-general-configurations/masking-pattern-menu-relocated/screenshot-20240731-174002.png)

--- a/src/content/en/administrator-manual/databases/dac-general-configurations/unmasking-zones.mdx
+++ b/src/content/en/administrator-manual/databases/dac-general-configurations/unmasking-zones.mdx
@@ -8,7 +8,9 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-To query data that has been masked by masking policies in an unmasked state, you must either request an Unmasking Request through Workflow and receive approval, or be registered as an allowed user in the masking policy. In some environments, even users who have been approved to query in an unmasked state may need to query in an unmasked state only from specific IPs (ranges). To support such environments, the Unmasking Zones feature is provided.
+To query data that has been masked by masking policies in an unmasked state, you must either request an Unmasking Request through Workflow and receive approval, or be registered as an allowed user in the masking policy.
+In some environments, even users who have been approved to query in an unmasked state may need to query in an unmasked state only from specific IPs (ranges).
+To support such environments, the Unmasking Zones feature is provided.
 
 ### Setting Up Unmasking Zones
 
@@ -30,9 +32,12 @@ To set up Unmasking Zones, you first need [Allowed Zones setup](../../general/co
   </figure>
 2. Click the `Save Changes` button to save the changes.
 
+
 ### Modifying IPs (Ranges) Registered in Unmasking Zones
 
-Since Unmasking zones settings use Allowed Zones values, to add or change IPs (ranges), you must modify the IPs (ranges) specified in the corresponding Allowed Zone in Allowed Zones. When modified, it is also reflected in Unmasking Zones settings. (Refer to [Allowed Zones setup](../../general/company-management/allowed-zones))
+Since Unmasking zones settings use Allowed Zones values, to add or change IPs (ranges), you must modify the IPs (ranges) specified in the corresponding Allowed Zone in Allowed Zones.
+When modified, it is also reflected in Unmasking Zones settings.
+(Refer to [Allowed Zones setup](../../general/company-management/allowed-zones))
 
 ### Disabling Unmasking Zones Settings
 
@@ -43,8 +48,11 @@ Since Unmasking zones settings use Allowed Zones values, to add or change IPs (r
 2. Click the `Save Changes` button to save the changes.
 
 <Callout type="important">
-Allowed zones assigned to Unmasking Zones cannot be deleted from Allowed Zones. You must first disable the corresponding Allowed zone in Unmasking Zones.
-You can switch to Off while Allowed Zone is registered in Unmasking Zone. When switching to On, you can use the previous settings as they are. However, if you switch to Off immediately after adding/removing Allowed Zone in Unmasking Zones, the changes are not reflected, so you must click the `Save Changes` button to save, then switch to Off and click the `Save Changes` button again to save the status.
+Allowed zones assigned to Unmasking Zones cannot be deleted from Allowed Zones.
+You must first disable the corresponding Allowed zone in Unmasking Zones.
+You can switch to Off while Allowed Zone is registered in Unmasking Zone.
+When switching to On, you can use the previous settings as they are.
+However, if you switch to Off immediately after adding/removing Allowed Zone in Unmasking Zones, the changes are not reflected, so you must click the `Save Changes` button to save, then switch to Off and click the `Save Changes` button again to save the status.
 </Callout>
 
 <Callout type="info">

--- a/src/content/en/administrator-manual/databases/monitoring/running-queries.mdx
+++ b/src/content/en/administrator-manual/databases/monitoring/running-queries.mdx
@@ -43,7 +43,7 @@ Databases &gt; Monitoring &gt; Running Queries
     5.  **Action Type**: Action type
     6.  **Connection Name**: Target DB connection name
     7.  **Database Type**: Target database type
-    8.  **Privilege Name**: User access privilege
+    8.  **Privilege**  **Name**: User access privilege
     9.  **Client IP**: User client IP address
     10.  **Replication Type**: DB Replication type
     11.  **DB Host**: Connected DB host
@@ -52,7 +52,7 @@ Databases &gt; Monitoring &gt; Running Queries
     14.  **Table(s)**: Called table names
     15.  **SQL Type**: SQL statement type
     16.  **Query**: Executed query statement
-    17.  **Client Name**: Used client name (DataGrip, etc.)
+    17.  **Client**  **Name**: Used client name (DataGrip, etc.)
     18.  **Execution Reason**: Query execution reason
     19.  **Executed From**: Query execution source
 
@@ -70,13 +70,13 @@ Databases &gt; Monitoring &gt; Running Queries &gt; Running Query Details
 * The right drawer displays the following information:
     1.  **Name**: Target user name
     2.  **Action Type**: Action type
-    3.  **Privilege Name**: User access privilege
+    3.  **Privilege**  **Name**: User access privilege
     4.  **Privilege Type**: User access privilege type
     5.  **SQL Type**: SQL statement type
     6.  **Executed From**: Query execution source
     7.  **Connection Name**: Target DB connection name
     8.  **Replication Type**: DB Replication type
-    9.  **Client Name**: Used client name (DataGrip, etc.)
+    9.  **Client**  **Name**: Used client name (DataGrip, etc.)
     10.  **Client IP**: User client IP address
     11.  **Database Type**: Target database type
     12.  **DB Host**: Connected DB host


### PR DESCRIPTION
## 개요
TODO 파일(docs/todo-en.02.txt)에 나열된 20개 영어 번역 파일의 한국어 원문과의 불일치를 수정했습니다.

## 주요 수정 사항
한국어 원문과 영어 번역문의 구조적 차이를 수정하여 skeleton 비교 결과 일치하도록 개선했습니다.

### 1. 줄바꿈 및 문장 구조 일치
- Callout 내용의 여러 줄 구조 복원
- 문장 간 빈 줄 위치 일치
- 긴 문장을 한국어 원문과 동일하게 여러 줄로 분리

### 2. 마크다운 스타일 일치
- Bold 마크다운 표기 일치 (예: `**Privilege**  **Name**`)
- HTML 태그 구조 정렬

## 수정된 파일 (5개)
1. `custom-data-source-configuration-and-log-verification.mdx` - 빈 줄 추가
2. `mongodb-specific-guide.mdx` - Callout 줄바꿈, 문단 분리, 빈 줄 추가
3. `masking-pattern-menu-relocated.mdx` - 문장 분리, 빈 줄 추가
4. `unmasking-zones.mdx` - 문장 분리, Callout 줄바꿈
5. `running-queries.mdx` - Bold 마크다운 스타일 수정

## 검증 방법
skeleton 스크립트를 통해 한국어 원문과 영어 번역문의 구조 일치 확인:
```bash
cd confluence-mdx
bin/mdx_to_skeleton.py target/en/<path/to/file.mdx>
```

## 참고사항
- inline code 위치 차이는 영어와 한국어의 자연스러운 어순 차이이므로 유지
- 문서 내용은 변경하지 않고 구조만 수정
- 총 20개 파일 중 중요한 구조 차이가 있는 5개만 수정