### PR TITLE
mdx: 제품 설치의 영어 문서 업데이트 03

### DIFF
--- a/src/content/en/installation/_meta.ts
+++ b/src/content/en/installation/_meta.ts
@@ -1,0 +1,9 @@
+export default {
+  'prerequisites': 'Prerequisites',
+  'installation': 'Installation',
+  'system-architecture-and-network-access-control': 'System Architecture and Network Access Control',
+  'container-environment-variables': 'Container Environment Variables',
+  'license-installation': 'License Installation',
+  'server-configuration-requirements': 'Server Configuration Requirements',
+  'querypie-acp-community-edition': 'QueryPie ACP Community Edition',
+};

--- a/src/content/en/installation/container-environment-variables.mdx
+++ b/src/content/en/installation/container-environment-variables.mdx
@@ -6,28 +6,28 @@ import { Callout } from 'nextra/components'
 
 # Container Environment Variables
 
-This document provides guidance on the environment variables required to run the QueryPie ACP Server Container.
+This document provides guidance on environment variables required to run QueryPie ACP's Server Container.
 This document applies to QueryPie 10.3.0 or later versions.
 
 ### Basic Environment Variables
 
 |  **Environment Variable Name**  |  **Default Value**         |  **Description**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | ------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| VERSION                         |                            | QueryPie installation version. Example) `10.3.0` This environment variable value specifies the tag of the Container Image.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| AGENT_SECRET                    |                            | Recommended value: 32-char random string via `openssl rand -hex 16` This is the secret key used for encrypted communication between the QueryPie Container and User Agent. It must be set to 32 ASCII characters. In a High Availability (HA) configuration, the `AGENT_SECRET` values in the `compose-env` of two or more QueryPie Server Containers must all be identical.                                                                                                                                                                                                                                                                                                 |
-| KEY_ENCRYPTION_KEY              |                            | Recommended value: 16-char random string via `openssl rand -hex 8` This is the Key used to encrypt and store the Data Encryption Key (DEK) that encrypts sensitive data in the QueryPie Meta DB. KEK is used to encrypt the DEK to prevent its exposure. DEK is the Key that encrypts secrets (Credentials) for DB connections and SSH server connections stored in the QueryPie Meta DB.                                                                                                                                                                                                                                                                                                                                                      |
-| DB_HOST                         |                            | Hostname or IP Address of MySQL used as Meta DB, Log DB, and Snapshot DB. For PoC purposes, if you install QueryPie Container, MySQL Container, etc. all on a Single Machine, you can enter `host.docker.internal`. If you configure a separate MySQL such as AWS Aurora instead of the Machine where the QueryPie Container is installed, enter the Hostname or IP Address of that MySQL.                                                                                                                                                                                                                                                                                                            |
+| VERSION                         |                            | QueryPie installation version.Example) `10.3.0`This environment variable specifies the tag of the Container Image.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| AGENT_SECRET                    |                            | Recommended value: 32-char random string via `openssl rand -hex 16`This is the secret key used for encrypted communication between QueryPie Container and User Agent. It must be set to 32 ASCII characters.If High Availability (HA) configuration is applied, all `AGENT_SECRET` values in the `compose-env` of two or more QueryPie Server Containers must be identical.                                                                                                                                                                                                                                                                                                                                                 |
+| KEY_ENCRYPTION_KEY              |                            | Recommended value: 16-char random string via `openssl rand -hex 8`This is a key used to encrypt and store the Data Encryption Key (DEK) that encrypts sensitive data in QueryPie Meta DB. KEK is used to encrypt DEK to prevent its exposure.DEK is a key used to encrypt secret values (Credentials) for DB connections and SSH server connections stored in QueryPie Meta DB.                                                                                                                                                                                                                                                                                                                                                      |
+| DB_HOST                         |                            | Hostname or IP Address of MySQL used as Meta DB, Log DB, and Snapshot DB.For PoC purposes, if you install QueryPie Container, MySQL Container, etc. all on a Single Machine, you can enter `host.docker.internal`.If you configure a separate MySQL such as AWS Aurora instead of the Machine where QueryPie Container is installed, enter the Hostname or IP Address of that MySQL.                                                                                                                                                                                                                                                                                                            |
 | DB_PORT                         | `3306`                     | TCP Port of MySQL used as Meta DB, Log DB, and Snapshot DB                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | DB_CATALOG                      | `querypie`                 | Catalog to be used by Meta DB                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | LOG_DB_CATALOG                  | `querypie_log`             | Catalog to be used by Log DB                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | ENG_DB_CATALOG                  | `querypie_snapshot`        | Catalog to be used by Snapshot DB                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| DB_USERNAME                     |                            | Recommended value: `querypie` Username of MySQL used as Meta DB, Log DB, and Snapshot DB                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| DB_PASSWORD                     |                            | Recommended value: 16-char random string via `openssl rand -hex 8` Password of MySQL used as Meta DB, Log DB, and Snapshot DB                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| DB_MAX_CONNECTION_SIZE          | `20`                       | Maximum number of connections QueryPie uses for Meta DB connection (recommended to use 20)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| DB_DRIVER_CLASS                 | `org.mariadb.jdbc.Driver`  | If Meta DB is AWS Aurora, it supports Failover in case of Aurora Instance partial failure. If you want to use the Failover feature with AWS Aurora, specify the dedicated driver `software.amazon.jdbc.Driver` provided by AWS.                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| REDIS_NODES                     |                            | Enter Host and Port information to connect to QueryPie Redis. When entering two or more Host and Port information, you can separate them with `,` like `Host1:Port1,Host2:Port2`. For PoC purposes, if you install QueryPie Container, Redis Container, etc. all on a Single Machine, you can enter `host.docker.internal:6379`. The Host can be entered in IP Address format or as an FQDN.                                                                                                                                                                                                                                                                                                            |
-| REDIS_PASSWORD                  |                            | Recommended value: 16-char random string via `openssl rand -hex 8` Redis Password                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| DAC_SKIP_SQL_COMMAND_RULE_FILE  | `skip_command_config.json` | Configure to not record SQL Queries automatically executed by tools (DataGrip, DBeaver, and other workbench tools), rather than queries entered by users, in the Audit Log. SQL Queries automatically executed by tools are sometimes called formatted queries because they have a fixed pattern of syntax. If you configure to not record these formatted queries in the Audit Log, the response speed of 3rd Party Tools perceived by users will be faster. It helps reduce the performance load on the QueryPie Server. For more details, please refer to the documentation at [https://chequer.atlassian.net/wiki/spaces/QCP/pages/851346405/10.2.x#%ED%99%98%EA%B2%BD%EB%B3%80%EC%88%98-%EC%B6%94%EA%B0%80.2](https://chequer.atlassian.net/wiki/spaces/QCP/pages/851346405/10.2.x#%ED%99%98%EA%B2%BD%EB%B3%80%EC%88%98-%EC%B6%94%EA%B0%80.2). |
+| DB_USERNAME                     |                            | Recommended value: `querypie`Username of MySQL used as Meta DB, Log DB, and Snapshot DB                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| DB_PASSWORD                     |                            | Recommended value: 16-char random string via `openssl rand -hex 8`Password of MySQL used as Meta DB, Log DB, and Snapshot DB                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| DB_MAX_CONNECTION_SIZE          | `20`                       | Maximum number of connections used by QueryPie for Meta DB connections (20 recommended)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| DB_DRIVER_CLASS                 | `org.mariadb.jdbc.Driver`  | If Meta DB is AWS Aurora, it supports Failover when Aurora Instance partially fails.If you want to use Failover functionality by applying AWS Aurora, specify the dedicated driver `software.amazon.jdbc.Driver` provided by AWS.                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| REDIS_NODES                     |                            | Enter Host and Port information to connect to QueryPie Redis. If you enter two or more Host and Port information, you can enter them separated by `,` like `Host1:Port1,Host2:Port2`.For PoC purposes, if you install QueryPie Container, Redis Container, etc. all on a Single Machine, you can enter `host.docker.internal:6379`.Host can be entered as an IP Address or FQDN.                                                                                                                                                                                                                                                                                                            |
+| REDIS_PASSWORD                  |                            | Recommended value: 16-char random string via `openssl rand -hex 8`Redis Password                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| DAC_SKIP_SQL_COMMAND_RULE_FILE  | `skip_command_config.json` | Configure to prevent SQL Queries automatically executed by tools (workbench tools such as DataGrip, DBeaver) rather than queries entered by users from being recorded in Audit Log.Tool-automated SQL Queries are sometimes called standardized Queries in the sense that the syntax patterns are predetermined.Configuring to prevent these standardized Queries from being recorded in Audit Log improves the response speed of 3rd Party Tools perceived by users. It helps reduce the performance load on QueryPie Server.For more details, please refer to [https://chequer.atlassian.net/wiki/spaces/QCP/pages/851346405/10.2.x#%ED%99%98%EA%B2%BD%EB%B3%80%EC%88%98-%EC%B6%94%EA%B0%80.2](https://chequer.atlassian.net/wiki/spaces/QCP/pages/851346405/10.2.x#%ED%99%98%EA%B2%BD%EB%B3%80%EC%88%98-%EC%B6%94%EA%B0%80.2). |
 
 
 ### Deprecated Environment Variables
@@ -59,14 +59,14 @@ QUERYPIE_WEB_URL
 </td>
 <td>
 <Callout type="info">
-In version 10.2.8 or later, this value is configured in the Web Console.
-It is not configured in environment variables.
+In version 10.2.8 or later, this value is set in the Web Console.
+It is not set in environment variables.
 </Callout>
-This is the QueryPie URL address for accessing the Web Console. <br/>(Example: `https://querypie.customer.com`)<br/>This URL is also called the Base URL of QueryPie.
-This URL should not end with `/`. Please be careful not to add `/` at the end of the URL like `https://querypie.customer.com/`.
-This URL is used for the following purposes:
-* Used as the callback address in the SSO Integration authentication process.
-* Used in the link for downloading User Agent from the Web Console.
+This is the URL address of QueryPie for accessing the Web Console. <br/>(Example. `https://querypie.customer.com`)<br/>This URL is also called the Base URL of QueryPie.
+This URL must not end with `/`. Please be careful not to add `/` at the end of the URL like `https://querypie.customer.com/`.
+This URL is used for the following purposes.
+* Used as a callback address in the authentication process of SSO Integration.
+* Used in links to download User Agent from Web Console.
 * For other detailed purposes, please refer to [https://chequer.atlassian.net/wiki/spaces/QCP/pages/876937310](https://chequer.atlassian.net/wiki/spaces/QCP/pages/876937310).
 </td>
 </tr>
@@ -79,11 +79,11 @@ AWS_ACCOUNT_ID
 </td>
 <td>
 <Callout type="info">
-In version 10.3.0 or later, you do not need to enter this value.
+In version 10.3.0 or later, this value is not entered.
 This value is automatically selected.
 </Callout>
-This is the value used when configuring QueryPie Admin &gt; CloudProvider &gt; CrossAccountRole.<br/>Please enter the Account ID of the AWS account where QueryPie is installed.
-Leave it empty in environments other than AWS.
+This value is used when setting QueryPie Admin &gt; CloudProvider &gt; CrossAccountRole.<br/>Please enter the Account ID of the AWS account where QueryPie is installed.
+For non-AWS environments, leave it empty.
 </td>
 </tr>
 <tr>
@@ -95,11 +95,11 @@ REDIS_HOST
 </td>
 <td>
 <Callout type="info">
-In version 10.2.1 or later, this value has been replaced with REDIS_NODES.
+In version 10.2.1 or later, this value has been replaced by REDIS_NODES.
 </Callout>
 Redis Hostname or IP Address - Used by QueryPie Container to store cache data.
 For PoC purposes, if you install QueryPie Container, Redis Container, etc. all on a Single Machine, you can enter `host.docker.internal`.
-If you configure a separate Redis such as AWS ElastiCache instead of the Machine where the QueryPie Container is installed, enter the Hostname or IP Address of that Redis.
+If you configure a separate Redis such as AWS ElastiCache instead of the Machine where QueryPie Container is installed, enter the Hostname or IP Address of that Redis.
 </td>
 </tr>
 <tr>
@@ -111,7 +111,7 @@ REDIS_PORT
 </td>
 <td>
 <Callout type="info">
-In version 10.2.1 or later, this value has been replaced with REDIS_NODES.
+In version 10.2.1 or later, this value has been replaced by REDIS_NODES.
 </Callout>
 Redis TCP Port
 </td>
@@ -125,12 +125,12 @@ REDIS_CONNECTION_MODE
 </td>
 <td>
 <Callout type="info">
-In version 10.3.0 or later, you do not need to enter this value.
+In version 10.3.0 or later, this value is not entered.
 This value is automatically selected.
 </Callout>
-Use the value `STANDALONE` or `CLUSTER`.
+Use a value of `STANDALONE` or `CLUSTER`.
 For PoC purposes, if you install QueryPie Container, Redis Container, etc. all on a Single Machine, you can enter `STANDALONE`.
-If you use QueryPie Redis in Cluster mode, enter `CLUSTER`. When using `CLUSTER` mode, you will enter multiple address values in `REDIS_NODES`.
+If you use QueryPie Redis in Cluster mode, enter `CLUSTER`. When using in `CLUSTER` mode, you will enter multiple addresses in `REDIS_NODES`.
 </td>
 </tr>
 <tr>
@@ -142,11 +142,11 @@ CABINET_DATA_DIR
 </td>
 <td>
 <Callout type="info">
-In version 10.2.8 or later, you do not need to enter this value.
-It is replaced with the OVEN component configuration.
+In version 10.2.8 or later, this value is not entered.
+It is replaced by OVEN component settings.
 </Callout>
 This is the location where images used for SAC &gt; RDP(WinSAC) session recording are stored in the EC2 instance server filesystem.
-(`/data` is recommended)
+(`/data` recommended)
 </td>
 </tr>
 </tbody>
@@ -159,50 +159,50 @@ This is the location where images used for SAC &gt; RDP(WinSAC) session recordin
 
 A: You cannot use `127.0.0.1` or `localhost` for DB_HOST and REDIS_HOST.
 
-In a Single Machine configuration, you can install MySQL and Redis all on one Linux machine.
-At this time, the QueryPie Container uses bridge mode, which is the default network mode.
+In a Single Machine configuration, you can install both MySQL and Redis on one Linux machine.
+At this time, QueryPie Container uses bridge mode, which is the default network mode.
 In bridge mode, `127.0.0.1` and `localhost` can only communicate between processes inside the container.
-Since MySQL and Redis run in separate Containers, the QueryPie Container cannot connect to MySQL and Redis using `127.0.0.1` or `localhost` addresses.
+Since MySQL and Redis run in separate Containers, QueryPie Container cannot connect to MySQL and Redis using `127.0.0.1` or `localhost` addresses.
 
-In this case, you can use the `host.docker.internal` address to connect to the host network of the Docker Host, that is, the Linux machine where the docker daemon is running.
+In this case, you can use the `host.docker.internal` address to connect to the Docker Host, that is, the host network of the Linux machine where the docker daemon is running.
 
 
 #### Q: Is it okay to change AGENT_SECRET during operation?
 
-A: The change procedure is complex and inconvenient for customer users, so we recommend not changing it.
+A: We recommend not changing it because the procedure is complicated and causes inconvenience to customer users.
 
-If you change this value, you must apply the following procedure:
+If you change this value, you must apply the following procedure.
 
-* You must change the value in the compose-env file and restart the QueryPie Container.
-* In a redundancy or multi-configuration, all QueryPie Containers must have the same value.
-* ⚠️ User Agent users must delete and uninstall the installed User Agent, then reinstall and use it.
+* Change the value in the compose-env file and restart the QueryPie Container.
+* In dualization or multi-configuration, all QueryPie Containers must have the same value.
+* ⚠️ User Agent users must uninstall the installed User Agent and reinstall it to use it.
 
-If you are unsure what value to generate initially, you can simply use the value generated from `uuidgen | tr -d '-'` in the Linux terminal.
+If you are unsure what value to generate initially, you can use the value generated by `uuidgen | tr -d '-'` in a Linux terminal.
 
-There is a plan to replace this environment variable with a method that configures itself within the server without user input.
+This environment variable is planned to be replaced by a method where the server configures itself without user input.
 
-#### Q: Can I change KEY_ENCRYPTION_KEY during operation?
+#### Q. Can I change KEY_ENCRYPTION_KEY during operation?
 
 A: You cannot change this value.
-You **must** keep the value used during the initial installation.
+You  **must**  keep the value used during initial installation.
 
-If you lose this value or specify a changed value as an environment variable, the QueryPie Container cannot read the encrypted sensitive data in the operating QueryPie Meta DB.
-As a result, the QueryPie Container will not operate normally.
+If you lose this value or specify a changed value as an environment variable, QueryPie Container cannot read the encrypted sensitive data in the operating QueryPie Meta DB.
+As a result, QueryPie Container cannot function properly.
 
 There are no constraints on the length or type of characters required for this environment variable value.
-For example, there are no constraints such as it must be 8 characters or more, or it must contain special characters.
-Although we do not recommend actually using such a value, even if the user sets a simple value like `1`, QueryPie will function normally.
+For example, there are no constraints such as it must be 8 characters or more, or special characters must be included.
+Although we do not recommend using such values, even if a user sets a simple value like `1`, QueryPie will function normally.
 
-However, we recommend consulting with the customer's security officer and configuring it according to the internal information security policies and guidelines of the customer.
+However, we recommend consulting with your customer's security officer to set it according to your customer's internal information security policies and guidelines.
 
 
 #### Q: Is AWS_ACCOUNT_ID a required value? What value should I enter?
 
-A: In QueryPie 10.3.0 or later versions, you do not need to enter AWS_ACCOUNT_ID.
-The QueryPie Server Container finds this value on its own.
+A: In QueryPie 10.3.0 or later, you do not enter AWS_ACCOUNT_ID.
+QueryPie Server Container automatically detects this value.
 
-The AWS_ACCOUNT_ID environment variable value is used as the default value when creating a Role in the target Account when using CrossAccount Role in the Cloud Provider configuration in the Web Console.
-The Account ID value shown in the screenshot below is the value provided in the AWS_ACCOUNT_ID environment variable.
+The AWS_ACCOUNT_ID environment variable value is used as the default value when creating a Role in the target Account when using CrossAccount Role in Cloud Provider settings in the Web Console.
+The Account ID value shown in the screenshot below is the value provided from the AWS_ACCOUNT_ID environment variable.
 
 
 <details>
@@ -215,24 +215,24 @@ The Account ID value shown in the screenshot below is the value provided in the 
 </details>
 
 
-#### Q: We do not use SAC or RDP features. Can I remove the CABINET_DATA_DIR item?
+#### Q: I do not use SAC or RDP functionality. Can I remove the CABINET_DATA_DIR item?
 
-A: In QueryPie 10.3.0 or later versions, the CABINET_DATA_DIR item is not used.
-It has been replaced with the configuration value of the OVEN component.
+A: In QueryPie 10.3.0 or later, the CABINET_DATA_DIR item is not used.
+It has been replaced by OVEN component settings.
 
 
 #### Q: Is Redis configuration required?
 
-A: The QueryPie Container server software requires Redis as an essential component.
+A: QueryPie Container's server software uses Redis as an essential component.
 
-Redis is used for the following purposes:
+Redis is used for the following purposes.
 
-* To cache session meta information of connected web servers
-* Message queue for background tasks within the server application
+* Caching session metadata of connected web servers
+* Message queue for background tasks within server applications
 
-However, even if the data stored in Redis is lost, no critical issues occur.
-Specific tasks and user requests running at that time will fail.
-After restarting Redis and the QueryPie Container, the QueryPie Container will operate normally.
+However, even if data stored in Redis is lost, critical issues do not occur.
+Specific tasks and user requests that were running at that time will fail.
+If you restart Redis and QueryPie Container, QueryPie Container will function normally.
 
 ### Environment Variables for Advanced Features
 

--- a/src/content/en/installation/container-environment-variables/_meta.ts
+++ b/src/content/en/installation/container-environment-variables/_meta.ts
@@ -1,0 +1,4 @@
+export default {
+  'querypieweburl': 'QUERYPIE_WEB_URL',
+  'optimizing-dbmaxconnectionsize': 'DB_MAX_CONNECTION_SIZE Optimization',
+};

--- a/src/content/en/installation/container-environment-variables/optimizing-dbmaxconnectionsize.mdx
+++ b/src/content/en/installation/container-environment-variables/optimizing-dbmaxconnectionsize.mdx
@@ -1,8 +1,8 @@
 ---
-title: 'Optimizing DB_MAX_CONNECTION_SIZE'
+title: 'DB_MAX_CONNECTION_SIZE Optimization'
 ---
 
-# Optimizing DB_MAX_CONNECTION_SIZE
+# DB_MAX_CONNECTION_SIZE Optimization
 
 ### Overview
 
@@ -10,17 +10,17 @@ This guide explains how to optimize the Database Connection Pool Size used in Qu
 
 #### QueryPie MySQL Configuration
 
-QueryPie Server operates by configuring Meta DB, Snapshot DB, and Log DB in a MySQL Database.
+QueryPie Server operates by configuring Meta DB, Snapshot DB, and Log DB in MySQL Database.
 
-* Meta DB: Data for features provided by the QueryPie Web Console, such as user accounts, connection settings, and access control policies, is stored in the Meta DB.
-* Snapshot DB: A data store temporarily used to record Audit Logs during SQL query execution.
-* Log DB: A data store that stores audit logs such as user access records and SQL execution records.
+* Meta DB: Data for features provided by QueryPie Web Console, such as user accounts, connection settings, and access control policies, are stored in Meta DB.
+* Snapshot DB: A temporary data storage used to record Audit Log during SQL query execution.
+* Log DB: A data storage that stores audit logs (Audit Log) such as user access records and SQL execution records.
 
 QueryPie Server has components that use the Spring framework, and these components configure a Database Connection Pool to store data in QueryPie MySQL.
 
 ### Setting Database Connection Pool Size
 
-When running the QueryPie Server Container, you can set the Database Connection Pool Size using environment variables.
+You can set the Database Connection Pool Size using environment variables when running QueryPie Server Container.
 
 #### `DB_MAX_CONNECTION_SIZE`
 
@@ -31,54 +31,54 @@ The default value is 20.
 
 Specifies the DB Connection Pool Size for Log DB.
 The default value is the value set in `DB_MAX_CONNECTION_SIZE`.
-If you do not separately set `LOG_DB_MAX_CONNECTION_SIZE`, it will be set to the same value as `DB_MAX_CONNECTION_SIZE`.
+If `LOG_DB_MAX_CONNECTION_SIZE` is not set separately, the same value as `DB_MAX_CONNECTION_SIZE` will be set.
 
-Since users have low need to control the Connection Pool Size of Snapshot DB, we do not provide an environment variable to control this value.
+The Connection Pool Size for Snapshot DB does not require user control, so we do not provide an environment variable to control this value.
 
-### For General User Usage and Load
+### General User Usage and Load Cases
 
 We recommend using the default value of 20 for `DB_MAX_CONNECTION_SIZE`.
-This is a Connection Pool Size that can be used generally in typical cases.
-We recommend this default value as it can provide sufficient processing performance not only in PoC environments but also in general Production environments.
+This is a Connection Pool Size that can be used in various general cases.
+We recommend this default value as a figure that can provide sufficient processing performance not only in PoC environments but also in general Production environments.
 
-### For High Usage and High Load
+### High Usage and High Load Cases
 
-We recommend setting the value of `DB_MAX_CONNECTION_SIZE` between 20 and 40.
+We recommend setting `DB_MAX_CONNECTION_SIZE` to a value between 20 and 40.
 Within an appropriate range, as `DB_MAX_CONNECTION_SIZE` increases, the amount of load that QueryPie can process simultaneously increases.
 
 If the DB server has high processing performance and many CPUs, increase `DB_MAX_CONNECTION_SIZE`.
-If the Linux VM where the Server Container operates has high processing performance and many CPUs, increase `DB_MAX_CONNECTION_SIZE`.
+If the Linux VM where Server Container runs has high processing performance and many CPUs, increase `DB_MAX_CONNECTION_SIZE`.
 If the number of Server Containers increases, decrease `DB_MAX_CONNECTION_SIZE`.
 
-### `DB_MAX_CONNECTION_SIZE` Configuration Value Summary Table
+### `DB_MAX_CONNECTION_SIZE` Setting Value Summary Table
 
 |  **DB_MAX_CONNECTION_SIZE**  |  **Description**                                                                 |
 | ---------------------------- | -------------------------------------------------------------------------------- |
-| 40                           | Suitable when MySQL DB has high throughput and high-performance hardware processing capabilities. We do not recommend using configuration values higher than 40. |
-| 30                           | Suitable when MySQL DB has high throughput and high-performance hardware processing capabilities.                                 |
-|  **20**                      |  **Recommended value suitable for production environments. A configuration value that can handle many requests universally.**                            |
-| 10                           | Suitable when you want to reduce the number of MySQL connections in a production environment.                                           |
-| 5                            | Suitable when performing functional tests in PoC or when there are few users in a production environment.                             |
+| 40                           | Suitable when MySQL DB has high throughput and high-spec hardware processing performance. Using a setting value higher than 40 is not recommended. |
+| 30                           | Suitable when MySQL DB has high throughput and high-spec hardware processing performance.                                 |
+|  **20**                      |  **Recommended value suitable for production environments. This is a setting value that can handle many requests universally.**                            |
+| 10                           | Suitable when you want to reduce MySQL connections in production environments.                                           |
+| 5                            | Suitable for PoC functional testing and production environments with few users.                             |
 
 ### Relationship Formula Between `DB_MAX_CONNECTION_SIZE` and Hardware Capacity
 
-Through internal performance optimization tests by the development team, we have derived the following relationship formula between `DB_MAX_CONNECTION_SIZE` and the hardware processing capacity of the QueryPie Server VM and DB.
-By setting the `DB_MAX_CONNECTION_SIZE` value with reference to this relationship formula, you can obtain optimal processing performance while setting the smallest possible `DB_MAX_CONNECTION_SIZE` value.
+Through internal performance optimization tests by the development team, we derived that there is the following relationship formula between `DB_MAX_CONNECTION_SIZE` and the hardware processing capacity of QueryPie Server VM and DB.
+By referring to this relationship formula, you can set the `DB_MAX_CONNECTION_SIZE` value to obtain optimal processing performance while setting the smallest possible `DB_MAX_CONNECTION_SIZE` value.
 
-#### When Configuring QueryPie MySQL Separately
+#### When QueryPie MySQL is Separately Configured
 
-This is when you do not run the QueryPie Server Container and QueryPie MySQL together in one Linux VM, but instead configure a separate MySQL Instance using a separate VM or Cloud Service.
-We recommend applying this in Production environments.
+This is the case where QueryPie Server Container and QueryPie MySQL are not run together in one Linux VM, but a separate MySQL Instance is configured using a separate VM or Cloud Service.
+This is recommended for Production environments.
 
 `DB_MAX_CONNECTION_SIZE` = `minimum ( Application_CPU_Count / Application_Node_Count, RDS_CPU_Count ) * 10`
 
-* Application_CPU_Count - Number of vCPUs in the Linux VM where the QueryPie Server Container runs
+* Application_CPU_Count - Number of vCPUs of the Linux VM where QueryPie Server Container runs
 * Application_Node_Count - Number of QueryPie Server Containers, or number of Linux VMs running, or number of Kubernetes Pods.
-    * For dual configuration, it becomes 2; for triple configuration, it becomes 3.
-* RDS_CPU_Count - Number of vCPUs in the VM Instance where the separately configured QueryPie MySQL runs
+    * For dualization configuration, it is 2, and for triple configuration, it is 3.
+* RDS_CPU_Count - Number of vCPUs of the VM Instance where separately configured QueryPie MySQL runs
 * minimum ( a, b, c, … ) - Selects the smallest value among multiple values separated by `,`.
 
-Example 1) The Linux VM where the Server Container runs has 4 vCPUs, and you operate 2 Linux VMs.
+Example 1) The Linux VM where Server Container runs has 4 vCPUs, and 2 Linux VMs are operated.
 AWS Aurora MySQL has 4 vCPUs.
 ```
 minimum ( Application_CPU_Count / Application_Node_Count, RDS_CPU_Count ) * 10
@@ -87,7 +87,7 @@ minimum ( Application_CPU_Count / Application_Node_Count, RDS_CPU_Count ) * 10
 = 20
 ```
 
-Example 2) The Linux VM where the Server Container runs has 8 vCPUs, and you operate 3 Linux VMs.
+Example 2) The Linux VM where Server Container runs has 8 vCPUs, and 3 Linux VMs are operated.
 AWS Aurora MySQL has 8 vCPUs.
 ```
 minimum ( Application_CPU_Count / Application_Node_Count, RDS_CPU_Count ) * 10
@@ -96,16 +96,16 @@ minimum ( Application_CPU_Count / Application_Node_Count, RDS_CPU_Count ) * 10
 = 27
 ```
 
-#### For Single Linux VM Configuration
+#### Single Linux VM Configuration
 
-This is when you run the QueryPie Server Container and QueryPie MySQL together on one Linux VM.
-This is suitable for use in PoC environments.
+This is the case where QueryPie Server Container and QueryPie MySQL are run together in one Linux VM.
+This is suitable for PoC environments.
 
 `DB_MAX_CONNECTION_SIZE` = `Application_CPU_Count * 2.5`
 
-* Application_CPU_Count - Number of vCPUs in the Linux VM where the QueryPie Server Container runs
+* Application_CPU_Count - Number of vCPUs of the Linux VM where QueryPie Server Container runs
 
-Example 1) The Linux VM where the Server Container runs has 4 vCPUs, and you run MySQL together.
+Example 1) The Linux VM where Server Container runs has 4 vCPUs, and MySQL is run together.
 In this case, it is appropriate to set `DB_MAX_CONNECTION_SIZE` to 10.
 ```
 Application_CPU_Count * 2.5
@@ -117,10 +117,10 @@ Application_CPU_Count * 2.5
 ### Allowing Sufficient Connections in QueryPie MySQL Settings
 
 QueryPie Server connects to QueryPie MySQL using a Connection Pool.
-If the MySQL Database Server does not allow sufficient connections, QueryPie Server will fail to create connections to MySQL and malfunction.
+If MySQL Database Server does not allow sufficient connections, QueryPie Server cannot create connections to MySQL, causing malfunction.
 This problem occurs when the number of DB connections required by QueryPie Server is greater than the number of connections allowed by QueryPie MySQL.
 
-#### Failure to Create DB Connections
+#### Symptoms of Not Being Able to Create DB Connections
 
 You will encounter the error message `[API] Could not open JPA EntityManager for transaction` in the Web Console.
 
@@ -134,7 +134,7 @@ You will encounter the error message `[API] Could not open JPA EntityManager for
 
 #### Solution 1) Increase the Number of Connections Allowed by QueryPie MySQL
 
-You can apply settings to increase both configuration values to 500 or more.
+You can apply settings to increase two setting values to 500 or more.
 This allows you to set the number of connections allowed by QueryPie MySQL to be greater than the number of DB connections required by QueryPie Server.
 
 * MAX_USER_CONNECTIONS 
@@ -145,10 +145,10 @@ This allows you to set the number of connections allowed by QueryPie MySQL to be
 
 #### Solution 2) Reduce DB_MAX_CONNECTION_SIZE
 
-If there are few QueryPie users and the usage load is low, you can reduce the `DB_MAX_CONNECTION_SIZE` configuration value.
+If the number of QueryPie users is small and the usage load is low, you can reduce the `DB_MAX_CONNECTION_SIZE` setting value.
 This allows you to set the number of DB connections required by QueryPie Server to be smaller than the number of connections allowed by QueryPie MySQL.
 
 Set `DB_MAX_CONNECTION_SIZE` to 10 or 5 instead of the default value of 20.
-In PoC environments, even if you set `DB_MAX_CONNECTION_SIZE` to 5, you can smoothly perform general functional tests.
+For PoC environments, even if you set `DB_MAX_CONNECTION_SIZE` to 5, you can perform general functional tests smoothly.
 
 

--- a/src/content/en/installation/container-environment-variables/querypieweburl.mdx
+++ b/src/content/en/installation/container-environment-variables/querypieweburl.mdx
@@ -11,38 +11,38 @@ import { Callout } from 'nextra/components'
 
 ## Overview
 
-QUERYPIE_WEB_URL is required for various paths such as service access, authentication integration, data download, external integration, and Proxy settings, so it must be configured.
+QUERYPIE_WEB_URL is used in various paths such as service access, authentication integration, data download, external integration, and Proxy settings, and must be configured.
 
 <Callout type="important">
-**Starting from QueryPie version 10.2.8, this environment variable is no longer used. It is replaced with Web Base URL in the General menu.**
+**Starting from QueryPie version 10.2.8, this environment variable is no longer used. It has been replaced by Web Base URL in the General menu.**
 <figure data-layout="center" data-align="center">
 ![screenshot-20250312-112533.png](/installation/container-environment-variables/querypieweburl/screenshot-20250312-112533.png)
 </figure>
 </Callout>
 
-## Use Cases
+## Usage
 
 * Redirect URL for authentication integration such as SAML/Google BigQuery OAuth
 * Endpoint URL for SCIM integration
-* URL for connecting to QueryPie Container from components installed on other servers, such as NOVAc
-* URL for links to navigate to QueryPie in Alerts, emails, Slack DMs, etc.
-* URL for the link to download files for User Agent installation
-* URL for the link to download files for Server Agent installation
-* URL for the link to download Audit Export Log/Report audit logs and report files
-* URL for the link to download AiDD scan results
-* URL for the link to download session recording files
-* QueryPie host information needed in Proxy environments
+* URL for components such as NOVAc installed on other servers to connect to QueryPie Container
+* URL for links to move to QueryPie in Alerts, emails, Slack DMs, etc.
+* URL for links to download files for User Agent installation
+* URL for links to download files for Server Agent installation
+* URL for links to download Audit Export Log/Report audit logs and report files
+* URL for links to download AiDD scan results
+* URL for links to download session recording files
+* QueryPie host information required in Proxy environments
 
 ## Q&A
 
-**Q. Is domain configuration required even when using only in an internal network?** <br/> **A.** You may use an IP address.
-However, it must be an address (IP or domain) that can be accessed from the user's PC.
-Do not use a Private IP Address that cannot be accessed from the user's PC.
+**Q. Is domain configuration necessary even when using only in an internal network?** <br/> **A.**  You can use an IP.
+However, it must be an address (IP or domain) that can be accessed from user PCs.
+You should not use a Private IP Address that cannot be accessed from user PCs.
 
 
-**Q. Is domain configuration required when using Okta as IdP?** <br/> **A.** Yes, it is required.
-In Okta, when entering the Base URL, you must use a URL that includes the https:// protocol.
-If you enter only http:// or an IP address, the following error will occur and configuration will not be possible.
+**Q. Is domain configuration necessary when using Okta as IdP?** <br/> **A.**  Yes, it is necessary.
+Okta requires a URL that includes the https:// protocol when entering the Base URL.
+If you enter only http:// or an IP address, the following error occurs and configuration is not possible.
 
 <Callout type="error">
 *Please review the form to correct the following error(s):*

--- a/src/content/en/installation/installation.mdx
+++ b/src/content/en/installation/installation.mdx
@@ -4,19 +4,19 @@ title: 'Installation'
 
 # Installation
 
-The methods for installing QueryPie ACP products are provided in separate guide documents according to the Container execution method and the version of the installation helper program.
+QueryPie ACP product installation methods are categorized and provided according to the Container execution method and the version of the installation helper program.
 
-### Running Containers with Compose Tool
+### Running Container with Compose Tool
 
-This is the general installation and execution method, and the installation method recommended by the manufacturer.
-This method involves downloading, running, and stopping Container Images using Docker Compose.
+This is a general installation and execution method, and is the installation method recommended by the manufacturer.
+This method uses Docker Compose to download, run, and stop Container Images.
 
-In this case, two installation methods are provided depending on the version of the installation helper program.
+In this case, two installation methods are provided according to the version of the installation helper program.
 
 #### Installing with setup.sh
 
-This is the installation helper program provided to partner engineers since QueryPie Version 9.
-You can download Container Images by obtaining an account on the Container Registry called Harbor.
+This is an installation helper program that has been provided to partner engineers since QueryPie Version 9.
+You can download Container Images by obtaining an account for Harbor, a Container Registry.
 
 You can install all released versions of the product.
 
@@ -25,13 +25,13 @@ For detailed installation methods, please refer to this document: [Installation 
 
 #### Installing with setup.v2.sh
 
-This is the installation helper program provided to end customers and partner engineers with the release of QueryPie ACP Community Edition released in August 2025.
-This method involves downloading and installing Container Images published on Docker Hub.
+This is an installation helper program provided to end customers and partner engineers along with the release of QueryPie ACP Community Edition in August 2025.
+This method downloads and installs Container Images published on Docker Hub.
 
-The installation process is automated, making it easy for first-time users to install the product.
-However, the actual installation process is equivalent between the setup.sh installation method and the setup.v2.sh installation method, with the difference being that setup.v2.sh has an automated process and does not support installation of older versions such as Version 10.
+The installation process is automated, making it easy for first-time installers to install the product.
+However, the actual installation process is equivalent between setup.sh and setup.v2.sh, with the difference that setup.v2.sh automates the process and does not support installation of older versions such as Version 10.
 
-It supports installation in macOS environments using Apple Silicon.
+It supports installation on macOS environments using Apple Silicon.
 
 Not all released versions of the product are provided.
 As of December 2025, Version 11.1.2 is provided.
@@ -39,14 +39,13 @@ As of December 2025, Version 11.1.2 is provided.
 For detailed installation methods, please refer to this document: [Installation Guide - setup.v2.sh (KO)](installation/installation-guide-setupv2sh)
 
 
-### Installing in Kubernetes Environment
+### Installing on Kubernetes Environment
 
 QueryPie ACP is a software product that operates in a Container environment.
-While installation and execution using Compose Tool is typical, it also operates smoothly in Kubernetes environments.
+While it is common to install and run using Compose Tool, it also works smoothly in Kubernetes environments.
 
-When installing the product in a Kubernetes environment, both Managed Kubernetes Clusters such as AWS EKS and GCP GKE, and Self-Hosted Clusters can be used.
+When installing the product in a Kubernetes environment, both Managed Kubernetes Clusters such as AWS EKS, GCP GKE, and Self-Hosted Clusters can be used.
 
-* AWS EKS Environment: [Installing on AWS EKS](installation/installing-on-aws-eks)
-* Helm Chart: [https://github.com/chequer-io/querypie-deployment](https://github.com/chequer-io/querypie-deployment)
-
+* AWS EKS environment: [Installing on AWS EKS Environment](installation/installing-on-aws-eks) 
+* Helm Chart: [https://github.com/chequer-io/querypie-deployment](https://github.com/chequer-io/querypie-deployment) 
 

--- a/src/content/en/installation/installation/_meta.ts
+++ b/src/content/en/installation/installation/_meta.ts
@@ -1,0 +1,6 @@
+export default {
+  'installation-guide-simple-configuration': 'Installation Guide - Simple Configuration',
+  'installation-guide-setupv2sh': 'Installation Guide - setup.v2.sh',
+  'comparison-of-setupsh-and-setupv2sh': 'Comparison of setup.sh and setup.v2.sh',
+  'installing-on-aws-eks': 'Installing on AWS EKS Environment',
+};

--- a/src/content/en/installation/installation/comparison-of-setupsh-and-setupv2sh.mdx
+++ b/src/content/en/installation/installation/comparison-of-setupsh-and-setupv2sh.mdx
@@ -1,0 +1,104 @@
+---
+title: 'Comparison of setup.sh and setup.v2.sh'
+---
+
+# Comparison of setup.sh and setup.v2.sh
+
+### Introduction
+
+As of August 2025, setup.sh is a QueryPie installation program provided for partners.
+setup.v2.sh is a QueryPie installation program provided along with the release of QueryPie Community Edition.
+
+This document examines how these two installation programs work, their features, and differences.
+
+### Installation Program Feature Scope
+
+#### Installation Features of setup.sh
+
+* Installs Container Engine and Compose Tool if not found.
+    * Container Engine: Docker
+    * Compose Tool: Docker Compose
+* Installs package.tar.gz for Compose at the `./querypie/version` path.
+
+#### Installation Features of setup.v2.sh
+
+* Installs Container Engine and Compose Tool if not found.
+    * Container Engine: Docker or Podman
+    * Compose Tool: Docker Compose
+* Installs package.tar.gz for Compose at the `./querypie/&lt;version&gt;` path.
+* Checks SELinux settings and performs `chcon` command for Container Volume Mount.
+* Automatically fills in setting values in the environment variable configuration file `.env`.
+* Downloads Container Images.
+* Performs QueryPie MySQL Migration and runs QueryPie App Container.
+* Creates a Symbolic Link `./querypie/current` pointing to `./querypie/&lt;version&gt;` to indicate the currently running version.
+
+#### Additional Features of setup.v2.sh for Upgrade, Deletion, etc.
+
+setup.v2.sh provides other major features in addition to product installation.
+
+* Can automatically run Upgrade.
+* Can run Uninstall to remove the installed product.
+* Can install only Container Engine (Docker or Podman).
+* Provides a mode that performs only Compose Package installation, equivalent to setup.sh.
+* **[Under Review]** Fills in setting values in the environment variable configuration file `.env` through user confirmation and input.
+
+### Differences in Compose Settings and Environment Configuration
+
+|  **Topic**        |  **setup.sh**                                              |  **setup.v2.sh**                                   |
+| ----------------- | ---------------------------------------------------------- | -------------------------------------------------- |
+| Image Registry    | `harbor.chequer.io/querypie/`                              | `docker.io/querypie/`                              |
+| Environment Variable Configuration File         | `compose-env`                                              | `.env`                                             |
+| Compose as Plugin | Not supported<br/>Uses `docker-compose` command                            | Supported<br/>Uses `docker compose` or `podman compose` command |
+| MySQL Data Dir    | `./querypie/&lt;version&gt;/mysql/`                        | `./querypie/mysql/`                                |
+| Application Log   | `/var/log/querypie/` - 10.2.x<br/>`./querypie/log/` - 11.x | `./querypie/log/`                                  |
+| Symlink for Running Version  | (None)                                                       | `./querypie/current`                               |
+
+### MySQL Data Dir Location Change
+
+As the MySQL Data Dir path has changed, the following advantages have emerged.
+
+* The constraint of having to maintain the path of the initial installation version when installing multiple versions during upgrade has been removed. After upgrade completion, you can delete old version Compose Packages.
+* It is not affected by the path location where QueryPie MySQL Container runs. There are no problems whether you run it from an old version Compose Package or a new version Compose Package.
+
+There are two things to note.
+
+* setup.sh must maintain the QueryPie MySQL Container running from the path of the initial installation version. setup.v2.sh runs the MySQL Container from the current installation version's path.
+* You can install a new version using setup.v2.sh on a server where the product has already been installed with setup.sh. However, due to the MySQL Data Dir change, existing data is not automatically migrated. The installation manager must appropriately move the MySQL Data directory according to the purpose, such as new installation or upgrade.
+
+
+### Rootless Mode Support
+
+When installing with setup.sh, additional configuration changes are required to run in a Rootless Mode Docker environment.
+
+When installing with setup.v2.sh, no additional configuration changes are required to run in a Rootless Mode Docker or Podman environment.
+
+#### setup.v2.sh - Rootless Mode Configuration Method
+
+First, configure the environment to run Container Engine in Rootless Mode.
+If you install Podman using setup.v2.sh, Rootless Mode environment is applied by default.
+If you use Docker, you must perform Rootless Mode configuration by referring to separate documentation.
+
+Then, when running `setup.v2.sh`, add the `--universal` option to install QueryPie, and a Compose package.tar.gz suitable for Rootless Mode will be installed.
+
+
+### Reporting setup.v2.sh Issues and Errors
+
+setup.v2.sh outputs script version and environment information to the console at the beginning of execution.
+
+When reporting issues related to setup.v2.sh, please include the following two pieces of information.
+
+* Command line including options when running setup.v2.sh, first 5 lines of console log including script version
+* Last 5 lines of console log or related content when the issue occurred
+
+#### Example of Console Log Including Script Version
+
+```
+jk@host ~ % ./setup.v2.sh --universal
+#### QueryPie Installer 25.08.4, /opt/homebrew/bin/bash 5.2.26(1)-release on Darwin arm64 ####
+### Install QueryPie version 11.1.1 ###
+# Directory ./querypie/ does not exist. QueryPie has not been installed on this system.
+Do you want to install QueryPie (11.1.1)?
+
+```
+
+

--- a/src/content/en/installation/installation/installation-guide-setupv2sh.mdx
+++ b/src/content/en/installation/installation/installation-guide-setupv2sh.mdx
@@ -1,0 +1,271 @@
+---
+title: 'Installation Guide - setup.v2.sh'
+---
+
+import { Callout } from 'nextra/components'
+
+# Installation Guide - setup.v2.sh
+
+
+## Introduction
+
+This installation guide explains how to install QueryPie server on a single server computer in a simple configuration.
+Even with a simple configuration installation, you can test most QueryPie features.
+
+The setup.v2.sh installation program introduced in this guide automatically performs the existing installation process.
+The automated installation process is largely the same as the existing installation process.
+For the existing installation process, please refer to this document: [https://querypie.atlassian.net/wiki/spaces/QM/pages/964952065/-?atl_f=PAGETREE](https://querypie.atlassian.net/wiki/spaces/QM/pages/964952065/-?atl_f=PAGETREE)
+
+This installation method is not suitable for use in actual production environments.
+For installation methods suitable for actual production environments, please refer to the separately provided [QueryPie Installation Guide].
+
+<Callout type="info">
+This is an installation guide for PoC purposes targeting QueryPie 10.3.0 or later versions.
+</Callout>
+
+## Prerequisites
+
+Before proceeding with installation, you must prepare the following.
+In summary, they are as follows.
+
+* 1 Linux server
+* 1 PC with a web browser installed
+
+For details, please refer to the following document: [Prerequisites - Simple Configuration](../prerequisites)
+
+## System Architecture
+
+Please refer to the following document: [System Architecture and Network Access Control](../system-architecture-and-network-access-control)
+
+## Installation Process
+
+### Running setup.v2.sh
+
+Download and run the `setup.v2.sh` script from the shell of the Linux server where you will install QueryPie.
+You can see the commands that setup.sh actually performs during the execution process.
+```bash
+$ # Download setup.v2.sh and execute it.
+$ bash <(curl -s https://dl.querypie.com/setup.v2.sh)
+```
+
+You can also save `setup.v2.sh` as a file and then run it as follows.
+```bash
+$ curl -s https://dl.querypie.com/setup.v2.sh -o setup.v2.sh
+$ bash setup.v2.sh
+```
+
+`setup.v2.sh` automatically selects and installs the version recommended by the manufacturer.
+If you want to install a specific version, you can use the following commands.
+```bash
+$ bash setup.v2.sh --install 10.3.4
+$ bash setup.v2.sh --upgrade 11.0.1
+$ bash setup.v2.sh --help
+#### setup.v2.sh - QueryPie Installer 25.08.8, /usr/bin/bash 4.4.20(1)-release on Linux x86_64 ####
+setup.v2.sh 25.08.8, the QueryPie installation script.
+Usage: setup.v2.sh [options]
+    or setup.v2.sh [options] --install <version>
+    or setup.v2.sh [options] --install-container-engine
+    or setup.v2.sh [options] --install-compose-package <version>
+    or setup.v2.sh [options] --upgrade <version>
+    or setup.v2.sh [options] --uninstall
+    or setup.v2.sh [options] --help
+
+FOR AWS AMI BUILD MAINTAINER:
+    or setup.v2.sh [options] --install-partially-for-ami <version>
+    or setup.v2.sh [options] --resume
+    or setup.v2.sh [options] --verify-installation
+    or setup.v2.sh [options] --verify-not-installed
+    or setup.v2.sh [options] --populate-env <env-file>
+    or setup.v2.sh [options] --reset-credential <env-file>
+
+ENVIRONMENT VARIABLES:
+
+  DOCKER_REGISTRY                Default: 'docker.io/querypie/'
+    The Docker registry to pull images from.
+    You may specify a private registry such as 'myregistry.example.com/querypie/'.
+    Note that the trailing slash is required, if you set this variable.
+    Actual image names will be like 'myregistry.example.com/querypie/querypie:11.1.1'.
+
+OPTIONS:
+  --yes               Assume "yes" to all prompts and run non-interactively.
+  -V, --version       Show the version of this script.
+  -x, --xtrace        Print commands and their arguments as they are executed.
+  -h, --help          Show this help message.
+$ 
+```
+
+### Installing QueryPie in Podman Environment
+
+Starting from `setup.v2.sh` version `25.08.8`, it supports execution environments with Podman + Docker Compose combination.
+
+The following Linux distributions recommend execution environments with Podman + Docker Compose combination.
+
+* Red Hat Enterprise Linux 8, 9, 10
+* Rocky 8, 9
+
+For detailed installation methods, please refer to this document: [Configuring Rootless Mode with Podman](../prerequisites/configuring-rootless-mode-with-podman)
+
+### Tasks Automatically Performed by setup.v2.sh
+
+`setup.v2.sh` automatically proceeds with the following main installation procedures.
+
+1. Download configuration files for Compose such as `docker-compose.yml` and `.env`
+    * The name of the environment variable configuration file `compose-env` has been changed to `.env`. `compose-env` is used as a template for creating configuration files.
+2. Set environment variable values in `.env`
+    * For descriptions of each environment variable, please refer to the [Container Environment Variables](../container-environment-variables) document.
+3. Download docker images
+    * Downloads images from the `docker.io/querypie/` registry. Therefore, Harbor login process is not required.
+4. Run mysql and redis containers
+5. Run querypie-tools container and perform migration
+6. Run querypie-app container
+7. Create a symbolic link `./querypie/current` pointing to the currently running version.
+
+After `setup.v2.sh` successfully starts the querypie-app container, you will see the following execution success notification message.
+```
++ docker exec querypie-app-1 readyz
+########################################################################
+#                                                                      #
+#     ██████╗ ██╗   ██╗███████╗██████╗ ██╗   ██╗██████╗ ██╗███████╗    #
+#    ██╔═══██╗██║   ██║██╔════╝██╔══██╗╚██╗ ██╔╝██╔══██╗██║██╔════╝    #
+#    ██║   ██║██║   ██║█████╗  ██████╔╝ ╚████╔╝ ██████╔╝██║█████╗      #
+#    ██║▄▄ ██║██║   ██║██╔══╝  ██╔══██╗  ╚██╔╝  ██╔═══╝ ██║██╔══╝      #
+#    ╚██████╔╝╚██████╔╝███████╗██║  ██║   ██║   ██║     ██║███████╗    #
+#     ╚══▀▀═╝  ╚═════╝ ╚══════╝╚═╝  ╚═╝   ╚═╝   ╚═╝     ╚═╝╚══════╝    #
+#                                                                      #
+########################################################################
+.--------------------------------------------------------.
+||  🚀 QueryPie Server has been successfully started! 🚀  |
+||  Timestamp in UTC: Mon Jul 28 17:04:31 UTC 2025        |
+||  Timestamp in KST: Tue Jul 29 02:04:31 KST 2025        |
+'--------------------------------------------------------'
++ popd
+~
+## Create a symbolic link 'current' pointing to 11.0.1
++ pushd ./querypie/
+~/querypie ~
++ rm -f current
++ ln -s 11.0.1 current
++ popd
+~
+### Installation completed successfully
+### Access QueryPie at http://172.31.11.201:8000 or https://172.31.11.201:8443 in your browser
+### Determine the public IP address of your host machine if needed
+[ec2-user@ip-172-31-11-201 ~]$ 
+```
+
+### Installation Complete
+
+Great job.
+Now you can see QueryPie in action.
+
+Please try accessing the URL like `http://172.31.11.201:8000` shown at the end of `setup.v2.sh` execution.
+This address uses the IP Address to connect from Local PC to Linux Server.
+You may need to change Firewall, AWS Security Group settings, etc. by referring to network connection configuration: [System Architecture and Network Access Control](../system-architecture-and-network-access-control)
+
+### Entering License
+
+License files can be entered on the web console screen.
+
+<figure data-layout="left" data-align="left">
+![Enter the license in PEM format.](/installation/installation/installation-guide-setupv2sh/image-20250718-063723.png)
+<figcaption>
+Enter the license in PEM format.
+</figcaption>
+</figure>
+
+## Basic Configuration Procedures
+
+This guide explains settings that must be performed after installation according to the operating environment.
+
+### Common Settings
+
+Common procedures required when using QueryPie immediately after installation.
+
+#### QueryPie Web Base URL Settings
+
+> Configuration path: Admin Page → General
+This is the URL address of QueryPie for accessing the Web Console. <br/>(Example. `https://querypie.customer.com`)<br/>This URL is also called the Base URL of QueryPie.
+
+This URL must not end with `/`. Please be careful not to add `/` at the end of the URL like `https://querypie.customer.com/`.
+
+This URL is used for the following purposes.
+
+* Used as a callback address in the authentication process of SSO Integration.
+* Used in links to download User Agent from Web Console.
+* For other detailed purposes, please refer to [https://chequer.atlassian.net/wiki/spaces/QCP/pages/876937310](https://chequer.atlassian.net/wiki/spaces/QCP/pages/876937310).
+
+<figure data-layout="center" data-align="center">
+![image-20250520-081112.png](/installation/installation/installation-guide-setupv2sh/image-20250520-081112.png)
+</figure>
+
+### Product-Specific Settings
+
+#### DAC/SAC: Proxy Access Address Settings
+
+Connect to QueryPie Database and register the address for DAC/SAC Proxy access.
+
+<Callout type="info">
+To connect to QueryPie Database from QueryPie Web Console, DB connection settings are required:[DB Connections](../../administrator-manual/databases/connection-management/db-connections)
+
+During the Database connection setup process, you need the Hostname, Username, and Password of QueryPie MySQL.
+
+* Hostname: `host.docker.internal`
+* Username: `querypie` (in case of default settings)
+* Password: (Check DB_PASSWORD in the .env file in the directory where QueryPie is installed.)
+
+Values set in .env such as DB_PASSWORD, REDIS_PASSWORD, KEY_ENCRYPTION_KEY must be kept secure.
+Please be careful not to expose these values to others.
+</Callout>
+
+Replace the `<customer-proxy-address>` part below with your customer's Proxy access IP or domain and execute the query.
+
+<Callout type="important">
+This address should not have a Scheme such as `http` or `https` attached.
+</Callout>
+```
+UPDATE querypie.proxies SET host = '<customer-proxy-address>' WHERE id = 1;
+```
+
+If the query execution is confirmed to be normal without errors, execute the following query to check if it has been registered.
+```
+SELECT * FROM querypie.proxies;
+```
+
+After registering the address for Proxy access in QueryPie Database, you do not need to restart the Server Container.
+When you attempt to log in from User Agent, after authentication through a web browser, you can use User Agent.
+
+<figure data-layout="center" data-align="center">
+![image-20250520-082706.png](/installation/installation/installation-guide-setupv2sh/image-20250520-082706.png)
+</figure>
+
+#### KAC: Proxy Access Address Settings
+
+Connect to QueryPie Database and register the address for KAC Proxy access.
+
+Replace the `<customer-proxy-fqdn>` part below with your customer's Proxy access IP or domain and execute the query.
+
+As a special note, unlike DAC/SAC settings, you can freely enter Schemes such as `http` or `https`.
+
+<Callout type="important">
+After configuration, QueryPie Container restart is required to issue TLS certificates matching the registered address internally.
+</Callout>
+```
+UPDATE querypie.k_proxy_setting SET host = 'https://<customer-proxy-fqdn>';
+```
+
+<figure data-layout="center" data-align="center">
+![image-20250520-084243.png](/installation/installation/installation-guide-setupv2sh/image-20250520-084243.png)
+</figure>
+
+#### WAC: Proxy Access Address Settings
+
+> Configuration path: Admin Page → Web Apps → Web App Configurations
+WAC Proxy access address settings can be performed from the Web Console.
+
+For detailed configuration procedures, please refer to the following document: [Initial WAC Setup in Web App Configurations](../../administrator-manual/web-apps/wac-quickstart/initial-wac-setup-in-web-app-configurations)
+
+<Callout type="important">
+After configuration, QueryPie Container restart is required to issue TLS certificates matching the registered address internally.
+</Callout>
+
+

--- a/src/content/en/installation/installation/installation-guide-simple-configuration.mdx
+++ b/src/content/en/installation/installation/installation-guide-simple-configuration.mdx
@@ -1,0 +1,390 @@
+---
+title: 'Installation Guide - Simple Configuration'
+---
+
+import { Callout } from 'nextra/components'
+
+# Installation Guide - Simple Configuration
+
+
+## Introduction
+
+This installation guide explains how to install QueryPie ACP server on a single server computer in a simple configuration.
+Even with a simple configuration installation, you can test most QueryPie features.
+
+However, this installation method is not suitable for use in actual production environments.
+For installation methods suitable for actual production environments, please refer to the separately provided [QueryPie Installation Guide].
+
+<Callout type="info">
+This is an installation guide for PoC purposes targeting QueryPie 10.3.0 or later versions.
+</Callout>
+
+## Prerequisites
+
+Before proceeding with installation, you must prepare the following.
+In summary, they are as follows.
+
+* 1 Linux server
+* 1 PC with a web browser installed
+
+For details, please refer to the following document: [Prerequisites - Simple Configuration](../prerequisites)
+
+## System Architecture
+
+Please refer to the following document: [System Architecture and Network Access Control](../system-architecture-and-network-access-control)
+
+## Installation Process
+
+### Running setup.sh
+
+Download and run the `setup.sh` script that can easily perform QueryPie installation.
+You can see the commands that setup.sh actually performs during the execution process.
+The "Manual steps replacing setup.sh" item below contains the commands that `setup.sh` executes.
+
+Install docker and docker-compose for QueryPie Service, and install configuration files such as docker-compose.yml.
+
+<Callout type="info">
+QP_VERSION and DOWNLOAD_VERSION presented below are examples.
+Please check with the technical support manager which version to install.
+</Callout>
+```bash
+# Download and run ./setup.sh with required environment variables.
+curl -L https://dl.querypie.com/releases/compose/setup.sh -o setup.sh
+chmod +x setup.sh
+export DOWNLOAD_VERSION=10.3.x
+export QP_VERSION=10.3.0
+./setup.sh
+
+# Grant permission of docker group
+sudo usermod -aG docker $USER
+
+# Please logout and ssh again to run docker command.
+```
+
+If you install docker for the first time, the current shell does not yet have permissions for the docker group.
+After logout, reconnect via ssh.
+
+<Callout type="important">
+If setup.sh does not run normally depending on OS version or type, install as follows.
+</Callout>
+<details>
+<summary>Manual steps replacing setup.sh</summary>
+```bash
+# Install docker
+curl -fsSL https://get.docker.com -o get-docker.sh
+sudo sh ./get-docker.sh
+sudo systemctl start docker
+sudo usermod -aG docker $USER
+
+# Install docker-compose
+curl -SL https://dl.querypie.com/releases/bin/v2.29.7/docker-compose-linux-x86_64 -o docker-compose
+chmod +x docker-compose
+sudo install -m 755 docker-compose /usr/local/bin/
+
+# Install docker-compose.yml and config files
+# NOTE: Please use the actual version number instead of '10.3.0'.
+mkdir -p querypie/10.3.0
+cd querypie/10.3.0
+curl -L https://dl.querypie.com/releases/compose/10.3.x/package.tar.gz -o package.tar.gz
+tar zxvf package.tar.gz
+
+# Install logrotate config for docker daemon
+sudo cp logrotate /etc/logrotate.d/querypie
+
+```
+</details>
+
+### Harbor Login
+
+Log in to Harbor Docker Registry to download QueryPie Docker Images.
+
+<Callout type="info">
+Harbor accounts for customers are issued and provided in advance during initial installation.
+</Callout>
+```bash
+docker login harbor.chequer.io
+Username:
+Password:
+```
+
+If a message like the following appears, you have successfully logged into Harbor.
+```bash
+WARNING! Your password will be stored unencrypted in /home/ubuntu/.docker/config.json.
+Configure a credential helper to remove this warning. See
+https://docs.docker.com/engine/reference/commandline/login/#credential-stores 
+
+Login Succeeded
+```
+
+### compose-env Configuration
+
+When you run the `./setup.sh` script, it creates configuration files such as `docker-compose.yml` and `compose-env` in the `querypie/&lt;version&gt;/` directory.
+Move into this directory and edit the configuration file named `compose-env`.
+
+For descriptions of each environment variable, please refer to the following document: [Container Environment Variables](../container-environment-variables)
+```bash
+# Version of QueryPie Docker Image to run: 10.3.0 or later.
+VERSION=10.3.0
+
+# Common
+## Secret key for encrypting communication between QueryPie client agents and QueryPie over port 9000/tcp.
+## Must be exactly 32 characters in length.
+## Suggested: 32-char random string via `openssl rand -hex 16`
+AGENT_SECRET=
+
+## Secret key used to encrypt sensitive information, such as database connection strings and SSH private keys.
+## This key can be any string but is immutable once set.
+## Suggested: 16-char random string via `openssl rand -hex 8`
+KEY_ENCRYPTION_KEY=
+
+# DB
+## Suggested: host.docker.internal
+DB_HOST=
+DB_PORT=3306
+DB_CATALOG=querypie
+LOG_DB_CATALOG=querypie_log
+ENG_DB_CATALOG=querypie_snapshot
+## Suggested: querypie
+DB_USERNAME=
+## Suggested: 16-char random string via `openssl rand -hex 8`
+DB_PASSWORD=
+DB_MAX_CONNECTION_SIZE=20
+## If you're using AWS Aurora, use the software.amazon.jdbc.Driver instead of org.mariadb.jdbc.Driver for automatic failover handling.
+DB_DRIVER_CLASS=org.mariadb.jdbc.Driver
+
+# Redis
+## REDIS_NODES should be specified as a "Host:Port" combination.
+## In CLUSTER MODE, when specifying multiple nodes, separate each address with a comma.
+## Example: Host1:6379,Host2:6379,Host3:6379
+## Suggested: host.docker.internal:6379
+REDIS_NODES=
+## Suggested: 16-char random string via `openssl rand -hex 8`
+REDIS_PASSWORD=
+
+DAC_SKIP_SQL_COMMAND_RULE_FILE=skip_command_config.json
+```
+
+### MySQL / Redis Startup
+
+In Single machine configuration, QueryPie MySQL and QueryPie Redis are run in Container mode within one VM.
+Run MySQL and Redis with the following commands.
+When running for the first time, it creates default accounts by applying the Username and Password defined in the `compose-env` file.
+```
+docker-compose --env-file compose-env --profile database up -d
+```
+```
+docker ps
+
+CONTAINER ID  IMAGE                                            ... NAMES
+0b8d8b9b9486  harbor.chequer.io/querypie/mysql:8.0.39          ... querypie-mysql-1
+6d96b9cdc95e  harbor.chequer.io/querypie/redis:7.4.2           ... querypie-redis-1
+```
+
+### Tools Startup
+
+QueryPie Tools is a tool used during the installation process.
+QueryPie Tools provides functionality to create Tables, Procedures, etc. in QueryPie MySQL.
+Database Tables, etc. in MySQL change according to product version, and configuration is managed using an open-source tool called Flyway.
+QueryPie Tools provides functionality to install product licenses.
+
+QueryPie Tools operates as an API server that accepts requests on TCP Port 8050.
+
+#### Running Tools
+
+Execute the following command to run QueryPie Tools.
+After that, you can check if the Container is running normally with the `docker ps` command. You can check Container logs with the `docker logs -f querypie-tools-1` command.
+```
+docker-compose --env-file compose-env --profile tools up -d
+```
+```
+docker ps
+
+CONTAINER ID  IMAGE                                            ... NAMES
+6e867d744acb  harbor.chequer.io/querypie/querypie-tools:10.3.0 ... querypie-tools-1
+0b8d8b9b9486  harbor.chequer.io/querypie/mysql:8.0.39          ... querypie-mysql-1
+6d96b9cdc95e  harbor.chequer.io/querypie/redis:7.4.2           ... querypie-redis-1
+```
+
+#### Running Migration
+
+The work of creating MySQL Tables, Procedures, etc. required by QueryPie is called Migration.
+Execute the following command to run Migration.
+For initial installation, it takes about 1~2 minutes in the process of creating hundreds of DB Tables.
+```
+docker exec -it querypie-tools-1 /app/script/migrate.sh runall
+```
+```
+[2025-05-20 07:43:15] QueryPie migration is started.
+--------------------------------------------------------------------------------
+[2025-05-20 07:43:15] QueryPie `V67.11__9.10.0.11_workflow_rule_migration.sql` is started.
+[2025-05-20 07:43:18] QueryPie `V67.11__9.10.0.11_workflow_rule_migration.sql` is finished.
+
+...
+[2025-05-20 07:44:17] QueryPie Snapshot `V5.0__10.2.8.0_oven_diary_tables_alter_json_column_type.sql` is started.
+[2025-05-20 07:44:17] QueryPie Snapshot `V5.0__10.2.8.0_oven_diary_tables_alter_json_column_type.sql` is finished.
+[2025-05-20 07:44:17] QueryPie Snapshot migration is finished.
+--------------------------------------------------------------------------------
+```
+
+#### License Installation
+
+You can install license files in QueryPie Tools with the following command. The file name `license.crt` is an example.
+Specify the name of the license file received from the technical support manager.
+License files are certificate files in x509 format, which are text files.
+```
+curl -XPOST 127.0.0.1:8050/license/upload -F file=@license.crt
+```
+```
+[License] Upload: Success
+```
+
+#### Stopping Tools
+
+Since the intermediate process for installation is complete, stop QueryPie Tools.
+```
+docker-compose --env-file compose-env --profile tools down
+```
+
+### QueryPie Startup
+
+After creating MySQL Database Tables and installing License using QueryPie Tools, the basic installation process is almost complete.
+Now you can use QueryPie by running QueryPie Server Container.
+Execute the following command to run QueryPie Server Container.
+```
+docker-compose --env-file compose-env --profile querypie up -d
+```
+
+QueryPie Container will run after about 1 minute 50 seconds to 2 minutes 10 seconds in a general server environment.
+```
+docker ps
+
+CONTAINER ID  IMAGE                                            ... NAMES
+69353ab980d8  harbor.chequer.io/querypie/querypie:10.3.0       ... querypie-app-1
+0b8d8b9b9486  harbor.chequer.io/querypie/mysql:8.0.39          ... querypie-mysql-1
+6d96b9cdc95e  harbor.chequer.io/querypie/redis:7.4.2           ... querypie-redis-1
+```
+
+After QueryPie Container's processes start normally, you will see the following execution success notification message in Container Log.
+```
+docker logs -f querypie-app-1
+
+....
+READYZ             | ########################################################################
+READYZ             | #                                                                      #
+READYZ             | #     ██████╗ ██╗   ██╗███████╗██████╗ ██╗   ██╗██████╗ ██╗███████╗    #
+READYZ             | #    ██╔═══██╗██║   ██║██╔════╝██╔══██╗╚██╗ ██╔╝██╔══██╗██║██╔════╝    #
+READYZ             | #    ██║   ██║██║   ██║█████╗  ██████╔╝ ╚████╔╝ ██████╔╝██║█████╗      #
+READYZ             | #    ██║▄▄ ██║██║   ██║██╔══╝  ██╔══██╗  ╚██╔╝  ██╔═══╝ ██║██╔══╝      #
+READYZ             | #    ╚██████╔╝╚██████╔╝███████╗██║  ██║   ██║   ██║     ██║███████╗    #
+READYZ             | #     ╚══▀▀═╝  ╚═════╝ ╚══════╝╚═╝  ╚═╝   ╚═╝   ╚═╝     ╚═╝╚══════╝    #
+READYZ             | #                                                                      #
+READYZ             | ########################################################################
+READYZ             | .--------------------------------------------------------.
+READYZ             | |  🚀 QueryPie Server has been successfully started! 🚀  |
+READYZ             | |  Timestamp in UTC: Sun Jan 26 15:00:56 UTC 2025        |
+READYZ             | |  Timestamp in KST: Mon Jan 27 00:00:56 KST 2025        |
+READYZ             | '--------------------------------------------------------'
+....
+```
+
+### Installation Complete
+
+Great job.
+Now you can see QueryPie in action.
+
+## Basic Configuration Procedures
+
+This guide explains settings that must be performed after installation according to the operating environment.
+
+### Common Settings
+
+Common procedures required when using QueryPie immediately after installation.
+
+#### QueryPie Web Base URL Settings
+
+> Configuration path: Admin Page → General
+This is the URL address of QueryPie for accessing the Web Console. <br/>(Example. `https://querypie.customer.com`)<br/>This URL is also called the Base URL of QueryPie.
+
+This URL must not end with `/`. Please be careful not to add `/` at the end of the URL like `https://querypie.customer.com/`.
+
+This URL is used for the following purposes.
+
+* Used as a callback address in the authentication process of SSO Integration.
+* Used in links to download User Agent from Web Console.
+* For other detailed purposes, please refer to [https://chequer.atlassian.net/wiki/spaces/QCP/pages/876937310](https://chequer.atlassian.net/wiki/spaces/QCP/pages/876937310).
+
+<figure data-layout="center" data-align="center">
+![image-20250520-081112.png](/installation/installation/installation-guide-simple-configuration/image-20250520-081112.png)
+</figure>
+
+### Product-Specific Settings
+
+#### DAC/SAC: Proxy Access Address Settings
+
+Connect to QueryPie Database and register the address for DAC/SAC Proxy access.
+
+<Callout type="info">
+To connect to QueryPie Database from QueryPie Web Console, DB connection settings are required:[DB Connections](../../administrator-manual/databases/connection-management/db-connections)
+
+During the Database connection setup process, you need the Hostname, Username, and Password of QueryPie MySQL.
+
+* Hostname: `host.docker.internal`
+* Username: `querypie` (in case of default settings)
+* Password: (Check DB_PASSWORD in the compose-env file in the directory where QueryPie is installed.)
+
+Values set in compose-env such as DB_PASSWORD, REDIS_PASSWORD, KEY_ENCRYPTION_KEY must be kept secure.
+Please be careful not to expose these values to others.
+</Callout>
+
+Replace the `<customer-proxy-address>` part below with your customer's Proxy access IP or domain and execute the query.
+
+<Callout type="important">
+This address should not have a Scheme such as `http` or `https` attached.
+</Callout>
+```
+UPDATE querypie.proxies SET host = '<customer-proxy-address>' WHERE id = 1;
+```
+
+If the query execution is confirmed to be normal without errors, execute the following query to check if it has been registered.
+```
+SELECT * FROM querypie.proxies;
+```
+
+After registering the address for Proxy access in QueryPie Database, you do not need to restart the Server Container.
+When you attempt to log in from User Agent, after authentication through a web browser, you can use User Agent.
+
+<figure data-layout="center" data-align="center">
+![image-20250520-082706.png](/installation/installation/installation-guide-simple-configuration/image-20250520-082706.png)
+</figure>
+
+#### KAC: Proxy Access Address Settings
+
+Connect to QueryPie Database and register the address for KAC Proxy access.
+
+Replace the `<customer-proxy-fqdn>` part below with your customer's Proxy access IP or domain and execute the query.
+
+As a special note, unlike DAC/SAC settings, you can freely enter Schemes such as `http` or `https`.
+
+<Callout type="important">
+After configuration, QueryPie Container restart is required to issue TLS certificates matching the registered address internally.
+</Callout>
+```
+UPDATE querypie.k_proxy_setting SET host = 'https://<customer-proxy-fqdn>';
+```
+
+<figure data-layout="center" data-align="center">
+![image-20250520-084243.png](/installation/installation/installation-guide-simple-configuration/image-20250520-084243.png)
+</figure>
+
+#### WAC: Proxy Access Address Settings
+
+> Configuration path: Admin Page → Web Apps → Web App Configurations
+WAC Proxy access address settings can be performed from the Web Console.
+
+For detailed configuration procedures, please refer to the following document: [Initial WAC Setup in Web App Configurations](../../administrator-manual/web-apps/wac-quickstart/initial-wac-setup-in-web-app-configurations)
+
+<Callout type="important">
+After configuration, QueryPie Container restart is required to issue TLS certificates matching the registered address internally.
+</Callout>
+
+

--- a/src/content/en/installation/installation/installing-on-aws-eks.mdx
+++ b/src/content/en/installation/installation/installing-on-aws-eks.mdx
@@ -1,0 +1,702 @@
+---
+title: 'Installing on AWS EKS Environment'
+---
+
+# Installing on AWS EKS Environment
+
+### 1. Overview
+
+#### 1.1 Purpose
+
+* Guide for the entire process of installing and configuring QueryPie on AWS EKS cluster
+* Provide configuration guide for stable operation
+
+#### 1.2 Target Audience
+
+* Engineers who understand basic Kubernetes concepts (Pod, Service, Deployment, etc.)
+* Engineers with AWS EKS experience
+
+#### 1.3 Estimated Time
+
+* Entire installation process: approximately 1 hour
+* Environment configuration: 15 minutes
+* Basic component (MySQL, Redis) installation: 15 minutes
+* QueryPie installation: 20 minutes
+* Installation verification and initial configuration: 10 minutes
+
+### 2. Prerequisites
+
+#### 2.1 Infrastructure Requirements
+
+* EKS cluster
+    * Recommended node specifications: r5.xlarge (4 vCPU, 32GB RAM)
+    * Kubernetes version: 1.24 or higher
+    * Required number of nodes: minimum 1 (3 or more recommended for production environments)
+
+#### 2.2 Local Environment Preparation
+
+1. Install and configure AWS CLI
+  ```bash
+brew install awscli
+aws configure  # Access Key, Secret Key required
+  ```
+2. Install kubectl
+  ```bash
+brew install kubectl
+  ```
+3. Install Helm (version 3.10.0 or higher required)
+  ```bash
+brew install helm
+  ```
+4. Install optional tools (recommended)
+  ```bash
+brew install kubectx  # Context switching tool
+brew install fzf      # Command-line fuzzy finder
+  ```
+
+#### 2.3 Access Permission Requirements
+
+* Harbor registry access permissions
+    * Account information (Username/Password)
+    * QueryPie image access permissions
+
+#### 2.4 Network Requirements
+
+* Internet connection (for image download)
+* Network environment accessible to EKS cluster
+* Environment where LoadBalancer can be used (for Ingress configuration)
+
+### 3. Basic Component Installation
+
+1. Before starting, create namespaces for QueryPie installation.
+```
+kubectl create namespace querypie
+```
+
+#### 3.1 MetaDB (MySQL) Installation
+
+MySQL is used as the database that stores QueryPie's metadata.
+
+##### 3.1.1 Create Persistent Volume
+
+1. Create a `pv.yml` file with the following content.
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: local-pv
+  labels:
+    app: mysql     
+spec:
+  capacity:
+    storage: 50Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: /var/lib/mysql
+    type: DirectoryOrCreate
+```
+
+1. Create PV.
+```bash
+kubectl apply -f pv.yml
+```
+
+##### 3.1.2 Deploy MySQL StatefulSet
+
+1. Create a `mysql.yml` file with the following content.
+```yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mysql
+  namespace: querypie
+spec:
+  selector:
+    matchLabels:
+      app: mysql
+  serviceName: mysql
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+        - name: mysql
+          image: mysql:8.0
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: querypie
+            - name: MYSQL_DATABASE
+              value: querypie
+            - name: MYSQL_USER
+              value: querypie
+            - name: MYSQL_PASSWORD
+              value: querypie
+          resources:
+            requests:
+              cpu: "0.5"
+              memory: "2Gi"
+          ports:
+            - containerPort: 3306
+              name: mysql
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/mysql
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 50Gi
+        storageClassName: ""              
+        selector:                       
+          matchLabels:
+            app: mysql
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  namespace: querypie
+  labels:
+    app: mysql
+spec:
+  type: ClusterIP
+  selector:
+    app: mysql
+  ports:
+    - port: 3306
+      targetPort: 3306
+      protocol: TCP
+      name: mysql
+```
+
+1. Create MySQL StatefulSet and Service.
+```bash
+kubectl apply -f mysql.yml
+```
+
+1. Wait until MySQL Pod runs normally.
+```bash
+kubectl get pods -w -n querypie | grep mysql
+```
+
+##### 3.1.3 Database Initialization
+
+1. Connect to MySQL.
+```bash
+kubectl exec -it mysql-0 -n querypie -- mysql -u root -p
+# Password: querypie
+```
+
+1. Create necessary databases.
+```sql
+DROP DATABASE IF EXISTS querypie;
+DROP DATABASE IF EXISTS querypie_log;
+DROP DATABASE IF EXISTS querypie_snapshot;
+
+CREATE database querypie CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+CREATE database querypie_log CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+CREATE database querypie_snapshot CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+
+GRANT ALL privileges ON querypie.* TO querypie@'%';
+GRANT ALL privileges ON querypie_log.* TO querypie@'%';
+GRANT ALL privileges ON querypie_snapshot.* TO querypie@'%';
+
+FLUSH PRIVILEGES;
+```
+
+1. Exit MySQL.
+```sql
+exit
+```
+
+#### 3.2 Redis Installation
+
+Redis is used as QueryPie's session and cache storage.
+
+1. Create a `redis.yml` file with the following content.
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: querypie
+  labels:
+    app: redis
+spec:
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7
+          imagePullPolicy: IfNotPresent
+          args: ["--requirepass", "querypie"]
+          ports:
+            - containerPort: 6379
+              protocol: TCP
+          resources:
+            limits:
+              cpu: "0.1"
+              memory: "1Gi"
+          volumeMounts:
+            - name: redis-data
+              mountPath: /data
+      restartPolicy: Always
+      volumes:
+        - name: redis-data
+          emptyDir: {}   # Data deleted on pod restart (OK for cache purposes)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: querypie
+  labels:
+    app: redis
+spec:
+  type: ClusterIP
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+      protocol: TCP
+```
+
+1. Create Redis Deployment and Service.
+```bash
+kubectl apply -f redis.yml
+```
+
+1. Wait until Redis Pod runs normally.
+```bash
+kubectl get pods -w -n querypie | grep redis
+```
+
+### 4. QueryPie Installation
+
+#### 4.1 Secret Configuration
+
+##### 4.1.1 Register Harbor Registry Authentication Information
+
+```bash
+kubectl create secret docker-registry querypie-regcred \
+  --docker-server=harbor.chequer.io \
+  --docker-username='{harbor-id}' \
+  --docker-password='{harbor-pw}' \
+  -n querypie
+```
+
+##### 4.1.2 QueryPie Environment Configuration
+
+1. Create a `querypie.env` file with the following content.
+```ini
+# Agent Secret (32-character random string)
+AGENT_SECRET=01234567890123456789012345678912
+KEK=querypie
+
+# QueryPie Meta DB connection information
+DB_CATALOG=querypie
+DB_HOST=mysql
+DB_USERNAME=querypie
+DB_PASSWORD=querypie
+DB_PORT=3306
+
+# QueryPie Log DB connection information
+LOG_DB_CATALOG=querypie_log
+LOG_DB_HOST=mysql
+LOG_DB_USERNAME=querypie
+LOG_DB_PASSWORD=querypie
+LOG_DB_PORT=3306
+
+# QueryPie Snapshot DB connection information
+ENG_DB_CATALOG=querypie_snapshot
+ENG_DB_HOST=mysql
+ENG_DB_USERNAME=querypie
+ENG_DB_PASSWORD=querypie
+ENG_DB_PORT=3306
+
+# Redis connection information
+REDIS_NODES=redis:6379
+REDIS_PASSWORD=querypie
+```
+
+1. Register the environment configuration file as a Secret.
+```bash
+kubectl create secret generic querypie-secret --from-env-file=querypie.env -n querypie
+```
+
+#### 4.2 Helm Chart Configuration
+
+##### 4.2.1 Add Helm Repository
+
+```bash
+# Add repository
+helm repo add querypie https://chequer-io.github.io/querypie-deployment/helm-chart
+
+# Check repository list
+helm repo list
+```
+
+##### 4.2.2 values.yaml Configuration
+
+1. Create a `values.yml` file with the following content.
+```yaml
+appVersion: &version 11.3.0
+
+global:
+  image: 
+    # -- Default registry used for all images
+    registry: harbor.chequer.io
+    # -- Default image tags used for all images
+    tag: *version
+    # -- Default image pull policy for all images
+    pullPolicy: IfNotPresent
+  # -- Default labels for all resources deployed by the chart
+  labels: {}
+
+# -- ServiceAccount for QueryPie and QueryPie tools pods
+# It is created for authenticating private image registry and AWS API.
+# @default -- {}
+serviceAccount:
+  labels: {}
+  annotations: {}
+  # -- The name of the secret used for pulling the QueryPie image from the private registry.
+  # To create, run `kubectl create secret docker-registry querypie-regcred --docker-server=harbor.chequer.io --docker-username=admin --docker-password=your-password`
+  imagePullSecrets:
+    - name: querypie-regcred
+
+querypie:
+  # -- Labels used for QueryPie pods.
+  labels: {}
+  # -- Annotations used for QueryPie pods.
+  annotations: {}
+  tolerations: {}
+  # -- NodeSelector for QueryPie pods
+  nodeSelector: {}
+  replicas: 1
+  # -- PodManagementPolicy for QueryPie pods. OrderedReady is fine for most cases, but Parallel is also good for large-scale deployments.
+  podManagementPolicy: Parallel
+  image:
+    # -- (string) Registry used for the QueryPie image. If not set, the global registry will be used.
+    registry:
+    # -- (string) Tag used for the QueryPie image. If not set, the global tag will be used.
+    tag:
+    # -- (string) PullPolicy used for the QueryPie image. If not set, the global pullPolicy will be used.
+    pullPolicy:
+    # -- Repository used for the QueryPie image. (required)
+    repository: querypie/querypie
+  ingress:
+    # -- (bool) If true, Ingress resource for QueryPie will be created.
+    enabled: true
+    labels: {}
+    # -- Annotations used for the Ingress resource.
+    # It is useful when you want to enable controller-specific feature for the Ingress resource.
+    annotations: {}
+    # -- (string) Class used for the Ingress resource. If not set, the default class will be used.
+    ingressClassName: ""
+    # -- Hostname used for the Ingress resource. If not set, every hostname will be accepted.
+    host: querypie.querypie.io #Enter the actually configured url
+    # -- Extra paths used for the Ingress resource.
+    # It is mostly used for redirecting HTTP to HTTPS if the ingress controller does not support redirect by default.
+
+  proxyService:
+    # -- Create a service resource for QueryPie Agent connections.
+    # Basically, it opens 9000/tcp port for the QueryPie Agent, and 40000~/tcp for the Agentless connections.
+    enabled: true
+    labels: {}
+    # -- Annotations used for the Service resource.
+    # It is useful when you want to enable controller-specific feature for the Service resource.
+    annotations: {}
+    type: LoadBalancer
+    loadBalancerClass: ""
+    # -- Set the externalTrafficPolicy to Local is recommended for auditing the real client IP address.
+    externalTrafficPolicy: "Local"
+    # -- SessionAffinity is not required for the QueryPie.
+    sessionAffinity: "None"
+  updateStrategy:
+    # -- The strategy used for updating the QueryPie pods.
+    # It is generally recommended to use the RollingUpdate strategy.
+    # But if required, you can change it to OnDelete for manual operations.
+    type: RollingUpdate
+  resources:
+    requests:
+      cpu: "2000m"
+      memory: 16Gi
+    limits:
+      # -- More than 2 CPU cores are recommended.
+      cpu: "2000m"
+      # -- More than 16Gi memory is recommended.
+      memory: 16Gi
+  logrotator:
+    image:
+      # -- (string) Registry used for the Logrotate image. If not set, the global registry will be used.
+      repository: querypie/logrotate
+      # -- (string) Tag used for the Logrotate image. If not set, the global tag will be used.
+      tag: latest
+  # -- External storage for the QueryPie Object Storage.
+  externalStorage:
+    # -- Type of the external storage.
+    # - none: No external storage.
+    # - persistentVolumeClaim: using a single Persistent Volume Claim for all QueryPie pods.
+    type: none
+    # -- Use a persistent volume claim for the external storage. It will be available if the type is persistentVolumeClaim.
+    persistentVolumeClaim:
+      # -- Use an existing Persistent Volume Claim for the external storage.
+      # If you set this to true, this helm chart will not create a new Persistent Volume Claim.
+      useExisting: false
+      # -- The name of the existing Persistent Volume Claim to be used.
+      claimName: ""
+      # -- Metadata of the Persistent Volume Claim.
+      metadata:
+        annotations: {}
+        labels: {}
+      # -- Spec of the Persistent Volume Claim.
+      spec:
+        storageClassName: ""
+        resources:
+          requests:
+            storage: 100Gi
+        # -- It is required to have ReadWriteMany access mode on production.
+        accessModes:
+          - ReadWriteMany
+  # -- Extra environment variables used for the QueryPie pods.
+  # This is useful for experimental features, debugging, workaround, and so on.
+  # for example:
+  # API_JVM_HEAPSIZE: '2g' will set the JVM heap size to 2GB.
+  extraEnvs: {}
+
+tools:
+  image:
+    # -- Registry used for the QueryPie tools image. If not set, the global registry will be used.
+    repository: querypie/querypie-tools
+
+config:
+  # -- External URL that users use to access the QueryPie via web.
+  # Specify the scheme, hostname, and port is required.
+  externalURL: "https://querypie.querypie.io" #Enter the actually configured url
+  secretName: "querypie-secret"
+
+  database:
+    querypie:
+      # -- The maximum number of connections that QueryPie can use for "metastore" purposes.
+      connectionPoolSize: 20
+
+  dac:
+    # -- This setting is used to ignore simple queries sent by client tools such as DataGrip.
+    # Please refer to the commented-out example below.
+    skipCommandConfigData: "{}"
+    # skipCommandConfig: |
+    #   {
+    #     "mysql": [
+    #       "^(/\\*.*?\\*/)?\\s*SELECT\\s+@@session\\s*\\.\\s*\\w+\\s*$",
+    #       "^(/\\*.*?\\*/)?\\s*SET\\s+session\\s+transaction\\s+\\w+(\\s+\\w+)*\\s*$",
+    #       "^(/\\*.*?\\*/)?\\s*SET\\s+net_write_timeout\\s*=\\s*\\d+\\s*$",
+    #       "^(/\\*.*?\\*/)?\\s*SELECT\\s+database\\s*\\(\\s*\\)\\s*$",
+    #       "^(/\\*.*?\\*/)?\\s*SET\\s+SQL_SELECT_LIMIT\\s*=\\s*\\w+$",
+    #       "^SHOW\\s+VARIABLES\\s+LIKE\\s+'aurora\\\\_version'\\s*$",
+    #       "^SELECT\\s+version\\s*\\(\\s*\\)\\s*,\\s*@@version_comment\\s*,\\s*database\\s*\\(\\s*\\)\\s*$",
+    #       "^SET\\s+autocommit\\s*=\\s*\\d+$",
+    #       "^(/\\*.*?\\*/)\\s*SELECT\\s+((@@session\\s*\\.\\s*|@@)\\w+(\\s+AS\\s+\\w+)?(\\s*,\\s*)?)+\\s*$"
+    #     ]
+    #   }
+    # -- The path where the skip command config file will be mounted.
+    skipCommandConfigFile: /app/arisa/skip_command_config.json
+```
+
+#### 4.3 QueryPie Installation
+
+1. Install QueryPie using Helm.
+```bash
+helm upgrade --install poc querypie/querypie --version 1.4.1 -n querypie -f values.yaml
+```
+
+1. Run database migration.
+```bash
+kubectl exec -it deployments/poc-querypie-tools -n querypie -- /app/script/migrate.sh runall
+```
+
+1. Register license. (Prepare license file.)
+```bash
+kubectl port-forward -n querypie deploy/poc-querypie-tools 8050:8050 &
+curl -X POST http://127.0.0.1:8050/license/upload -F file=@license.crt
+[License] Upload: Success  # Result
+# Stop port-forward
+jobs
+kill %1
+```
+
+#### 4.4 Installation Verification
+
+1. Check Pod status.
+```bash
+kubectl get pods -n querypie
+```
+
+1. Check logs.
+```bash
+kubectl logs pod/poc-querypie-0 -f
+```
+
+1. Check service access.
+```bash
+kubectl port-forward -n querypie statefulsets/poc-querypie 80:80
+```
+
+### 5. Troubleshooting Guide
+
+#### 5.1 Pre-Installation Checks
+
+##### 5.1.1 Check Cluster Access Permissions
+
+```bash
+# Check cluster access
+kubectl cluster-info
+
+# Check current context
+kubectl config current-context
+
+# Check namespace access permissions
+kubectl auth can-i create deployment -n querypie
+```
+
+##### 5.1.2 Check Resource Status
+
+```bash
+# Check node resource status
+kubectl top nodes
+
+# Check available storage classes
+kubectl get storageclass
+```
+
+#### 5.2 General Troubleshooting
+
+##### 5.2.1 Check Pod Status
+
+```bash
+# Query Pod status
+kubectl get pods -n querypie
+
+# Check Pod detailed information
+kubectl describe pod <pod-name> -n querypie
+
+# Check Pod logs
+kubectl logs <pod-name> -n querypie
+kubectl logs <pod-name> -n querypie --previous  # Check previous logs if restarted
+```
+
+Key problem statuses and checks:
+
+* `ImagePullBackOff`: Check Harbor registry authentication information
+* `Pending`: Check if node resources are insufficient
+* `CrashLoopBackOff`: Check application errors through logs
+
+##### 5.2.2 Check Service Connections
+
+```bash
+# Check Service status
+kubectl get svc -n querypie
+
+# Check Endpoints
+kubectl get endpoints -n querypie
+
+# Test MySQL Service connection
+kubectl exec -it mysql-0 -- mysql -u querypie -p -h mysql querypie
+
+# Test Redis Service connection
+kubectl exec -it $(kubectl get pod -l app=redis -o jsonpath='{.items[0].metadata.name}') -- redis-cli -a querypie ping
+```
+
+##### 5.2.3 Check Ingress
+
+```bash
+# Check Ingress status
+kubectl get ingress -n querypie
+
+# Check Ingress detailed information
+kubectl describe ingress -n querypie
+```
+
+#### 5.3 Resource Monitoring
+
+```bash
+# Check Pod CPU/Memory usage
+kubectl top pods -n querypie
+
+# Check Node CPU/Memory usage
+kubectl top nodes
+
+# Check resource limits of specific Pod
+kubectl get pod <pod-name> -n querypie -o jsonpath='{.spec.containers[0].resources}'
+```
+
+#### 5.4 Check Installation Configuration
+
+```bash
+# Check ConfigMap
+kubectl get configmap -n querypie
+
+# Check Secret list
+kubectl get secrets -n querypie
+
+# Check PV/PVC status
+kubectl get pv
+kubectl get pvc -n querypie
+```
+
+#### 5.5 Information Required for Support Requests
+
+If troubleshooting is difficult, collect the following information and contact the support team:
+
+1. Environment information
+```bash
+# Kubernetes version
+kubectl version --short
+
+# Node information
+kubectl get nodes -o wide
+
+# Helm version
+helm version
+```
+
+1. QueryPie status information
+```bash
+# Helm deployment status
+helm status poc -n querypie
+
+# Pod detailed information
+kubectl describe pod/poc-querypie-0 -n querypie
+
+# Recent event list
+kubectl get events -n querypie --sort-by='.lastTimestamp'
+```
+
+1. Log information
+```bash
+# Save QueryPie logs
+kubectl logs pod/poc-querypie-0 -n querypie > querypie.log
+
+# Save related component logs
+kubectl logs mysql-0 > mysql.log
+kubectl logs $(kubectl get pod -l app=redis -o jsonpath='{.items[0].metadata.name}') > redis.log
+```
+
+### 6. References
+
+* [Amazon EKS Workshop](https://www.eksworkshop.com)
+* [Amazon EKS Documentation](https://docs.aws.amazon.com/eks/)
+* [Kubernetes Official Documentation](https://kubernetes.io/docs/)
+

--- a/src/content/en/installation/license-installation.mdx
+++ b/src/content/en/installation/license-installation.mdx
@@ -4,16 +4,16 @@ title: 'License Installation'
 
 # License Installation
 
-This guide explains how to install a Product License for QueryPie products for initial installation and upgrade installation.
+This guide explains how to install Product License for QueryPie product during initial installation and upgrade installation.
 
 ### When Installing QueryPie for the First Time
 
-When installing QueryPie for the first time, you can install the Product License by running a component called QueryPie Tools.
-QueryPie Tools is a tool that works separately from QueryPie Server and is used for product installation, upgrades, license installation, etc.
+When installing QueryPie for the first time, you can install Product License by running a component called QueryPie Tools.
+QueryPie Tools is a tool that operates separately from QueryPie Server and is used for product installation, upgrade, license installation, etc.
 
-The method of installing a Product License using QueryPie Tools is briefly explained as follows.
+To briefly explain how to install Product License using QueryPie Tools:
 
-Run the QueryPie Tools Container using the `docker-compose` command.
+Run QueryPie Tools Container using the `docker-compose` command.
 ```
 ubuntu@querypie:~/querypie/10.2.4$ docker-compose --env-file compose-env --profile tools up -d
 [+] Running 1/1
@@ -21,27 +21,27 @@ ubuntu@querypie:~/querypie/10.2.4$ docker-compose --env-file compose-env --profi
 ubuntu@querypie:~/querypie/10.2.4$ 
 ```
 
-Install the license file named `license.crt` through the QueryPie Tools API using the `curl` command. The `license.crt` license file name is an example, and it is the product license file received from the technical support representative and moved and saved on the server.
-You may use a different file name.
+Install the `license.crt` license file through QueryPie Tools API using the `curl` command. The `license.crt` license file name is an example, and it is the product license file transferred and stored on the server from the technical support manager.
+You can use a different file name.
 ```
 ubuntu@querypie:~/querypie/10.2.4$ curl -XPOST 127.0.0.1:8050/license/upload -F file=@license.crt
 [License] Upload: Success
 ubuntu@querypie:~/querypie/10.2.4$ 
 ```
 
-If you see the response message `[License] Upload: Success`, the license has been installed successfully.
+If you see the response message `[License] Upload: Success`, the license has been installed normally.
 
 For detailed explanations of the overall product installation process and Product License installation steps, please refer to the following document: [Installation Guide - Simple Configuration](installation/installation-guide-simple-configuration)
 
-### When Extending the License of QueryPie in Use
+### When Extending License for QueryPie in Use
 
-There may be cases where you want to extend the license of QueryPie currently in use.
+There may be cases where you want to extend the license for QueryPie currently in use.
 For example, assume a case where you want to install a Production License on a QueryPie Server Instance that was running PoC and extend the existing PoC License.
 
 If the validity period of the new Production license does not overlap with the validity period of the existing PoC license, you can simply add and install the new Production license.
 The procedure is as follows.
 
-Run the QueryPie Tools Container using the `docker-compose` command.
+Run QueryPie Tools Container using the `docker-compose` command.
 
 `docker-compose --env-file compose-env --profile tools up -d`
 ```
@@ -51,8 +51,8 @@ ubuntu@querypie:~/querypie/10.2.4$ docker-compose --env-file compose-env --profi
 ubuntu@querypie:~/querypie/10.2.4$ 
 ```
 
-Install the license file named `license.crt` through the QueryPie Tools API using the `curl` command. The `license.crt` license file name is an example, and it is the product license file received from the technical support representative and moved and saved on the server.
-You may use a different file name.
+Install the `license.crt` license file through QueryPie Tools API using the `curl` command. The `license.crt` license file name is an example, and it is the product license file transferred and stored on the server from the technical support manager.
+You can use a different file name.
 
 `curl -XPOST 127.0.0.1:8050/license/upload -F file=@license.crt`
 ```
@@ -61,35 +61,35 @@ ubuntu@querypie:~/querypie/10.2.4$ curl -XPOST 127.0.0.1:8050/license/upload -F 
 ubuntu@querypie:~/querypie/10.2.4$ 
 ```
 
-If you see the response message `[License] Upload: Success`, the license has been installed successfully.
+If you see the response message `[License] Upload: Success`, the license has been installed normally.
 
-Looking at the detailed process, it is the same as the license installation process at the time of initial installation.
+Looking at the detailed process, it is the same as the license installation process at the initial installation time.
 
 However, in some cases, you may encounter the response message `[License] Upload: The periods overlap.`, and in this case, the new license installation has failed.
-If you encounter this response message, please refer to the "When Replacing the License of QueryPie in Use" section for how to handle it.
+If you encounter this response message, please refer to the "When Replacing License for QueryPie in Use" section for how to handle it.
 
 
-### When Replacing the License of QueryPie in Use
+### When Replacing License for QueryPie in Use
 
-QueryPie's License management function has one limitation: if the validity period of an existing license partially overlaps with the validity period of a new license, the new license cannot be installed additionally.
-Due to this, when trying to install a license with overlapping validity periods, you must delete the existing license through a separate procedure and then install a new license.
+QueryPie's License management functionality has one constraint: if the validity period of the existing license partially overlaps with the validity period of the new license, you cannot install the new license additionally.
+Due to this, when installing a license with an overlapping validity period, you must delete the existing license through a separate procedure and then install the new license.
 
-( We recognize that this limitation causes customer inconvenience, but changing the license function is an issue under internal review.
+( We recognize that this constraint causes customer inconvenience, and this is a matter under internal review for license functionality changes.
 )
 
 There are two main methods to delete an existing license.
 
-* Using mysql client inside Docker Container to delete the existing license
-* Connecting to QueryPie MySQL from QueryPie Web Console to delete the existing license
-    * For customers using QueryPie DAC functionality, they can connect to the QueryPie MySQL Database by adding a DAC Database Connection. The detailed method is not explained in this document.
+* Delete the existing license using mysql client inside Docker Container
+* Delete the existing license by connecting to QueryPie MySQL from QueryPie Web Console
+    * For customers using QueryPie DAC functionality, you can connect to QueryPie MySQL Database by adding a DAC Database Connection. Detailed methods are not explained in this document.
 
 This document explains how to delete an existing license using mysql client inside Docker Container.
 
-#### Deleting an Existing License
+#### Deleting Existing License
 
 Connect to the Linux server where QueryPie Server Container is running via terminal.
 
-Execute the docker exec command to run bash inside the QueryPie Server Container.
+Execute the docker exec command to run bash inside QueryPie Server Container.
 
 `docker exec -it querypie-app-1 bash`
 ```
@@ -99,7 +99,7 @@ ubuntu@querypie:~/querypie/10.2.4$ docker exec -it querypie-app-1 bash
 
 Run mysql client inside the Container to connect to QueryPie MySQL.
 Inside the Container, environment variables are defined, so information for connecting to QueryPie MySQL is provided.
-Please note that in the `mysql` command below, there is no space between the option name and option value, such as `-h`, `$DB_HOST`, etc.
+Please note that in the `mysql` command below, there is no space between option names and option values such as `-h`, `$DB_HOST`.
 
 `mysql -h$DB_HOST -u$DB_USERNAME -p$DB_PASSWORD $DB_CATALOG`
 ```
@@ -155,12 +155,12 @@ ubuntu@querypie:~/querypie/10.2.4$
 ```
 
 
-#### Running QueryPie Tools to Install License
+#### Run QueryPie Tools to Install License
 
 Now run QueryPie Tools to install the License.
 You can install the license in the same way as during initial installation.
 
-Run the QueryPie Tools Container using the `docker-compose` command.
+Run QueryPie Tools Container using the `docker-compose` command.
 
 `docker-compose --env-file compose-env --profile tools up -d`
 ```
@@ -170,8 +170,8 @@ ubuntu@querypie:~/querypie/10.2.4$ docker-compose --env-file compose-env --profi
 ubuntu@querypie:~/querypie/10.2.4$ 
 ```
 
-Install the license file named `license.crt` through the QueryPie Tools API using the `curl` command. The `license.crt` license file name is an example, and it is the product license file received from the technical support representative and moved and saved on the server.
-You may use a different file name.
+Install the `license.crt` license file through QueryPie Tools API using the `curl` command. The `license.crt` license file name is an example, and it is the product license file transferred and stored on the server from the technical support manager.
+You can use a different file name.
 
 `curl -XPOST 127.0.0.1:8050/license/upload -F file=@license.crt`
 ```
@@ -180,18 +180,17 @@ ubuntu@querypie:~/querypie/10.2.4$ curl -XPOST 127.0.0.1:8050/license/upload -F 
 ubuntu@querypie:~/querypie/10.2.4$ 
 ```
 
-If you see the response message `[License] Upload: Success`, the license has been installed successfully.
+If you see the response message `[License] Upload: Success`, the license has been installed normally.
 
-#### Restarting QueryPie Server Container
+#### Restart QueryPie Server Container
 
 Now, please restart the QueryPie Server Container.
 
 * `docker-compose --env-file compose-env --profile querypie down`
 * `docker-compose --env-file compose-env --profile querypie up -d`
 
-Please check in the installed QueryPie Web Console whether the product is working properly.
+Please check in the installed QueryPie Web Console whether the product is functioning normally.
 
 So far, we have looked at the process of replacing an existing license and installing a new license.
-Thank you for your work.
-
+Great job.
 

--- a/src/content/en/installation/prerequisites.mdx
+++ b/src/content/en/installation/prerequisites.mdx
@@ -9,8 +9,8 @@ import { Callout } from 'nextra/components'
 
 ### Summary
 
-Before proceeding with installation, you need to prepare the following items.
-In summary, they are as follows:
+Before proceeding with installation, you must prepare the following.
+In summary, they are as follows.
 
 * 1 Linux server
 * 1 PC with a web browser installed
@@ -18,91 +18,91 @@ In summary, they are as follows:
 ### Server Environment
 
 * 1 server computer with Linux OS installed: referred to as `Server VM` below.
-    * You may use cloud services such as AWS, Azure, Google Cloud Platform, etc.
+    * You can also use cloud services such as AWS, Azure, Google Cloud Platform.
 * Hardware performance and capacity
-    * The server computer specifications are presented with 4 vCPUs and 16GiB Memory as the basic specifications. This performance specification is suitable for testing various QueryPie features.
-    * For cases where hundreds or more users use it with high traffic, 8 vCPUs and 32 GiB Memory are recommended as the recommended specifications.
-    * It is recommended to configure the root file system size to 100GiB or more.
+    * Server computer specifications are presented with 4 vCPUs and 16GiB Memory as basic specifications. This performance specification is suitable for testing various QueryPie features.
+    * For cases where hundreds or more users use it with high traffic, we recommend 8 vCPUs and 32 GiB Memory as recommended specifications.
+    * We recommend configuring the Root file system size to 100GiB or more.
 * CPU Architecture
-    * CPU with x86_64 or AMD64 architecture is recommended. Please apply CPUs such as AMD64, Intel Xeon, etc.
-    * **[BETA]** Starting from QueryPie version 11.1.1, CPUs with ARM64 architecture are supported.
-        * Since production-level feature testing has not been performed, it is recommended for feature testing in development environments and trial use.
-        * For AWS, instance types such as `t4g.xlarge`, `m7g.xlarge` can be used.
-    * **[BETA]** Starting from QueryPie version 11.1.1, macOS environments using Apple Silicon CPUs are supported.
+    * CPU recommends x86_64 or AMD64 architecture. Please apply CPUs such as AMD64, Intel Xeon.
+    * **[BETA]** Starting from QueryPie version 11.1.1, it supports CPUs with ARM64 architecture.
+        * Since production-level functional testing has not been performed, it is recommended for functional testing and trial use in development environments.
+        * For AWS, you can use instance types such as `t4g.xlarge`, `m7g.xlarge`.
+    * **[BETA]** Starting from QueryPie version 11.1.1, it supports macOS environments using Apple Silicon CPU.
 * `Server VM` must have an IP address that users can access.
-    * It is recommended to set up a Fully Qualified Domain Name (FQDN) for connection.
-* The following ports must be open on `Server VM`:
+    * We recommend setting a Fully Qualified Domain Name (FQDN) for connection.
+* The following ports must be open on `Server VM`.
     * TCP 80: QueryPie web service port
     * TCP 9000: Port for QueryPie User Agent to connect to QueryPie Server
-    * (Optional): If you want to access via HTTPS using port 443 TLS(SSL) instead of 80, TCP 443 port access must be available.
+    * (Optional): If you want to access via HTTPS using port 443 TLS(SSL) instead of 80, TCP 443 port access must be possible.
 
 <Callout type="info">
-Summary of recommended server specifications for production environments.
+This summarizes server recommended specifications for Production environments.
 * Basic specifications: Hardware: CPU 4 vCPUs, AMD64 Architecture, Memory 16 GiB, Disk 100 GiB+
     * AWS EC2: m6i.xlarge, m7i.xlarge, 
-    * GCP Compute Engine: c4-standard-4, n4-standard-4 (or -standard-4 models with AMD64 architecture)
+    * GCP Compute Engine: c4-standard-4, n4-standard-4 (or AMD64 architecture -standard-4 models)
 * Recommended specifications for multi-user production environments: Hardware: CPU 4 or 8 vCPUs, AMD64 Architecture, Memory 32 GiB, Disk 100 GiB+
     * AWS EC2: m6i.2xlarge, m7i.2xlarge, r6i.xlarge
-    * GCP Compute Engine: c4-standard-8, n4-standard-8 (or -standard-8 models with AMD64 architecture)
+    * GCP Compute Engine: c4-standard-8, n4-standard-8 (or AMD64 architecture -standard-8 models)
 * OS: Linux (install and use docker daemon)
 </Callout>
 
 ### Linux Distributions
 
-QueryPie ACP works properly on most Linux distributions that can use Docker and Podman.
-And, when using QueryPie ACP products on some Linux distributions, you can receive technical support effectively.
+QueryPie ACP works normally on most Linux distributions that can use Docker and Podman.
+And when using QueryPie ACP product on some Linux distributions, you can receive technical support effectively.
 
 #### Verified Linux Distributions for Installation and Operation
 
-* Amazon Linux 2, Amazon Linux 2023: Only available on AWS Cloud.
+* Amazon Linux 2, Amazon Linux 2023: Only provided on AWS Cloud.
 * Ubuntu Server 22.04 LTS, 24.04 LTS
 * Red Hat Enterprise Linux 8, 9, 10
 * Rocky Linux 8, 9
 
-For detailed information on the support status of various Linux distributions and Docker, Podman, please refer to this document: [Linux Distribution and Docker, Podman Support Status](prerequisites/linux-distribution-and-docker-podman-support-status)
+For detailed information on support status of various Linux distributions and Docker, Podman, please refer to this document: [Linux Distribution and Docker, Podman Support Status](prerequisites/linux-distribution-and-docker-podman-support-status)
 
 ### Container Engine and Compose Tool
 
 QueryPie is provided in Container format.
-Therefore, a Container Engine is required.
-Tools that create, run, and stop containers from images, such as Docker and Podman, are called Container Engines.
-Also, to easily use Container Engines, a Compose Tool is required.
-Docker Compose is called a Compose Tool.
+Therefore, Container Engine is required.
+Container Engine refers to tools for creating, running, and stopping Containers from Images, such as Docker and Podman.
+Also, Compose Tool is required to easily use Container Engine.
+Docker Compose is called Compose Tool.
 
-#### Container Engine and Version
+#### Container Engine and Versions
 
 * Docker Desktop: Version 20.10 or later
 * Docker Community Edition: Version 20.10 or later
-* Docker Enterprise Edition: The product name has been changed to Docker Desktop.
+* Docker Enterprise Edition: Product name has been changed to Docker Desktop.
 * Podman: Version 4.9.0 or later
 
-#### Compose Tool and Version
+#### Compose Tool and Versions
 
 * Docker Compose: Version 2.29.0 or later
-    * Docker Compose is recommended over Podman Compose. It has been verified to work properly with the combination of Podman and Docker Compose.
+    * We recommend using Docker Compose over Podman Compose. We have verified that it works normally with Podman and Docker Compose combination.
 * Podman Compose: Version 1.5.0 or later
 
-### Server FQDN Setup and TLS Certificate
+### Server FQDN Settings and TLS Certificate
 
 This item is not required.
 However, it is a recommended item from both security and user usability perspectives.
 
 * Prepare a Fully Qualified Domain Name (FQDN) connected to `Server VM`.
-    * Apply DNS settings connected to the IP address of `Server VM` to prepare settings that can connect to the host with FQDN.
-* Prepare a TLS certificate Certificate corresponding to FQDN.
-    * It is used to access with `https` address.
+    * Prepare settings to connect to the host with FQDN by applying DNS settings connected to the IP address of `Server VM`.
+* Prepare a TLS Certificate Certificate corresponding to FQDN.
+    * Used to access with `https` address.
 
 ### User PC Environment
 
 * PC with web browser installed: referred to as `User PC` below.
-    * Use the latest versions of browsers such as Chrome, Firefox, Safari, Edge, etc.
-    * Using a web browser is required. Even when using QueryPie User Agent, a connection via web browser is required.
-* `User PC` must be able to open a web browser with the IP address or FQDN of `Server VM` and access the QueryPie web service.
-* When installing QueryPie User Agent, it is only supported on some OS. It can be used on OS that supports .NET8 or higher.
+    * Use the latest versions of browsers such as Chrome, Firefox, Safari, Edge.
+    * Using a web browser is required. Even when using QueryPie User Agent, a web browser connection is required.
+* `User PC` must be able to open a web browser with the IP address or FQDN of `Server VM` and access QueryPie web service.
+* When installing QueryPie User Agent, it is only supported on some OSes. It can be used on OSes that support .NET8 or higher.
     * QueryPie User Agent runs on Windows, MacOS, and Linux OS.
-        * For Windows OS, Windows 8 or later version must be used.
-        * For MacOS OS, MacOS 10.15 or later version must be used. MacOS 12 (Monterey) or later version is recommended.
-        * For Linux OS, Debian 9 or later, Ubuntu 16.04 or later, Fedora 30 or later versions must be used.
+        * For Windows OS, you must use Windows 8 or later.
+        * For MacOS OS, you must use MacOS 10.15 or later. We recommend MacOS 12 (Monterey) or later.
+        * For Linux OS, you must use Debian 9 or later, Ubuntu 16.04 or later, Fedora 30 or later.
     * For Linux OS, headless mode is not supported. It must be run in a GUI environment using X-Window, VNC, etc.
-    * If you use QueryPie only with a web browser without using User Agent, you may ignore this item.
+    * If you use QueryPie only with a web browser without using User Agent, you can ignore this item.
 

--- a/src/content/en/installation/prerequisites/_meta.ts
+++ b/src/content/en/installation/prerequisites/_meta.ts
@@ -1,0 +1,4 @@
+export default {
+  'linux-distribution-and-docker-podman-support-status': 'Linux Distribution and Docker, Podman Support Status',
+  'configuring-rootless-mode-with-podman': 'Configuring Rootless Mode with Podman',
+};

--- a/src/content/en/installation/prerequisites/configuring-rootless-mode-with-podman.mdx
+++ b/src/content/en/installation/prerequisites/configuring-rootless-mode-with-podman.mdx
@@ -1,0 +1,126 @@
+---
+title: 'Configuring Rootless Mode with Podman'
+---
+
+# Configuring Rootless Mode with Podman
+
+Podman is a container engine that can replace Docker.
+QueryPie supports both Docker and Podman container engine environments.
+Podman operates in Rootless Mode in basic installation configuration.
+Accordingly, if you need to configure a Rootless Mode environment according to your customer's security policy, we recommend implementing it with Podman.
+
+### Installing Podman Easily
+
+You can install Podman easily using setup.v2.sh.
+Podman automatically installed by setup.v2.sh applies Rootless Mode by default.
+
+The method to install Podman using setup.v2.sh is as follows.
+```bash
+$ bash <(curl -s https://dl.querypie.com/setup.v2.sh) --install-container-engine
+```
+
+This command automatically detects the Linux distribution of the server and installs Podman if Podman is smoothly supported.
+Linux distributions that install Podman are as follows.
+
+* Red Hat Enterprise Linux 8, 9, 10
+* Rocky 8, 9
+* Ubuntu 24.04 LTS
+
+Linux distributions that install Docker instead of Podman are as follows.
+For reasons why Docker should be used in the Linux distributions below, please refer to this document: [https://querypie.atlassian.net/wiki/spaces/QCP/pages/1298530305/Docker+Podman+and+Linux+Distributions+KO?atl_f=PAGETREE](https://querypie.atlassian.net/wiki/spaces/QCP/pages/1298530305/Docker+Podman+and+Linux+Distributions+KO?atl_f=PAGETREE)
+
+* Amazon Linux 2, Amazon Linux 2023
+* Ubuntu 22.04 LTS
+
+### Manually Installing Rootless Mode Podman
+
+On Red Hat Enterprise Linux and Rocky, you can install Podman directly manually with the following commands.
+```bash
+$ sudo dnf -y -q --best install podman podman-plugins podman-manpages podman-docker
+$ systemctl --user enable --now podman.socket
+```
+
+Please note that you must activate the `podman.socket` service using the `systemctl` command. You must activate the `podman.socket` service to use Docker Compose and Podman together.
+
+When using the `--user` option in the `systemctl` command, it is installed in Rootless Mode. If you do not use the `--user` option, it is installed in Rootful Mode.
+
+On Ubuntu 24.04 LTS, you can install Podman directly manually with the following commands.
+```bash
+$ sudo apt -qq update
+$ sudo apt-get -y -qq install podman podman-docker
+$ systemctl --user enable --now podman.socket
+```
+
+### Installing QueryPie in Rootless Mode Podman
+
+You can install QueryPie easily in a Rootless Mode Podman environment using setup.v2.sh.
+
+When installing QueryPie for the first time, execute the following command from the home directory of the Linux account where you will install the Compose package.
+setup.v2.sh automatically installs the recommended version of QueryPie.
+```bash
+$ bash <(curl -s https://dl.querypie.com/setup.v2.sh)
+```
+
+If you want to install by specifying a QueryPie version, you can specify the version as follows.
+```bash
+$ bash <(curl -s https://dl.querypie.com/setup.v2.sh) --install 11.0.1
+```
+
+When you execute the above command, the entire installation process is automatically performed, including package.tar.gz configuration for Compose, `.env` environment variable configuration, Container image download, Migration execution, Container execution, and systemd service registration for Rootless Mode Podman.
+
+#### Linux Server Restart and systemd Service Registration
+
+For Rootless Mode Podman, if the Linux server restarts, Containers will not run automatically without additional configuration.
+This is a characteristic of Rootless Mode Podman.
+
+For Containers to run automatically when the Linux server restarts, you must register and activate a systemd service that executes the `podman compose up -d` command.
+systemd service files for QueryPie are provided by default in package.tar.gz for Compose.
+
+If you install QueryPie using `setup.v2.sh`, it automatically performs these systemd service registration and activation processes.
+Therefore, users do not need to execute this part directly.
+
+However, to smoothly perform QueryPie installation and operation, understanding of systemd service registration and activation processes is necessary, and you can solve problems by directly controlling systemd services.
+
+First, system configuration is required for systemd user mode services to be automatically activated. You must turn on linger mode for this user using the `loginctl` command.
+If you do not apply this setting, systemd services will only work after the user logs into the Linux system.
+To automatically activate systemd services when the user is not logged into the Linux server, please turn on linger mode.
+```bash
+$ sudo loginctl enable-linger $USER
+```
+
+Create a symbolic link pointing to the systemd service file under `$HOME/.config/systemd/user/`.
+```bash
+$ systemctl --user link querypie/current/systemd/podman-querypie-database.service
+Created symlink /home/ec2-user/.config/systemd/user/podman-querypie-database.service → /home/ec2-user/querypie/current/systemd/podman-querypie-database.service.
+$ systemctl --user link querypie/current/systemd/podman-querypie-app.service
+Created symlink /home/ec2-user/.config/systemd/user/podman-querypie-app.service → /home/ec2-user/querypie/current/systemd/podman-querypie-app.service.
+```
+
+Activate the service with the systemd enable command.
+```bash
+$ systemctl --user enable --now podman-querypie-database.service
+Created symlink /home/ec2-user/.config/systemd/user/default.target.wants/podman-querypie-database.service → /home/ec2-user/querypie/11.1.1/systemd/podman-querypie-database.service.
+$ systemctl --user enable --now podman-querypie-app.service
+Created symlink /home/ec2-user/.config/systemd/user/default.target.wants/podman-querypie-app.service → /home/ec2-user/querypie/11.1.1/systemd/podman-querypie-app.service.
+```
+
+When Using Separately Configured MySQL
+
+If you use a separately configured MySQL instead of running MySQL on one Linux server using the default `./querypie/&lt;version&gt;/compose.yml`, you can change the systemd service operation scope.
+
+You just need to not activate `podman-querypie-database.service`.
+You can turn off running systemd services with the following command.
+```bash
+$ systemctl --user disable podman-querypie-database.service
+```
+
+To smoothly operate QueryPie, you must be familiar with managing systemd services using the `systemctl` command.
+However, this document does not cover in detail how to manage systemd services using the `systemctl` command.
+
+### References
+
+* Running containers automatically using systemd services in Red Hat Enterprise Linux, Rootless Podman environment
+    * [https://www.redhat.com/en/blog/container-systemd-persist-reboot](https://www.redhat.com/en/blog/container-systemd-persist-reboot) 
+    * [https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/building_running_and_managing_containers/assembly_porting-containers-to-systemd-using-podman_building-running-and-managing-containers](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/building_running_and_managing_containers/assembly_porting-containers-to-systemd-using-podman_building-running-and-managing-containers) 
+
+

--- a/src/content/en/installation/prerequisites/linux-distribution-and-docker-podman-support-status.mdx
+++ b/src/content/en/installation/prerequisites/linux-distribution-and-docker-podman-support-status.mdx
@@ -1,0 +1,323 @@
+---
+title: 'Linux Distribution and Docker, Podman Support Status'
+---
+
+import { Callout } from 'nextra/components'
+
+# Linux Distribution and Docker, Podman Support Status
+
+This document is a technical guide for selecting container-based deployment and operation environments for QueryPie Server.
+QueryPie Server has been verified on Docker and Podman container engines, and supports optimal operation environment selection by analyzing compatibility and recommended configurations on various Linux distributions.
+This document provides technical basis and practical guidelines that system architects and infrastructure engineers can refer to when designing environments.
+
+Installation methods, verification scripts, operation procedures, etc. are not covered in this document.
+
+* Last updated: August 29, 2025 
+* Verification date: August 29, 2025
+
+### Container Engine and Compose
+
+QueryPie Server is deployed and operated in a container-based manner, and has completed functional verification and provides technical support on two container engines: Docker and Podman.
+
+Docker is a widely used container engine that includes the engine itself and tool chains (Compose, etc.), and is provided in community free version and commercial version (Desktop).
+Podman is an open-source container engine that provides command systems and workflows similar to Docker while supporting rootless execution by default, and is especially recommended as standard in RHEL series.
+
+Docker and Podman can be used together with Compose to run and manage multiple Containers.
+Compose is suitable for running and operating software by running multiple Containers on a single host.
+Docker Compose is widely used as an implementation of Compose, and both Docker and Podman can be used with Docker Compose.
+Docker Compose consists of a single executable file and has no dependencies on other packages, making installation easy.
+For Podman, an implementation called Podman Compose implemented in Python is also provided.
+
+#### Recommended Container Engine and Compose Configuration
+
+QueryPie primarily recommends **Docker + Docker Compose** combination or **Podman + Docker Compose** combination in operation environments.
+The recommended minimum versions are verified as Docker Engine 23.0 (released February 2023) or higher, Docker Compose 2.29.0 (released July 2024) or higher, and Podman 4.9.0 (released January 2024) or higher.
+
+Podman + Podman Compose combination is technically supported, but requires Python dependencies and additional environment configuration, and has functional limitations compared to Docker Compose, so it is classified as a secondary recommended configuration.
+
+<Callout type="important">
+Depending on the Linux distribution, only one of Docker or Podman may be supported.
+Accordingly, you must appropriately select and use the two container engines according to the situation.
+Please note that the widely used Amazon Linux 2023 does not support Podman, and Red Hat Enterprise Linux 10 released in 2025 does not support Docker.
+</Callout>
+
+### Linux Distribution Status Summary Table
+
+The table below summarizes the distributions for which QueryPie officially provides technical support and Docker and Podman support status.
+Docker and Podman support status is based on whether versions for running and managing QueryPie are provided.
+
+For old versions of Podman 3.x, or cases where reliable packages are not provided, technical support is not provided by the QueryPie team, and it is classified as a condition where QueryPie cannot be used.
+
+<table data-table-width="760" data-layout="default" local-id="1e7d3698-ac8b-43f8-8fc8-c306e24dd14c">
+<colgroup>
+<col/>
+<col/>
+<col/>
+<col/>
+</colgroup>
+<tbody>
+<tr>
+<th>
+**Distribution / Version**
+</th>
+<th>
+**Release Date**
+</th>
+<th>
+**Technical Support End Date (EOL/EOS)**
+</th>
+<th>
+**Docker, Podman Support**
+</th>
+</tr>
+<tr>
+<td>
+**Amazon Linux 2**
+</td>
+<td>
+June 2018
+</td>
+<td>
+June 30, 2026
+</td>
+<td>
+* Docker default support
+* Podman not supported ➖ 
+</td>
+</tr>
+<tr>
+<td>
+**Amazon Linux 2023**
+</td>
+<td>
+March 2023
+</td>
+<td>
+Standard Support: June 2027, Maintenance Support: until June 2029
+</td>
+<td>
+* Docker default support
+* Podman not supported ➖ 
+</td>
+</tr>
+<tr>
+<td>
+**Red Hat Enterprise Linux 8**
+</td>
+<td>
+May 2019
+</td>
+<td>
+Full Support: May 2024,<br/>Maintenance: until 2029
+</td>
+<td>
+* Podman default support
+* Docker available
+</td>
+</tr>
+<tr>
+<td>
+**Red Hat Enterprise Linux 9**
+</td>
+<td>
+May 2022
+</td>
+<td>
+Approximately 10 years (until 2032)
+</td>
+<td>
+* Podman default support
+* Docker available
+</td>
+</tr>
+<tr>
+<td>
+**Red Hat Enterprise Linux 10**
+</td>
+<td>
+May 2025
+</td>
+<td>
+Approximately 10 years (until 2035)
+</td>
+<td>
+* Podman default support
+* Docker not supported ➖
+</td>
+</tr>
+<tr>
+<td>
+**Ubuntu 22.04 LTS (Jammy)**
+</td>
+<td>
+April 2022
+</td>
+<td>
+April 2027 (up to 2032 with ESM)
+</td>
+<td>
+* Podman cannot be used ➖ old version 3.4.4
+* Docker default support
+</td>
+</tr>
+<tr>
+<td>
+**Ubuntu 24.04 LTS (Noble)**
+</td>
+<td>
+April 2024
+</td>
+<td>
+April 2029 (2036 with ESM)
+</td>
+<td>
+* Podman default support
+* Docker default support
+</td>
+</tr>
+<tr>
+<td>
+**Rocky Linux 8**
+</td>
+<td>
+June 2021
+</td>
+<td>
+Same as RHEL 8 (until 2029)
+</td>
+<td>
+RHEL 8 binary compatible
+</td>
+</tr>
+<tr>
+<td>
+**Rocky Linux 9**
+</td>
+<td>
+July 2022
+</td>
+<td>
+Same as RHEL 9 (until 2032)
+</td>
+<td>
+RHEL 9 binary compatible
+</td>
+</tr>
+<tr>
+<td>
+**CentOS Stream**
+</td>
+<td>
+After 2021
+</td>
+<td>
+Rolling release, no EOS
+</td>
+<td>
+Pre-reflects next RHEL, low stability
+</td>
+</tr>
+</tbody>
+</table>
+
+### Linux Distribution Characteristics
+
+This explains the status of Linux distributions for which the QueryPie team provides technical support.
+
+#### Amazon Linux 2 (Released June 2018)
+
+Amazon Linux 2 is a distribution provided by AWS optimized for EC2 based on the RHEL 7 series, and has been widely used for long-term stable operation.
+According to AWS's official support policy, Amazon Linux 2's official security and bug patch provision is scheduled until 2026-06-30 (source: [Amazon Linux 2 FAQs](https://aws.amazon.com/amazon-linux-2/faqs/)), so if you are planning new server construction or long-term operation, please consider migration to Amazon Linux 2023 or Ubuntu/RHEL series with longer life cycles.
+
+From a container perspective, Amazon Linux 2 is designed to easily install and operate Docker through amazon-linux-extras, and this path is the standard approach consistently guided in AWS documentation.
+On the other hand, Podman is not provided in the default repository, and even though there are unofficial paths to install through third-party repositories (COPR, etc.), they are outside AWS's package management and support system, so Docker use is realistic for server workloads that value consistency of operation systems and support policies.
+Compose can deploy and update Docker Compose plugins (v2) together, enabling stable management of multi-container services on a single host.
+
+* Suitable for using Docker and Docker Compose combination.
+*  **<u>Podman is not supported</u>** .
+
+#### Amazon Linux 2023 (Released March 2023)
+
+Amazon Linux 2023 (AL2023) is a next-generation AWS Linux that adopts Fedora as upstream, clearly defining periodic releases and support schedules.
+GA was completed in March 2023, and follows a 5-year support model where Standard Support is until June 30, 2027, and Maintenance Support is until June 30, 2029 (source: [Amazon Linux 2023 FAQs](https://aws.amazon.com/linux/amazon-linux-2023/faqs/)).
+
+AL2023 has switched package management to dnf, and Docker is installed and operated through standard procedures according to official documentation.
+Installation guides provided by AWS also present Docker-centered operation models, and Podman packages are not currently included in official repositories.
+As a result, if deploying QueryPie Server on EC2, Docker + Docker Compose combination is the most concise and well-documented path in AL2023.
+
+* Suitable for using Docker and Docker Compose combination. When installing dnf packages of Amazon Linux 2023,  **Docker 25.0.8**  version is installed by default.
+*  **<u>Podman is not supported.</u>**  Amazon Linux 2023 has difficulty installing Podman, and verified installation packages are not provided. Many users have requested adding Podman to the distribution, but AWS seems to politely refuse this and does not provide technical support for Podman.
+
+#### Red Hat Enterprise Linux 8 (Released May 2019)
+
+RHEL 8 was released on May 7, 2019, Full Support ended on May 31, 2024, Maintenance Support continues until May 31, 2029, and Extended Life Cycle Support (ELS) when selected continues until May 31, 2032.
+As the center of the EL8 ecosystem most widely deployed in enterprise sites, Red Hat provides Podman as the default container engine instead of Docker engine.
+Podman provides compatibility with docker commands and sockets expected by many tools through Docker-compatible CLI and REST API (packages such as podman-docker).
+Docker itself is not provided or supported in Red Hat's default channels, but methods of adding Docker official repositories for installation are used in the field.
+In terms of Compose, methods of using Docker Compose (v2 plugin) together with Docker engine, or using compatibility layers with Podman to utilize docker-compose-based deployment files as-is have been verified.
+
+* Suitable for using Podman and Docker Compose combination.  **Podman 4.9.4**  version is installed.
+* Suitable for using Docker and Docker Compose combination.  **Latest version Docker packages are provided** . As of August 2025,  **28.3.3**  version is provided.
+    * [https://docs.docker.com/engine/install/rhel/](https://docs.docker.com/engine/install/rhel/)
+
+#### Red Hat Enterprise Linux 9 (Released May 2022)
+
+RHEL 9 was released on May 18, 2022, Full Support is until May 31, 2027, Maintenance Support is until May 31, 2032, and optional ELS is until May 31, 2035.
+The operation model is the same as RHEL 8, Podman-centered, and maturity has increased in rootless mode and system integration (systemd user services, etc.).
+QueryPie Server can use Podman as the standard engine without problems, and by adding podman-docker compatibility packages, existing docker-compose.yml assets can be reused with little change.
+Docker CE is outside the support scope of official RHEL repositories, but methods of adding Docker-side repositories for installation and operation are widely used in practice.
+
+* Suitable for using Podman and Docker Compose combination.  **Podman 4.9.4**  version is installed.
+* Suitable for using Docker and Docker Compose combination.  **Latest version Docker packages are provided** . As of August 2025,  **28.3.3**  version is provided.
+    * [https://docs.docker.com/engine/install/rhel/](https://docs.docker.com/engine/install/rhel/) 
+
+#### Red Hat Enterprise Linux 10 (Released May 2025)
+
+RHEL 10 was released on May 20, 2025, and according to Red Hat's standard policy, has a roadmap where Full Support is until May 31, 2030, Maintenance Support is until May 31, 2035, and optional ELS is until May 31, 2038.
+In RHEL 10, Docker engine and docker commands have been removed from default provision, and Red Hat's official support is limited to Podman.
+Installing Docker from external upstream is technically possible but outside the support scope of RHEL 10 itself, and Red Hat documentation also states this.
+Therefore, when operating QueryPie Server on RHEL 10, selecting Podman as first priority and maintaining Docker Compose syntax in Compose files but applying them through Podman's Docker API compatibility layer is the most realistic configuration.
+
+* Suitable for using Podman and Docker Compose combination.  **Podman 5.4.0**  version is installed.
+*  **Docker packages are not provided** . (As of August 2025) Docker packages are prepared in CentOS Stream 10, but errors occur when installing and running them.
+
+#### Ubuntu 22.04 LTS Jammy Jellyfish
+
+Ubuntu 22.04 LTS was released on April 21, 2022, standard support is until April 2027, and Extended Security Maintenance (ESM) is until April 2032.
+Canonical provides both Docker and Podman through official documentation and repositories in server and cloud environments, with Docker available through Docker official APT repositories or Ubuntu's docker.io/plugin packages, and Podman installable from distribution default repositories.
+Compose is easiest with Docker Compose v2 plugin, and in Podman environments, configurations that reuse existing Compose files through Docker API compatibility are common in practice.
+Ubuntu's unique broad community ecosystem and fast security patch provision are advantageous for stable operation of containerized applications like QueryPie Server.
+
+*  **Not suitable for using Podman** . The Podman 3.4.4 version provided in default repositories is not compatible with Docker Compose, so it is not recommended.
+* Suitable for using Docker and Docker Compose combination.  **Latest version Docker packages are provided** . As of August 2025,  **28.3.3**  version is provided.
+    * [https://docs.docker.com/engine/install/ubuntu/](https://docs.docker.com/engine/install/ubuntu/)
+
+#### Ubuntu 24.04 LTS Noble Numbat
+
+Ubuntu 24.04 LTS was released on April 25, 2024, standard support is until April 2029, and ESM continues until April 2036.
+As befitting the latest LTS, container-related toolchain versions have been upgraded, and Docker can be deployed together with the latest Compose plugin from both Docker official repositories and Canonical packages.
+Podman is also provided in default repositories, making rootless execution and per-user container management natural, and non-interactive execution in CI/CD smooth.
+If server standardization from a long-term perspective is needed, 24.04 LTS has advantages in that it can secure both longer security update windows and latest kernel and toolchain bases compared to 22.04 LTS.
+
+* Suitable for using Podman and Docker Compose combination.  **Podman 4.9.3**  version is installed.
+* Suitable for using Docker and Docker Compose combination.  **Latest version Docker packages are provided** . As of August 2025,  **28.3.3**  version is provided.
+    * [https://docs.docker.com/engine/install/ubuntu/](https://docs.docker.com/engine/install/ubuntu/)
+
+#### Rocky Linux 9 (Released July 2022)
+
+Rocky Linux 9 also follows the same release policy as RHEL 9, and maintenance support is provided until May 31, 2032.
+The default container stack is Podman, and rootless execution and cgroup and systemd integration have matured, making it easy to operate complex multi-container services.
+Docker CE on Rocky 9 also commonly uses a model of installation through Docker's own repositories rather than official (Red Hat) channels, and deployment automation can be simplified by adding Compose plugins.
+QueryPie Server has been verified to operate with equal quality on both engines.
+
+* Suitable for using Podman and Docker Compose combination.  **Podman 4.9.4**  version is installed.
+* Suitable for using Docker and Docker Compose combination.  **Latest version Docker packages are provided** . As of August 2025,  **28.3.3**  version is provided.
+    * [https://docs.docker.com/engine/install/rhel/](https://docs.docker.com/engine/install/rhel/) 
+
+#### CentOS Stream (After 2021)
+
+As a replacement distribution for existing CentOS, it adopts a rolling update method that pre-reflects the next release of RHEL.
+In terms of stability, it has variability compared to RHEL and Amazon Linux, so it is suitable for development and test environments rather than long-term operation.
+Since it is not suitable for QueryPie operation environments, we recommend not using it.
+
+

--- a/src/content/en/installation/querypie-acp-community-edition.mdx
+++ b/src/content/en/installation/querypie-acp-community-edition.mdx
@@ -6,7 +6,7 @@ title: 'QueryPie ACP Community Edition'
 
 ### 🧭 Before You Start
 
-**QueryPie Community Edition** allows you to experience the core features provided by **QueryPie Enterprise**.
+**QueryPie Community Edition** allows you to experience the core features provided in **QueryPie Enterprise**.
 
 * Database Access Controller
 * System Access Controller
@@ -15,11 +15,11 @@ title: 'QueryPie ACP Community Edition'
 
 However, Community Edition supports **up to 5 active users**. *(If you need to register more than 5 users, please consider upgrading to the* [ *Enterprise Plan* ](https://www.querypie.com/ko/plans) *.)*
 
-QueryPie runs as a typical web application and also includes proxy-based network server functionality.
+QueryPie runs as a general web application and also includes proxy-based network server functionality.
 
 ### 🖥️ Recommended Server Specifications
 
-For smooth installation and operation of QueryPie Community Edition, the following system environment is recommended.
+For smooth installation and operation of QueryPie Community Edition, we recommend the following system environment.
 
 <table data-table-width="834" data-layout="center" local-id="7fd726e9-fc83-4263-a08f-8daf43a53c3b">
 <colgroup>
@@ -40,9 +40,9 @@ For smooth installation and operation of QueryPie Community Edition, the followi
 Basic Specifications
 </td>
 <td>
-* Hardware : AMD64 Architecture, CPU 4 vCPUs, Memory 16 GiB, Disk 100 GiB+
-* AWS EC2 : m6i.xlarge, m7i.xlarge
-* GCP Compute Engine : c4-standard-4, n4-standard-4 (or AMD64 architecture -standard-4 models)
+* Hardware: AMD64 Architecture, CPU 4 vCPUs, Memory 16 GiB, Disk 100 GiB+
+* AWS EC2: m6i.xlarge, m7i.xlarge
+* GCP Compute Engine: c4-standard-4, n4-standard-4 (or AMD64 architecture -standard-4 models)
 </td>
 </tr>
 <tr>
@@ -51,18 +51,18 @@ Trial Use
 </td>
 <td>
 * Hardware: ARM64 Architecture, 4 vCPUs, Memory 16 GiB, Disk 30 GiB+
-* AWS EC2 : t4g.xlarge, m7g.xlarge
+* AWS EC2: t4g.xlarge, m7g.xlarge
 * OS: Linux or macOS with Docker
 </td>
 </tr>
 <tr>
 <td>
-Recommended Specifications for Production Environment with Multiple Users
+Recommended Specifications for Production Environments with Multiple Users
 </td>
 <td>
 * Hardware: AMD64 Architecture, 8 vCPUs, Memory 32 GiB, Disk 100 GiB+
-* AWS EC2 : m6i.2xlarge, m7i.2xlarge
-* GCP Compute Engine : c4-standard-8, n4-standard-8 (or AMD64 architecture -standard-8 models)
+* AWS EC2: m6i.2xlarge, m7i.2xlarge
+* GCP Compute Engine: c4-standard-8, n4-standard-8 (or AMD64 architecture -standard-8 models)
 </td>
 </tr>
 <tr>
@@ -84,32 +84,32 @@ For detailed requirements, please refer to the following document: [Prerequisite
 
 #### 1. Execute Command in Terminal
 
-After connecting to the terminal of the Linux server, execute the following command in the home directory:
+After connecting to the Linux server's terminal, execute the following command from the home directory:
 ```
 bash <(curl -s https://dl.querypie.com/setup.v2.sh)
 ```
 
-⏱️ Installation usually takes **7~10 minutes**.
+⏱️ Installation usually takes about **7~10 minutes**.
 
 <figure data-layout="center" data-align="center">
-![Screen when installation starts](/installation/querypie-acp-community-edition/image-20250718-063107.png)
+![Screen showing installation has started](/installation/querypie-acp-community-edition/image-20250718-063107.png)
 <figcaption>
-Screen when installation starts
+Screen showing installation has started
 </figcaption>
 </figure>
 
 
 <figure data-layout="center" data-align="center">
-![Screen when installation is completed](/installation/querypie-acp-community-edition/image-20250718-063140.png)
+![Screen showing installation has completed](/installation/querypie-acp-community-edition/image-20250718-063140.png)
 <figcaption>
-Screen when installation is completed
+Screen showing installation has completed
 </figcaption>
 </figure>
 
-#### 2. Apply for License During Installation
+#### 2. Obtain License During Installation
 
 QueryPie Community Edition requires license registration.
-While installation is in progress, [submit a license application](https://querypie.com/querypie/license/community/apply), and a `.crt` text file will be sent to the email address entered during application.
+While installation is in progress, [submit a license application form](https://querypie.com/querypie/license/community/apply), and a `.crt` text file will be sent to the email address you entered during application.
 
 #### 3. Access After Installation
 
@@ -120,7 +120,7 @@ or
 https://<server IP address> 
 ```
 
-The IP address of the Linux server where QueryPie is installed must be accessible from the user's PC.
+The IP address of the Linux server where QueryPie is installed must be accessible from user PCs.
 
 #### 4. License Registration
 
@@ -151,8 +151,8 @@ Initial login screen
 
 #### 6. Installation Complete 🎉
 
-Installation has been completed successfully.
-Please refer to the Administrator Manual for environment configuration: [Administrator Manual](../administrator-manual)
+Installation has been successfully completed.
+Please refer to the administrator manual for environment configuration: [Administrator Manual](../administrator-manual)
 
 <figure data-layout="center" data-align="center">
 ![First guide screen after login](/installation/querypie-acp-community-edition/image-20250718-064043.png)
@@ -167,12 +167,12 @@ First guide screen after login
 * To use QueryPie, you must register a valid license after installation.
 * Licenses are provided as text files with `.crt` extension.
 * Licenses are sent to the email address entered during application.
-* Each license is valid for 1 year from the date of issue.
+* Each license is valid for 1 year from the date of issuance.
 * Licenses are issued to the applicant and cannot be transferred to third parties.
 
 ### 💬 Support and Inquiries
 
-If you have any questions during QueryPie Community installation and use, you can contact us directly through [QueryPie AIP](https://app.querypie.com/).
+If you have questions about QueryPie Community installation and use, you can contact us directly through [QueryPie AIP](https://app.querypie.com/).
 By following the procedure below to set up the **QueryPie Customer Center** preset in MCP, you can receive support directly in the chat window.
 
 <figure data-layout="center" data-align="center">
@@ -188,5 +188,4 @@ By following the procedure below to set up the **QueryPie Customer Center** pres
 1. Chat tab → Select `@QueryPie` and enter your question.
 
 You can also join the [official QueryPie Discord channel](https://discord.gg/NsP98BHBm2) to share questions and experiences with other users.
-
 

--- a/src/content/en/installation/server-configuration-requirements.mdx
+++ b/src/content/en/installation/server-configuration-requirements.mdx
@@ -4,7 +4,7 @@ title: 'Server Configuration Requirements'
 
 # Server Configuration Requirements
 
-This guide provides information on hardware performance and processing capacity requirements for installing and operating QueryPie.
+This guide provides information on hardware performance and processing capacity for servers to install and operate QueryPie.
 * [https://querypie.atlassian.net/wiki/spaces/QM/pages/903086124/Public+Cloud?atl_f=PAGETREE](https://querypie.atlassian.net/wiki/spaces/QM/pages/903086124/Public+Cloud?atl_f=PAGETREE) 
 * [On-Premise VM Requirements](server-configuration-requirements/on-premise-vm-requirements) 
-* [Server Configuration Requirements Summary](server-configuration-requirements/server-configuration-requirements-summary) 
+* [Server Configuration Requirements Summary Table](server-configuration-requirements/server-configuration-requirements-summary) 

--- a/src/content/en/installation/server-configuration-requirements/_meta.ts
+++ b/src/content/en/installation/server-configuration-requirements/_meta.ts
@@ -1,0 +1,5 @@
+export default {
+  'public-cloud-production-server-requirements': 'Public Cloud Production Server Requirements',
+  'on-premise-vm-requirements': 'On-Premise VM Requirements',
+  'server-configuration-requirements-summary': 'Server Configuration Requirements Summary Table',
+};

--- a/src/content/en/installation/server-configuration-requirements/on-premise-vm-requirements.mdx
+++ b/src/content/en/installation/server-configuration-requirements/on-premise-vm-requirements.mdx
@@ -1,0 +1,38 @@
+---
+title: 'On-Premise VM Requirements'
+---
+
+# On-Premise VM Requirements
+
+### Overview
+
+This guide provides instructions for operating QueryPie Server Container on a Virtual Machine running on an On-Premise physical server.
+For production environment operation, we recommend applying the following configuration.
+
+* Apply High Availability configuration
+* Apply L7 Load Balancer and L4 Load Balancer for high availability and load distribution suitable configuration.
+* Place 2 or more VM Instances as Upstream servers of Load Balancer. If the required processing capacity is high, apply Scale-Out configuration by increasing the number of VM Instances.
+
+### QueryPie Container VM Model
+
+Basic specifications: CPU 4 vCPUs AMD64 Architecture, Memory 15 GiB or more, Disk 100 GiB, CPU AMD
+
+* We recommend creating two or more VMs with basic specifications and applying Scale-Out configuration.
+
+Recommended specifications for high throughput: CPU 8 vCPUs AMD64 Architecture, Memory 30 GiB or more, Disk 100 GiB
+
+* We recommend creating two or more VMs with recommended specifications and applying Scale-Out configuration.
+
+### QueryPie MySQL VM Model
+
+Basic specifications: CPU 2 vCPUs, Memory 8 GiB or more, Disk 100 GiB or more
+
+Recommended specifications for high throughput: CPU 8 vCPUs, Memory 32 GiB or more, Disk 100 GiB or more ( **storage capacity size needs separate calculation** )
+
+### QueryPie Redis VM Model
+
+Basic specifications: CPU 2 vCPUs, Memory 1 GiB or more
+
+Recommended specifications for high throughput: CPU 2 vCPUs, Memory 3 GiB or more
+
+

--- a/src/content/en/installation/server-configuration-requirements/public-cloud-production-server-requirements.mdx
+++ b/src/content/en/installation/server-configuration-requirements/public-cloud-production-server-requirements.mdx
@@ -1,0 +1,159 @@
+---
+title: 'Public Cloud Production Server Requirements'
+---
+
+# Public Cloud Production Server Requirements
+
+### Overview
+
+When operating QueryPie servers on Public Cloud such as AWS, GCP, Azure, we recommend applying the following configuration.
+
+* Apply High Availability configuration
+    * Apply Application Load Balancer and Network Load Balancer for high availability and load distribution suitable configuration.
+    * Place 2 or more VM Instances as Upstream servers of Load Balancer. If the required processing capacity is high, apply Scale-Out configuration by increasing the number of VM Instances.
+* Apply Managed Service MySQL and Redis instead of VM for QueryPie MySQL and Redis.
+    * For AWS, we recommend using Aurora RDS for MySQL, Aurora RDS for MariaDB, and ElastiCache.
+* VM OS supports most Linux distributions. However, you must be able to install and use docker daemon.
+    * For AWS, we recommend Amazon Linux.
+    * For GCP, we recommend Ubuntu 24.04 LTS (or the latest LTS version after that).
+
+### QueryPie Container VM Model
+
+Basic specifications: CPU 4 vCPUs AMD64 Architecture, Memory 15 GiB or more, Disk 100 GiB, CPU AMD
+
+* We recommend creating two or more VMs with basic specifications and applying Scale-Out configuration.
+* AWS EC2 Instance Type: m6i.xlarge, m7i.xlarge
+* GCP Compute Engine Machine Type: c4-standard-4, n4-standard-4 (or AMD64 architecture -standard-4 models)
+* Disk IO performance: Apply general-purpose Disk Volume. For AWS, apply EBS General Purpose SSD (gp3).
+
+Recommended specifications for high throughput: CPU 8 vCPUs AMD64 Architecture, Memory 30 GiB or more, Disk 100 GiB
+
+* We recommend creating two or more VMs with recommended specifications and applying Scale-Out configuration.
+* AWS EC2: m6i.2xlarge, m7i.2xlarge
+* GCP Compute Engine: c4-standard-8, n4-standard-8 (or AMD64 architecture -standard-8 models)
+* Disk IO performance: Apply Volume with high IOPS. Apply AWS EBS Provisioned IOPS SSD (io1) or Volume with higher performance.
+
+### QueryPie MySQL
+
+Basic specifications: CPU 2 vCPUs, Memory 16 GiB or more, Disk 100 GiB or more
+
+* We recommend using Managed Service MySQL or MariaDB.
+* AWS Aurora: db.r7g.large, db.r6g.large
+* Disk IO performance: Apply general-purpose Disk Volume. For AWS, apply EBS General Purpose SSD (gp3).
+
+Recommended specifications for high throughput: CPU 4 vCPUs, Memory 32 GiB or more, Disk 100 GiB or more ( **storage capacity size needs separate calculation** )
+
+* We recommend using Managed Service MySQL or MariaDB.
+* AWS Aurora: db.r7g.xlarge, db.r6g.xlarge
+* Disk IO performance: Apply Volume with high IOPS. Apply AWS EBS Provisioned IOPS SSD (io1) or Volume with higher performance.
+* Disk capacity: QueryPie stores Audit Log recorded by QueryPie in MySQL. You need to appropriately calculate the storage space size according to the frequency of Audit Log recording, average size, and retention period.
+
+### QueryPie Redis
+
+Basic specifications: CPU 2 vCPUs, Memory 1 GiB or more
+
+* We recommend using Managed Service Redis-compatible services.
+* AWS ElastiCache On-Demand Nodes: cache.t4g.small or similar models
+
+Recommended specifications for high throughput: CPU 2 vCPUs, Memory 3 GiB or more
+
+* We recommend using Managed Service Redis-compatible services.
+* AWS ElastiCache On-Demand Nodes: cache.t4g.medium or similar models
+
+
+### VM Configuration Method by Availability Zone
+
+This guide explains how to place VMs and adjust VM specifications according to Availability Zones.
+
+#### In production environments, create and place VMs in 3 (or 4) Availability Zones.
+
+Distribute VMs evenly across each Availability Zone so that VMs are not concentrated in one Availability Zone.
+
+If service usage is not high and there is plenty of CPU resources on VM servers, you can configure the service with 2 VMs.
+If service usage increases, increase the number of VMs to keep the maximum usage normally measured below a certain level.
+Specific adjustment criteria are explained below.
+
+#### Adjust VM specifications so that maximum usage normally measured can be processed even if one VM Instance stops service.
+
+For example, when configuring 3 VMs to provide service, adjust VM specifications so that maximum usage can be processed with only 2 VMs.
+Adjust so that CPU usage does not exceed 85% when 2 VMs are processing maximum usage.
+If 2 VMs show 85% CPU usage, that means using a total of 170% CPU.
+If 3 VMs divide and process this load, one VM will use approximately 56% CPU.
+Therefore, when 3 VMs are operating normally, CPU usage should not exceed 56% during the period showing maximum usage.
+
+|  **Number of VMs**  |  **When 1 Instance Stops**            |  **Maximum CPU Usage During Normal Operation**       |
+| ----------- | --------------------------- | ---------------------------- |
+| 2           | 1 x 85% CPU = 85% CPU Usage  | 85% CPU / 2 = 43% CPU / 1  |
+| 3           | 2 x 85% CPU = 170% CPU Usage | 170% CPU / 3 = 56% CPU / 1 |
+| 4           | 3 x 85% CPU = 255% CPU Usage | 255% CPU / 4 = 63% CPU / 1 |
+| 5           | 4 x 85% CPU = 340% CPU Usage | 340% CPU / 5 = 68% CPU / 1 |
+
+When applying Scale-Out configuration by increasing the number of VMs, the acceptable level for maximum CPU usage during normal operation becomes higher.
+In this way, when 1 VM fails, you can provide service normally with the remaining VMs while increasing VM resource utilization normally, improving processing performance relative to cost.
+
+If you do not increase the number of VMs and keep 2 or 3 fixed, if actual usage is higher than the calculated reference value for maximum CPU usage during normal operation, increase the number of CPUs in VMs or change Instance Type to high specifications to show actual usage lower than the calculated reference value.
+
+#### Do not apply Auto Scaling Group settings.
+
+Do not apply Auto Scaling Group settings that automatically increase or decrease Upstream servers according to the traffic and load level processed by the service.
+
+QueryPie has web application characteristics, but unlike general web applications, it has functional characteristics where it establishes connections with specific DBs and systems according to user access, executes SQL Queries through these connections, and performs system commands through ssh.
+Accordingly, it operates by maintaining DB connections and ssh connections within specific Server Containers where users are connected and executing subsequent queries and commands.
+
+When applying Auto Scaling Group, when the number of Upstream servers changes, authentication of sessions connected to Web Console may be disconnected, requiring re-login.
+
+Reference - [Why is Sticky Session necessary in HA configuration?](#target-title-not-found)
+
+
+### Basis for Required Performance
+
+#### Types of Computing Resources Required by QueryPie Server
+
+QueryPie Server Container and MySQL mainly use computing resources to process the following types of tasks.
+
+* MySQL stores data for the function of recording Audit Log according to user access, query execution, command execution, etc.
+* Query and allow or deny access control policies according to user access, query execution, command execution.
+* Execute Workflow tasks including multiple SQL queries in the background.
+* According to SSO Integration, periodically receive lists of multiple users and update each user's QueryPie account information.
+* Register or change multiple DB and Server assets and change access control policies using External API.
+
+#### Memory Size Required by QueryPie Container
+
+* QueryPie Container uses approximately 7 GiB of memory at initial execution. Depending on user usage, the memory used by Container can increase by about 2~3 GiB.
+* When accessing Mongo or Document DB, memory usage can increase by 1 GiB or more.
+* When executing SQL queries that receive large amounts of Result Set, memory usage can increase.
+* During the process of recording Audit Log, temporary files are created and used inside the Container. Accordingly, you need to allocate about 1~2 GiB of memory for OS Cache for Disk devices.
+
+
+### FAQ
+
+#### Q: Please provide a guide for estimating server processing capacity according to the number of users.
+
+A: It is difficult to generally provide a guide for estimating server processing capacity according to the number of users in your customer's company.
+I will explain why it is difficult to provide a guide.
+
+QueryPie is generally recommended to be used under conditions where access control and audit logs are recorded for human user access, query execution, and command execution.
+For non-human users, it is when Applications or Programs access target systems through QueryPie.
+
+QueryPie has performance that can process 70 or more queries per second with low Latency for simple queries based on DAC on 1 basic specification VM.
+Processing 70 queries per second means performance that can process 4,200 queries per minute and 250,000 queries per hour.
+
+For cases where hundreds or thousands of users execute light queries daily, it provides processing performance that can be processed sufficiently with 1 or 2 basic specification VMs.
+
+However, when using the following types of queries and access methods, the required server processing capacity increases significantly, and it is generally difficult to estimate the actual required server processing capacity at this time.
+
+* When human users execute SQL Queries consisting of tens of thousands or more Statements
+* When human users execute SQL Queries that obtain hundreds of thousands or more ResultSets
+* When non-human users, Applications or Programs connect to DB and operate
+* When running application performance test programs while connected to DB through QueryPie
+* When running application test code and integration test cases while connected to DB through QueryPie
+* When automating the process of registering and managing 10,000 or more DB and System assets through External API
+
+Most cases reported by customers where QueryPie's server processing capacity is insufficient are the cases above.
+For such cases, you can attempt to estimate the required processing capacity in advance, but there are limitations in accurately or meaningfully estimating it.
+For such cases, we recommend approaching in the following way.
+
+* When newly introducing QueryPie, perform gradual deployment for internal users, monitor VM CPU, Memory, and Disk IO usage indicators, and monitor whether performance is sufficient.
+* If there is an existing access control system in use, receive and analyze user usage indicators. We need usage indicators such as user access count, query execution count, ResultSet size, generated Audit Log size, etc. for a period of about 1 day or 1 week.
+
+

--- a/src/content/en/installation/server-configuration-requirements/server-configuration-requirements-summary.mdx
+++ b/src/content/en/installation/server-configuration-requirements/server-configuration-requirements-summary.mdx
@@ -1,0 +1,75 @@
+---
+title: 'Server Configuration Requirements Summary Table'
+---
+
+# Server Configuration Requirements Summary Table
+
+This is a summary table that briefly organizes the hardware processing capacity requirements guide for QueryPie servers.
+
+### Recommended Configuration by Deployment Environment
+
+#### Public Cloud Environment (AWS, GCP, Azure)
+
+| Component   | Recommendation                                                   |
+| ------- | ------------------------------------------------------- |
+| High Availability Configuration | Apply Application Load Balancer, Network Load Balancer     |
+| VM Instances | Configure 2 or more VMs as Upstream servers (Scale-Out method)               |
+| Database  | Managed Service MySQL/MariaDB (AWS Aurora, etc.)        |
+| Cache Service  | Managed Service Redis (AWS ElastiCache, etc.)           |
+| OS      | Linux distribution (AWS: Amazon Linux, GCP: Ubuntu 24.04 LTS recommended) |
+
+#### On-Premise Environment
+
+| Component   | Recommendation                                     |
+| ------- | ----------------------------------------- |
+| High Availability Configuration | Apply L7 Load Balancer, L4 Load Balancer     |
+| VM Instances | Configure 2 or more VMs as Upstream servers (Scale-Out method) |
+
+### Specifications by Component and Capacity
+
+#### QueryPie Container VM Specifications
+
+| Category                 | Basic Specifications                         | Recommended Specifications                             |
+| ------------------ | ----------------------------- | --------------------------------- |
+| CPU                | 4 vCPUs (AMD64 architecture)          | 8 vCPUs (AMD64 architecture)              |
+| Memory                | 15 GiB or more                     | 30 GiB or more                         |
+| Disk                | 100 GiB                       | 100 GiB                           |
+| AWS EC2 Instance       | m6i.xlarge, m7i.xlarge        | m6i.2xlarge, m7i.2xlarge          |
+| GCP Compute Engine | c4-standard-4, n4-standard-4  | c4-standard-8, n4-standard-8      |
+| Disk IO Performance          | EBS General Purpose SSD (gp3) | EBS Provisioned IOPS SSD (io1) or higher |
+| Recommended Configuration              | 2 or more basic specification VMs                 | 2 or more recommended specification VMs                     |
+
+#### QueryPie MySQL Specifications
+
+| Category              | Basic Specifications                         | Recommended Specifications                             |
+| --------------- | ----------------------------- | --------------------------------- |
+| CPU             | 2 vCPUs                       | 4 vCPUs                           |
+| Memory             | 16 GiB or more                     | 32 GiB or more                         |
+| Disk             | 100 GiB or more                    | 100 GiB or more (storage capacity separate calculation)           |
+| AWS Aurora Instance | db.r7g.large, db.r6g.large    | db.r7g.xlarge, db.r6g.xlarge      |
+| Disk IO Performance       | EBS General Purpose SSD (gp3) | EBS Provisioned IOPS SSD (io1) or higher |
+| Notes            | Managed Service method recommended         | Managed Service method recommended             |
+
+#### QueryPie Redis Specifications
+
+| Category              | Basic Specifications                 | Recommended Specifications                 |
+| --------------- | --------------------- | --------------------- |
+| CPU             | 2 vCPUs               | 2 vCPUs               |
+| Memory             | 1 GiB or more              | 3 GiB or more              |
+| AWS ElastiCache | cache.t4g.small       | cache.t4g.medium      |
+| Notes            | Managed Service method recommended | Managed Service method recommended |
+
+### Memory Usage Reference
+
+| Category                        | Usage      |
+| ------------------------- | -------- |
+| Initial execution                   | Approximately 7 GiB  |
+| Increase due to user usage             | 2~3 GiB  |
+| Additional when accessing Mongo/Document DB | 1 GiB or more |
+| Additional memory for OS cache             | 1~2 GiB  |
+
+### Performance Reference
+
+* Basic specification VM 1 unit: Can process 70 or more simple queries per second for DAC (4,200 per minute, 250,000 per hour)
+* For hundreds to thousands of users running daily light queries, 1-2 basic specification VMs are sufficient
+

--- a/src/content/en/installation/system-architecture-and-network-access-control.mdx
+++ b/src/content/en/installation/system-architecture-and-network-access-control.mdx
@@ -7,12 +7,12 @@ title: 'System Architecture and Network Access Control'
 
 ### System Architecture
 
-Learn how QueryPie Server, QueryPie User Agent, User PC's Web Browser, and systems such as Database and Linux Server that users want to access are configured and connected.
+Learn how QueryPie Server, QueryPie User Agent, Web Browser on User PC, and systems such as Database and Linux Server that users want to access are configured and connected.
 
 #### System Architecture Diagram
 
 This system architecture is for the case of installing QueryPie Service on a single Linux server.
-It does not include web services with TLS certificates applied, multi-node configurations for high availability, etc.
+It does not include web services with TLS certificates applied, multi-configuration for high availability, etc.
 
 <figure data-layout="center" data-align="center">
 ![Overview of QueryPie System Architecture ](/installation/system-architecture-and-network-access-control/image-20251204-043839.png)
@@ -23,19 +23,19 @@ Overview of QueryPie System Architecture
 
 Descriptions of each component are as follows.
 
-#### User PC's Web Browser
+#### Web Browser on User PC
 
 Users access QueryPie web service through a web browser on their PC.
-A web browser is required to use QueryPie.
+A web browser is essential to use QueryPie.
 QueryPie administrators and security policy operators manage QueryPie services through QueryPie Web Console.
 
 Also, QueryPie users can access target systems through QueryPie Web SQL Editor and Web Terminal.
 
-#### User PC's QueryPie User Agent
+#### QueryPie User Agent on User PC
 
-When using Database Client Application or SSH Client Application running on User PC, QueryPie User Agent is required.
-QueryPie User Agent serves as a Local Proxy Agent running on User PC.
-You can download QueryPie User Agent after logging into QueryPie Web Console.
+When using Database Client Applications or SSH Client Applications running on User PC, QueryPie User Agent is required.
+QueryPie User Agent performs the role of a Local Proxy Agent running on User PC.
+You can download QueryPie User Agent by logging into QueryPie Web Console.
 
 QueryPie User Agent supports most Database Client Applications and SSH Client Applications running on User PC.
 (Hereafter referred to as `3rd Party Tool`.) For specific examples, please refer to this document: [Supported 3rd Party Tools (KO)](#target-title-not-found)
@@ -43,7 +43,7 @@ QueryPie User Agent supports most Database Client Applications and SSH Client Ap
 #### QueryPie Server
 
 QueryPie Server running on Linux VM provides Web Console, Web SQL Editor, and Web Terminal as web services.
-It also plays a key role in providing a Proxy server that understands SQL protocol and ssh protocol and performs access control.
+It also performs a core role of providing a Proxy server that understands SQL protocol and ssh protocol and performs access control.
 
 QueryPie Server requires two components.
 
@@ -52,29 +52,29 @@ QueryPie Server requires two components.
 
 #### QueryPie Database
 
-QueryPie Database stores data necessary for QueryPie Server to operate.
+QueryPie Database stores data for QueryPie Server operation.
 It stores QueryPie's User Account, Admin Account, information about systems to connect to, access control policies, etc.
-In addition, it stores audit information such as User's Query Log and System Access Log.
+It also stores Audit information such as User's Query Log and System Access Log.
 
-MySQL, MariaDB, or compatible Databases can be used as QueryPie Database.
+You can use MySQL, MariaDB, or compatible Databases as QueryPie Database.
 
 * AWS Aurora MySQL
 * GCP Cloud SQL for MySQL
 
 #### QueryPie Redis
 
-QueryPie Redis serves as a Cache for QueryPie Server to operate.
-It is a component that is required for QueryPie Server to operate.
+QueryPie Redis performs a Cache role for QueryPie Server operation.
+It is a component that is essential for QueryPie Server to operate.
 
 #### Target Database
 
-The Database server that users want to access.
-QueryPie Server serves as an intermediary between users and Target Database.
+This is the Database server that users want to access.
+QueryPie Server performs an intermediary role between users and Target Database.
 
 #### Target Server System
 
-Systems such as Linux Server and Windows Server that users want to access.
-QueryPie Server serves as an intermediary between users and Target Server System.
+This is a system such as Linux Server or Windows Server that users want to access.
+QueryPie Server performs an intermediary role between users and Target Server System.
 
 ### Network Access Control Settings
 
@@ -82,19 +82,19 @@ QueryPie Server serves as an intermediary between users and Target Server System
 
 Centered on the Linux VM where QueryPie is installed, network connections are divided into two types: Outbound and Inbound.
 
-* Outbound : Network access from the Linux VM where QueryPie is installed to the external internet.
-* Inbound : Network access from user's PC or customer's internal network to the Linux VM where QueryPie is installed.
+* Outbound: Network access from the Linux VM where QueryPie is installed to the external internet.
+* Inbound: Network access from user PCs or customer's internal network to the Linux VM where QueryPie is installed.
 
 #### Network Access for Software Installation
 
 |  **Access Type**  |  **Source**     |  **Destination**                                                                                                      |  **Protocol**  |  **Port**  |  **Description**                                                             |
 | ----------------- | --------------- | --------------------------------------------------------------------------------------------------------------------- | -------------- | ---------- | ---------------------------------------------------------------------------- |
-| Outbound          | QueryPie Server | FQDN: `dl.querypie.com`<br/>IPv4 Address: <br/>`18.67.51.51`,<br/>`18.67.51.67`,<br/>`18.67.51.73`,<br/>`18.67.51.76` | TCP            | 443        | Website for downloading configuration files for product installation.                                            |
-| Outbound          | QueryPie Server | FQDN: `harbor.querypie.io`<br/>IPv4 Address:<br/>`15.164.47.8`, `52.79.197.102`                                       | TCP            | 443        | Website for downloading Docker Images for product installation. In Docker terms, it is a Docker Registry. |
+| Outbound          | QueryPie Server | FQDN: `dl.querypie.com`<br/>IPv4 Address: <br/>`18.67.51.51`,<br/>`18.67.51.67`,<br/>`18.67.51.73`,<br/>`18.67.51.76` | TCP            | 443        | This is a website for downloading configuration files for product installation.                                            |
+| Outbound          | QueryPie Server | FQDN: `harbor.querypie.io`<br/>IPv4 Address:<br/>`15.164.47.8`, `52.79.197.102`                                       | TCP            | 443        | This is a website for downloading Docker Images for product installation. In Docker terms, this is a Docker Registry. |
 
 #### Network Access for Product Use
 
-The items below describe network access for product use.
+The items below explain network access for product use.
 They are divided into Common, DAC, SAC, KAC, and WAC according to QueryPie product features.
 
 #### Common
@@ -136,13 +136,13 @@ They are divided into Common, DAC, SAC, KAC, and WAC according to QueryPie produ
 
 #### WAC
 
-|  **Access Ty** pe |  **Source**        |  **Destination**                                 |  **Type**  |  **Protocol**  |  **Port**  |  **Description**                 |
+|  **Access Type** |  **Source**        |  **Destination**                                 |  **Type**  |  **Protocol**  |  **Port**  |  **Description**                 |
 | ----------------- | ------------------ | ------------------------------------------------ | ---------- | -------------- | ---------- | -------------------------------- |
 | Inbound           | All the users<br/> | QueryPie Server<br/>or<br/>Network Load Balancer | Custom TCP | TCP            | 7447       | From Users to QueryPie WAC Proxy |
 
 ### Load Balancer Settings
 
-This table explains the settings for applying Load Balancer to QueryPie Service for load balancing and fault tolerance.
+This table explains settings for applying Load Balancer to QueryPie Service for load distribution and fault tolerance.
 
 |  **LB**                            |  **Listener**  |  **Target**        |  **Health Check**         |  **LB Option**  |  **Description**          |
 | ---------------------------------- | -------------- | ------------------ | ------------------------- | --------------- | ------------------------- |
@@ -151,5 +151,4 @@ This table explains the settings for applying Load Balancer to QueryPie Service 
 | Network Load Balancer<br/>(L4)     | TCP / 9000     | querypie:9000      | http://querypie:80/readyz | default         | QueryPie Agent (DAC, SAC) |
 | Network Load Balancer<br/>(L4)     | TCP / 6443     | querypie:6443      | http://querypie:80/readyz | default         | QueryPie Agent (KAC)      |
 | Network Load Balancer<br/>(L4)     | TCP / 7447     | querypie:7447      | http://querypie:80/readyz | default         | QueryPie Agent (WAC)      |
-
 


### PR DESCRIPTION
## Description
- 제품설치와 기술지원 문서 하위의 한국어 문서 추가에 대응하는 영어 번역을 다시 수행합니다.
  - AIP 에서 작업을 수행하면서 누락된 문서가 다수 있었습니다. Cursor 에게 작업을 지시하여, 누락된 문서를 포함하여 문서 번역을 다시 수행하였습니다.

### 사용한 프롬프트

@docs/compare.txt 에 나열된 한국어 MDX 문서에 대한 영어 번역문을 작성하여 주세요.

1. @docs/translation.md 가이드를 잘 읽고, 이 가이드에 맞추어 번역을 수행하여 주세요.

2. 원문과 번역문의 Skeleton MDX 비교 및 번역문의 줄바꿈, Markdown 문법 일치시키기
  -  MDX 번역문이 존재하는 경우, 한국어 원문과 번역문의 차이는 `cd confluence-mdx; bin/mdx_to_skeleton.py --use-ignore <path/to//mdx>` 로 알아냅니다. venv 환경에서 실행해야 합니다.
    - 예) `cd confluence-mdx; bin/mdx_to_skeleton.py --use-ignore target/en/administrator-manual/audit/server-logs/session-logs.mdx`
  - venv 환경은 `confluence-mdx/venv`에 있습니다. 따라서, `cd confluence-mdx; source venv/bin/activate`를 실행하여, venv 환경을 사용할 수 있습니다.
  - 한국어 원문과 번역문의 줄바꿈 차이가 발견되면, 번역문을 수정하여, 줄바꿈이 동일하도록 수정합니다. 한국어 원문에서 한 줄에 한 문장씩 위치한 경우, 번역문에서도 한 줄에 한 문장씩 위치해야 합니다.

3. 1cb06c3cac78b914d2d4d4198ce686e027d4625a 이 commit 에 포함된 한국어 MDX, _meta.ts 파일에 대응하는 영어 MDX, _meta.ts 파일이 존재하는지 확인하여 주세요. 대응하는 영어 파일이 없으면, @docs/translation.md 을 참조하여, 번역하여 주세요.

