### PR TITLE
mdx: 영어 문서 불일치 재수정 06

### DIFF
--- a/src/content/en/administrator-manual/servers/server-access-control.mdx
+++ b/src/content/en/administrator-manual/servers/server-access-control.mdx
@@ -6,7 +6,9 @@ title: 'Server Access Control'
 
 ### Overview
 
-This document provides a guide for effectively managing server access permissions in QueryPie. It provides methods to repeatedly grant pre-defined access permissions through RBAC, and also provides functionality to grant access permissions to individual servers through Direct Permission. It also provides prohibited command template functionality and allows you to activate locked server accounts in QueryPie.
+This document provides a guide for effectively managing server access permissions in QueryPie.
+It provides methods to repeatedly grant pre-defined access permissions through RBAC, and also provides functionality to grant access permissions to individual servers through Direct Permission.
+It also provides prohibited command template functionality and allows you to activate locked server accounts in QueryPie.
 
 
 ### Server Access Permission Management Guide Quick Links

--- a/src/content/en/administrator-manual/servers/server-access-control/access-control.mdx
+++ b/src/content/en/administrator-manual/servers/server-access-control/access-control.mdx
@@ -6,7 +6,8 @@ title: 'Access Control'
 
 ### Overview
 
-Supports granting and revoking management of access permissions to servers managed by the organization for QueryPie users and groups. Access Control represents the final step for granting and applying server access permissions.
+Supports granting and revoking management of access permissions to servers managed by the organization for QueryPie users and groups.
+Access Control represents the final step for granting and applying server access permissions.
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; Servers &gt; Server Access Control &gt; Access Control](/administrator-manual/servers/server-access-control/access-control/image-20240902-051205.png)

--- a/src/content/en/administrator-manual/servers/server-access-control/policies/enabling-server-proxy.mdx
+++ b/src/content/en/administrator-manual/servers/server-access-control/policies/enabling-server-proxy.mdx
@@ -11,9 +11,12 @@ By default, you can connect to servers via the web Terminal provided by QueryPie
 With proxy connections alongside the web Terminal, you can control server access, apply policies, and retain logs reliably across diverse user environments.
 Currently supported proxy clients include (Mac) iTerm2, Terminal, and (Windows) Windows Console Host, Windows Terminal, and PuTTY.
 
+
 ### Enable the Proxy option
 
 To allow server access through the proxy, you must first create a policy with Proxy Usage enabled.
 For how to create a policy and enable Proxy Usage, refer to the document below.
 
-* [Setting server access policy](setting-server-access-policy)
+* [Setting server access policy](setting-server-access-policy) 
+
+


### PR DESCRIPTION
## 개요
영어 번역문과 한국어 원문 간의 skeleton 구조 불일치를 수정했습니다.

## 변경사항
todo-en.06.txt 파일에 나열된 20개 파일 중 불일치가 발견된 3개 파일을 수정했습니다.

### 수정된 파일
1. **src/content/en/administrator-manual/servers/server-access-control.mdx**
   - Overview 섹션의 줄바꿈 수정
   - 한국어 원문: 3개 문장으로 분리
   - 수정 전: 1개의 긴 문장
   - 수정 후: 3개 문장으로 분리하여 한국어 원문과 동일한 구조로 변경

2. **src/content/en/administrator-manual/servers/server-access-control/access-control.mdx**
   - Overview 섹션의 줄바꿈 수정
   - 한국어 원문: 2개 문장으로 분리
   - 수정 전: 1개의 긴 문장
   - 수정 후: 2개 문장으로 분리하여 한국어 원문과 동일한 구조로 변경

3. **src/content/en/administrator-manual/servers/server-access-control/policies/enabling-server-proxy.mdx**
   - 빈 줄 형식 수정
   - "### Enable the Proxy option" 앞에 빈 줄 추가 (1개 → 2개)
   - 마지막 링크 뒤에 빈 줄 추가 (0개 → 2개)
   - 한국어 원문과 동일한 빈 줄 형식으로 변경

## 검증 결과
- `bin/review-skeleton-diff.sh --yes ../docs/todo-en.06.txt` 실행 결과: ✅ 모든 파일이 skeleton 비교를 통과
- 20개 파일 모두 한국어 원문과 skeleton 구조가 일치함을 확인

## 체크리스트
- [x] 한국어 원문과 영어 번역문의 줄바꿈 구조 일치 확인
- [x] skeleton 비교 도구로 검증 완료
- [x] 번역 품질 및 의미 보존 확인
- [x] 마크다운 문법 오류 없음 확인