### PR TITLE
confluence-mdx: GitHub Actions CI 및 옵션 지원 개선

### DIFF
--- a/.github/workflows/generate-mdx-from-confluence.yml
+++ b/.github/workflows/generate-mdx-from-confluence.yml
@@ -1,0 +1,92 @@
+name: Generate MDX from Confluence
+
+on:
+  workflow_dispatch:
+    inputs:
+      use_local:
+        description: 'Use local files (--local option)'
+        required: false
+        default: true
+        type: boolean
+      use_attachments:
+        description: 'Download attachments from Confluence pages (--attachments option)'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  generate-mdx:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # 전체 히스토리 가져오기 (git status를 위해 필요)
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Pull latest Docker image
+        working-directory: ./confluence-mdx
+        run: |
+          docker compose pull confluence-mdx
+      
+      - name: Generate MDX files
+        working-directory: ./confluence-mdx
+        run: |
+          # 옵션 구성
+          OPTIONS=""
+          
+          if [ "${{ inputs.use_local }}" == "true" ]; then
+            OPTIONS="$OPTIONS --local"
+          fi
+          if [ "${{ inputs.use_attachments }}" == "true" ]; then
+            OPTIONS="$OPTIONS --attachments"
+          fi
+          
+          # 명령어 실행 (--no-build 옵션으로 로컬 빌드 방지)
+          echo "Running: docker compose run --rm --no-build confluence-mdx full $OPTIONS"
+          docker compose run --rm --no-build confluence-mdx full $OPTIONS
+      
+      - name: Check for changes
+        run: |
+          echo "## Changed Files" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          # git status로 변경된 파일 확인
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "### Modified Files" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            git status --short >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            
+            # target 디렉토리 관련 변경사항만 별도로 표시
+            echo "### Changes in target directory" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            git status --short confluence-mdx/target/ src/content/ public/ 2>/dev/null || echo "No changes in target-related directories" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            
+            # 전체 변경사항 통계
+            echo "### Change Statistics" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            git diff --stat HEAD >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          else
+            echo "No changes detected." >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          # 콘솔에도 출력
+          echo "=== Git Status ==="
+          git status
+          
+          echo ""
+          echo "=== Changes in target-related directories ==="
+          git status --short confluence-mdx/target/ src/content/ public/ 2>/dev/null || echo "No changes in target-related directories"
+          
+          echo ""
+          echo "=== Change Statistics ==="
+          git diff --stat HEAD || echo "No changes to show"
+

--- a/confluence-mdx/compose.yml
+++ b/confluence-mdx/compose.yml
@@ -12,7 +12,9 @@
 #   ATLASSIAN_API_TOKEN=your-api-token
 #
 # Main Commands:
-#   - Full workflow: docker compose run --rm confluence-mdx full
+#   - Full workflow (without attachments): docker compose run --rm confluence-mdx full
+#   - Full workflow with attachments: docker compose run --rm confluence-mdx full --attachments
+#   - Full workflow with local files (no API calls): docker compose run --rm confluence-mdx full --local
 #   - Collect data: docker compose run --rm confluence-mdx pages_of_confluence.py --attachments
 #   - Translate titles: docker compose run --rm confluence-mdx translate_titles.py
 #   - Convert: docker compose run --rm confluence-mdx convert
@@ -24,8 +26,8 @@
 #   - Push: docker push docker.io/querypie/confluence-mdx:latest
 #
 # Notes:
-#   - var/ data is included in the image, so image rebuild is required when updating
-#   - target/ directory is volume mounted and saved to host
+#   - Data in var/ directory is included in the image, so image rebuild is required when updating
+#   - target/ directory is volume mounted and persisted on the host
 #   - Network connection is required for Confluence API calls
 #
 # ============================================================================
@@ -38,11 +40,15 @@ services:
     image: docker.io/querypie/confluence-mdx:latest
     container_name: confluence-mdx
     working_dir: /workdir
-    # Load environment variables from .env file (if exists)
+    # Load environment variables from .env file (if it exists)
     # Create .env file with: ATLASSIAN_USERNAME=your-email@example.com and ATLASSIAN_API_TOKEN=your-token
     env_file:
       - .env
     volumes:
+      # Mount files in var to host
+      - ./var/pages.yaml:/workdir/var/pages.yaml
+      - ./var/list.en.txt:/workdir/var/list.en.txt
+      - ./var/list.txt:/workdir/var/list.txt
       # Mount output directories to host (matching symlink structure in target/)
       # target/ko -> ../../src/content/ko
       - ../src/content/ko:/workdir/target/ko
@@ -54,7 +60,7 @@ services:
       - ../public:/workdir/target/public
       # Mount log files to host (optional)
       - ./logs:/workdir/logs
-    # Default command is help (modify command section to change)
+    # Default command is 'help' (modify command section to override)
     command: ["help"]
     # Uncomment below to keep container running after exit
     # restart: "no"

--- a/confluence-mdx/scripts/entrypoint.sh
+++ b/confluence-mdx/scripts/entrypoint.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-set -e
 
-case "$1" in
+set -o errexit -o nounset
+
+case "${1:-help}" in
   pages_of_confluence.py|translate_titles.py|generate_commands_for_xhtml2markdown.py|confluence_xhtml_to_markdown.py)
     echo "+ python bin/$@"
     exec python "bin/$@"
@@ -15,11 +16,11 @@ case "$1" in
     echo "+ bash bin/xhtml2markdown.ko.sh"
     exec bash bin/xhtml2markdown.ko.sh
     ;;
-  full)
-    # Execute full workflow
+  full) # Execute full workflow
+    shift
     echo "# Starting full workflow..."
-    echo "+ python bin/pages_of_confluence.py --attachments"
-    python bin/pages_of_confluence.py --attachments
+    echo "+ python bin/pages_of_confluence.py $@"
+    python bin/pages_of_confluence.py "$@"
     echo "+ python bin/translate_titles.py"
     python bin/translate_titles.py
     echo "+ python bin/generate_commands_for_xhtml2markdown.py var/list.en.txt > bin/xhtml2markdown.ko.sh"


### PR DESCRIPTION
## Description

Confluence에서 MDX 파일 생성 워크플로우를 GitHub Actions로 자동화하고, `full` 명령어에 `--local`, `--attachments` 옵션 지원을 추가했습니다.

### 1. GitHub Actions 워크플로우 추가
- `.github/workflows/generate-mdx-from-confluence.yml` 신규 생성
- `workflow_dispatch`로 수동 실행 가능
- `--local`, `--attachments` 옵션을 UI에서 선택 가능
- 변경된 파일 자동 감지 및 리포트 생성

### 2. Docker Compose 설정 개선
- `var/` 디렉토리 파일들을 호스트에 마운트하여 데이터 영속성 확보
- 주석 개선 및 사용 예시 추가

### 3. Entrypoint 스크립트 리팩토링
- `full` 명령어에 옵션 전달 지원 (`shift`로 인자 처리)
- 에러 처리 강화 (`set -o errexit -o nounset`)
- 기본값 처리 개선 (`${1:-help}`)
