### PR TITLE
confluence-mdx: Overview 페이지를 수집 대상에서 제외

### DIFF
--- a/confluence-mdx/bin/pages_of_confluence.py
+++ b/confluence-mdx/bin/pages_of_confluence.py
@@ -881,6 +881,14 @@ class ConfluencePageProcessor:
                     space_key=self.config.space_key
                 )
                 
+                # Exclude specific page_id from collection (576585864)
+                # 576585864 - https://querypie.atlassian.net/wiki/spaces/QM/overview
+                excluded_page_id = "576585864"
+                original_count = len(page_ids)
+                page_ids = [pid for pid in page_ids if pid != excluded_page_id]
+                if original_count != len(page_ids):
+                    self.logger.info(f"Excluded page ID {excluded_page_id} from collection ({original_count} -> {len(page_ids)} pages)")
+                
                 # Download each page through all 4 stages and output to stdout
                 # Store downloaded pages for list.txt
                 self.logger.warning(f"Downloading {len(page_ids)} recently modified pages")


### PR DESCRIPTION
## Description
### 문제 현상
Generate MDX From Confluence GitHub Action 을 실행한 경우, 문서 수집 대상이 아닌 QM Space 의 Overview 페이지가 수집되고 MDX 변환됩니다. https://github.com/querypie/querypie-docs/actions/workflows/generate-mdx-from-confluence.yml

### 해결 방법
- 다음 페이지를 pages_of_confluence.py 의 --recent mode 수집 대상에서 제외합니다.
  - 576585864 - https://querypie.atlassian.net/wiki/spaces/QM/overview
