### PR TITLE
mdx: 영어 문서 불일치 재수정 03

### DIFF
--- a/src/content/en/administrator-manual/general/company-management/allowed-zones.mdx
+++ b/src/content/en/administrator-manual/general/company-management/allowed-zones.mdx
@@ -16,7 +16,8 @@ From 11.3.0, the expression has been changed from “IP Band(s)” to “IP Addr
 
 ### Viewing Registered Allowed Zone List
 
-To view the Allowed Zone list, access the Administrator &gt; General &gt; Company Management &gt; Allowed Zones page. You can search by Allowed Zone name.
+To view the Allowed Zone list, access the Administrator &gt; General &gt; Company Management &gt; Allowed Zones page.
+You can search by Allowed Zone name.
 
 <Callout type="info">
 **Default** Allowed Zone is created by default during QueryPie installation and has an allow-all (0.0.0.0/0) value.
@@ -55,7 +56,7 @@ In the Mapped List by Allowed Zones area within the drawer, you can check DB con
 
 ### Adding Allowed Zones
 
-`Create Allowed Zone` Click the button on the Allowed Zone list page to display the Allowed Zone input fields.
+Click the `Create Allowed Zone` button on the Allowed Zone list page to display the Allowed Zone input fields.
 
 <figure data-layout="center" data-align="center">
 ![Input fields displayed when creating Allowed Zone](/administrator-manual/general/company-management/allowed-zones/image-20251009-031536.png)
@@ -74,7 +75,8 @@ Input fields displayed when creating Allowed Zone
 
 ### Deleting Allowed Zones
 
-Select the Allowed Zone you want to delete with a checkbox in the Allowed Zone list, and the `Delete` button will appear. Click the button and then click the `Delete` button in the confirmation modal to complete the deletion.
+Select the Allowed Zone you want to delete with a checkbox in the Allowed Zone list, and the `Delete` button will appear.
+Click the button and then click the `Delete` button in the confirmation modal to complete the deletion.
 
 <figure data-layout="center" data-align="center">
 ![Delete Option Activated](/administrator-manual/general/company-management/allowed-zones/screenshot-20240730-220112.png)
@@ -82,3 +84,5 @@ Select the Allowed Zone you want to delete with a checkbox in the Allowed Zone l
 Delete Option Activated
 </figcaption>
 </figure>
+
+


### PR DESCRIPTION
## 개요
영어 번역 문서와 한국어 원문 간의 구조적 불일치를 수정하는 작업입니다.

## 검증 방법
`todo-en.03.txt` 파일에 나열된 20개의 영어 번역 문서를 `mdx_to_skeleton.py` 스크립트로 검증하였습니다.

## 작업 내역

### 수정된 파일 (1개)
- `src/content/en/administrator-manual/general/company-management/allowed-zones.mdx`

### 변경 사항
1. **줄바꿈 일치**: 한국어 원문의 줄바꿈 구조에 맞춰 영어 번역문 수정
   - "Viewing Registered Allowed Zone List" 섹션: 두 문장을 별도 줄로 분리
   - "Deleting Allowed Zones" 섹션: 두 문장을 별도 줄로 분리
   
2. **문장 순서 수정**: "Adding Allowed Zones" 섹션에서 버튼 이름 위치 조정
   - 변경 전: `` `Create Allowed Zone` Click the button...``
   - 변경 후: ``Click the `Create Allowed Zone` button...``

3. **파일 끝 공백**: 파일 끝에 빈 줄 2개 추가 (한국어 원문과 일치)

### 검증 결과
- 검사 대상: 20개 파일
- 수정 완료: 1개 파일
- 이미 일치: 19개 파일
- **모든 파일이 skeleton 비교 통과** ✅

### 검증 명령
```bash
cd confluence-mdx
bin/mdx_to_skeleton.py ../src/content/en/administrator-manual/general/company-management/allowed-zones.mdx
```

## 체크리스트
- [x] 한국어 원문과 영어 번역문의 줄바꿈 일치 확인
- [x] skeleton 비교로 구조 일치 검증
- [x] 자연스러운 영어 표현 유지
- [x] 모든 대상 파일 검증 완료