### PR TITLE
fix: 테이블이 main element 폭을 초과하는 문제 수정

### DIFF
--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -8,6 +8,7 @@ import { Metadata } from 'next';
 import React from 'react';
 import { LastUpdated } from '@/components/last-updated';
 import LanguageSelector2 from "@/components/language-selector2";
+import TableWidthFix from "@/components/table-width-fix";
 
 const defaultMetadata: Metadata = {
   title: {
@@ -95,6 +96,7 @@ export default async function RootLayout({ children, params }) {
           }}
           lastUpdated={<LastUpdated locale={lang} />}
         >
+          <TableWidthFix />
           {children}
         </Layout>
       </body>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -31,4 +31,106 @@ article main figure figcaption {
 /* Custom styles for QueryPie branding */
 .querypie-custom {
   /* Add QueryPie specific styles here */
-} 
+}
+
+/* Table overflow fix - Ensure tables fit within main element width */
+/* Fix for tables with data-table-width attribute that exceed parent width */
+/* 
+ * When a table has data-table-width attribute and its content exceeds the parent width,
+ * we make the table itself a scrollable container while maintaining its internal table structure.
+ */
+article main table[data-table-width] {
+  display: block;
+  overflow-x: auto;
+  overflow-y: visible;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+/* Restore table display for table children to maintain proper table structure */
+article main table[data-table-width] > thead,
+article main table[data-table-width] > tbody,
+article main table[data-table-width] > tfoot {
+  display: table;
+  width: 100%;
+  table-layout: auto;
+}
+
+article main table[data-table-width] > colgroup {
+  display: table-column-group;
+}
+
+article main table[data-table-width] > colgroup > col {
+  display: table-column;
+}
+
+/* Ensure table rows and cells maintain proper table layout */
+article main table[data-table-width] tr {
+  display: table-row;
+}
+
+article main table[data-table-width] td,
+article main table[data-table-width] th {
+  display: table-cell;
+  white-space: normal;
+  word-wrap: break-word;
+  vertical-align: top;
+}
+
+/* Fix for all tables (including GFM markdown tables) to fit within main element width */
+/* Override Nextra's table styles to ensure tables don't overflow main element */
+/* Use block display with overflow for scrolling, but maintain table structure internally */
+article main > table,
+article main > * > table {
+  display: block !important;
+  overflow-x: auto !important;
+  overflow-y: visible !important;
+  width: 100% !important;
+  max-width: 100% !important;
+  box-sizing: border-box !important;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Restore table display for table children to maintain proper table structure */
+/* Important: Use fixed layout to ensure all rows use the same column widths */
+/* Make thead and tbody share the same table structure with fixed layout */
+article main > table > thead,
+article main > table > tbody,
+article main > table > tfoot,
+article main > * > table > thead,
+article main > * > table > tbody,
+article main > * > table > tfoot {
+  display: table !important;
+  width: 100% !important;
+  min-width: 0 !important;
+  max-width: 100% !important;
+  table-layout: fixed !important;
+}
+
+article main > table > colgroup,
+article main > * > table > colgroup {
+  display: table-column-group !important;
+}
+
+article main > table > colgroup > col,
+article main > * > table > colgroup > col {
+  display: table-column !important;
+}
+
+/* Ensure table rows and cells maintain proper table layout */
+article main > table tr,
+article main > * > table tr {
+  display: table-row !important;
+}
+
+article main > table td,
+article main > table th,
+article main > * > table td,
+article main > * > table th {
+  display: table-cell !important;
+  white-space: normal !important;
+  word-wrap: break-word !important;
+  overflow-wrap: break-word !important;
+  vertical-align: top;
+}

--- a/src/components/table-width-fix.tsx
+++ b/src/components/table-width-fix.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useEffect } from 'react'
+
+/**
+ * Component to fix table column width synchronization
+ * Ensures that tbody rows use the same column widths as thead
+ */
+export default function TableWidthFix() {
+  useEffect(() => {
+    const syncTableColumnWidths = () => {
+      const tables = document.querySelectorAll('main table')
+      
+      tables.forEach((table) => {
+        const thead = table.querySelector('thead')
+        const tbody = table.querySelector('tbody')
+        
+        if (thead && tbody) {
+          const theadCells = Array.from(thead.querySelectorAll('th, td'))
+          
+          if (theadCells.length === 0) return
+          
+          // Get computed widths from thead cells
+          const theadWidths = theadCells.map((cell) => {
+            const computed = window.getComputedStyle(cell)
+            return computed.width
+          })
+          
+          // Apply thead column widths to all tbody rows
+          const allTbodyRows = tbody.querySelectorAll('tr')
+          allTbodyRows.forEach((row) => {
+            const rowCells = Array.from(row.querySelectorAll('td, th'))
+            rowCells.forEach((cell, cellIndex) => {
+              if (theadWidths[cellIndex]) {
+                ;(cell as HTMLElement).style.width = theadWidths[cellIndex]
+                ;(cell as HTMLElement).style.minWidth = theadWidths[cellIndex]
+                ;(cell as HTMLElement).style.maxWidth = theadWidths[cellIndex]
+              }
+            })
+          })
+        }
+      })
+    }
+    
+    // Run on mount and after a short delay to ensure DOM is ready
+    syncTableColumnWidths()
+    const timeoutId = setTimeout(syncTableColumnWidths, 100)
+    
+    // Also run when window is resized
+    window.addEventListener('resize', syncTableColumnWidths)
+    
+    return () => {
+      clearTimeout(timeoutId)
+      window.removeEventListener('resize', syncTableColumnWidths)
+    }
+  }, [])
+  
+  return null // This component doesn't render anything
+}
+


### PR DESCRIPTION
## Description

문서 페이지의 테이블이 main element의 폭을 초과하여 오른쪽 일부가 가려지는 문제를 수정합니다.
- 제품설치와 기술지원 -> 컨테이너 환경변수 페이지에서 테이블 폭 문제가 있습니다.
- Preview Link: https://querypie-docs-git-jk-fix-css-for-table-querypie.vercel.app/ko/installation/container-environment-variables

### 문제 현상
- main element의 폭(832px)보다 테이블의 실제 콘텐츠 폭(1557px, 920px)이 더 넓게 렌더링됨
- thead의 첫 번째 행은 main element 폭에 맞게 그려지지만, tbody의 이후 행들은 더 넓게 그려짐
- 테이블 오른쪽 일부가 가려져서 내용을 확인할 수 없음

### 해결 방안
- `globals.css`에 테이블 스타일 규칙 추가: table을 `display: block`으로 설정하고 `overflow-x: auto` 적용
- `table-width-fix.tsx` 컴포넌트 추가: thead의 열 너비를 계산하여 tbody의 모든 행에 동일하게 적용
- `layout.tsx`에 `TableWidthFix` 컴포넌트 추가하여 모든 페이지에서 자동 실행

## Additional notes
- 총 3개 파일 변경 (165줄 추가, 1줄 삭제)
- GFM 마크다운 테이블과 HTML 테이블 모두 지원
- 윈도우 리사이즈 시에도 열 너비 동기화 유지
