### PR TITLE
mdx_to_skeleton: 비교 대상에서 제외하는 대상파일 설정

### DIFF
--- a/confluence-mdx/bin/mdx_to_skeleton.py
+++ b/confluence-mdx/bin/mdx_to_skeleton.py
@@ -97,6 +97,7 @@ from skeleton_diff import (
     compare_with_korean_skel,
     process_directories_recursive,
     initialize_config,
+    should_exclude_file,
 )
 from skeleton_common import (
     extract_language_code,
@@ -1221,6 +1222,15 @@ def convert_and_compare_mdx_to_skeleton(input_path: Path) -> Tuple[Path, Optiona
     Raises:
         FileNotFoundError: If Korean MDX file is not found
     """
+    # Check if file should be excluded from comparison
+    if should_exclude_file(input_path):
+        # Still convert to skeleton, but skip comparison
+        output_path = input_path.parent / f"{input_path.stem}.skel.mdx"
+        if output_path.exists():
+            output_path.unlink()
+        output_path = convert_mdx_to_skeleton(input_path)
+        return output_path, None, None
+    
     # Step 1: Convert input MDX to skeleton MDX
     # Delete existing skeleton file if it exists
     output_path = input_path.parent / f"{input_path.stem}.skel.mdx"
@@ -1242,7 +1252,7 @@ def convert_and_compare_mdx_to_skeleton(input_path: Path) -> Tuple[Path, Optiona
     if not korean_exists:
         logger.warning(f"Corresponding Korean MDX file not found: {korean_mdx_path}")
         return output_path, None, None
-
+    
     # Step 3: Convert Korean MDX to skeleton MDX
     # Delete existing skeleton file if it exists
     korean_skel_path = korean_mdx_path.parent / f"{korean_mdx_path.stem}.skel.mdx"


### PR DESCRIPTION
## Description

### 변경사항

- **파일 제외 로직 중앙화**: `should_exclude_file()` 함수를 새로 추가하여 제외 패턴 체크 로직을 재사용 가능한 형태로 리팩토링
- **비교 프로세스 개선**: `mdx_to_skeleton.py`에서 제외 대상 파일은 skeleton 변환은 수행하되 비교는 건너뛰도록 수정
- **파일 타입 처리 개선**: `.mdx`와 `.skel.mdx` 파일 모두 처리할 수 있도록 `should_exclude_file()` 함수 구현

### 주요 특징

- 제외 로직의 중복 제거 및 유지보수성 향상
- 제외 대상 파일도 skeleton 변환은 유지하여 일관성 보장
- `skeleton_diff.py`의 `compare_with_korean_skel()` 함수에서 기존 인라인 제외 체크를 함수 호출로 대체하여 코드 가독성 개선
