### PR TITLE
ci: confluence-mdx Docker 이미지 빌드 및 푸시 자동화 workflow 추가

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -1,0 +1,56 @@
+name: Build and Push Docker Image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'confluence-mdx/**'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'confluence-mdx/**'
+
+jobs:
+  build-and-push:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Setup cache directory
+        working-directory: ./confluence-mdx
+        run: |
+          set -o errexit -o nounset -o pipefail -o xtrace
+          ./bin/1-setup-cache.sh
+
+      - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
+          password: ${{ secrets.CONTAINER_REGISTRY_CREDENTIAL }}
+
+      - name: Build Docker image
+        working-directory: ./confluence-mdx
+        run: |
+          set -o errexit -o nounset -o pipefail -o xtrace
+          docker compose --progress=plain build
+
+      - name: Push Docker image
+        if: github.event_name != 'pull_request'
+        working-directory: ./confluence-mdx
+        run: |
+          set -o errexit -o nounset -o pipefail -o xtrace
+          docker compose push
+


### PR DESCRIPTION
## Description

### GitHub Actions workflow 추가
- **Docker 이미지 빌드 및 푸시 자동화**: `confluence-mdx` 디렉토리의 Docker 이미지를 자동으로 빌드하고 registry에 푸시하는 workflow 추가
  - `workflow_dispatch`: 수동 실행 지원
  - `push`/`pull_request`: `confluence-mdx/**` 경로 변경 시 자동 트리거
  - Pull Request에서는 빌드만 수행하고 푸시는 하지 않음 (보안 및 안정성)

### 빌드 프로세스 개선
- **Cache 디렉토리 사전 설정**: Docker 이미지 빌드 전에 `1-setup-cache.sh` 스크립트를 실행하여 cache 디렉토리 준비
  - 기존 Docker 이미지에서 numeric 디렉토리를 추출하여 cache에 복사
  - 빌드 시간 단축 및 안정성 향상
- **Docker Buildx 활용**: 최신 Docker 빌드 기능 활용
- **진행 상황 표시**: `--progress=plain` 옵션으로 빌드 로그 가독성 향상

### 보안 및 권한 관리
- **Container Registry 인증**: `CONTAINER_REGISTRY_USERNAME`, `CONTAINER_REGISTRY_CREDENTIAL` secrets 사용
- **최소 권한 원칙**: 필요한 권한만 부여 (`contents: read`, `packages: write`)
- **PR 보호**: Pull Request에서는 이미지 푸시를 수행하지 않아 실수로 인한 잘못된 이미지 푸시 방지

## 변경 파일
- `.github/workflows/build-and-push-docker-image.yml`: 신규 파일 (57줄 추가)

