### PR TITLE
mdx_to_skeleton: 개별 파일 비교 시 ignore 패턴 사용 옵션 추가

### DIFF
--- a/confluence-mdx/bin/mdx_to_skeleton.py
+++ b/confluence-mdx/bin/mdx_to_skeleton.py
@@ -947,13 +947,27 @@ def main():
         metavar='FILE',
         help='Output file path to save list of unmatched files (only used with --recursive option). Each line contains a path with target/{lang} prefix.'
     )
+    parser.add_argument(
+        '--use-ignore',
+        action='store_true',
+        help='Use ignore_skeleton_diff.yaml patterns when comparing files (only applies to single file mode).'
+    )
+    parser.add_argument(
+        '--ignore-file',
+        type=Path,
+        metavar='FILE',
+        help='Path to ignore_skeleton_diff.yaml file. If not specified, uses default location (same directory as script).'
+    )
 
     args = parser.parse_args()
 
-    # Initialize config if recursive mode is used
-    if args.recursive is not None:
+    # Initialize config if recursive mode is used or if --use-ignore is specified
+    if args.recursive is not None or args.use_ignore:
         exclude_patterns = args.exclude if args.exclude and len(args.exclude) > 0 else ['/index.skel.mdx']
-        initialize_config(args.max_diff, exclude_patterns)
+        # For single file mode, max_diff is not applicable, so use None
+        max_diff_for_config = args.max_diff if args.recursive is not None else None
+        ignore_file_path = args.ignore_file if args.ignore_file else None
+        initialize_config(max_diff_for_config, exclude_patterns, ignore_file_path)
 
     try:
         if args.compare:
@@ -983,7 +997,6 @@ def main():
                 return 1
 
             output_path, _, _ = convert_mdx_to_skeleton(args.input_path)
-            print(f"Successfully created: {output_path}")
             return 0
         else:
             # No arguments provided

--- a/confluence-mdx/bin/review-skeleton-diff.sh
+++ b/confluence-mdx/bin/review-skeleton-diff.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Review skeleton diff for files listed in todo file
+
+set -e
+
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <todo-file>"
+    exit 1
+fi
+
+TODO_FILE="$1"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFLUENCE_MDX_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$CONFLUENCE_MDX_DIR"
+
+# Process each file
+while IFS= read -r file || [ -n "$file" ]; do
+    echo "=========================================="
+    echo "Processing: $file"
+    echo "=========================================="
+    echo ""
+    
+    # Step 1: Run without --use-ignore
+    echo "--- Step 1: mdx_to_skeleton.py (without --use-ignore) ---"
+    bin/mdx_to_skeleton.py "$file" 2>&1
+    echo ""
+    
+    # Step 2: Run with --use-ignore
+    echo "--- Step 2: mdx_to_skeleton.py (with --use-ignore) ---"
+    bin/mdx_to_skeleton.py --use-ignore "$file" 2>&1
+    echo ""
+    
+    # Ask for user confirmation
+    read -p "Continue to next file? (yes/no/quit): " answer < /dev/tty
+    case "$answer" in
+        [Yy]es|[Yy])
+            echo ""
+            ;;
+        *)
+            exit 0
+            ;;
+    esac
+    
+done < "$TODO_FILE"
+
+echo "Review completed for all files!"

--- a/confluence-mdx/bin/skeleton_diff.py
+++ b/confluence-mdx/bin/skeleton_diff.py
@@ -548,12 +548,12 @@ def process_directories_recursive(directories: List[Path], convert_func) -> Tupl
     return 0, all_unmatched_file_paths
 
 
-def initialize_config(max_diff: int, exclude_patterns: List[str], ignore_file_path: Optional[Path] = None):
+def initialize_config(max_diff: Optional[int], exclude_patterns: List[str], ignore_file_path: Optional[Path] = None):
     """
     Initialize global configuration for recursive processing.
     
     Args:
-        max_diff: Maximum number of diffs to output before stopping
+        max_diff: Maximum number of diffs to output before stopping (None for single file mode)
         exclude_patterns: List of paths to exclude from diff comparison
         ignore_file_path: Path to ignore_skeleton_diff.yaml file. If None, uses default location.
     """


### PR DESCRIPTION
## Description
- `mdx_to_skeleton.py`에 `--use-ignore` 옵션 추가
  - 개별 파일 비교 모드에서 `ignore_skeleton_diff.yaml` 패턴 사용 여부를 선택 가능
  - 기본값은 사용하지 않음 (기존 동작 유지)
- `--ignore-file` 옵션 추가
  - 기본 `ignore_skeleton_diff.yaml` 대신 사용할 ignore 파일 경로 지정 가능
- `skeleton_diff.py`의 `initialize_config()` 함수 수정
  - `max_diff` 파라미터를 `Optional[int]`로 변경하여 개별 파일 모드에서도 호출 가능하도록 수정
- 개별 파일 모드에서 성공 메시지 로깅 제거
  - "Successfully created: ..." 메시지 제거
  - 실패한 경우에만 에러 로그 출력
- `review-skeleton-diff.sh`:
  - `mdx_to_skeleton.py`에 `--use-ignore` 옵션 적용 여부를 비교하여, ignore_skeleton_diff.yaml 를 리뷰하기 위한 스크립트 구현

