### PR TITLE
mdx: 영어 문서 불일치 재수정 09

### DIFF
--- a/src/content/en/user-manual/user-agent.mdx
+++ b/src/content/en/user-manual/user-agent.mdx
@@ -273,7 +273,7 @@ export KUBECONFIG="${KUBECONFIG}:<user-specified-path>"
 * Reference: [Organizing Cluster Access Using kubeconfig Files](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/)
 * Reference: [Configure Access to Multiple Clusters](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)
 
-4) `Copy` the command line to copy it, declare it in the client, and you can switch the context to an accessible cluster.
+4) `Copy` the command line, declare it in the client, and you can switch the context to an accessible cluster.
 ```
 export KUBECONFIG="${KUBECONFIG}:${HOME}/.kube/querypie-kubeconfig"
 ```

--- a/src/content/en/user-manual/workflow.mdx
+++ b/src/content/en/user-manual/workflow.mdx
@@ -205,4 +205,3 @@ The approval status list for requests is as follows.
 </tr>
 </tbody>
 </table>
-

--- a/src/content/en/user-manual/workflow/approval-additional-features-proxy-approval-resubmission-etc.mdx
+++ b/src/content/en/user-manual/workflow/approval-additional-features-proxy-approval-resubmission-etc.mdx
@@ -128,5 +128,3 @@ At this time, you can see that already deleted data (approval rules, approvers, 
 2. Modify any values you want to change on the resubmission page.
 3. Click the `Save` button to save.
 4. You can check your request history and approval status in Workflow &gt; Sent Request &gt; In Progress menu.
-
-

--- a/src/content/en/user-manual/workflow/requesting-access-role.mdx
+++ b/src/content/en/user-manual/workflow/requesting-access-role.mdx
@@ -78,7 +78,8 @@ QueryPie Web &gt; Workflow &gt; Submit Request &gt; Access Role Request &gt; Ste
     2. **Kubernetes Access Control**: Accessible Kubernetes cluster names, platforms, API URLs
 
 <Callout type="important">
-Access Role Request can only request one role at a time. Since separate approval requests are required for each role, permission management can be strengthened.
+Access Role Request can only request one role at a time.
+Since separate approval requests are required for each role, permission management can be strengthened.
 </Callout>
 
 <figure data-layout="center" data-align="center">
@@ -101,5 +102,3 @@ QueryPie Web &gt; Workflow &gt; Submit Request &gt; Access Role Request &gt; Ste
 * **Title**: Enter the request title.
 * **Reason for Request**: Enter the reason for requesting access permission.
 * **Submit**: If you have completed all the requests, click the `Submit` button to complete the request submission.
-
-

--- a/src/content/en/user-manual/workflow/requesting-db-access.mdx
+++ b/src/content/en/user-manual/workflow/requesting-db-access.mdx
@@ -103,5 +103,3 @@ Bulk application through checkboxes and Apply button
     *  **Read-Only Permission**  : Permission to only SELECT.
     *  **Other Permissions**  : Permissions additionally created by administrators, and if no permissions are created, only the above two permissions are displayed. 
 * If you have completed specifying the approval rules and entering the request body, click the `Submit` button at the bottom of the page to submit the request.
-
-

--- a/src/content/en/user-manual/workflow/requesting-ip-registration.mdx
+++ b/src/content/en/user-manual/workflow/requesting-ip-registration.mdx
@@ -116,5 +116,3 @@ If the request is successfully submitted, a screen indicating that the request h
 A. To resolve this, we have provided a  **login page**  link on the IP blocking and registration request page.
 Clicking this link will allow you to access the login page normally.
 </Callout>
-
-

--- a/src/content/en/user-manual/workflow/requesting-server-access.mdx
+++ b/src/content/en/user-manual/workflow/requesting-server-access.mdx
@@ -121,5 +121,3 @@ For how to access servers with granted permissions, please refer to the [Connect
 Permissions granted through Direct Permission are applied when **Default Role** is selected in the server list.
 Access permission policies are subject to the default server access policies set at the time of Server Access Request application.
 </Callout>
-
-

--- a/src/content/en/user-manual/workflow/requesting-server-privilege.mdx
+++ b/src/content/en/user-manual/workflow/requesting-server-privilege.mdx
@@ -148,5 +148,3 @@ Therefore, the field for entering or selecting Commands is not displayed on the 
 
 
 For how to access servers with granted permissions, please refer to the [Connecting to Authorized Servers](../server-access-control/connecting-to-authorized-servers) document.
-
-

--- a/src/content/en/user-manual/workflow/requesting-sql-export.mdx
+++ b/src/content/en/user-manual/workflow/requesting-sql-export.mdx
@@ -8,7 +8,9 @@ import { Callout } from 'nextra/components'
 
 ### Overview
 
-You can submit SQL Export Request by following the steps below. This requests data export for which you do not have permission on specific DB connections, and after approval, the executor can execute the approved data export once.
+You can submit SQL Export Request by following the steps below.
+This requests data export for which you do not have permission on specific DB connections, and after approval, the executor can execute the approved data export once.
+
 
 ### Requesting SQL Export Request
 
@@ -69,6 +71,7 @@ User &gt; Workflow &gt; Submit Request &gt; SQL Export Request &gt; Request Summ
 </figcaption>
 </figure>
 
+
 * **Title**: Enter the request title.
 * **Connection**: Select the target connection for which you want to request SQL execution. Only connections for which you have permission can be selected.
 * **Database**: Select the database within the selected connection for which you want to request data export.
@@ -79,6 +82,7 @@ User &gt; Workflow &gt; Submit Request &gt; SQL Export Request &gt; Request Summ
 * **Execution Expiration Date**: Select the last date when the Executor can execute. The default selection date is one week later.
 * **Reason for Request**: Enter the reason for requesting SQL Export permission.
 * **Submit**: After completing the draft, click the `Submit` button to complete the submission.
+
 
 ### Downloading Approved Data
 
@@ -95,5 +99,3 @@ Approved Export Request items become immediately downloadable upon approval comp
     1. After checking the details, if you don't want to download, you can cancel by clicking the `Cancel` button.
 5. The download results can be checked in the Results tab within the detail page.
 6. You can check the request history where you downloaded in Workflow &gt; Executions &gt; Done menu.
-
-

--- a/src/content/en/user-manual/workflow/requesting-sql.mdx
+++ b/src/content/en/user-manual/workflow/requesting-sql.mdx
@@ -10,15 +10,15 @@ import { Callout } from 'nextra/components'
 
 You can request execution of queries for which you do not have permission on specific DB connections by following the steps below.
 After approval, the executor can execute the approved query once and view the results.
- by following the steps below. After approval, the executor can execute the approved query once and view the results.
+
 
 ### Requesting SQL Request
 
 #### 1. Selecting Approval Rules
 
 * Select an Approval Rule to choose the appropriate approval rule for your purpose. The approval target varies depending on the selected rule.
-* If a pre-configured approval rule is selected, the approver is automatically assigned and cannot be added or modified.
-* **Approval Expiration Date**: Enter the approval expiration date. The maximum value can be set through Maximum Approval Duration. The Approval Expiration Date cannot exceed the Execution Expiration Date. If exceeded, the request cannot be submitted.
+* If an approval rule where the administrator has designated approvers is selected, approvers are automatically assigned and cannot be added or modified.
+*  **Approval Expiration Date** : Enter the approval expiration date. You can set the maximum value through Maximum Approval Duration. The Approval Expiration Date cannot exceed the Execution Expiration Date. If exceeded, the request cannot be submitted.
     * However, when submitting in Urgent Mode, the above condition is ignored.
 
 <figure data-layout="center" data-align="center">
@@ -29,9 +29,9 @@ After approval, the executor can execute the approved query once and view the re
 
 * Click the `+` button in the approval line to display a popup window where you can assign step-by-step approvers.
 * In this popup window, add approval conditions and approvers, then click the `Save` button to save the approval line.
-* Available approval conditions are as follows:
-    * **A single Assignee can complete the approval request**: The approval request is approved with just one approval from multiple people.
-    * **All Assignees must approve this request**: All approvers must approve for the approval request to be approved.
+* Available approval conditions are as follows.
+    *  **A single Assignee can complete the approval request**  : The approval request is approved with just one approval from multiple people.
+    *  **All Assignees must approve this request**  : All approvers must approve for the approval request to be approved.
 
 <figure data-layout="center" data-align="center">
 ![image-20240807-125031.png](/user-manual/workflow/requesting-sql/image-20240807-125031.png)
@@ -59,7 +59,7 @@ After approval, the executor can execute the approved query once and view the re
 
 <Callout type="important">
 **Q. I can't see the Urgent Mode switch.**
-A. If you select an approval rule where the administrator has not allowed Urgent Mode, this feature will not be displayed as such.
+A. If you select an approval rule where the administrator has not allowed Urgent Mode, this feature will not be displayed.
 </Callout>
 
 #### 5. Entering Request Information
@@ -68,16 +68,17 @@ A. If you select an approval rule where the administrator has not allowed Urgent
 ![Screenshot-2025-08-26-at-12.47.02-AM.png](/user-manual/workflow/requesting-sql/Screenshot-2025-08-26-at-12.47.02-AM.png)
 </figure>
 
-* **Title**: Enter the request title.
-* **Connection**: Select the target connection for which you want to request SQL execution. Only connections for which you have permission can be selected.
-* **Database**: Select the database within the selected connection for which you want to request SQL execution.
-* **Content Type**: Select the method for entering the SQL statement you want to request.
-    * Text: You can write queries up to 9,999 lines, 10 million characters, or 5MB.
-    * File: You can upload .sql files with no execution size limit. However, Storage configuration is required.
-* **Preferred Execution Date**: Select the date when you want the query to be executed. The default selection date is the day of the request.
-* **Execution Expiration Date**: Select the last date when the Executor can execute. The default selection date is one week later.
-* **Reason for Request**: Enter the reason for requesting SQL execution permission.
-* **Submit**: After completing the draft, click the `Submit` button to complete the submission.
+*  **Title**  : Enter the request title.
+*  **Connection**  : Select the target connection for which you want to request SQL execution. Only connections for which you have permission can be selected.
+*  **Database**  : Select the database within the selected connection for which you want to request SQL execution.
+*  **Content Type**  : Select the method for entering the SQL statement you want to request.
+    * Text : You can write queries up to 9,999 lines, 10 million characters, or 5MB.
+    * File : You can upload .sql files with no execution size limit. However, Storage configuration is required.
+*  **Preferred Execution Date**  : Select the date when you want the query to be executed. The default selection date is the day of the request.
+*  **Execution Expiration Date**  : Select the last date when the Executor can execute. The default selection date is one week later.
+*  **Reason for Request**  : Enter the reason for requesting SQL execution permission.
+*  **Submit**  : After completing the draft, click the `Submit` button to complete the submission.
+
 
 ### Executing Approved SQL
 
@@ -97,8 +98,11 @@ Workflow &gt; Executions &gt; To Do &gt; Request Details &gt; Execute
 4. The execution results can be checked in the Results tab within the detail page for success/failure.
 5. You can check the request history where you are the executor in Workflow &gt; Received Requests &gt; Done menu.
 
+
+
 <Callout type="info">
-When approval process is enforced for DML Query execution<br/>When performing `INSERT`, `UPDATE`, `DELETE` statements, administrators may have created policies to force approval processes through Workflow. In this case, the following message appears when performing queries in the Web Editor.<br/>`[ENGINE][30105] In this DML operation, you need to get approval throgh SQL Request.`
+When approval process is enforced for DML Query execution<br/>When performing `INSERT`, `UPDATE`, `DELETE` statements, administrators may have created policies to force approval processes through Workflow.
+In this case, the following message appears when performing queries in the Web Editor.<br/>`[ENGINE][30105] In this DML operation, you need to get approval throgh SQL Request.`
 
 <figure data-layout="center" data-align="center">
 ![Warning message in Web Editor](/user-manual/workflow/requesting-sql/image-20250629-155649.png)
@@ -107,7 +111,8 @@ Warning message in Web Editor
 </figcaption>
 </figure>
 
-In this case, you can click the `SEND SQL Request` button to immediately move to the SQL Request form in Workflow and proceed with the request.<br/>You must select an appropriate Approval Rule and choose whether it is DML. If it is DML, you cannot use the File attachment method in Content Type.
+In this case, you can click the `SEND SQL Request` button to immediately move to the SQL Request form in Workflow and proceed with the request.<br/>You must select an appropriate Approval Rule and choose whether it is DML.
+If it is DML, you cannot use the File attachment method in Content Type.
 
 <figure data-layout="center" data-align="center">
 ![SQL Request form in Workflow](/user-manual/workflow/requesting-sql/image-20250629-161143.png)
@@ -116,7 +121,5 @@ SQL Request form in Workflow
 </figcaption>
 </figure>
 </Callout>
-
-
 
 

--- a/src/content/en/user-manual/workflow/requesting-sql/using-execution-plan-explain-feature.mdx
+++ b/src/content/en/user-manual/workflow/requesting-sql/using-execution-plan-explain-feature.mdx
@@ -97,4 +97,3 @@ That is, if the submitter performed the execution plan in JSON format and attach
 <Callout type="important">
 optimizer_trace and analyze are not supported in the execution plan (Explain) execution feature provided in SQL Request.
 </Callout>
-

--- a/src/content/en/user-manual/workflow/requesting-unmasking-mask-removal-request.mdx
+++ b/src/content/en/user-manual/workflow/requesting-unmasking-mask-removal-request.mdx
@@ -64,7 +64,7 @@ A. If you select an approval rule where the administrator has not allowed Urgent
 #### 5. Entering Request Details
 
 <Callout type="info">
-From version 11.3.0, the way to specify the expiration has changed.<br/>For policy exception requests, the field name is unified as "<strong>Policy Exception Schedule</strong>", and you can explicitly specify the start and end times of validity.
+From version 11.3.0, the way to specify the expiration has changed.<br/>For policy exception requests, the field name is unified as " **Policy Exception Schedule** ", and you can explicitly specify the start and end times of validity.
 </Callout>
 
 * **Title**: Enter the request title.


### PR DESCRIPTION
## Description
- `cd confluence-mdx; bin/review-skeleton-diff.sh --yes ../docs/todo-en.09.txt` 에서 불일치가 발생하지 않도록, 영어 번역문을 수정합니다.

## Additional notes
@mdx_to_skeleton.py 를 활용하여, mdx 파일의 번역 오류, 줄바꿈 불일치, markdown syntax 불일치를 수정하여 주세요.
보완대상 영어파일 목록: docs/todo-en.09.txt 에 영어 번역문 파일이 20개 나열되어 있습니다.
  - 20개 파일을 모두 한번에 비교하려면, 다음의 명령을 실행합니다. `cd confluence-mdx; bin/review-skeleton-diff.sh --yes ../docs/todo-en.09.txt`
  - 한국어 원문과 영어 번역문의 차이를 하나의 mdx 파일에 대해 확인하려면,`cd confluence-mdx; source venv/bin/activate; bin/mdx_to_skeleton.py --use-ignore <path/to/en/mdx>` 로 알아냅니다.
    - 예) `cd confluence-mdx; source venv/bin/activate; bin/mdx_to_skeleton.py --use-ignore target/en/administrator-manual/audit/server-logs/session-logs.mdx`
  - 한국어 원문과 영어 번역문의 줄바꿈 차이가 발견되면, 영어 번역문을 수정하여, 줄바꿈이 동일하도록 수정합니다. 한국어 원문에서 한 줄에 한 문장씩 위치한 경우, 번역문에서도 한 줄에 한 문장씩 위치해야 합니다.
  - 줄바꿈이 동일한 경우, 영어와 한국어의 어순 차이에 의해, inline code 위치가 다른 것, **bold** 표시의 위치가 다른 것에 대해서는, 자연스러운 영어 번역 결과를 우선하도록 합니다. inline code 위치가 달라도 무방합니다. **bold** 표시 문구의 위치가 달라도 무방합니다.
  - 영어 번역이 적절하지 않거나, 영어 표현이 @translation.md  에 부합하지 않은 경우, 영어 번역을 다시 수행하여 주세요.
