### PR TITLE
confluence-mdx: 가로 구분선 수정

### DIFF
--- a/confluence-mdx/bin/confluence_xhtml_to_markdown.py
+++ b/confluence-mdx/bin/confluence_xhtml_to_markdown.py
@@ -1107,7 +1107,9 @@ class MultiLineParser:
         elif node.name in ['a']:
             self.markdown_lines.append(SingleLineParser(node).as_markdown)
         elif node.name in ['hr']:
-            self.markdown_lines.append(f'---\n')
+            # Using --- after a sentence means an H2 heading.
+            # To prevent ambiguity with headings, use ______ for a horizontal rule.
+            self.markdown_lines.append(f'______\n')
         else:
             logging.warning(f"MultiLineParser: Unexpected {print_node_with_properties(node)} from {ancestors(node)} in {INPUT_FILE_PATH}")
             self.markdown_lines.append(f'[{node.name}]\n')


### PR DESCRIPTION
## Description
### 문제 현상
문장이 포함된 줄 다음에 빈 줄 없이 `---`이 사용되면, H2 heading 으로 간주됩니다. 이로 인해, 기존 가로줄의 렌더링이 의도에 맞지 않게, H2 heading 으로 표현되는 경우가 있습니다.

<img width="1475" height="1061" alt="image" src="https://github.com/user-attachments/assets/8d4129ba-2627-40a4-b78d-83e5d9190175" />

### 해결 방안
`---` 대신 `______` 를 사용하여, 가로 구분선을 표현합니다.

## Additional notes
- 이번 PR 에서는 MDX 문서 변경사항을 포함하지 않습니다. 후속 PR 에서 문서를 변경합니다.
