### PR TITLE
mdx_to_skeleton: Skeleton MDX 변환 기능의 버그 수정

### DIFF
--- a/confluence-mdx/bin/mdx_to_skeleton.py
+++ b/confluence-mdx/bin/mdx_to_skeleton.py
@@ -877,7 +877,8 @@ def convert_mdx_to_skeleton(input_path: Path) -> Tuple[Path, Optional[str], Opti
     content = re.sub(r'(_TEXT_)(&[a-zA-Z]+;|&#\d+;|&#x[0-9a-fA-F]+;)', r'\1 \2', content)
     
     # Remove trailing spaces after HTML tags at end of lines
-    content = re.sub(r'(<br/?>|/>)\s+\n', r'\1\n', content)
+    # Note: Use [ \t]+ instead of \s+ to avoid matching newlines, which would remove blank lines
+    content = re.sub(r'(<br/?>|/>)[ \t]+\n', r'\1\n', content)
     # Remove trailing spaces after HTML tags before newlines (but preserve spaces before other content)
     lines = content.split('\n')
     processed_final_lines = []

--- a/confluence-mdx/tests/testcases/544379140/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544379140/expected.skel.mdx
@@ -116,6 +116,7 @@ _TEXT_
 **_TEXT_**
 
 _TEXT_ <br/>
+
 _TEXT_
 
 - _TEXT_


### PR DESCRIPTION
## Description
- HTML tag 이후 공백 처리 과정에서 빈 줄이 사라지는 버그가 있었습니다.
  - 이로 인해, Skeleton MDX 의 줄번호와 원문 MDX 줄번호가 불일치하는 문제가 발생하였습니다.
- Regular expression 을 개선하여, 빈 줄이 사라지지 않도록 수정합니다.

## Additional notes
- 
