### PR TITLE
mdx: 영어 문서 불일치 재수정 05

### DIFF
--- a/src/content/en/administrator-manual/kubernetes/connection-management/cloud-providers.mdx
+++ b/src/content/en/administrator-manual/kubernetes/connection-management/cloud-providers.mdx
@@ -18,6 +18,7 @@ Administrator &gt; Kubernetes &gt; Connection Management &gt; Cloud Providers
 </figcaption>
 </figure>
 
+
 ### Viewing Cloud Providers
 
 1. Navigate to Administrator &gt; Kubernetes &gt; Connection Management &gt; Cloud Providers menu
@@ -32,12 +33,14 @@ Administrator &gt; Kubernetes &gt; Connection Management &gt; Cloud Providers
     6.  **Updated At** : Cloud provider last modification date and time
 5. Click on each row to view cloud provider details
 
+
 ### Creating Cloud Providers
 
 1. Navigate to Administrator &gt; Kubernetes &gt; Connection Management &gt; Cloud Providers menu
 2. Click the `+ Create Provider` button in the top right
 3. Create a cloud provider by referring to the following guide:
     * [Synchronizing Kubernetes Resources from AWS](cloud-providers/synchronizing-kubernetes-resources-from-aws)
+
 
 ### Deleting Cloud Providers
 

--- a/src/content/en/administrator-manual/kubernetes/connection-management/cloud-providers/synchronizing-kubernetes-resources-from-aws.mdx
+++ b/src/content/en/administrator-manual/kubernetes/connection-management/cloud-providers/synchronizing-kubernetes-resources-from-aws.mdx
@@ -14,7 +14,8 @@ You can synchronize resources within AWS, register them as clusters managed by Q
 <Callout type="info">
 #### Prerequisites
 
-1. To synchronize with AWS resources, ensure that the necessary policy actions have been attached to the AWS IAM role assigned to the QueryPie instance. The policy must include all of the following actions:
+1. To synchronize with AWS resources, ensure that the necessary policy actions have been attached to the AWS IAM role assigned to the QueryPie instance.
+The policy must include all of the following actions:
 
 * eks:ListClusters
 * eks:DescribeCluster
@@ -24,6 +25,7 @@ You can synchronize resources within AWS, register them as clusters managed by Q
 * eks:ListAssociatedAccessPolicies
 * eks:AssociateAccessPolicy
 </Callout>
+
 
 ### Modifying AWS EKS Authentication Mode
 
@@ -46,6 +48,7 @@ AWS Console &gt; EKS &gt; Clusters &gt; `{cluster}` &gt; Access &gt; Access conf
 6. If the Authentication mode is **"ConfigMap"**, click the **Manage access** button on the right
 7. Change the Cluster authentication mode to **"EKS API and ConfigMap"**
 8. Click `Save changes` to save the changes
+
 
 ### Registering AWS Integration Information in QueryPie
 
@@ -79,10 +82,10 @@ Administrator &gt; Kubernetes &gt; Connection Management &gt; Cloud Providers &g
 
 <Callout type="important">
 **Q. I clicked the Save button but got an error saying "Already exists cloud provider."**
-A.
-If there is already a Cloud Provider registered with `Default Credentials` as **Credential** and the same `Region`, duplicate registration is not possible.
+A. If there is already a Cloud Provider registered with `Default Credentials` as **Credential** and the same `Region`, duplicate registration is not possible.
 In this case, you can register normally by selecting a different `Region`.
 </Callout>
+
 
 ### Synchronizing and Managing Registered AWS Cloud Provider
 
@@ -106,6 +109,7 @@ Administrator &gt; Kubernetes &gt; Connection Management &gt; Cloud Providers &g
     5.  **Role ARN** : Cannot be changed
     6.  **Search Filter** : Can be changed
     7.  **Replication Frequency** : Can be changed
+
 
 ### Dry Run/Synchronization Log Notation
 

--- a/src/content/en/administrator-manual/kubernetes/connection-management/clusters.mdx
+++ b/src/content/en/administrator-manual/kubernetes/connection-management/clusters.mdx
@@ -18,6 +18,7 @@ Administrator &gt; Kubernetes &gt; Connection Management &gt; Clusters
 </figcaption>
 </figure>
 
+
 ### Viewing Clusters
 
 1. Navigate to Administrator &gt; Kubernetes &gt; Connection Management &gt; Clusters menu
@@ -33,11 +34,13 @@ Administrator &gt; Kubernetes &gt; Connection Management &gt; Clusters
     7.  **Updated At**  : Cluster last modification date and time
 5. Click on each row to view cluster details
 
+
 ### Creating Clusters
 
 1. Navigate to Administrator &gt; Kubernetes &gt; Connection Management &gt; Clusters menu
 2. Click the `+ Create Cluster` button in the top right
-3. Create a cluster manually by referring to the [Manually Registering Kubernetes Clusters](clusters/manually-registering-kubernetes-clusters) guide
+3. Refer to the [Manually Registering Kubernetes Clusters](clusters/manually-registering-kubernetes-clusters) guide to manually create a cluster
+
 
 ### Deleting Clusters
 

--- a/src/content/en/administrator-manual/kubernetes/connection-management/clusters/manually-registering-kubernetes-clusters.mdx
+++ b/src/content/en/administrator-manual/kubernetes/connection-management/clusters/manually-registering-kubernetes-clusters.mdx
@@ -33,7 +33,7 @@ To manually register individual servers, you need to enter basic server informat
             * :check_mark:  **Verified**  : Indicates that the cluster connection was successful and the service account token and CA certificate were entered correctly. 
             * :cross_mark:  **Verification Failed**  : Indicates that the cluster connection failed, there may be an error in the service account token and CA certificate values, or network connection failed. 
     6.  **Logging Options**  : Select logging options for the cluster. 
-        1.  **Request Audit**  : This is an option to enable logging for Kubernetes API call history for the cluster, and the default is `On`. When this function is switched to `Off`, 
+        1.  **Request Audit**  : This is an option to enable logging for Kubernetes API call history for the cluster, and the default is `On`. When this function is switched to `Off`,
             1. Kubernetes API call history for the cluster will not be recorded. 
             2. All Request Audit Types and Pod Session Recording below are bulk deactivated. 
         2.  **Request Audit Types**  : Administrators can select the target Verb to audit for the cluster. The default selects all of the following basic verbs. 
@@ -47,8 +47,8 @@ To manually register individual servers, you need to enter basic server informat
                 7. `delete`
                 8. `deletecollection`
             2. ✅ Select All : Audits all API calls. 
-        3.  **Pod Session Recording**  : This is an option to enable recording for sessions opened by Pod exec commands within the cluster, and the default is `On`. This function is switched to `Off` if the following conditions are not met: 
-            1. Request Audit must be enabled to `On`. 
+        3.  **Pod Session Recording**  : This is an option to enable recording for sessions opened by Pod exec commands within the cluster, and the default is `On`. This function is switched to `Off` if the following conditions are not met:
+            1. Request Audit must be enabled to `On`.
             2. The following verbs must be selected in Request Audit Types:
                 1. `create`
                 2. `get`
@@ -67,7 +67,7 @@ To manually register individual servers, you need to enter basic server informat
 </figure>
 
 * Administrators must be able to access the target Kubernetes cluster in advance.
-* Administrators can download the script by clicking the "download and run this script" link in the Credential information box at Administrator &gt; Kubernetes &gt; Connection Management &gt; Clusters &gt; Create Cluster. 
+* Administrators can download the script by clicking the "download and run this script" link in the Credential information box at Administrator &gt; Kubernetes &gt; Connection Management &gt; Clusters &gt; Create Cluster.
 <details>
 <summary>generate_kubepie_sa.sh script content </summary>
 ```

--- a/src/content/en/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-action-configuration-reference-guide.mdx
+++ b/src/content/en/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-action-configuration-reference-guide.mdx
@@ -9,9 +9,11 @@ title: 'Kubernetes Policy Action Configuration Reference Guide'
 In QueryPie KAC, you configure access control policies for k8s using YAML-based policies.
 This guide explains how to set Actions to avoid difficulties using client tools such as kubectl, Lens, and k9s due to misconfigured policies.
 
+
 ### Guide for API Groups settings
 
 Commonly used resources like pods belong to the core group and thus use an empty string ("") for apiGroups, whereas deployments and replicasets belong to "apps", and ingresses belong to "networking.k8s.io".
+
 It is burdensome for administrators to know and set each value one by one.
 
 While you may need to separate by apiGroups if there are resources with the same name, that is not common.
@@ -60,6 +62,7 @@ allow:
       verbs: ["get", "list", "watch"]
       ```
 
+
 ### Guide for Verbs settings
 
 The part that most affects 3rd-party client tool usage is verbs.
@@ -107,6 +110,7 @@ allow:
       name: "*"
       verbs: ["get", "list", "delete", "deletecollection"]
       ```
+
 
 ### Other recommended configuration examples
 

--- a/src/content/en/administrator-manual/servers/connection-management/proxyjump-configurations/creating-proxyjump.mdx
+++ b/src/content/en/administrator-manual/servers/connection-management/proxyjump-configurations/creating-proxyjump.mdx
@@ -8,7 +8,9 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-Through ProxyJump settings, you can connect to servers in other Network Zones or apply QueryPie's access control to servers with overlapping CIDR. QueryPie must be able to connect to Jump Hosts. Proxyjump for Windows Servers is also supported.
+Through ProxyJump settings, you can connect to servers in other Network Zones or apply QueryPie's access control to servers with overlapping CIDR.
+QueryPie must be able to connect to Jump Hosts.
+Proxyjump for Windows Servers is also supported.
 
 
 ### Creating ProxyJump

--- a/src/content/en/administrator-manual/servers/connection-management/server-agents-for-rdp.mdx
+++ b/src/content/en/administrator-manual/servers/connection-management/server-agents-for-rdp.mdx
@@ -8,7 +8,9 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-QueryPie can perform access control and permission management for Windows Servers. To connect remotely through RDP Protocol, you must install Server Agent on the Windows Server you want to manage. You can also check RDP sessions in real-time and force terminate connected RDP sessions through the Kill Session feature.
+QueryPie can perform access control and permission management for Windows Servers.
+To connect remotely through RDP Protocol, you must install Server Agent on the Windows Server you want to manage.
+You can also check RDP sessions in real-time and force terminate connected RDP sessions through the Kill Session feature.
 
 <Callout type="info">
 * Windows Server Agent only supports Windows Server 2012 and above.
@@ -75,7 +77,8 @@ In this case, it can be resolved as follows.
 
 ### Updating Server Agents
 
-You can directly update Server Agents to the latest version from the QueryPie web screen. Updates proceed to agent versions compatible with the currently used QueryPie version.
+You can directly update Server Agents to the latest version from the QueryPie web screen.
+Updates proceed to agent versions compatible with the currently used QueryPie version.
 
 1. Navigate to Administrator &gt; Servers &gt; Connection Management &gt; Server Agents for RDP menu.
 2. Select the checkbox on the left of the target server to update in the table.

--- a/src/content/en/administrator-manual/servers/connection-management/server-agents-for-rdp/installing-and-removing-server-agent.mdx
+++ b/src/content/en/administrator-manual/servers/connection-management/server-agents-for-rdp/installing-and-removing-server-agent.mdx
@@ -8,7 +8,8 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-To connect remotely to Windows Server, you must install QueryPie Server Agent. After installing QueryPie Server Agent, Windows Servers are automatically added to the Servers menu in QueryPie.
+To connect remotely to Windows Server, you must install QueryPie Server Agent.
+After installing QueryPie Server Agent, Windows Servers are automatically added to the Servers menu in QueryPie.
 
 
 ### Installing Server Agent
@@ -21,7 +22,9 @@ To connect remotely to Windows Server, you must install QueryPie Server Agent. A
     * You can access the Server Agent download page by adding `/for-agent/server-agent/download` after the installed QueryPie domain address.<br/>e.g. `https://sac.querypie.io/for-agent/server-agent/download`
 
 <Callout type="info">
-In 11.3.0, administrators can also download server agents through the UI (the `Download Server Agent` button on the Admin &gt; Servers &gt; Connection Management &gt; RDP Server Agent page). You can still download using the existing download link page. (Use this when non-QueryPie users need to download agents externally)
+In 11.3.0, administrators can also download server agents through the UI (the `Download Server Agent` button on the Admin &gt; Servers &gt; Connection Management &gt; RDP Server Agent page).
+You can still download using the existing download link page.
+(Use this when non-QueryPie users need to download agents externally)
 <figure data-layout="center" data-align="center">
 ![RDP Server Agent Download Button Provided](/administrator-manual/servers/connection-management/server-agents-for-rdp/installing-and-removing-server-agent/image-20251010-085601.png)
 <figcaption>

--- a/src/content/en/administrator-manual/servers/connection-management/server-groups.mdx
+++ b/src/content/en/administrator-manual/servers/connection-management/server-groups.mdx
@@ -6,7 +6,8 @@ title: 'Server Groups'
 
 ### Overview
 
-QueryPie can set policies and grant access permissions by Server Group unit. You can also select servers in bulk through server tags, or have servers synchronized later automatically selected in server groups.
+QueryPie can set policies and grant access permissions by Server Group unit.
+You can also select servers in bulk through server tags, or have servers synchronized later automatically selected in server groups.
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Servers &gt; Connection Management &gt; Server Groups](/administrator-manual/servers/connection-management/server-groups/image-20240902-045633.png)

--- a/src/content/en/administrator-manual/servers/connection-management/server-groups/managing-servers-as-groups.mdx
+++ b/src/content/en/administrator-manual/servers/connection-management/server-groups/managing-servers-as-groups.mdx
@@ -8,12 +8,11 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-You can group numerous servers and apply accessible accounts and policies at once. You can create server groups according to purpose and conveniently manage policies in bulk, and grant grouped server group permissions to individual users or user groups at once.
+You can group numerous servers and apply accessible accounts and policies at once.
+You can create server groups according to purpose and conveniently manage policies in bulk, and grant grouped server group permissions to individual users or user groups at once.
 
 <Callout type="info">
 We recommend registering each resource required for server group registration in advance.
-1. Administrator &gt; Servers &gt; Server Account Management &gt;  **Server Account Templates** 
-2. Administrator &gt; Servers &gt; Server Account Management &gt;  **SSH Key Configurations** 
 </Callout>
 
 
@@ -42,7 +41,8 @@ Server groups can manage servers based on Tags. By specifying specific Tags in t
 
 ### Creating/Modifying Server Groups
 
-You can create server groups by entering the information below. Some items can be modified after creation.
+You can create server groups by entering the information below.
+Some items can be modified after creation.
 
 #### 1. Entering Basic Information and Adding Servers by Tag
 


### PR DESCRIPTION
## 📋 작업 내용

영어 번역문서와 한국어 원문 간의 구조적 불일치를 수정했습니다.

### 수정 사항

#### 주요 수정 내용
- **줄바꿈 일치**: 한국어 원문과 영어 번역문의 줄바꿈을 일치시킴
- **빈 줄 추가**: 섹션 사이에 빈 줄 추가하여 한국어 원문과 동일한 구조 유지
- **문장 구조 개선**: 한 줄에 여러 문장이 있던 부분을 각 문장별로 줄 분리
- **Callout 내부 텍스트**: Callout 컴포넌트 내부의 텍스트 줄바꿈 수정

### 수정된 파일 (총 10개)

#### Kubernetes 관련 (5개)
1. `cloud-providers.mdx`
   - 섹션 사이 빈 줄 3곳 추가

2. `synchronizing-kubernetes-resources-from-aws.mdx`
   - 사전 준비사항 문단 줄바꿈 수정
   - 섹션 사이 빈 줄 5곳 추가
   - Callout 내부 텍스트 줄바꿈 개선

3. `clusters.mdx`
   - 섹션 사이 빈 줄 3곳 추가
   - 문장 순서 조정

4. `manually-registering-kubernetes-clusters.mdx`
   - 문장 끝 줄바꿈 3곳 수정

5. `kubernetes-policy-action-configuration-reference-guide.mdx`
   - 문단 줄바꿈 추가로 가독성 향상
   - 섹션 사이 빈 줄 3곳 추가

#### Servers 관련 (5개)
6. `creating-proxyjump.mdx`
   - Overview 섹션 문단 줄바꿈 수정

7. `server-agents-for-rdp.mdx`
   - Overview 섹션 문단 줄바꿈 수정
   - 여러 섹션 문단 줄바꿈 개선

8. `installing-and-removing-server-agent.mdx`
   - Overview 섹션 문단 줄바꿈 수정
   - Callout 내부 텍스트 줄바꿈 수정

9. `server-groups.mdx`
   - Overview 섹션 문단 줄바꿈 수정

10. `managing-servers-as-groups.mdx`
    - Overview 섹션 문단 줄바꿈 수정
    - Callout 내용 간소화
    - 섹션 문단 줄바꿈 개선

### 검증 방법

각 파일에 대해 skeleton 비교를 통해 한국어 원문과의 구조적 일치를 확인했습니다:
```bash
cd confluence-mdx
bin/mdx_to_skeleton.py target/en/<파일경로>
```

### 기타 참고사항
- inline code 위치가 다른 경우: 자연스러운 영어 어순을 우선하여 수정하지 않음
- 번역 내용 자체는 변경하지 않고 구조적 일치만 개선