### PR TITLE
confluence-mdx: GitHub Actions CI 오류 수정

### DIFF
--- a/.github/workflows/generate-mdx-from-confluence.yml
+++ b/.github/workflows/generate-mdx-from-confluence.yml
@@ -23,32 +23,39 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # 전체 히스토리 가져오기 (git status를 위해 필요)
-      
+
+      - name: Workflow Options
+        run: |
+          echo "Use local files (--local): ${{ inputs.use_local }}"
+          echo "Download attachments (--attachments): ${{ inputs.use_attachments }}"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Pull latest Docker image
         working-directory: ./confluence-mdx
         run: |
-          docker compose pull confluence-mdx
-      
+          set -o xtrace
+          docker --version
+          docker compose version
+          # 플랫폼을 명시적으로 지정하여 아키텍처 불일치 오류 방지
+          DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose --progress=quiet pull confluence-mdx
+
       - name: Generate MDX files
         working-directory: ./confluence-mdx
         run: |
           # 옵션 구성
           OPTIONS=""
-          
-          if [ "${{ inputs.use_local }}" == "true" ]; then
+          if [[ "${{ inputs.use_local }}" == "true" ]]; then
             OPTIONS="$OPTIONS --local"
           fi
-          if [ "${{ inputs.use_attachments }}" == "true" ]; then
+          if [[ "${{ inputs.use_attachments }}" == "true" ]]; then
             OPTIONS="$OPTIONS --attachments"
           fi
-          
-          # 명령어 실행 (--no-build 옵션으로 로컬 빌드 방지)
-          echo "Running: docker compose run --rm --no-build confluence-mdx full $OPTIONS"
-          docker compose run --rm --no-build confluence-mdx full $OPTIONS
-      
+          set -o xtrace
+          touch .env # Create an empty .env to prevent missing .env error.
+          docker compose run --rm confluence-mdx full $OPTIONS
+
       - name: Check for changes
         run: |
           echo "## Changed Files" >> $GITHUB_STEP_SUMMARY
@@ -61,14 +68,14 @@ jobs:
             git status --short >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            
+          
             # target 디렉토리 관련 변경사항만 별도로 표시
             echo "### Changes in target directory" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
             git status --short confluence-mdx/target/ src/content/ public/ 2>/dev/null || echo "No changes in target-related directories" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            
+          
             # 전체 변경사항 통계
             echo "### Change Statistics" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY

--- a/confluence-mdx/compose.yml
+++ b/confluence-mdx/compose.yml
@@ -34,6 +34,7 @@
 
 services:
   confluence-mdx:
+    platform: linux/amd64  # GitHub Actions runner는 x86_64 아키텍처 사용
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
## Description

### GitHub Actions 워크플로우 개선
- Docker 플랫폼을 `linux/amd64`로 명시적 지정하여 아키텍처 불일치 오류 해결
- 디버깅을 위한 `set -o xtrace` 및 Docker 버전 로깅 추가
- `.env` 파일 자동 생성으로 missing .env 오류 방지
- `docker compose run`에서 `--no-build` 옵션 제거
- 조건문을 `[[`로 변경하여 bash best practice 준수
- Workflow 옵션 로깅 추가로 디버깅 용이성 향상

### Docker Compose 설정
- `compose.yml`에 `platform: linux/amd64` 명시적 지정

