### PR TITLE
mdx: 영어 문서 불일치 재수정 04

### DIFF
--- a/src/content/en/administrator-manual/general/user-management/provisioning/okta-provisioning-integration-guide.mdx
+++ b/src/content/en/administrator-manual/general/user-management/provisioning/okta-provisioning-integration-guide.mdx
@@ -22,7 +22,7 @@ Since QueryPie's SCIM functionality is built based on RFC 7643 to comply with th
             * Edit groups' application assignments
         * Application
             * Manage applications
-* Refer to the [Okta IP range allowlist](https://s3.amazonaws.com/okta-ip-ranges/ip_ranges.json) on the [https://help.okta.com/en-us/content/topics/security/ip-address-allow-listing.htm](https://help.okta.com/en-us/content/topics/security/ip-address-allow-listing.htm) page to identify the IP ranges for your tenant and allow inbound traffic exceptions in advance.
+* Refer to the [https://help.okta.com/en-us/content/topics/security/ip-address-allow-listing.htm](https://help.okta.com/en-us/content/topics/security/ip-address-allow-listing.htm) page for the [Okta IP range allowlist](https://s3.amazonaws.com/okta-ip-ranges/ip_ranges.json) to identify the IP ranges for your tenant and allow inbound traffic exceptions in advance.
 * QueryPie must be installed with a license.
 * You need an account with Owner/Application Admin Role permissions in QueryPie.
 * You must complete the [Activating Provisioning](activating-provisioning) step first.

--- a/src/content/en/administrator-manual/general/user-management/roles.mdx
+++ b/src/content/en/administrator-manual/general/user-management/roles.mdx
@@ -73,7 +73,9 @@ The Detail tab displays the list of policies assigned to the administrator role 
 
 ### Removing Policies from Administrator Roles
 
-Enter the detail page of the administrator role you want to remove policies from in the Roles list. Select the policy you want to remove with a checkbox in the policy list in the Detail tab, then click the `Delete` button. Click the `OK` button in the confirmation modal to complete policy removal.
+Enter the detail page of the administrator role you want to remove policies from in the Roles list.
+Select the policy you want to remove with a checkbox in the policy list in the Detail tab, then click the `Delete` button.
+Click the `OK` button in the confirmation modal to complete policy removal.
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; General &gt; User Management &gt; Roles &gt; List Details](/administrator-manual/general/user-management/roles/screenshot-20240726-132233.png)
@@ -100,7 +102,8 @@ Role Modification Modal
 Two methods are provided for deleting administrator roles that are no longer used.
 
 <Callout type="important">
-When an administrator role is deleted, that role is immediately revoked from users who had previously been assigned that role. Administrator role deletion cannot be undone, so please execute carefully.
+When an administrator role is deleted, that role is immediately revoked from users who had previously been assigned that role.
+Administrator role deletion cannot be undone, so please execute carefully.
 <figure data-layout="center" data-align="center">
 ![screenshot-20240726-132448.png](/administrator-manual/general/user-management/roles/screenshot-20240726-132448.png)
 </figure>
@@ -108,7 +111,8 @@ When an administrator role is deleted, that role is immediately revoked from use
 
 #### Deleting from Administrator Role List
 
-Select the role you want to delete with a checkbox in the Roles list, then click the `Delete` button displayed in the table header. In the confirmation modal, correctly enter the deletion confirmation phrase "DELETE" and click the `Delete` button to complete administrator role deletion.
+Select the role you want to delete with a checkbox in the Roles list, then click the `Delete` button displayed in the table header.
+In the confirmation modal, correctly enter the deletion confirmation phrase "DELETE" and click the `Delete` button to complete administrator role deletion.
 
 <figure data-layout="center" data-align="center">
 ![Administrator &gt; General &gt; User Management &gt; Roles](/administrator-manual/general/user-management/roles/screenshot-20240726-132801.png)

--- a/src/content/en/administrator-manual/general/user-management/users.mdx
+++ b/src/content/en/administrator-manual/general/user-management/users.mdx
@@ -122,7 +122,6 @@ Administrator &gt; General &gt; User Management &gt; Users &gt; List Details
 </figcaption>
 </figure>
 
-
 <Callout type="info">
 Only users registered through QueryPie can modify Profile information and delete users, and users integrated through SCIM must reflect modifications through ledger data updates.
 </Callout>

--- a/src/content/en/administrator-manual/general/user-management/users/user-profile.mdx
+++ b/src/content/en/administrator-manual/general/user-management/users/user-profile.mdx
@@ -125,6 +125,7 @@ A. The Tags tab allows you to view and manage Tags assigned to individual users,
 It is planned for support in future versions.
 </Callout>
 
+
 ### Reference: User Attribute List
 
 |  **Attribute Name**           |  **Variable**           |  **Description**                       |  **Notes**  |

--- a/src/content/en/administrator-manual/general/workflow-management.mdx
+++ b/src/content/en/administrator-manual/general/workflow-management.mdx
@@ -20,8 +20,7 @@ You can also configure approval settings for the entire workflow.
 
 #### Slack DM Notification Settings
 
-You can receive step-by-step content of requests through Slack DM and process them directly.
-For Slack integration methods to send Slack DM notifications, refer to the [Slack DM Integration](system/integrations/integrating-with-slack-dm) document.
+You can receive step-by-step content of requests through Slack DM and process them directly. For Slack integration methods to send Slack DM notifications, refer to the [Slack DM Integration](system/integrations/integrating-with-slack-dm) document.
 
 
 <Callout type="info">

--- a/src/content/en/administrator-manual/kubernetes.mdx
+++ b/src/content/en/administrator-manual/kubernetes.mdx
@@ -14,6 +14,8 @@ import { Callout } from 'nextra/components'
 
 QueryPie KAC is a Kubernetes API protection solution for centrally managing cloud infrastructure such as AWS EKS and other on-premises Kubernetes clusters.
 With KAC, administrators can perform granular control over user Kubernetes resource API access restrictions and management, as well as audit and monitor Kubernetes APIs requested by users.
+
+
 ### Recommended KAC Initial Setup Order
 
 For administrators new to QueryPie KAC (Kubernetes Access Controller), we recommend following the setup order below for smooth Kubernetes management.

--- a/src/content/en/administrator-manual/kubernetes/connection-management.mdx
+++ b/src/content/en/administrator-manual/kubernetes/connection-management.mdx
@@ -8,6 +8,8 @@ title: 'Connection Management'
 
 This document is a guide to help you effectively manage Kubernetes clusters in QueryPie.
 You can learn how to synchronize managed Kubernetes clusters from Cloud Providers at once through the cloud synchronization feature, and how to manually register on-premises Kubernetes clusters.
+
+
 ### Kubernetes Cluster Management Guide Quick Links
 
 (Unsupported xhtml node: &lt;ac:structured-macro name="children"&gt;)


### PR DESCRIPTION
## Description
- `cd confluence-mdx; bin/review-skeleton-diff.sh --yes ../docs/todo-en.04.txt` 에서 차이가 발생하지 않도록, 번역문을 수정하였습니다.

## Additional notes
@mdx_to_skeleton.py 를 활용하여, mdx 파일의 번역 오류, 줄바꿈 불일치, markdown syntax 불일치를 수정하여 주세요.
보완대상 영어파일 목록: docs/todo-en.04.txt 에 영어 번역문 파일이 20개 나열되어 있습니다.
  - 20개 파일을 모두 한번에 비교하려면, 다음의 명령을 실행합니다. `cd confluence-mdx; bin/review-skeleton-diff.sh --yes ../docs/todo-en.04.txt`
  - 한국어 원문과 영어 번역문의 차이를 하나의 mdx 파일에 대해 확인하려면,`cd confluence-mdx; source venv/bin/activate; bin/mdx_to_skeleton.py --use-ignore <path/to/en/mdx>` 로 알아냅니다.
    - 예) `cd confluence-mdx; source venv/bin/activate; bin/mdx_to_skeleton.py --use-ignore target/en/administrator-manual/audit/server-logs/session-logs.mdx`
  - 한국어 원문과 영어 번역문의 줄바꿈 차이가 발견되면, 영어 번역문을 수정하여, 줄바꿈이 동일하도록 수정합니다. 한국어 원문에서 한 줄에 한 문장씩 위치한 경우, 번역문에서도 한 줄에 한 문장씩 위치해야 합니다.
  - 줄바꿈이 동일한 경우, 영어와 한국어의 어순 차이에 의해, inline code 위치가 다른 것, **bold** 표시의 위치가 다른 것에 대해서는, 자연스러운 영어 번역 결과를 우선하도록 합니다. inline code 위치가 달라도 무방합니다. **bold** 표시 문구의 위치가 달라도 무방합니다.
  - 영어 번역이 적절하지 않거나, 영어 표현이 @translation.md  에 부합하지 않은 경우, 영어 번역을 다시 수행하여 주세요.

