### PR TITLE
mdx: 영어 문서 불일치 재수정 09

### DIFF
--- a/src/content/en/user-manual/user-agent.mdx
+++ b/src/content/en/user-manual/user-agent.mdx
@@ -243,7 +243,7 @@ Agent &gt; Settings &gt; Configure Kubeconfig Path
 </figure>
 
 *  **Path Configuration**  : You can specify the storage path for the Kubeconfig file.
-    * The default value is `${HOME}/.kube/querypie-kubeconfig` setting.
+    * The default value is `$HOME/.kube/querypie-kubeconfig`.
     * Click the `Upload` button on the right of the path field to display a popup where you can specify a local file path. 
 
 
@@ -270,8 +270,8 @@ export KUBECONFIG="${KUBECONFIG}:<user-specified-path>"
 
 3) For more detailed information about kubeconfig, please refer to the following links.
 
-* Reference: [kubeconfig file merging](https://kubernetes.io/ko/docs/concepts/configuration/organize-cluster-access-kubeconfig/#kubeconfig-%ED%8C%8C%EC%9D%BC-%EB%B3%91%ED%95%A9)
-* Reference: [KUBECONFIG environment variable setting](https://kubernetes.io/ko/docs/tasks/access-application-cluster/configure-access-multiple-clusters/#kubeconfig-%ED%99%98%EA%B2%BD-%EB%B3%80%EC%88%98-%EC%84%A4%EC%A0%95)
+* Reference: [Organizing Cluster Access Using kubeconfig Files](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/)
+* Reference: [Configure Access to Multiple Clusters](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)
 
 4) `Copy` the command line to copy it, declare it in the client, and you can switch the context to an accessible cluster.
 ```

--- a/src/content/en/user-manual/workflow/requesting-access-role.mdx
+++ b/src/content/en/user-manual/workflow/requesting-access-role.mdx
@@ -59,7 +59,7 @@ Roles are granted immediately upon approval, and you can access servers or Kuber
 
 <Callout type="important">
 **Q. I can't see the Urgent Mode switch.**
-A. If you select an approval rule where the administrator has not allowed Urgent Mode, this feature will not be displayed as such.
+A. If you select an approval rule where the administrator has not allowed Urgent Mode, this feature will not be displayed.
 </Callout>
 
 #### 5. Selecting Target Role


### PR DESCRIPTION
## 변경 사항 요약

영어 번역 문서의 불일치 및 오류를 수정했습니다.

## 수정된 파일 목록

### 1. `src/content/en/user-manual/user-agent.mdx`
- **수정 내용:**
  - `${HOME}` 변수 형식을 `$HOME`으로 통일하여 일관성 개선
  - Kubernetes 문서 링크를 한국어에서 영어 버전으로 변경
    - `https://kubernetes.io/ko/docs/...` → `https://kubernetes.io/docs/...`
  - "setting" 불필요한 단어 제거

### 2. `src/content/en/user-manual/workflow/requesting-access-role.mdx`
- **수정 내용:**
  - Urgent Mode 설명 문구 개선
  - "as such" 불필요한 표현 제거하여 명확성 향상

## 검증 결과

### 파일 검증 완료
- ✅ 14개 영어 문서 모두 검토 완료
- ✅ 한국어 문자 누락 없음
- ✅ 번역 품질 검증 완료
- ✅ 구조적 일관성 확인

### 수정 대상 파일 목록
총 14개 파일 중 2개 파일만 수정 필요:
- `user-manual/user-agent.mdx` ✓ 수정 완료
- `user-manual/workflow/requesting-access-role.mdx` ✓ 수정 완료

나머지 12개 파일은 이미 올바르게 번역되어 있어 수정 불필요:
- `user-manual/workflow.mdx`
- `user-manual/workflow/approval-additional-features-proxy-approval-resubmission-etc.mdx`
- `user-manual/workflow/requesting-db-access.mdx`
- `user-manual/workflow/requesting-db-policy-exception.mdx`
- `user-manual/workflow/requesting-ip-registration.mdx`
- `user-manual/workflow/requesting-restricted-data-access.mdx`
- `user-manual/workflow/requesting-server-access.mdx`
- `user-manual/workflow/requesting-server-privilege.mdx`
- `user-manual/workflow/requesting-sql-export.mdx`
- `user-manual/workflow/requesting-sql.mdx`
- `user-manual/workflow/requesting-sql/using-execution-plan-explain-feature.mdx`
- `user-manual/workflow/requesting-unmasking-mask-removal-request.mdx`

## 체크리스트
- [x] 한국어 원문과의 구조적 일관성 확인
- [x] 번역 톤 및 용어 일관성 검증
- [x] 마크다운/MDX 문법 오류 확인
- [x] 한국어 문자 누락 확인
- [x] 링크 및 참조 검증