### PR TITLE
confluence-mdx: 첨부 파일 캐시 활용 및 Docker 빌드 프로세스 개선

### DIFF
--- a/confluence-mdx/Dockerfile
+++ b/confluence-mdx/Dockerfile
@@ -1,5 +1,7 @@
 # Confluence-MDX Container Image
 # Use Python 3.9 based image
+# Platform: linux/amd64
+# Build with: docker build --platform linux/amd64 -t <image-name> .
 FROM python:3.9-slim
 
 # Set working directory
@@ -17,17 +19,18 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy application files
 COPY bin/ ./bin/
+RUN chmod +x bin/*.py bin/*.sh
 COPY etc/ ./etc/
 COPY tests/ ./tests/
 
-# Copy var/ data (included in image)
-COPY var/ ./var/
+# Copy cache/ data (included in image)
+COPY cache/ ./cache/
+
+# Populate var/ directory by running pages_of_confluence.py --remote --attachments
+RUN python3 bin/pages_of_confluence.py --remote --attachments
 
 # Create target/ directory
 RUN mkdir -p target/ko target/en target/ja target/public
-
-# Grant execute permissions
-RUN chmod +x bin/*.py bin/*.sh 2>/dev/null || true
 
 # Set entrypoint
 COPY scripts/entrypoint.sh /entrypoint.sh

--- a/confluence-mdx/compose.yml
+++ b/confluence-mdx/compose.yml
@@ -3,7 +3,8 @@
 # ============================================================================
 #
 # Quick Start:
-#   1. Build image: docker compose build
+#   1. Build image: docker compose --progress=plain build
+#      (Use --progress=plain to see raw command output without Docker formatting)
 #   2. Show help: docker compose run --rm confluence-mdx help
 #   3. Full workflow: docker compose run --rm confluence-mdx full
 #
@@ -12,8 +13,8 @@
 #   ATLASSIAN_API_TOKEN=your-api-token
 #
 # Main Commands:
-#   - Full workflow (without attachments): docker compose run --rm confluence-mdx full
-#   - Full workflow with attachments: docker compose run --rm confluence-mdx full --attachments
+#   - Full workflow for recent updates: docker compose run --rm confluence-mdx full
+#   - Full workflow with attachments: docker compose run --rm confluence-mdx full --remote --attachments
 #   - Full workflow with local files (no API calls): docker compose run --rm confluence-mdx full --local
 #   - Collect data: docker compose run --rm confluence-mdx pages_of_confluence.py --attachments
 #   - Translate titles: docker compose run --rm confluence-mdx translate_titles.py
@@ -21,7 +22,8 @@
 #   - Interactive shell: docker compose run --rm confluence-mdx bash
 #
 # Container Commands (without compose):
-#   - Build: docker build -t docker.io/querypie/confluence-mdx:latest .
+#   - Build: docker build --platform linux/amd64 --progress=plain -t docker.io/querypie/confluence-mdx:latest .
+#     (Use --progress=plain to see raw command output without Docker formatting)
 #   - Run: docker run docker.io/querypie/confluence-mdx:latest help
 #   - Push: docker push docker.io/querypie/confluence-mdx:latest
 #


### PR DESCRIPTION
## Description

### 첨부 파일 다운로드 로직 개선
- **캐시 우선 사용**: API 다운로드 전 `cache/` 디렉토리에서 파일 확인
  - 캐시에 파일이 있고 크기가 일치하면 복사하여 사용
  - 캐시 미스 시에만 API에서 다운로드
  - 불필요한 API 호출 감소로 빌드 시간 단축
- **로그 메시지 개선**: 캐시 복사와 API 다운로드를 구분하여 로깅
  - 캐시 복사: `info` 레벨, API 다운로드: `warning` 레벨

### Dockerfile 빌드 프로세스 개선
- **Platform 명시**: `linux/amd64` 플랫폼 명시로 크로스 플랫폼 빌드 안정성 향상
- **캐시 디렉토리 활용**: `var/` 대신 `cache/` 디렉토리를 이미지에 포함
- **빌드 시 데이터 준비**: `RUN` 단계에서 `pages_of_confluence.py --remote --attachments` 실행하여 `var/` 디렉토리 생성
- **권한 설정 순서 최적화**: `chmod` 실행 순서 조정

### compose.yml 문서화 개선
- **빌드 옵션 명시**: `--progress=plain` 옵션 추가로 빌드 출력 가독성 향상
- **사용법 주석 업데이트**: 최신 명령어 옵션 반영

## 변경 파일
- `confluence-mdx/Dockerfile`: 6줄 추가, 5줄 삭제
- `confluence-mdx/bin/pages_of_confluence.py`: 30줄 추가, 17줄 삭제
- `confluence-mdx/compose.yml`: 4줄 추가, 2줄 삭제

