### PR TITLE
confluence-mdx: 도구 설정 개선 및 MCP 가이드 추가

### DIFF
--- a/confluence-mdx/README.md
+++ b/confluence-mdx/README.md
@@ -30,22 +30,22 @@ cache/ 디렉토리를 채우는 경우,  bin/pages_of_confluence.py 를 실행�
 최근 1주일 Confluence Space 에서 업데이트된 문서를 한국어 MDX 로 변환합니다.
 ```bash
 # --recent 옵션이 기본 적용됩니다.
-docker compose --progress=plain full
-docker compose --progress=plain full --recent
+docker compose --progress=plain run --rm confluence-mdx full
+docker compose --progress=plain run --rm confluence-mdx full --recent
 ```
 
 전체 Confluence Space 문서를 내려받아 한국어 MDX 로 변환합니다.
 ```bash
 # --remote: Confluence API 를 호출하여 var/ 데이터를 업데이트합니다.
-docker compose --progress=plain full --remote
+docker compose --progress=plain run --rm confluence-mdx full --remote
 # --attachments: 첨부파일을 내려받아 변환하는 작업을 포함합니다.
-docker compose --progress=plain full --remote --attachments
+docker compose --progress=plain run --rm confluence-mdx full --remote --attachments
 ```
 
 Confluence API 를 호출하지 않고, `var/`에 저장된 데이터를 이용하여 한국어 MDX 전체를 변환합니다.
 ```bash
 # --local: Confluence API 를 호출하지 않습니다.
-docker compose --progress=plain full --local
+docker compose --progress=plain run --rm confluence-mdx full --local
 ```
 
 ## GitHub Action 설정

--- a/confluence-mdx/bin/pages_of_confluence.py
+++ b/confluence-mdx/bin/pages_of_confluence.py
@@ -51,7 +51,7 @@ class Config:
     """Centralized configuration management"""
     base_url: str = "https://querypie.atlassian.net/wiki"
     space_key: str = "QM"  # Confluence space key
-    days: int = 7  # Number of days to look back for modified pages
+    days: int = 21  # Number of days to look back for modified pages
     default_start_page_id: str = "608501837"  # Root Page ID of "QueryPie Docs" (for breadcrumbs)
     quick_start_page_id: str = "544375784"  # QueryPie Overview having less children
     default_output_dir: str = "var"
@@ -281,8 +281,8 @@ class ApiClient:
         url = f"{self.config.base_url}/rest/api/content/{page_id}/child/attachment"
         return self.make_request(url, "V1 API attachments")
 
-    def get_recently_modified_pages(self, days: int = 7, space_key: str = "QM") -> List[str]:
-        """Get list of page IDs modified in the last N days from the specified space"""
+    def get_recently_modified_pages(self, days: int, space_key: str) -> List[str]:
+        """Get a list of page IDs modified in the last N days from the specified space"""
         try:
             # Calculate the date threshold
             threshold_date = datetime.now() - timedelta(days=days)

--- a/confluence-mdx/compose.yml
+++ b/confluence-mdx/compose.yml
@@ -48,6 +48,8 @@ services:
     env_file:
       - .env
     volumes:
+      # Use translation file from host
+      - ./etc/korean-titles-translations.txt:/workdir/etc/korean-titles-translations.txt
       # Mount files in var to host
       - ./var/pages.yaml:/workdir/var/pages.yaml
       - ./var/list.en.txt:/workdir/var/list.en.txt

--- a/confluence-mdx/etc/korean-titles-translations.txt
+++ b/confluence-mdx/etc/korean-titles-translations.txt
@@ -158,3 +158,4 @@ DB_MAX_CONNECTION_SIZE 최적화 | Optimizing DB_MAX_CONNECTION_SIZE
 Public Cloud 운영서버 요구사항 | Public Cloud Production Server Requirements
 On-Premise VM 요구사항 | On-Premise VM Requirements
 서버구성 요구사항 요약표 | Server Configuration Requirements Summary
+MCP 설정 가이드 | MCP Configuration Guide

--- a/confluence-mdx/scripts/entrypoint.sh
+++ b/confluence-mdx/scripts/entrypoint.sh
@@ -4,8 +4,17 @@ set -o errexit -o nounset
 
 case "${1:-help}" in
   pages_of_confluence.py|translate_titles.py|generate_commands_for_xhtml2markdown.py|confluence_xhtml_to_markdown.py)
-    echo "+ python bin/$@"
-    exec python "bin/$@"
+    command=$1
+    shift
+    echo "+ python bin/$command $@"
+    exec python bin/$command "$@"
+    ;;
+  title)
+    shift
+    echo "+ python bin/pages_of_confluence.py $@"
+    python bin/pages_of_confluence.py "$@"
+    echo "+ python bin/translate_titles.py"
+    python bin/translate_titles.py
     ;;
   generate_commands)
     shift

--- a/confluence-mdx/var/list.en.txt
+++ b/confluence-mdx/var/list.en.txt
@@ -279,3 +279,4 @@
 1688371232	Installation />> Server Configuration Requirements />> On-Premise VM Requirements
 1692303361	Installation />> Server Configuration Requirements />> Server Configuration Requirements Summary
 1239416833	Installation />> QueryPie ACP Community Edition
+1735589937	Installation />> QueryPie ACP Community Edition />> MCP Configuration Guide

--- a/confluence-mdx/var/list.txt
+++ b/confluence-mdx/var/list.txt
@@ -279,3 +279,4 @@
 1688371232	제품 설치와 기술지원 />> 서버구성 요구사항 />> On-Premise VM 요구사항
 1692303361	제품 설치와 기술지원 />> 서버구성 요구사항 />> 서버구성 요구사항 요약표
 1239416833	제품 설치와 기술지원 />> QueryPie ACP Community Edition
+1735589937	제품 설치와 기술지원 />> QueryPie ACP Community Edition />> MCP 설정 가이드

--- a/confluence-mdx/var/pages.yaml
+++ b/confluence-mdx/var/pages.yaml
@@ -4691,3 +4691,18 @@
   "path":
   - "installation"
   - "querypie-acp-community-edition"
+- "page_id": "1735589937"
+  "title": "MCP 설정 가이드"
+  "title_orig": "MCP 설정 가이드"
+  "breadcrumbs":
+  - "제품 설치와 기술지원"
+  - "QueryPie ACP Community Edition"
+  - "MCP 설정 가이드"
+  "breadcrumbs_en":
+  - "Installation"
+  - "QueryPie ACP Community Edition"
+  - "MCP Configuration Guide"
+  "path":
+  - "installation"
+  - "querypie-acp-community-edition"
+  - "mcp-configuration-guide"


### PR DESCRIPTION
## Description
- `--recent` 옵션 기본 기간을 7일에서 21일로 변경
- compose.yml에서 `korean-titles-translations.txt`를 호스트에서 마운트하도록 변경
- entrypoint.sh에 `title` 명령어 추가 (pages_of_confluence.py와 translate_titles.py 실행)
- README.md의 docker compose 명령어를 `run --rm confluence-mdx` 형식으로 수정
- 새로운 문서 "MCP 설정 가이드"를 pages.yaml 및 번역 파일에 추가

