### PR TITLE
fix: Update github repository url

### DIFF
--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -73,7 +73,7 @@ export default async function RootLayout({ children, params }) {
           pageMap={pageMap}
           navbar={navbar}
           footer={<Footer>{new Date().getFullYear()} &copy; QueryPie, Inc.</Footer>}
-          docsRepositoryBase="https://github.com/chequer-io/querypie-docs/blob/main"
+          docsRepositoryBase="https://github.com/querypie/querypie-docs/blob/main"
           editLink="Edit this page on GitHub"
           feedback={{
             content: 'Question? Give us feedback',


### PR DESCRIPTION
## Description
- Fix the github url as https://github.com/querypie/querypie-docs .
- 웹사이트의 오른쪽 Table of Contents 영역의 하단에 보이는 질문 남기기, GitHub 링크로 이동하기, 부분의 url 을 수정합니다.

## Additional notes
- 
