### PR TITLE
open-api: fetch-openapi-spec 스크립트 구현

### DIFF
--- a/docs/plan-to-migrate-openapi-spec.md
+++ b/docs/plan-to-migrate-openapi-spec.md
@@ -103,94 +103,202 @@ public/openapi-specification/
 
 ## 구현 계획
 
-### 1단계: 스크립트 개발
+### 접근 방법 2: 사내 QueryPie 인스턴스에서 다운로드
 
-**스크립트 위치:** `scripts/fetch-openapi-spec/`
+이 구현 계획은 사내 QueryPie 인스턴스의 OpenAPI Specification 엔드포인트에서 직접 JSON 파일을 다운로드하는 방법을 기반으로 합니다.
 
-**기능 요구사항:**
-- Docker 이미지에서 OpenAPI Spec 추출
-- 버전 정보 파싱 및 디렉토리 생성
-- JSON 유효성 검증
-- 변경 감지 (기존 파일과 비교)
-- 에러 처리 및 로깅
+### 1단계: TypeScript 프로그램 개발
 
-**스크립트 구조:**
+**프로그램 이름:** `fetch-openapi-spec`
+
+**프로그램 위치:** `scripts/fetch-openapi-spec/`
+
+**주요 기능 요소:**
+1. **URL 인자 파싱**: 실행 시 전달받은 URL에서 API 버전(v0.9 또는 v2) 자동 감지
+2. **HTTP 다운로드**: 사내 QueryPie 인스턴스에서 OpenAPI Spec JSON 파일 다운로드
+3. **버전 정보 추출**: JSON 파일의 `info.x-querypie-version` 필드에서 QueryPie 버전 추출
+4. **JSON 포맷팅**: 다운로드한 JSON을 사람이 읽기 쉬운 형태로 포맷팅 (들여쓰기, 정렬)
+5. **디렉토리 구조 생성**: 버전별 디렉토리 자동 생성
+6. **파일 저장**: 포맷팅된 JSON 파일을 적절한 경로에 저장
+7. **에러 처리**: 네트워크 오류, JSON 파싱 오류, 파일 쓰기 오류 등 처리
+8. **로깅**: 진행 상황 및 결과를 콘솔에 출력
+
+**코드 파일 구조:**
 ```
 scripts/fetch-openapi-spec/
-  index.ts                    # 메인 스크립트
-  docker-extractor.ts         # Docker 이미지에서 추출하는 로직
-  version-parser.ts           # 버전 정보 파싱
-  json-validator.ts           # JSON 유효성 검증
-  README.md                   # 사용 방법 문서
+  index.ts                      # 메인 진입점, CLI 인자 처리
+  downloader.ts                 # HTTP 다운로드 로직
+  version-parser.ts             # 버전 정보 추출 및 파싱
+  json-formatter.ts             # JSON 포맷팅 로직
+  file-manager.ts               # 디렉토리 생성 및 파일 저장
+  types.ts                      # TypeScript 타입 정의
+  utils.ts                      # 유틸리티 함수
+  package.json                  # 의존성 관리
+  tsconfig.json                 # TypeScript 설정
+  README.md                     # 사용 방법 문서
 ```
 
-### 2단계: GitHub Actions 워크플로우
+**실행 방법:**
+```bash
+# V0.9 API Spec 다운로드
+npm run fetch-openapi-spec -- https://internal.dev.querypie.io/api/docs/specification/external
+
+# V2 API Spec 다운로드
+npm run fetch-openapi-spec -- https://internal.dev.querypie.io/api/docs/specification/external-v2
+```
+
+**URL에서 API 버전 구분 로직:**
+- URL 경로에 `/external-v2` 또는 `/v2`가 포함되어 있으면 → `v2.json`으로 저장
+- URL 경로에 `/external`만 포함되어 있으면 → `v0.9.json`으로 저장
+- 또는 명시적으로 `--api-version` 옵션으로 지정 가능
+
+### 2단계: JSON 포맷팅 구현
+
+**포맷팅 요구사항:**
+- 들여쓰기: 2 spaces
+- 키 정렬: 알파벳 순서로 정렬 (선택사항)
+- 줄바꿈: 객체/배열의 각 요소를 새 줄에 배치
+- 최대 줄 길이: 가독성을 위해 적절한 길이 유지
+
+**구현 방법:**
+- Node.js의 `JSON.stringify()` 메서드 사용
+- `JSON.stringify(obj, null, 2)` 형태로 포맷팅
+- 또는 `prettier` 라이브러리 사용 고려 (더 세밀한 제어 가능)
+
+**예상 출력 형태:**
+```json
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "QueryPie API",
+    "version": "V2",
+    "x-querypie-version": "11.4.1-eee1211"
+  },
+  "servers": [
+    {
+      "url": "https://internal.dev.querypie.io",
+      "description": "Generated server url"
+    }
+  ]
+}
+```
+
+### 3단계: 디렉토리 구조 및 파일 저장
+
+**저장 경로 구조:**
+```
+public/openapi-specification/
+  {querypie-version}/          # 예: 11.4.1, 11.5.0
+    v0.9.json                  # V0.9 API Specification
+    v2.json                     # V2 API Specification
+```
+
+**버전 추출 로직:**
+1. 다운로드한 JSON 파일에서 `info.x-querypie-version` 필드 읽기
+2. 버전 형식: `{major}.{minor}.{patch}-{commit-hash}` (예: `11.4.1-eee1211`)
+3. 디렉토리명에는 `{major}.{minor}.{patch}` 부분만 사용 (예: `11.4.1`)
+4. 해당 디렉토리가 없으면 자동 생성
+5. 파일명은 API 버전에 따라 `v0.9.json` 또는 `v2.json`으로 저장
+
+**파일 저장 로직:**
+- 기존 파일이 있으면 덮어쓰기
+- 변경사항 감지 기능 (선택사항): 기존 파일과 해시 비교하여 변경 여부 확인
+- 저장 전 JSON 유효성 검증 수행
+
+### 4단계: 추가 JSON 파일 변경 로직 구현 (향후 확장)
+
+이 단계는 향후 필요에 따라 JSON 파일을 추가로 가공하거나 변경하는 기능을 구현하기 위한 확장 포인트입니다.
+
+**예상 변경 사항:**
+1. **서버 URL 변경**: `servers[].url` 필드를 프로덕션 URL로 변경
+2. **민감 정보 제거**: 내부 정보나 개발 환경 관련 내용 제거
+3. **메타데이터 추가**: 다운로드 날짜, 소스 URL 등의 메타데이터 추가
+4. **스키마 정규화**: OpenAPI 스키마를 표준 형식으로 정규화
+5. **예제 데이터 보강**: API 예제 데이터 추가 또는 수정
+
+**구현 구조:**
+```
+scripts/fetch-openapi-spec/
+  transformers/
+    server-url-transformer.ts   # 서버 URL 변경
+    metadata-transformer.ts      # 메타데이터 추가
+    schema-normalizer.ts         # 스키마 정규화
+    example-enricher.ts          # 예제 데이터 보강
+  transformer-registry.ts        # 변환기 등록 및 실행 관리
+```
+
+**변환기 실행 순서:**
+1. JSON 다운로드
+2. 기본 포맷팅
+3. 등록된 변환기들을 순차적으로 실행
+4. 최종 포맷팅
+5. 파일 저장
+
+**변환기 활성화 방법:**
+- 환경 변수로 제어: `TRANSFORM_SERVER_URL=true`
+- 설정 파일로 제어: `config.json`에서 변환기 활성화 여부 지정
+- CLI 옵션으로 제어: `--transform server-url`
+
+### 5단계: 에러 처리 및 로깅
+
+**에러 처리 시나리오:**
+1. **네트워크 오류**: 연결 실패, 타임아웃, HTTP 에러 상태 코드
+2. **JSON 파싱 오류**: 다운로드한 파일이 유효한 JSON이 아닌 경우
+3. **버전 정보 누락**: `x-querypie-version` 필드가 없는 경우
+4. **파일 시스템 오류**: 디렉토리 생성 실패, 파일 쓰기 권한 오류
+5. **URL 형식 오류**: 잘못된 URL 형식 또는 접근 불가능한 엔드포인트
+
+**로깅 레벨:**
+- `INFO`: 정상 진행 상황 (다운로드 시작, 파일 저장 완료 등)
+- `WARN`: 경고 사항 (기존 파일 덮어쓰기, 버전 형식 이상 등)
+- `ERROR`: 에러 발생 시 상세 정보 출력
+
+**출력 예시:**
+```
+[INFO] Starting OpenAPI Spec download...
+[INFO] URL: https://internal.dev.querypie.io/api/docs/specification/external-v2
+[INFO] Detected API version: v2
+[INFO] Downloading JSON file...
+[INFO] Extracted QueryPie version: 11.4.1-eee1211
+[INFO] Creating directory: public/openapi-specification/11.4.1
+[INFO] Formatting JSON file...
+[INFO] Saving file: public/openapi-specification/11.4.1/v2.json
+[INFO] Download completed successfully!
+```
+
+### 6단계: GitHub Actions 워크플로우 (선택사항)
 
 **워크플로우 파일:** `.github/workflows/fetch-openapi-spec.yml`
 
 **트리거 방식:**
 1. **수동 트리거 (workflow_dispatch)**: 필요 시 수동으로 실행
-2. **스케줄 트리거 (schedule)**: 주기적으로 최신 버전 확인
-3. **릴리스 트리거 (release)**: 새 버전 릴리스 시 자동 실행
+2. **스케줄 트리거 (schedule)**: 주기적으로 최신 버전 확인 (예: 매주 월요일)
 
 **워크플로우 단계:**
 1. Repository 체크아웃
-2. Docker 이미지 다운로드 (또는 레지스트리에서 pull)
-3. OpenAPI Spec 추출 스크립트 실행
-4. 변경사항 확인
-5. 변경사항이 있으면 PR 생성 또는 직접 커밋
+2. Node.js 환경 설정
+3. 의존성 설치 (`npm install`)
+4. OpenAPI Spec 다운로드 스크립트 실행
+   - V0.9: `npm run fetch-openapi-spec -- <v0.9-url>`
+   - V2: `npm run fetch-openapi-spec -- <v2-url>`
+5. 변경사항 확인 (`git diff`)
+6. 변경사항이 있으면 PR 생성 또는 직접 커밋
 
-### 3단계: OpenAPI Spec 표시
+**필요한 Secrets:**
+- `QUERYPIE_INSTANCE_URL`: 사내 QueryPie 인스턴스 URL (선택사항)
+- `QUERYPIE_AUTH_TOKEN`: 인증 토큰 (필요한 경우)
 
-**표시 방법 옵션:**
+### 참고: 웹페이지 서비스 제공
 
-#### 옵션 A: Redoc을 사용한 정적 HTML 생성
-- Redoc CLI를 사용하여 OpenAPI Spec JSON에서 HTML 생성
-- 빌드 시점에 HTML 파일 생성
-- Next.js의 정적 파일로 제공
+`public/openapi-specification/` 디렉토리의 Spec 파일을 웹페이지로 서비스 제공하는 기능은 별도의 구현 단계로 구분하며, 이 문서의 구현 계획 범위에는 포함하지 않습니다.
 
-#### 옵션 B: Next.js 컴포넌트로 통합
-- `@redocly/react-doc` 또는 유사한 라이브러리 사용
-- 런타임에 OpenAPI Spec JSON을 읽어서 렌더링
-- 동적 라우팅으로 버전별 페이지 제공
+웹페이지 서비스 제공을 위한 구현은 다음을 포함할 수 있습니다:
+- Next.js 컴포넌트로 OpenAPI Spec 렌더링
+- Redoc 또는 Swagger UI 통합
+- 버전별 동적 라우팅
+- API 문서 페이지 생성
 
-#### 옵션 C: iframe으로 Swagger UI 임베드
-- 별도 서버에서 Swagger UI 제공
-- 문서 사이트에서 iframe으로 임베드
-- 가장 간단하지만 별도 인프라 필요
-
-**권장 방법:** 옵션 B (Next.js 컴포넌트로 통합)
-- 문서 사이트와 일관된 UI/UX
-- SEO 최적화 가능
-- 버전별 동적 라우팅 용이
-
-### 4단계: 문서 페이지 생성
-
-**페이지 구조:**
-```
-src/content/{lang}/api/
-  index.mdx                    # API 문서 인덱스 페이지
-  [version]/
-    index.mdx                  # 버전별 API 문서 페이지
-    v0.9.mdx                   # V0.9 API 문서
-    v2.mdx                     # V2 API 문서
-```
-
-**MDX 파일 예시:**
-```mdx
----
-title: 'API Documentation - V2'
----
-
-import { OpenAPISpec } from '@/components/OpenAPISpec'
-
-# QueryPie API V2
-
-<OpenAPISpec 
-  specPath="/openapi-specification/11.4.1/v2.json"
-  version="v2"
-/>
-```
+이러한 기능들은 별도의 문서나 이슈에서 계획 및 구현됩니다.
 
 ## 기술적 고려사항
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "format": "npx prettier --write .",
     "generate-pagefind": "pagefind --site .next/server/app --output-path public/_pagefind",
     "generate-sitemap": "npx tsx scripts/generate-sitemap/index.ts",
+    "fetch-openapi-spec": "npx tsx scripts/fetch-openapi-spec/index.ts",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:run": "vitest run"

--- a/public/openapi-specification/11.4.1/v0.9.json
+++ b/public/openapi-specification/11.4.1/v0.9.json
@@ -1,0 +1,14137 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "contact": {
+      "name": "QueryPie",
+      "url": "https://chequer.atlassian.net/servicedesk/customer"
+    },
+    "description": "QueryPie API",
+    "title": "QueryPie API",
+    "version": "0.9",
+    "x-logo": {
+      "altText": "QueryPie logo",
+      "url": "/api/docs/assets/querypie.svg"
+    },
+    "x-querypie-version": "11.4.1-eee1211"
+  },
+  "servers": [
+    {
+      "url": "https://internal.dev.querypie.io",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/api/external/access-approvals": {
+      "get": {
+        "deprecated": true,
+        "description": "List of Access Approval",
+        "operationId": "list_7",
+        "parameters": [
+          {
+            "description": "Approval Status",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Approval Status"
+            }
+          },
+          {
+            "description": "Page Number (Zero-based)",
+            "example": 0,
+            "in": "query",
+            "name": "pageNumber",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Page Number (Zero-based)",
+              "example": 0
+            }
+          },
+          {
+            "description": "Page Size",
+            "example": 50,
+            "in": "query",
+            "name": "pageSize",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Page Size",
+              "example": 50
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.Responses$PageResponseCom.querypie.newworkflow.interfaces.external.v1.ExternalAccessApprovalDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "List of Access Approval",
+        "tags": [
+          "Access Approval API"
+        ]
+      }
+    },
+    "/api/external/access-controls/grant": {
+      "post": {
+        "description": "Grant Roles By Cluster",
+        "operationId": "grant",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalAccessControlDto$GrantRoleRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalAccessControlDto$GrantResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Grant Roles",
+        "tags": [
+          "Access Control API"
+        ]
+      }
+    },
+    "/api/external/access-controls/revoke": {
+      "post": {
+        "description": "Revoke Roles By Cluster",
+        "operationId": "revoke",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalAccessControlDto$RevokeRoleRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalAccessControlDto$RevokeResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Revoke Roles",
+        "tags": [
+          "Access Control API"
+        ]
+      }
+    },
+    "/api/external/alerts/data-export": {
+      "post": {
+        "description": "[Data Export] Create",
+        "operationId": "create_15",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationDataExportDto$Request"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationDataExportDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[Data Export] Create",
+        "tags": [
+          "Alert API"
+        ]
+      }
+    },
+    "/api/external/alerts/data-export/{uuid}": {
+      "get": {
+        "description": "[Data Export] Detail",
+        "operationId": "detail_11",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationDataExportDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[Data Export] Detail",
+        "tags": [
+          "Alert API"
+        ]
+      },
+      "put": {
+        "description": "[Data Export] Update",
+        "operationId": "update_11",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationDataExportDto$Request"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationDataExportDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[Data Export] Update",
+        "tags": [
+          "Alert API"
+        ]
+      }
+    },
+    "/api/external/alerts/db-connection-attempt": {
+      "post": {
+        "description": "[DB Connection Attempt] Create",
+        "operationId": "create_14",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationDbConnectionAttemptDto$Request"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationDbConnectionAttemptDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[DB Connection Attempt] Create",
+        "tags": [
+          "Alert API"
+        ]
+      }
+    },
+    "/api/external/alerts/db-connection-attempt/{uuid}": {
+      "get": {
+        "description": "[DB Connection Attempt] Detail",
+        "operationId": "detail_10",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationDbConnectionAttemptDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[DB Connection Attempt] Detail",
+        "tags": [
+          "Alert API"
+        ]
+      },
+      "put": {
+        "description": "[DB Connection Attempt] Update",
+        "operationId": "update_10",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationDbConnectionAttemptDto$Request"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationDbConnectionAttemptDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[DB Connection Attempt] Update",
+        "tags": [
+          "Alert API"
+        ]
+      }
+    },
+    "/api/external/alerts/prevented-sql-execution": {
+      "post": {
+        "description": "[Prevented SQL Execution] Create",
+        "operationId": "create_13",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationPreventedSqlExecutionDto$Request"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationPreventedSqlExecutionDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[Prevented SQL Execution] Create",
+        "tags": [
+          "Alert API"
+        ]
+      }
+    },
+    "/api/external/alerts/prevented-sql-execution/{uuid}": {
+      "get": {
+        "description": "[Prevented SQL Execution] Detail",
+        "operationId": "detail_9",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationPreventedSqlExecutionDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[Prevented SQL Execution] Detail",
+        "tags": [
+          "Alert API"
+        ]
+      },
+      "put": {
+        "description": "[Prevented SQL Execution] Update",
+        "operationId": "update_9",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationPreventedSqlExecutionDto$Request"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationPreventedSqlExecutionDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[Prevented SQL Execution] Update",
+        "tags": [
+          "Alert API"
+        ]
+      }
+    },
+    "/api/external/alerts/sensitive-data-access": {
+      "post": {
+        "description": "[Sensitive Data Access] Create",
+        "operationId": "create_12",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationSensitiveDataAccessDto$Request"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationSensitiveDataAccessDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[Sensitive Data Access] Create",
+        "tags": [
+          "Alert API"
+        ]
+      }
+    },
+    "/api/external/alerts/sensitive-data-access/{uuid}": {
+      "get": {
+        "description": "[Sensitive Data Access] Detail",
+        "operationId": "detail_8",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationSensitiveDataAccessDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[Sensitive Data Access] Detail",
+        "tags": [
+          "Alert API"
+        ]
+      },
+      "put": {
+        "description": "[Sensitive Data Access] Update",
+        "operationId": "update_8",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationSensitiveDataAccessDto$Request"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationSensitiveDataAccessDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[Sensitive Data Access] Update",
+        "tags": [
+          "Alert API"
+        ]
+      }
+    },
+    "/api/external/alerts/sql-execution": {
+      "post": {
+        "description": "[SQL Execution] Create",
+        "operationId": "create_11",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationSqlExecutionDto$Request"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationSqlExecutionDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[SQL Execution] Create",
+        "tags": [
+          "Alert API"
+        ]
+      }
+    },
+    "/api/external/alerts/sql-execution/{uuid}": {
+      "get": {
+        "description": "[SQL Execution] Detail",
+        "operationId": "detail_7",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationSqlExecutionDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[SQL Execution] Detail",
+        "tags": [
+          "Alert API"
+        ]
+      },
+      "put": {
+        "description": "[SQL Execution] Update",
+        "operationId": "update_7",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationSqlExecutionDto$Request"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationSqlExecutionDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[SQL Execution] Update",
+        "tags": [
+          "Alert API"
+        ]
+      }
+    },
+    "/api/external/alerts/unusual-login-attempt": {
+      "post": {
+        "description": "[Unusual Login Attempt] Create",
+        "operationId": "create_10",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationUnusualLoginAttemptDto$Request"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationUnusualLoginAttemptDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[Unusual Login Attempt] Create",
+        "tags": [
+          "Alert API"
+        ]
+      }
+    },
+    "/api/external/alerts/unusual-login-attempt/{uuid}": {
+      "get": {
+        "description": "[Unusual Login Attempt] Detail",
+        "operationId": "detail_6",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationUnusualLoginAttemptDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[Unusual Login Attempt] Detail",
+        "tags": [
+          "Alert API"
+        ]
+      },
+      "put": {
+        "description": "[Unusual Login Attempt] Update",
+        "operationId": "update_6",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationUnusualLoginAttemptDto$Request"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationUnusualLoginAttemptDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[Unusual Login Attempt] Update",
+        "tags": [
+          "Alert API"
+        ]
+      }
+    },
+    "/api/external/alerts/workflow-new-request": {
+      "post": {
+        "description": "[Workflow New Request] Create",
+        "operationId": "create_9",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationWorkflowNewRequestDto$Request"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationWorkflowNewRequestDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[Workflow New Request] Create",
+        "tags": [
+          "Alert API"
+        ]
+      }
+    },
+    "/api/external/alerts/workflow-new-request/{uuid}": {
+      "get": {
+        "description": "[Workflow New Request] Detail",
+        "operationId": "detail_5",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationWorkflowNewRequestDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[Workflow New Request] Detail",
+        "tags": [
+          "Alert API"
+        ]
+      },
+      "put": {
+        "description": "[Workflow New Request] Update",
+        "operationId": "update_5",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationWorkflowNewRequestDto$Request"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationWorkflowNewRequestDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[Workflow New Request] Update",
+        "tags": [
+          "Alert API"
+        ]
+      }
+    },
+    "/api/external/approval-rules": {
+      "get": {
+        "deprecated": true,
+        "operationId": "findAll_3",
+        "parameters": [
+          {
+            "description": "Request Type",
+            "example": "SQL",
+            "in": "query",
+            "name": "requestType",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Request Type",
+              "example": "SQL"
+            }
+          },
+          {
+            "description": "Page Number",
+            "example": 0,
+            "in": "query",
+            "name": "pageNumber",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "description": "Page Number",
+              "example": 0
+            }
+          },
+          {
+            "description": "Page Size",
+            "example": 50,
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "maximum": 2147483647,
+              "type": "string",
+              "description": "Page Size",
+              "example": 50,
+              "default": "2147483647"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.Responses$PageResponseCom.querypie.newworkflow.interfaces.external.v1.ExternalApprovalRuleDto$PartialResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "List",
+        "tags": [
+          "Approval Rule API"
+        ]
+      }
+    },
+    "/api/external/approval-rules/{uuid}": {
+      "delete": {
+        "deprecated": true,
+        "operationId": "delete_8",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Delete",
+        "tags": [
+          "Approval Rule API"
+        ]
+      },
+      "get": {
+        "deprecated": true,
+        "operationId": "find_3",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v1.ExternalApprovalRuleDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Detail",
+        "tags": [
+          "Approval Rule API"
+        ]
+      }
+    },
+    "/api/external/approvals": {
+      "get": {
+        "deprecated": true,
+        "description": "List of Approval",
+        "operationId": "list_6",
+        "parameters": [
+          {
+            "description": "Approval Status",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Approval Status"
+            }
+          },
+          {
+            "description": "Page Number (Zero-based)",
+            "example": 0,
+            "in": "query",
+            "name": "pageNumber",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Page Number (Zero-based)",
+              "example": 0
+            }
+          },
+          {
+            "description": "Page Size",
+            "example": 50,
+            "in": "query",
+            "name": "pageSize",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Page Size",
+              "example": 50
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.Responses$PageResponseCom.querypie.newworkflow.interfaces.external.v1.ExternalApprovalDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "List of Approval",
+        "tags": [
+          "Approval API"
+        ]
+      }
+    },
+    "/api/external/approvals/{approvalUuid}/approve": {
+      "post": {
+        "deprecated": true,
+        "description": "Approve Approval By UUID",
+        "operationId": "approveByUuid",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "approvalUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v1.ExternalApprovalDto$ReviewRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Approve Approval By UUID",
+        "tags": [
+          "Approval API"
+        ]
+      }
+    },
+    "/api/external/approvals/{approvalUuid}/reject": {
+      "post": {
+        "deprecated": true,
+        "description": "Reject Approval By UUID",
+        "operationId": "rejectByUuid",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "approvalUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Reject Approval By UUID",
+        "tags": [
+          "Approval API"
+        ]
+      }
+    },
+    "/api/external/audit-logs": {
+      "get": {
+        "deprecated": true,
+        "operationId": "findPageableList_1",
+        "parameters": [
+          {
+            "description": "Cursor. Received from list reponse.",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Cursor. Received from list reponse."
+            }
+          },
+          {
+            "description": "Count.(max=100)",
+            "example": 50,
+            "in": "query",
+            "name": "count",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Count.(max=100)",
+              "example": 50
+            }
+          },
+          {
+            "description": "Action Type",
+            "example": "EXPORT_DATA",
+            "in": "query",
+            "name": "actionType",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Action Type",
+              "example": "EXPORT_DATA"
+            }
+          },
+          {
+            "description": "Cluster Group ID",
+            "example": 1,
+            "in": "query",
+            "name": "clusterGroupId",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Cluster Group ID",
+              "example": 1
+            }
+          },
+          {
+            "description": "Cluster ID",
+            "example": 1,
+            "in": "query",
+            "name": "clusterId",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Cluster ID",
+              "example": 1
+            }
+          },
+          {
+            "description": "Start Date",
+            "example": "UTC Date Time",
+            "in": "query",
+            "name": "startDate",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Start Date",
+              "example": "UTC Date Time"
+            }
+          },
+          {
+            "description": "End Date",
+            "example": "UTC Date Time",
+            "in": "query",
+            "name": "endDate",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "End Date",
+              "example": "UTC Date Time"
+            }
+          },
+          {
+            "description": "Database Type",
+            "example": "MySQL",
+            "in": "query",
+            "name": "databaseType",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Database Type",
+              "example": "MySQL"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.Responses$ScanResponseCom.querypie.dbam.controller.dto.ExternalSqlAuditLogDto$AuditLogResponseJava.lang.String"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "List of SQL Audit",
+        "tags": [
+          "Audit Log API"
+        ]
+      }
+    },
+    "/api/external/audit-logs/{id}": {
+      "get": {
+        "deprecated": true,
+        "operationId": "find_2",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalSqlAuditLogDto$AuditLogResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Detail",
+        "tags": [
+          "Audit Log API"
+        ]
+      }
+    },
+    "/api/external/audit-logs/{uuid}": {
+      "get": {
+        "deprecated": true,
+        "operationId": "find_1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalSqlAuditLogDto$AuditLogResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Detail",
+        "tags": [
+          "Audit Log API"
+        ]
+      }
+    },
+    "/api/external/cloud-providers": {
+      "get": {
+        "description": "List of Cloud Provider By Company",
+        "operationId": "list_5",
+        "parameters": [
+          {
+            "description": "Page Number (Zero-based)",
+            "example": 0,
+            "in": "query",
+            "name": "pageNumber",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Page Number (Zero-based)",
+              "example": 0
+            }
+          },
+          {
+            "description": "Page Size",
+            "example": 50,
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Page Size",
+              "example": 50
+            }
+          },
+          {
+            "description": "Deleted (if not presented, Default : false)",
+            "example": true,
+            "in": "query",
+            "name": "deleted",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Deleted (if not presented, Default : false)",
+              "example": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.Responses$PageResponseCom.querypie.dbam.controller.dto.ExternalCloudProviderDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "List of Cloud Provider",
+        "tags": [
+          "Cloud Provider API"
+        ]
+      },
+      "post": {
+        "description": "Create Cloud Provider",
+        "operationId": "create_8",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalCloudProviderDto$CreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalCloudProviderDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Create Cloud Provider",
+        "tags": [
+          "Cloud Provider API"
+        ]
+      }
+    },
+    "/api/external/cloud-providers/{cloudProviderUuid}": {
+      "delete": {
+        "description": "Delete Cloud Provider",
+        "operationId": "delete_7",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "cloudProviderUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Delete Cloud Provider",
+        "tags": [
+          "Cloud Provider API"
+        ]
+      },
+      "put": {
+        "description": "Update Cloud Provider",
+        "operationId": "create",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "cloudProviderUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalCloudProviderDto$UpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalCloudProviderDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Update Cloud Provider",
+        "tags": [
+          "Cloud Provider API"
+        ]
+      }
+    },
+    "/api/external/connection-auth-logs": {
+      "get": {
+        "deprecated": true,
+        "operationId": "findPageableList",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "pageNumber",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "Page Number (Zero-based)",
+              "format": "int32",
+              "example": 0
+            }
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "Page Size",
+              "format": "int32",
+              "example": 50
+            }
+          },
+          {
+            "in": "query",
+            "name": "startDate",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Start Date",
+              "example": "UTC Date Time"
+            }
+          },
+          {
+            "in": "query",
+            "name": "endDate",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "End Date",
+              "example": "UTC Date Time"
+            }
+          },
+          {
+            "description": "Action Type",
+            "example": "CONNECT | DISCONNECT",
+            "in": "query",
+            "name": "actionType",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Action Type",
+              "example": "CONNECT | DISCONNECT"
+            }
+          },
+          {
+            "description": "Cluster Group ID",
+            "example": 1,
+            "in": "query",
+            "name": "clusterGroupId",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Cluster Group ID",
+              "example": 1
+            }
+          },
+          {
+            "description": "Cluster ID",
+            "example": 1,
+            "in": "query",
+            "name": "clusterId",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Cluster ID",
+              "example": 1
+            }
+          },
+          {
+            "description": "Database Type",
+            "example": "MySQL",
+            "in": "query",
+            "name": "databaseType",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Database Type",
+              "example": "MySQL"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.Responses$PageResponseCom.querypie.dbam.controller.dto.ExternalUserAuthHistoryDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "List of Authentication",
+        "tags": [
+          "Authentication History"
+        ]
+      }
+    },
+    "/api/external/connections": {
+      "get": {
+        "description": "List of Cluster Group and Cluster By Company",
+        "operationId": "list_4",
+        "parameters": [
+          {
+            "description": "Page Number (Zero-based)",
+            "example": 0,
+            "in": "query",
+            "name": "pageNumber",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Page Number (Zero-based)",
+              "example": 0
+            }
+          },
+          {
+            "description": "Page Size",
+            "example": 50,
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Page Size",
+              "example": 50
+            }
+          },
+          {
+            "description": "Status",
+            "example": "Default is Active Only",
+            "in": "query",
+            "name": "connectionStatus",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Status",
+              "example": "Default is Active Only"
+            }
+          },
+          {
+            "description": "Cloud Provider UUID",
+            "example": 1,
+            "in": "query",
+            "name": "cloudProviderUuid",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Cloud Provider UUID",
+              "example": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.Responses$PageResponseCom.querypie.dbam.controller.dto.ExternalConnectionDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "List of Cluster Group",
+        "tags": [
+          "Connection API"
+        ]
+      },
+      "post": {
+        "description": "Create Cluster Group and Cluster",
+        "operationId": "createClusterGroup_1",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$CreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Create Cluster Group",
+        "tags": [
+          "Connection API"
+        ]
+      }
+    },
+    "/api/external/connections/clusters/{clusterUuid}/instances": {
+      "get": {
+        "description": "List of instance by cluster",
+        "operationId": "findAll_2",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "clusterUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$InstanceResponse"
+                  }
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "List of instance",
+        "tags": [
+          "Connection API"
+        ]
+      },
+      "post": {
+        "description": "Create Instance",
+        "operationId": "create_7",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "clusterUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$CreateInstanceRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$InstanceResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Create Instance",
+        "tags": [
+          "Connection API"
+        ]
+      }
+    },
+    "/api/external/connections/clusters/{clusterUuid}/instances/{instanceUuid}": {
+      "delete": {
+        "description": "Delete Instance",
+        "operationId": "delete_6",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "clusterUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "instanceUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Delete Instance",
+        "tags": [
+          "Connection API"
+        ]
+      },
+      "patch": {
+        "description": "Update Instance",
+        "operationId": "update_13",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "clusterUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "instanceUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$UpdateInstanceRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$InstanceResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Update Instance",
+        "tags": [
+          "Connection API"
+        ]
+      }
+    },
+    "/api/external/connections/{clusterGroupId}": {
+      "post": {
+        "deprecated": true,
+        "description": "Create Cluster to Cluster Group",
+        "operationId": "addCluster_1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "clusterGroupId",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$AddClusterRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$ClusterResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Create Cluster",
+        "tags": [
+          "Connection API"
+        ]
+      }
+    },
+    "/api/external/connections/{clusterGroupId}/{clusterId}": {
+      "delete": {
+        "deprecated": true,
+        "description": "Delete Cluster from Cluster Group",
+        "operationId": "removeCluster_2",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "clusterGroupId",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "in": "path",
+            "name": "clusterId",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Delete Cluster",
+        "tags": [
+          "Connection API"
+        ]
+      },
+      "put": {
+        "deprecated": true,
+        "description": "Update Cluster",
+        "operationId": "updateCluster_1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "clusterGroupId",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "in": "path",
+            "name": "clusterId",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$UpdateClusterRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$ClusterResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Update Cluster",
+        "tags": [
+          "Connection API"
+        ]
+      }
+    },
+    "/api/external/connections/{clusterGroupUuid}": {
+      "delete": {
+        "description": "Delete Cluster Group and Cluster",
+        "operationId": "deleteClusterGroup",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "clusterGroupUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Delete Cluster Group",
+        "tags": [
+          "Connection API"
+        ]
+      }
+    },
+    "/api/external/connections/{clusterGroupUuid}/clusters": {
+      "post": {
+        "description": "Create Cluster to Cluster Group",
+        "operationId": "addCluster",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "clusterGroupUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$AddClusterRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$ClusterResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Create Cluster",
+        "tags": [
+          "Connection API"
+        ]
+      }
+    },
+    "/api/external/connections/{clusterGroupUuid}/clusters/{clusterUuid}": {
+      "delete": {
+        "description": "Delete Cluster from Cluster Group",
+        "operationId": "removeCluster_1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "clusterGroupUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "clusterUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Delete Cluster",
+        "tags": [
+          "Connection API"
+        ]
+      },
+      "get": {
+        "description": "Find Cluster from Cluster Group",
+        "operationId": "findCluster",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "clusterGroupUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "clusterUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$ClusterResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Find Cluster",
+        "tags": [
+          "Connection API"
+        ]
+      },
+      "put": {
+        "description": "Update Cluster",
+        "operationId": "updateCluster",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "clusterGroupUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "clusterUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$UpdateClusterRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$ClusterResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Update Cluster",
+        "tags": [
+          "Connection API"
+        ]
+      }
+    },
+    "/api/external/connections/{uuid}": {
+      "patch": {
+        "description": "Update Cluster Group and Clusters (Exist Cluster Group & Cluster)",
+        "operationId": "update_12",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$UpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Update Cluster Group",
+        "tags": [
+          "Connection API"
+        ]
+      }
+    },
+    "/api/external/masking-patterns": {
+      "get": {
+        "description": "List of Masking Pattern",
+        "operationId": "findPolicies_2",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalMaskingPatternDto$Response"
+                  }
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "List of Masking Pattern",
+        "tags": [
+          "Masking Pattern API"
+        ]
+      }
+    },
+    "/api/external/network-zones": {
+      "get": {
+        "description": "List of Network Zone",
+        "operationId": "list_3",
+        "parameters": [
+          {
+            "description": "Page Number (Zero-based)",
+            "example": 0,
+            "in": "query",
+            "name": "pageNumber",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Page Number (Zero-based)",
+              "example": 0
+            }
+          },
+          {
+            "description": "Page Size",
+            "example": 50,
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Page Size",
+              "example": 50
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.Responses$PageResponseCom.querypie.dbam.controller.dto.ExternalNetworkZoneDto$ZoneInfoResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "List of Network Zone",
+        "tags": [
+          "Network Zone API"
+        ]
+      },
+      "post": {
+        "operationId": "create_6",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalNetworkZoneDto$CreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalNetworkZoneDto$ZoneInfoResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Create network zone",
+        "tags": [
+          "Network Zone API"
+        ]
+      }
+    },
+    "/api/external/network-zones/default": {
+      "get": {
+        "description": "find default network zone",
+        "operationId": "defaultZone",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalNetworkZoneDto$ZoneInfoResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "find default network zone",
+        "tags": [
+          "Network Zone API"
+        ]
+      }
+    },
+    "/api/external/network-zones/{zoneUuid}": {
+      "delete": {
+        "operationId": "delete_5",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "zoneUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalNetworkZoneDto$ZoneInfoResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Delete network zone",
+        "tags": [
+          "Network Zone API"
+        ]
+      },
+      "get": {
+        "description": "Detail",
+        "operationId": "detail_4",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "zoneUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalNetworkZoneDto$ZoneInfoResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Detail",
+        "tags": [
+          "Network Zone API"
+        ]
+      },
+      "put": {
+        "operationId": "update_4",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "zoneUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalNetworkZoneDto$UpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalNetworkZoneDto$ZoneInfoResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Update network zone",
+        "tags": [
+          "Network Zone API"
+        ]
+      }
+    },
+    "/api/external/notification-channels": {
+      "get": {
+        "description": "List of Notification channel",
+        "operationId": "findAll_1",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filterKey",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "filterValue",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sortKey",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sortType",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "ASC",
+                "DESC"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "viewType",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "ALL",
+                "ActiveOnly",
+                "InactiveOnly",
+                "DeletedOnly"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "pageNumber",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.Responses$PageResponseCom.querypie.notification.controller.dto.ExternalNotificationChannelDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "List",
+        "tags": [
+          "Notification Channels API"
+        ]
+      },
+      "post": {
+        "description": "Create Notification channel",
+        "operationId": "create_5",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.notification.controller.dto.ExternalNotificationChannelDto$CreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.notification.controller.dto.ExternalNotificationChannelDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Create",
+        "tags": [
+          "Notification Channels API"
+        ]
+      }
+    },
+    "/api/external/notification-channels/users": {
+      "get": {
+        "description": "List users for Notification channel recipients",
+        "operationId": "listUsers",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.notification.controller.dto.ExternalNotificationChannelDto$ListUserResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "List Users",
+        "tags": [
+          "Notification Channels API"
+        ]
+      }
+    },
+    "/api/external/notification-channels/{uuid}": {
+      "delete": {
+        "description": "Delete Notification channel",
+        "operationId": "delete_4",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Delete",
+        "tags": [
+          "Notification Channels API"
+        ]
+      },
+      "get": {
+        "description": "Detail of Notification channel",
+        "operationId": "find",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.notification.controller.dto.ExternalNotificationChannelDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Detail",
+        "tags": [
+          "Notification Channels API"
+        ]
+      },
+      "put": {
+        "description": "Update Notification channel",
+        "operationId": "update_3",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.notification.controller.dto.ExternalNotificationChannelDto$UpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.notification.controller.dto.ExternalNotificationChannelDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Update",
+        "tags": [
+          "Notification Channels API"
+        ]
+      }
+    },
+    "/api/external/notifications": {
+      "get": {
+        "description": "List",
+        "operationId": "findPolicies_1",
+        "parameters": [
+          {
+            "description": "Page Number (Zero-based)",
+            "example": 0,
+            "in": "query",
+            "name": "pageNumber",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Page Number (Zero-based)",
+              "example": 0
+            }
+          },
+          {
+            "description": "Page Size",
+            "example": 50,
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Page Size",
+              "example": 50
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.Responses$PageResponseCom.querypie.dbam.controller.dto.ExternalPolicyNotificationDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "List",
+        "tags": [
+          "Alert API"
+        ]
+      }
+    },
+    "/api/external/notifications/{notificationUuid}": {
+      "delete": {
+        "description": "Delete",
+        "operationId": "delete_3",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "notificationUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Delete",
+        "tags": [
+          "Alert API"
+        ]
+      }
+    },
+    "/api/external/policies": {
+      "get": {
+        "description": "List of Policy",
+        "operationId": "findPolicies",
+        "parameters": [
+          {
+            "description": "Page Number (Zero-based)",
+            "example": 0,
+            "in": "query",
+            "name": "pageNumber",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Page Number (Zero-based)",
+              "example": 0
+            }
+          },
+          {
+            "description": "Page Size",
+            "example": 50,
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Page Size",
+              "example": 50
+            }
+          },
+          {
+            "description": "Policy Type",
+            "example": "DATA_ACCESS",
+            "in": "query",
+            "name": "policyType",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Policy Type",
+              "example": "DATA_ACCESS"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.Responses$PageResponseCom.querypie.dbam.controller.dto.ExternalPolicyDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "List of Policy",
+        "tags": [
+          "Policy API"
+        ]
+      },
+      "post": {
+        "description": "Create Policy",
+        "operationId": "createPolicy",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalPolicyDto$CreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalPolicyDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Create Policy",
+        "tags": [
+          "Policy API"
+        ]
+      }
+    },
+    "/api/external/policies/{policyUuid}": {
+      "delete": {
+        "description": "Delete Policy",
+        "operationId": "deletePolicy",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "policyUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Delete Policy",
+        "tags": [
+          "Policy API"
+        ]
+      },
+      "put": {
+        "description": "Update Policy",
+        "operationId": "updatePolicy",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "policyUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalPolicyDto$UpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalPolicyDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Update Policy",
+        "tags": [
+          "Policy API"
+        ]
+      }
+    },
+    "/api/external/policies/{policyUuid}/data-accesses": {
+      "post": {
+        "description": "Create DataAccess Rule",
+        "operationId": "createDataAccess_1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "policyUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalPolicyDto$DataAccessCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalPolicyDto$DataAccessResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Create DataAccess Rule",
+        "tags": [
+          "Policy API"
+        ]
+      }
+    },
+    "/api/external/policies/{policyUuid}/data-accesses/{ruleUuid}": {
+      "put": {
+        "description": "Update DataAccess Rule",
+        "operationId": "createDataAccess",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "policyUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "ruleUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalPolicyDto$DataAccessUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalPolicyDto$DataAccessResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Update DataAccess Rule",
+        "tags": [
+          "Policy API"
+        ]
+      }
+    },
+    "/api/external/policies/{policyUuid}/data-levels": {
+      "post": {
+        "description": "Create SensitiveData Rule",
+        "operationId": "createDataLevel_1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "policyUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalPolicyDto$DataLevelCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalPolicyDto$DataLevelResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Create SensitiveData Rule",
+        "tags": [
+          "Policy API"
+        ]
+      }
+    },
+    "/api/external/policies/{policyUuid}/data-levels/{ruleUuid}": {
+      "put": {
+        "description": "Update SensitiveData Rule",
+        "operationId": "createDataLevel",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "policyUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "ruleUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalPolicyDto$DataLevelUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalPolicyDto$DataLevelResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Update SensitiveData Rule",
+        "tags": [
+          "Policy API"
+        ]
+      }
+    },
+    "/api/external/policies/{policyUuid}/data-masking": {
+      "post": {
+        "description": "Create DataMasking Rule",
+        "operationId": "createDataMasking_1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "policyUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalPolicyDto$DataMaskingCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalPolicyDto$DataMaskingResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Create DataMasking Rule",
+        "tags": [
+          "Policy API"
+        ]
+      }
+    },
+    "/api/external/policies/{policyUuid}/data-masking/{ruleUuid}": {
+      "put": {
+        "description": "Update DataMasking Rule",
+        "operationId": "createDataMasking",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "policyUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "ruleUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalPolicyDto$DataMaskingUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalPolicyDto$DataMaskingResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Update DataMasking Rule",
+        "tags": [
+          "Policy API"
+        ]
+      }
+    },
+    "/api/external/policies/{policyUuid}/rules": {
+      "get": {
+        "description": "List of Rule",
+        "operationId": "findRules",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "policyUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalPolicyDto$RuleResponse"
+                  }
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "List of Rule",
+        "tags": [
+          "Policy API"
+        ]
+      }
+    },
+    "/api/external/policies/{policyUuid}/rules/{ruleUuid}": {
+      "delete": {
+        "description": "Delete Rule",
+        "operationId": "deleteRule",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "policyUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "ruleUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Delete Rule",
+        "tags": [
+          "Policy API"
+        ]
+      }
+    },
+    "/api/external/proxies": {
+      "get": {
+        "operationId": "search",
+        "parameters": [
+          {
+            "description": "Proxy enabled",
+            "example": true,
+            "in": "query",
+            "name": "enabled",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Proxy enabled",
+              "example": true,
+              "default": "true"
+            }
+          },
+          {
+            "description": "Proxy host name",
+            "example": "proxy.querypie.com",
+            "in": "query",
+            "name": "host",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Proxy host name",
+              "example": "proxy.querypie.com"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalProxyDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Search proxies",
+        "tags": [
+          "Proxy API"
+        ]
+      },
+      "post": {
+        "operationId": "create_4",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalProxyDto$CreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalProxyDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Create proxy",
+        "tags": [
+          "Proxy API"
+        ]
+      }
+    },
+    "/api/external/proxies/ports": {
+      "post": {
+        "operationId": "proxyPortMappingConnections",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$ProxyPortMappingRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "proxy port mapping",
+        "tags": [
+          "Proxy API"
+        ]
+      }
+    },
+    "/api/external/role-mappings": {
+      "get": {
+        "description": "Find Mapped Roles by Company",
+        "operationId": "findByCompany",
+        "parameters": [
+          {
+            "description": "Page Number (Zero-based)",
+            "example": 0,
+            "in": "query",
+            "name": "pageNumber",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Page Number (Zero-based)",
+              "example": 0
+            }
+          },
+          {
+            "description": "Page Size",
+            "example": 50,
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Page Size",
+              "example": 50
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.Responses$PageResponseCom.querypie.dbam.controller.dto.ExternalAccessControlDto$ByCompanySearchResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Find Mapped Roles by Company",
+        "tags": [
+          "Role Mapping API"
+        ]
+      }
+    },
+    "/api/external/role-mappings/clusters/{clusterUuid}": {
+      "get": {
+        "description": "Find Mapped Roles by Cluster",
+        "operationId": "findByCluster",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "clusterUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalAccessControlDto$ByClusterSearchResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Find Mapped Roles by Cluster",
+        "tags": [
+          "Role Mapping API"
+        ]
+      }
+    },
+    "/api/external/role-mappings/users/{userUuid}": {
+      "get": {
+        "description": "Find Mapped Roles by User",
+        "operationId": "findByUser",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalAccessControlDto$ByUserSearchResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Find Mapped Roles by User",
+        "tags": [
+          "Role Mapping API"
+        ]
+      }
+    },
+    "/api/external/role-mappings/{roleMapUuid}/renew": {
+      "patch": {
+        "description": "Update Mapped Roles by Active Status",
+        "operationId": "updateRoleMapByEnable",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "roleMapUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Update Mapped Roles by Active",
+        "tags": [
+          "Role Mapping API"
+        ]
+      }
+    },
+    "/api/external/roles": {
+      "get": {
+        "description": "List of Role",
+        "operationId": "list_2",
+        "parameters": [
+          {
+            "description": "Role Name",
+            "example": "Default",
+            "in": "query",
+            "name": "roleName",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Role Name",
+              "example": "Default"
+            }
+          },
+          {
+            "description": "Privilege Type",
+            "example": "ALL",
+            "in": "query",
+            "name": "privilegeType",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Privilege Type",
+              "example": "ALL"
+            }
+          },
+          {
+            "description": "Page Number (Zero-based)",
+            "example": 0,
+            "in": "query",
+            "name": "pageNumber",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Page Number (Zero-based)",
+              "example": 0
+            }
+          },
+          {
+            "description": "Page Size",
+            "example": 50,
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Page Size",
+              "example": 50
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.Responses$PageResponseCom.querypie.dbam.controller.dto.ExternalRoleDto$RoleResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "List of Role",
+        "tags": [
+          "Cluster Role API"
+        ]
+      },
+      "post": {
+        "description": "Create Role",
+        "operationId": "createClusterGroup",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalRoleDto$CreateRoleRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalRoleDto$RoleResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Create Role",
+        "tags": [
+          "Cluster Role API"
+        ]
+      }
+    },
+    "/api/external/roles/access-levels": {
+      "get": {
+        "deprecated": true,
+        "operationId": "findAccessLevels",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/com.querypie.iam.controller.dto.RoleDto$Response"
+                  }
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Access Level",
+        "tags": [
+          "Role API"
+        ]
+      }
+    },
+    "/api/external/roles/company": {
+      "get": {
+        "deprecated": true,
+        "operationId": "findCompanyRoles",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/com.querypie.iam.controller.dto.RoleDto$Response"
+                  }
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Access Level",
+        "tags": [
+          "Role API"
+        ]
+      }
+    },
+    "/api/external/roles/connection": {
+      "get": {
+        "operationId": "findConnectionRoles",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/com.querypie.iam.controller.dto.RoleDto$Response"
+                  }
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Access Level",
+        "tags": [
+          "Role API"
+        ]
+      }
+    },
+    "/api/external/roles/system": {
+      "get": {
+        "operationId": "findSystemRoles",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/com.querypie.iam.controller.dto.RoleDto$Response"
+                  }
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Access Level",
+        "tags": [
+          "Role API"
+        ]
+      }
+    },
+    "/api/external/roles/{roleUuid}": {
+      "delete": {
+        "description": "Remove Role",
+        "operationId": "removeCluster",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "roleUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Remove Role",
+        "tags": [
+          "Cluster Role API"
+        ]
+      },
+      "put": {
+        "description": "Update Role",
+        "operationId": "updateClusterGroup",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "roleUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalRoleDto$UpdateRoleRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalRoleDto$RoleResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Update Role",
+        "tags": [
+          "Cluster Role API"
+        ]
+      }
+    },
+    "/api/external/user-groups": {
+      "get": {
+        "description": "UserGroup List API",
+        "operationId": "list_1",
+        "parameters": [
+          {
+            "description": "Name",
+            "example": "Brant",
+            "in": "query",
+            "name": "name",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Name",
+              "example": "Brant"
+            }
+          },
+          {
+            "description": "Page Number (Zero-based)",
+            "example": 0,
+            "in": "query",
+            "name": "pageNumber",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Page Number (Zero-based)",
+              "example": 0,
+              "default": "0"
+            }
+          },
+          {
+            "description": "Page Size",
+            "example": 50,
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Page Size",
+              "example": 50,
+              "default": "50"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.Responses$PageResponseCom.querypie.iam.controller.dto.ExternalUserGroupDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "List of UserGroup",
+        "tags": [
+          "UserGroup API"
+        ]
+      },
+      "post": {
+        "description": "UserGroup Create API",
+        "operationId": "create_2",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserGroupDto$CreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserGroupDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Create UserGroup",
+        "tags": [
+          "UserGroup API"
+        ]
+      }
+    },
+    "/api/external/user-groups/{userGroupUuid}": {
+      "delete": {
+        "description": "UserGroup Delete API",
+        "operationId": "delete_1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userGroupUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Delete UserGroup",
+        "tags": [
+          "UserGroup API"
+        ]
+      },
+      "put": {
+        "description": "UserGroup Update API",
+        "operationId": "update_2",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userGroupUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserGroupDto$UpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserGroupDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Update UserGroup",
+        "tags": [
+          "UserGroup API"
+        ]
+      }
+    },
+    "/api/external/user-groups/{userGroupUuid}/users": {
+      "get": {
+        "operationId": "findAll",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userGroupUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserDto$Response"
+                  }
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "List",
+        "tags": [
+          "UserGroup`s User API"
+        ]
+      }
+    },
+    "/api/external/user-groups/{userGroupUuid}/users/{userUuid}": {
+      "delete": {
+        "operationId": "delete_2",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userGroupUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "userUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Remove",
+        "tags": [
+          "UserGroup`s User API"
+        ]
+      },
+      "post": {
+        "operationId": "create_3",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userGroupUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "userUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Add",
+        "tags": [
+          "UserGroup`s User API"
+        ]
+      }
+    },
+    "/api/external/users": {
+      "get": {
+        "description": "User List API",
+        "operationId": "list",
+        "parameters": [
+          {
+            "description": "Login ID",
+            "example": "brant",
+            "in": "query",
+            "name": "loginId",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Login ID",
+              "example": "brant"
+            }
+          },
+          {
+            "description": "Email",
+            "example": "brant@querypie.com",
+            "in": "query",
+            "name": "email",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Email",
+              "example": "brant@querypie.com"
+            }
+          },
+          {
+            "description": "Name",
+            "example": "Brant",
+            "in": "query",
+            "name": "name",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Name",
+              "example": "Brant"
+            }
+          },
+          {
+            "description": "Locked (if not presented, Default : false)",
+            "example": false,
+            "in": "query",
+            "name": "locked",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Locked (if not presented, Default : false)",
+              "example": false
+            }
+          },
+          {
+            "description": "Expired (if not presented, Default : false)",
+            "example": false,
+            "in": "query",
+            "name": "expired",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Expired (if not presented, Default : false)",
+              "example": false
+            }
+          },
+          {
+            "description": "Deleted (if not presented, Default : false)",
+            "example": true,
+            "in": "query",
+            "name": "deleted",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Deleted (if not presented, Default : false)",
+              "example": true
+            }
+          },
+          {
+            "description": "Page Number (Zero-based)",
+            "example": 0,
+            "in": "query",
+            "name": "pageNumber",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Page Number (Zero-based)",
+              "example": 0,
+              "default": "0"
+            }
+          },
+          {
+            "description": "Page Size",
+            "example": 50,
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Page Size",
+              "example": 50,
+              "default": "50"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.Responses$PageResponseCom.querypie.iam.controller.dto.ExternalUserDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "List of User",
+        "tags": [
+          "User API"
+        ]
+      },
+      "post": {
+        "description": "User Create API",
+        "operationId": "create_1",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserDto$CreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Create User",
+        "tags": [
+          "User API"
+        ]
+      }
+    },
+    "/api/external/users/activate": {
+      "put": {
+        "description": "User activate API",
+        "operationId": "activate",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserDto$UserChangeStatusRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Activate User",
+        "tags": [
+          "User API"
+        ]
+      }
+    },
+    "/api/external/users/deactivate": {
+      "put": {
+        "description": "User deactivate API",
+        "operationId": "deactivate",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserDto$UserChangeStatusRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Deactivate User",
+        "tags": [
+          "User API"
+        ]
+      }
+    },
+    "/api/external/users/{userUuid}": {
+      "delete": {
+        "description": "User Delete API",
+        "operationId": "delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Delete User",
+        "tags": [
+          "User API"
+        ]
+      },
+      "put": {
+        "description": "User Update API",
+        "operationId": "update_1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserDto$UpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Update User",
+        "tags": [
+          "User API"
+        ]
+      }
+    },
+    "/api/external/users/{userUuid}/roles": {
+      "put": {
+        "operationId": "update",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.iam.controller.dto.UserRoleDto$UserAccessLevelUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.Responses$ListResponseCom.querypie.iam.controller.dto.UserRoleDto$Response"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Update User Role",
+        "tags": [
+          "User Role API"
+        ]
+      }
+    },
+    "/api/external/workflow/access-requests/{workflowRequestUuid}": {
+      "get": {
+        "description": "Access Request Detail",
+        "operationId": "detail_2",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workflowRequestUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$AccessRequestResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[Access Request] Detail",
+        "tags": [
+          "Workflow API"
+        ]
+      }
+    },
+    "/api/external/workflow/access-requests/{workflowRequestUuid}/approve": {
+      "post": {
+        "operationId": "approve_2",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workflowRequestUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.access.ExternalAccessRequestDto$ApproveRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[Access Request] Approve",
+        "tags": [
+          "Workflow API"
+        ]
+      }
+    },
+    "/api/external/workflow/access-requests/{workflowRequestUuid}/reject": {
+      "post": {
+        "operationId": "reject_2",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workflowRequestUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.access.ExternalAccessRequestDto$RejectRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[Access Request] Reject",
+        "tags": [
+          "Workflow API"
+        ]
+      }
+    },
+    "/api/external/workflow/export-requests/{workflowRequestUuid}": {
+      "get": {
+        "description": "Export Request Detail",
+        "operationId": "detail_1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workflowRequestUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$ExportRequestResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[Export Request] Detail",
+        "tags": [
+          "Workflow API"
+        ]
+      }
+    },
+    "/api/external/workflow/export-requests/{workflowRequestUuid}/approve": {
+      "post": {
+        "operationId": "approve_1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workflowRequestUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.export.ExternalExportRequestDto$ApproveRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[Export Request] Approve",
+        "tags": [
+          "Workflow API"
+        ]
+      }
+    },
+    "/api/external/workflow/export-requests/{workflowRequestUuid}/reject": {
+      "post": {
+        "operationId": "reject_1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workflowRequestUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.export.ExternalExportRequestDto$RejectRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[Export Request] Reject",
+        "tags": [
+          "Workflow API"
+        ]
+      }
+    },
+    "/api/external/workflow/requests": {
+      "get": {
+        "deprecated": true,
+        "operationId": "page",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "pageNumber",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "Page number",
+              "format": "int32"
+            }
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "Page size",
+              "format": "int32"
+            }
+          },
+          {
+            "description": "Request type",
+            "in": "query",
+            "name": "requestType",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Request type"
+            }
+          },
+          {
+            "description": "Start requested at",
+            "in": "query",
+            "name": "startRequestedAt",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Start requested at"
+            }
+          },
+          {
+            "description": "End requested at",
+            "in": "query",
+            "name": "endRequestedAt",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "End requested at"
+            }
+          },
+          {
+            "description": "Start updated at",
+            "in": "query",
+            "name": "startUpdatedAt",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Start updated at"
+            }
+          },
+          {
+            "description": "End updated at",
+            "in": "query",
+            "name": "endUpdatedAt",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "End updated at"
+            }
+          },
+          {
+            "description": "Approval status",
+            "in": "query",
+            "name": "approvalStatus",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Approval status"
+            }
+          },
+          {
+            "description": "Execution status",
+            "in": "query",
+            "name": "executionStatus",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Execution status"
+            }
+          },
+          {
+            "description": "Urgent",
+            "in": "query",
+            "name": "urgent",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Urgent"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.Responses$PageResponseCom.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$PageResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "All Requests",
+        "tags": [
+          "Workflow API"
+        ]
+      }
+    },
+    "/api/external/workflow/rules": {
+      "get": {
+        "operationId": "page_1",
+        "parameters": [
+          {
+            "description": "page number",
+            "in": "query",
+            "name": "pageNumber",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "page number"
+            }
+          },
+          {
+            "description": "page size",
+            "in": "query",
+            "name": "pageSize",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "page size"
+            }
+          },
+          {
+            "description": "Request type",
+            "in": "query",
+            "name": "requestType",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Request type"
+            }
+          },
+          {
+            "description": "Approval Status",
+            "in": "query",
+            "name": "approvalStatus",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Approval Status"
+            }
+          },
+          {
+            "description": "Execution Status",
+            "in": "query",
+            "name": "executionStatus",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Execution Status"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.api.dto.Responses$PageResponseCom.querypie.newworkflow.interfaces.external.v2.rule.ExternalWorkflowRuleDto$PageResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "List",
+        "tags": [
+          "Approval Rule API V2"
+        ]
+      },
+      "post": {
+        "operationId": "add",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.rule.ExternalWorkflowRuleDto$AddRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Add approval rule",
+        "tags": [
+          "Approval Rule API V2"
+        ]
+      }
+    },
+    "/api/external/workflow/rules/{uuid}": {
+      "delete": {
+        "operationId": "remove",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Remove approval rule",
+        "tags": [
+          "Approval Rule API V2"
+        ]
+      },
+      "get": {
+        "operationId": "detail_3",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.rule.ExternalWorkflowRuleDto$DetailResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Detail",
+        "tags": [
+          "Approval Rule API V2"
+        ]
+      },
+      "put": {
+        "operationId": "edit",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.rule.ExternalWorkflowRuleDto$EditRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Edit approval rule",
+        "tags": [
+          "Approval Rule API V2"
+        ]
+      }
+    },
+    "/api/external/workflow/sql-requests/{workflowRequestUuid}": {
+      "get": {
+        "description": "SQL Request Detail",
+        "operationId": "detail",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workflowRequestUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$SqlRequestResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[SQL Request] Detail",
+        "tags": [
+          "Workflow API"
+        ]
+      }
+    },
+    "/api/external/workflow/sql-requests/{workflowRequestUuid}/approve": {
+      "post": {
+        "operationId": "approve",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workflowRequestUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.sql.ExternalSqlRequestDto$ApproveRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[SQL Request] Approve",
+        "tags": [
+          "Workflow API"
+        ]
+      }
+    },
+    "/api/external/workflow/sql-requests/{workflowRequestUuid}/reject": {
+      "post": {
+        "operationId": "reject",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workflowRequestUuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.sql.ExternalSqlRequestDto$RejectRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "[SQL Request] Reject",
+        "tags": [
+          "Workflow API"
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "com.querypie.api.dto.PageableDto": {
+        "required": [
+          "currentPage",
+          "pageSize",
+          "totalElements",
+          "totalPages"
+        ],
+        "type": "object",
+        "properties": {
+          "currentPage": {
+            "type": "integer",
+            "description": "Current page number",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "description": "Number of items included in the page",
+            "format": "int32"
+          },
+          "totalElements": {
+            "type": "integer",
+            "description": "Total number of existing items",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "description": "Total number of pages",
+            "format": "int32"
+          }
+        }
+      },
+      "com.querypie.api.dto.Responses$ListResponseCom.querypie.iam.controller.dto.UserRoleDto$Response": {
+        "required": [
+          "list",
+          "page"
+        ],
+        "type": "object",
+        "properties": {
+          "list": {
+            "type": "array",
+            "description": "Object list per entry",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.iam.controller.dto.UserRoleDto$Response"
+            }
+          },
+          "page": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.PageableDto"
+          }
+        }
+      },
+      "com.querypie.api.dto.Responses$PageResponseCom.querypie.dbam.controller.dto.ExternalAccessControlDto$ByCompanySearchResponse": {
+        "required": [
+          "list",
+          "page"
+        ],
+        "type": "object",
+        "properties": {
+          "list": {
+            "type": "array",
+            "description": "Object list per entry",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalAccessControlDto$ByCompanySearchResponse"
+            }
+          },
+          "page": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.PageableDto"
+          }
+        }
+      },
+      "com.querypie.api.dto.Responses$PageResponseCom.querypie.dbam.controller.dto.ExternalCloudProviderDto$Response": {
+        "required": [
+          "list",
+          "page"
+        ],
+        "type": "object",
+        "properties": {
+          "list": {
+            "type": "array",
+            "description": "Object list per entry",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalCloudProviderDto$Response"
+            }
+          },
+          "page": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.PageableDto"
+          }
+        }
+      },
+      "com.querypie.api.dto.Responses$PageResponseCom.querypie.dbam.controller.dto.ExternalConnectionDto$Response": {
+        "required": [
+          "list",
+          "page"
+        ],
+        "type": "object",
+        "properties": {
+          "list": {
+            "type": "array",
+            "description": "Object list per entry",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$Response"
+            }
+          },
+          "page": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.PageableDto"
+          }
+        }
+      },
+      "com.querypie.api.dto.Responses$PageResponseCom.querypie.dbam.controller.dto.ExternalNetworkZoneDto$ZoneInfoResponse": {
+        "required": [
+          "list",
+          "page"
+        ],
+        "type": "object",
+        "properties": {
+          "list": {
+            "type": "array",
+            "description": "Object list per entry",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalNetworkZoneDto$ZoneInfoResponse"
+            }
+          },
+          "page": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.PageableDto"
+          }
+        }
+      },
+      "com.querypie.api.dto.Responses$PageResponseCom.querypie.dbam.controller.dto.ExternalPolicyDto$Response": {
+        "required": [
+          "list",
+          "page"
+        ],
+        "type": "object",
+        "properties": {
+          "list": {
+            "type": "array",
+            "description": "Object list per entry",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalPolicyDto$Response"
+            }
+          },
+          "page": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.PageableDto"
+          }
+        }
+      },
+      "com.querypie.api.dto.Responses$PageResponseCom.querypie.dbam.controller.dto.ExternalPolicyNotificationDto$Response": {
+        "required": [
+          "list",
+          "page"
+        ],
+        "type": "object",
+        "properties": {
+          "list": {
+            "type": "array",
+            "description": "Object list per entry",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalPolicyNotificationDto$Response"
+            }
+          },
+          "page": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.PageableDto"
+          }
+        }
+      },
+      "com.querypie.api.dto.Responses$PageResponseCom.querypie.dbam.controller.dto.ExternalRoleDto$RoleResponse": {
+        "required": [
+          "list",
+          "page"
+        ],
+        "type": "object",
+        "properties": {
+          "list": {
+            "type": "array",
+            "description": "Object list per entry",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalRoleDto$RoleResponse"
+            }
+          },
+          "page": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.PageableDto"
+          }
+        }
+      },
+      "com.querypie.api.dto.Responses$PageResponseCom.querypie.dbam.controller.dto.ExternalUserAuthHistoryDto$Response": {
+        "required": [
+          "list",
+          "page"
+        ],
+        "type": "object",
+        "properties": {
+          "list": {
+            "type": "array",
+            "description": "Object list per entry",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalUserAuthHistoryDto$Response"
+            }
+          },
+          "page": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.PageableDto"
+          }
+        }
+      },
+      "com.querypie.api.dto.Responses$PageResponseCom.querypie.iam.controller.dto.ExternalUserDto$Response": {
+        "required": [
+          "list",
+          "page"
+        ],
+        "type": "object",
+        "properties": {
+          "list": {
+            "type": "array",
+            "description": "Object list per entry",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserDto$Response"
+            }
+          },
+          "page": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.PageableDto"
+          }
+        }
+      },
+      "com.querypie.api.dto.Responses$PageResponseCom.querypie.iam.controller.dto.ExternalUserGroupDto$Response": {
+        "required": [
+          "list",
+          "page"
+        ],
+        "type": "object",
+        "properties": {
+          "list": {
+            "type": "array",
+            "description": "Object list per entry",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserGroupDto$Response"
+            }
+          },
+          "page": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.PageableDto"
+          }
+        }
+      },
+      "com.querypie.api.dto.Responses$PageResponseCom.querypie.newworkflow.interfaces.external.v1.ExternalAccessApprovalDto$Response": {
+        "required": [
+          "list",
+          "page"
+        ],
+        "type": "object",
+        "properties": {
+          "list": {
+            "type": "array",
+            "description": "Object list per entry",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v1.ExternalAccessApprovalDto$Response"
+            }
+          },
+          "page": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.PageableDto"
+          }
+        }
+      },
+      "com.querypie.api.dto.Responses$PageResponseCom.querypie.newworkflow.interfaces.external.v1.ExternalApprovalDto$Response": {
+        "required": [
+          "list",
+          "page"
+        ],
+        "type": "object",
+        "properties": {
+          "list": {
+            "type": "array",
+            "description": "Object list per entry",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v1.ExternalApprovalDto$Response"
+            }
+          },
+          "page": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.PageableDto"
+          }
+        }
+      },
+      "com.querypie.api.dto.Responses$PageResponseCom.querypie.newworkflow.interfaces.external.v1.ExternalApprovalRuleDto$PartialResponse": {
+        "required": [
+          "list",
+          "page"
+        ],
+        "type": "object",
+        "properties": {
+          "list": {
+            "type": "array",
+            "description": "Object list per entry",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v1.ExternalApprovalRuleDto$PartialResponse"
+            }
+          },
+          "page": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.PageableDto"
+          }
+        }
+      },
+      "com.querypie.api.dto.Responses$PageResponseCom.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$PageResponse": {
+        "required": [
+          "list",
+          "page"
+        ],
+        "type": "object",
+        "properties": {
+          "list": {
+            "type": "array",
+            "description": "Object list per entry",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$PageResponse"
+            }
+          },
+          "page": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.PageableDto"
+          }
+        }
+      },
+      "com.querypie.api.dto.Responses$PageResponseCom.querypie.newworkflow.interfaces.external.v2.rule.ExternalWorkflowRuleDto$PageResponse": {
+        "required": [
+          "list",
+          "page"
+        ],
+        "type": "object",
+        "properties": {
+          "list": {
+            "type": "array",
+            "description": "Object list per entry",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.rule.ExternalWorkflowRuleDto$PageResponse"
+            }
+          },
+          "page": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.PageableDto"
+          }
+        }
+      },
+      "com.querypie.api.dto.Responses$PageResponseCom.querypie.notification.controller.dto.ExternalNotificationChannelDto$Response": {
+        "required": [
+          "list",
+          "page"
+        ],
+        "type": "object",
+        "properties": {
+          "list": {
+            "type": "array",
+            "description": "Object list per entry",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.notification.controller.dto.ExternalNotificationChannelDto$Response"
+            }
+          },
+          "page": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.PageableDto"
+          }
+        }
+      },
+      "com.querypie.api.dto.Responses$ScanResponseCom.querypie.dbam.controller.dto.ExternalSqlAuditLogDto$AuditLogResponseJava.lang.String": {
+        "required": [
+          "hasNext",
+          "list"
+        ],
+        "type": "object",
+        "properties": {
+          "hasNext": {
+            "type": "boolean",
+            "description": "'true' if there is more logs."
+          },
+          "list": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalSqlAuditLogDto$AuditLogResponse"
+            }
+          },
+          "nextCursor": {
+            "type": "string",
+            "description": "Next cursor"
+          }
+        }
+      },
+      "com.querypie.api.dto.notification.ExternalNotificationChannel": {
+        "required": [
+          "name",
+          "type",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "HTTP",
+              "AGIT",
+              "SLACK",
+              "EMAIL"
+            ]
+          },
+          "uuid": {
+            "type": "string"
+          }
+        }
+      },
+      "com.querypie.api.dto.notification.ExternalNotificationDataExportDto$Request": {
+        "required": [
+          "channelUuid",
+          "intervalMinutes",
+          "messageTemplate",
+          "name",
+          "rows",
+          "selectAll"
+        ],
+        "type": "object",
+        "properties": {
+          "channelUuid": {
+            "type": "string"
+          },
+          "clusterGroupUuid": {
+            "type": "string",
+            "description": "If specified, alert occurs only when export SQL result data on this connection. <br>Required if connectionSelectAll is false"
+          },
+          "description": {
+            "type": "string"
+          },
+          "intervalMinutes": {
+            "minimum": 0,
+            "type": "integer",
+            "description": "The interval in minutes for triggering an alert. <br>If set to `0`, the alert is based solely on the row count, ignoring the time interval.",
+            "format": "int32"
+          },
+          "messageTemplate": {
+            "type": "string",
+            "description": "Alert Policy Message Template <br><b>Message Template Variables</b>\n- Cluster Group Id : {{clusterGroupId}}\n- Cluster Group Name : {{clusterGroupName}}\n- Cluster Id : {{clusterId}}\n- DB Host : {{dbHost}}\n- Replication Type : {{replicationType}}\n- DB Name : {{dbName}}\n- DB User : {{dbUser}}\n- Database Type : {{databaseType}}\n- Host Name : {{hostName}}\n- User Id : {{userId}}\n- User Name : {{userName}}\n- Email : {{email}}\n- Login Id : {{loginId}}\n- Action Type : {{actionType}}\n- SQL Type : {{sqlType}}\n- SQL Text : {{sqlText}}\n- Executed Result : {{execResult}}\n- Executed Millis : {{execMillis}}\n- Executed IP : {{execIp}}\n- Exported Rows : {{expRows}}\n- Reason Comment : {{reasonComment}}\n- Connection Label : {{connectionLabel}}",
+            "example": "{{userName}} exported {{expRows}} rows.\nSQL : {{sqlText}} ({{sqlType}})"
+          },
+          "name": {
+            "type": "string"
+          },
+          "rows": {
+            "minimum": 1,
+            "type": "integer",
+            "description": "An alert occurs if exported data row count is greater than or equal to this value.",
+            "format": "int32"
+          },
+          "selectAll": {
+            "type": "boolean",
+            "description": "If true, alert is occurs when export SQL result data on all DB Connections."
+          },
+          "subjectTemplate": {
+            "type": "string",
+            "description": "Alert Policy Subject Template"
+          }
+        }
+      },
+      "com.querypie.api.dto.notification.ExternalNotificationDataExportDto$Response": {
+        "required": [
+          "channel",
+          "description",
+          "messageTemplate",
+          "name",
+          "rows",
+          "selectAll",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "channel": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationChannel"
+          },
+          "clusterGroupUuid": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "messageTemplate": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "rows": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "selectAll": {
+            "type": "boolean"
+          },
+          "subjectTemplate": {
+            "type": "string"
+          },
+          "uuid": {
+            "type": "string"
+          }
+        }
+      },
+      "com.querypie.api.dto.notification.ExternalNotificationDbConnectionAttemptDto$Request": {
+        "required": [
+          "channelUuid",
+          "condition",
+          "description",
+          "messageTemplate",
+          "name",
+          "selectAll"
+        ],
+        "type": "object",
+        "properties": {
+          "actionCount": {
+            "minimum": 1,
+            "type": "integer",
+            "description": "failure action count",
+            "format": "int32"
+          },
+          "channelUuid": {
+            "type": "string"
+          },
+          "clusterGroupUuid": {
+            "type": "string",
+            "description": "If specified, alert occurs only when attempt to connect to this DB connection.<br>Required if connectionSelectAll is false"
+          },
+          "condition": {
+            "type": "string",
+            "description": "DB connection attempt result status that create a alert.",
+            "enum": [
+              "ALWAYS",
+              "SUCCESS",
+              "FAIL"
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "intervalMinutes": {
+            "minimum": 1,
+            "type": "integer",
+            "description": "failure interval minutes",
+            "format": "int32"
+          },
+          "messageTemplate": {
+            "type": "string",
+            "description": "Alert Policy Message Template <br><b>Message Template Variables</b>\n - Cluster Group Id : {{clusterGroupId}}\n - Cluster Group Name : {{clusterGroupName}}\n - Cluster Id : {{clusterId}}\n - DB Host : {{dbHost}}\n - Replication Type : {{replicationType}}\n - DB Name : {{dbName}}\n - DB User : {{dbUser}}\n - Database Type : {{databaseType}}\n - Host Name : {{hostName}}\n - User Id : {{userId}}\n - User Name : {{userName}}\n - Email : {{email}}\n - Login Id : {{loginId}}\n - Auth Type : {{authType}}\n - Action Type : {{actionType}}\n - Action At : {{actionAt}}\n - Privilege Types : {{privilegeTypes}}\n - Error : {{error}}\n - Error Message : {{errorMessage}}\n - Client IP : {{clientIp}}\n - Result : {{result}}\n - Failure Action Count : {{failureActionCount}}\n - Failure Interval Minutes : {{failureIntervalMinutes}}",
+            "example": "{{userName}} attempted to connect to the [{{replicationType}}] {{clusterGroupName}} ({{clusterId}}) connection.\nResult: {{result}}\nError Message : {{errorMessage}}"
+          },
+          "name": {
+            "type": "string"
+          },
+          "selectAll": {
+            "type": "boolean",
+            "description": "If true, alert is created for all DB connection attempt."
+          },
+          "subjectTemplate": {
+            "type": "string",
+            "description": "Alert Policy Subject Template"
+          }
+        }
+      },
+      "com.querypie.api.dto.notification.ExternalNotificationDbConnectionAttemptDto$Response": {
+        "required": [
+          "channel",
+          "condition",
+          "messageTemplate",
+          "name",
+          "selectAll",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "actionCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "channel": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationChannel"
+          },
+          "clusterGroupUuid": {
+            "type": "string"
+          },
+          "condition": {
+            "type": "string",
+            "enum": [
+              "ALWAYS",
+              "SUCCESS",
+              "FAIL"
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "intervalMinutes": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "messageTemplate": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "selectAll": {
+            "type": "boolean"
+          },
+          "subjectTemplate": {
+            "type": "string"
+          },
+          "uuid": {
+            "type": "string"
+          }
+        }
+      },
+      "com.querypie.api.dto.notification.ExternalNotificationPreventedSqlExecutionDto$Request": {
+        "required": [
+          "channelUuid",
+          "messageTemplate",
+          "name",
+          "selectAll"
+        ],
+        "type": "object",
+        "properties": {
+          "channelUuid": {
+            "type": "string"
+          },
+          "clusterGroupUuid": {
+            "type": "string",
+            "description": "Connection-uuid to send alert when attempted Prevented Query <br>Required if connectionSelectAll is true"
+          },
+          "description": {
+            "type": "string"
+          },
+          "messageTemplate": {
+            "type": "string",
+            "description": "Alert Policy Message Template <br><b>Message Template Variables</b>\n- Cluster Group Id : {{clusterGroupId}}\n- Cluster Group Name : {{clusterGroupName}}\n- Cluster Id : {{clusterId}}\n- DB Host : {{dbHost}}\n- Replication Type : {{replicationType}}\n- DB Name : {{dbName}}\n- DB User : {{dbUser}}\n- Database Type : {{databaseType}}\n- Host Name : {{hostName}}\n- User Id : {{userId}}\n- User Name : {{userName}}\n- Email : {{email}}\n- Login Id : {{loginId}}\n- Action Type : {{actionType}}\n- SQL Type : {{sqlType}}\n- SQL Text : {{sqlText}}\n- Executed Result : {{execResult}}\n- Executed Millis : {{execMillis}}\n- Executed IP : {{execIp}}\n- Exported Rows : {{expRows}}\n- Reason Comment : {{reasonComment}}\n- Connection Label : {{connectionLabel}}",
+            "example": "{{userName}} executed {{sqlType}} statement with a restricted access."
+          },
+          "name": {
+            "type": "string"
+          },
+          "selectAll": {
+            "type": "boolean",
+            "description": "If true, alert occurs when running Prevented SQL on all DB connections"
+          },
+          "subjectTemplate": {
+            "type": "string",
+            "description": "Alert Policy Subject Template"
+          }
+        }
+      },
+      "com.querypie.api.dto.notification.ExternalNotificationPreventedSqlExecutionDto$Response": {
+        "required": [
+          "channel",
+          "messageTemplate",
+          "name",
+          "selectAll",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "channel": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationChannel"
+          },
+          "clusterGroupUuid": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "messageTemplate": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "selectAll": {
+            "type": "boolean"
+          },
+          "subjectTemplate": {
+            "type": "string"
+          },
+          "uuid": {
+            "type": "string"
+          }
+        }
+      },
+      "com.querypie.api.dto.notification.ExternalNotificationSensitiveDataAccessDto$Level": {
+        "required": [
+          "value"
+        ],
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "com.querypie.api.dto.notification.ExternalNotificationSensitiveDataAccessDto$Policy": {
+        "required": [
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "uuid": {
+            "type": "string"
+          }
+        }
+      },
+      "com.querypie.api.dto.notification.ExternalNotificationSensitiveDataAccessDto$Request": {
+        "required": [
+          "channelUuid",
+          "intervalMinutes",
+          "messageTemplate",
+          "name",
+          "rows"
+        ],
+        "type": "object",
+        "properties": {
+          "channelUuid": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "intervalMinutes": {
+            "minimum": 0,
+            "type": "integer",
+            "description": "The interval in minutes for triggering an alert. <br>If set to `0`, the alert is based solely on the row count, ignoring the time interval.",
+            "format": "int32"
+          },
+          "level": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationSensitiveDataAccessDto$Level"
+          },
+          "messageTemplate": {
+            "type": "string",
+            "description": "Alert Policy Message Template <br><b>Message Template Variables</b>\n - Cluster Group Uuid : {{clusterGroupUuid}}\n - Cluster Group Name : {{clusterGroupName}}\n - Cluster Uuid : {{clusterUuid}}\n - Cluster Name : {{clusterName}}\n - Replication Type : {{replicationType}}\n - Database Host : {{databaseHost}}\n - Database Name : {{databaseName}}\n - Database User : {{databaseUser}}\n - Database Type : {{databaseType}}\n - User Uuid : {{userUuid}}\n - User Name : {{userName}}\n - Email : {{email}}\n - Login Id : {{loginId}}\n - Policy Name : {{policyName}}\n - Object Path : {{objectPath}}\n - Level : {{level}}",
+            "example": "{{userName}} access to {{clusterGroupName}} ({{clusterGroupUuid}}) connection.\nSensitive Level : {{level}}"
+          },
+          "name": {
+            "type": "string"
+          },
+          "policy": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationSensitiveDataAccessDto$Policy"
+          },
+          "rows": {
+            "minimum": 0,
+            "type": "integer",
+            "description": "An alert occurs if query result row count is greater than or equal to this value.",
+            "format": "int32"
+          },
+          "subjectTemplate": {
+            "type": "string",
+            "description": "Alert Policy Subject Template"
+          }
+        }
+      },
+      "com.querypie.api.dto.notification.ExternalNotificationSensitiveDataAccessDto$Response": {
+        "required": [
+          "channel",
+          "messageTemplate",
+          "name",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "channel": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationChannel"
+          },
+          "description": {
+            "type": "string"
+          },
+          "level": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationSensitiveDataAccessDto$Level"
+          },
+          "messageTemplate": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "policy": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationSensitiveDataAccessDto$Policy"
+          },
+          "privilegeTypes": {
+            "type": "string"
+          },
+          "subjectTemplate": {
+            "type": "string"
+          },
+          "uuid": {
+            "type": "string"
+          }
+        }
+      },
+      "com.querypie.api.dto.notification.ExternalNotificationSqlExecutionDto$Request": {
+        "required": [
+          "channelUuid",
+          "intervalMinutes",
+          "messageTemplate",
+          "name",
+          "privilegeTypes",
+          "privilegeVendor",
+          "rows",
+          "selectAll"
+        ],
+        "type": "object",
+        "properties": {
+          "channelUuid": {
+            "type": "string"
+          },
+          "clusterGroupUuid": {
+            "type": "string",
+            "description": "If specified, alert occurs only when execute query on this connection. <br>Required if connectionSelectAll is false"
+          },
+          "description": {
+            "type": "string"
+          },
+          "intervalMinutes": {
+            "minimum": 0,
+            "type": "integer",
+            "description": "The interval in minutes for triggering an alert. <br>If set to `0`, the alert is based solely on the row count, ignoring the time interval.",
+            "format": "int32"
+          },
+          "messageTemplate": {
+            "type": "string",
+            "description": "Alert Policy Message Template <br><b>Message Template Variables</b>\n- Cluster Group Id : {{clusterGroupId}}\n- Cluster Group Name : {{clusterGroupName}}\n- Cluster Id : {{clusterId}}\n- DB Host : {{dbHost}}\n- Replication Type : {{replicationType}}\n- DB Name : {{dbName}}\n- DB User : {{dbUser}}\n- Database Type : {{databaseType}}\n- Host Name : {{hostName}}\n- User Id : {{userId}}\n- User Name : {{userName}}\n- Email : {{email}}\n- Login Id : {{loginId}}\n- Action Type : {{actionType}}\n- SQL Type : {{sqlType}}\n- SQL Text : {{sqlText}}\n- Executed Result : {{execResult}}\n- Executed Millis : {{execMillis}}\n- Executed IP : {{execIp}}\n- Exported Rows : {{expRows}}\n- Reason Comment : {{reasonComment}}\n- Connection Label : {{connectionLabel}}",
+            "example": "{{userName}} executed {{expRows}} rows. SQL : {{sqlText}} ({{sqlType}})"
+          },
+          "name": {
+            "type": "string"
+          },
+          "privilegeTypes": {
+            "type": "array",
+            "description": "Target Privilege Types to send Alert",
+            "items": {
+              "type": "string",
+              "description": "Target Privilege Types to send Alert"
+            }
+          },
+          "privilegeVendor": {
+            "type": "string",
+            "enum": [
+              "SQL",
+              "REDIS"
+            ]
+          },
+          "rows": {
+            "minimum": 1,
+            "type": "integer",
+            "description": "An alert occurs if query result row count is greater than or equal to this value.",
+            "format": "int32"
+          },
+          "selectAll": {
+            "type": "boolean",
+            "description": "If true, alert occurs when execute query on all DB connections"
+          },
+          "subjectTemplate": {
+            "type": "string",
+            "description": "Alert Policy Subject Template"
+          }
+        }
+      },
+      "com.querypie.api.dto.notification.ExternalNotificationSqlExecutionDto$Response": {
+        "required": [
+          "channel",
+          "messageTemplate",
+          "name",
+          "privilegeTypes",
+          "privilegeVendor",
+          "rows",
+          "selectAll",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "channel": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationChannel"
+          },
+          "clusterGroupUuid": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "messageTemplate": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "privilegeTypes": {
+            "type": "string"
+          },
+          "privilegeVendor": {
+            "type": "string",
+            "enum": [
+              "SQL",
+              "REDIS"
+            ]
+          },
+          "rows": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "selectAll": {
+            "type": "boolean"
+          },
+          "subjectTemplate": {
+            "type": "string"
+          },
+          "uuid": {
+            "type": "string"
+          }
+        }
+      },
+      "com.querypie.api.dto.notification.ExternalNotificationUnusualLoginAttemptDto$Request": {
+        "required": [
+          "actionCount",
+          "channelUuid",
+          "intervalMinutes",
+          "messageTemplate",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "actionCount": {
+            "minimum": 2,
+            "type": "integer",
+            "description": "failure action count",
+            "format": "int32"
+          },
+          "channelUuid": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "intervalMinutes": {
+            "minimum": 1,
+            "type": "integer",
+            "description": "failure interval minutes",
+            "format": "int32"
+          },
+          "messageTemplate": {
+            "type": "string",
+            "description": "Alert Policy Message Template <br><b>Message Template Variables</b>\n - User Id : {{userId}}\n - User Name : {{userName}}\n - Email : {{email}}\n - Login Id : {{loginId}}\n - Result : {{result}}\n - Current Action Count : {{currentActionCount}}\n - Interval Minutes : {{intervalMinutes}}",
+            "example": "{{userName}} attempted to login {{currentActionCount}} times in {{intervalMinutes}} minutes on different IPs."
+          },
+          "name": {
+            "type": "string"
+          },
+          "subjectTemplate": {
+            "type": "string",
+            "description": "Alert Policy Subject Template"
+          }
+        }
+      },
+      "com.querypie.api.dto.notification.ExternalNotificationUnusualLoginAttemptDto$Response": {
+        "required": [
+          "actionCount",
+          "channel",
+          "intervalMinutes",
+          "messageTemplate",
+          "name",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "actionCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "channel": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationChannel"
+          },
+          "description": {
+            "type": "string"
+          },
+          "intervalMinutes": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "messageTemplate": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "subjectTemplate": {
+            "type": "string"
+          },
+          "uuid": {
+            "type": "string"
+          }
+        }
+      },
+      "com.querypie.api.dto.notification.ExternalNotificationWorkflowNewRequestDto$Request": {
+        "required": [
+          "channelUuid",
+          "messageTemplate",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "channelUuid": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "messageTemplate": {
+            "type": "string",
+            "description": "Alert Policy Message Template <br><b>Message Template Variables</b>\n - Request Title : {{requestTitle}}\n - Assignees : {{assignees}}\n - Comment : {{comment}}\n - User Name : {{userName}}\n - Email : {{email}}\n - Access Type : {{accessType}}",
+            "example": "{{userName}} has requested {{accessType}}.\nTitle : {{requestTitle}}\nAssignees : {{assignees}}\nComments : {{comment}}"
+          },
+          "name": {
+            "type": "string"
+          },
+          "subjectTemplate": {
+            "type": "string",
+            "description": "Alert Policy Subject Template"
+          }
+        }
+      },
+      "com.querypie.api.dto.notification.ExternalNotificationWorkflowNewRequestDto$Response": {
+        "required": [
+          "channel",
+          "messageTemplate",
+          "name",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "channel": {
+            "$ref": "#/components/schemas/com.querypie.api.dto.notification.ExternalNotificationChannel"
+          },
+          "description": {
+            "type": "string"
+          },
+          "messageTemplate": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "subjectTemplate": {
+            "type": "string"
+          },
+          "uuid": {
+            "type": "string"
+          }
+        }
+      },
+      "com.querypie.dac.connection.tag.model.ConnectionTagDto": {
+        "required": [
+          "key",
+          "synchronized",
+          "value"
+        ],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "synchronized": {
+            "type": "boolean"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "description": "Connection Tags"
+      },
+      "com.querypie.dbam.controller.dto.ExternalAccessControlDto$ByClusterSearchResponse": {
+        "type": "object",
+        "properties": {
+          "clusterGroupName": {
+            "type": "string",
+            "description": "Cluster Group Name"
+          },
+          "clusterGroupUuid": {
+            "type": "string",
+            "description": "Cluster Group UUID",
+            "example": "1"
+          },
+          "clusterUuid": {
+            "type": "string",
+            "description": "Cluster UUID",
+            "example": "1"
+          },
+          "host": {
+            "type": "string",
+            "description": "Host",
+            "example": "test-db.querypie.com"
+          },
+          "type": {
+            "type": "string",
+            "description": "Cluster Replication Type",
+            "example": "MASTER",
+            "enum": [
+              "MASTER",
+              "SLAVE",
+              "SINGLE"
+            ]
+          },
+          "users": {
+            "type": "array",
+            "description": "List of Users",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalAccessControlDto$UserInformation"
+            }
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalAccessControlDto$ByCompanySearchResponse": {
+        "type": "object",
+        "properties": {
+          "cluster": {
+            "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalAccessControlDto$ClusterInformation"
+          },
+          "email": {
+            "type": "string",
+            "description": "Email",
+            "example": "brant@querypie.com"
+          },
+          "loginId": {
+            "type": "string",
+            "description": "Login ID",
+            "example": "brant"
+          },
+          "userName": {
+            "type": "string",
+            "description": "User Name",
+            "example": "Brant Hwang"
+          },
+          "userUuid": {
+            "type": "string",
+            "description": "User UUID",
+            "example": "1"
+          }
+        },
+        "description": "Object list per entry"
+      },
+      "com.querypie.dbam.controller.dto.ExternalAccessControlDto$ByUserSearchResponse": {
+        "type": "object",
+        "properties": {
+          "clusters": {
+            "type": "array",
+            "description": "List of Clusters",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalAccessControlDto$ClusterInformation"
+            }
+          },
+          "email": {
+            "type": "string",
+            "description": "Email",
+            "example": "brant@querypie.com"
+          },
+          "loginId": {
+            "type": "string",
+            "description": "Login ID",
+            "example": "brant"
+          },
+          "userName": {
+            "type": "string",
+            "description": "User Name",
+            "example": "Brant Hwang"
+          },
+          "userUuid": {
+            "type": "string",
+            "description": "User UUID",
+            "example": "1"
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalAccessControlDto$ClusterInformation": {
+        "required": [
+          "active"
+        ],
+        "type": "object",
+        "properties": {
+          "active": {
+            "type": "boolean",
+            "description": "Cluster by User Active status [true(Active) / false(Deactive)]"
+          },
+          "clusterGroupName": {
+            "type": "string",
+            "description": "Cluster Group Name"
+          },
+          "clusterGroupUuid": {
+            "type": "string",
+            "description": "Cluster Group UUID",
+            "example": "1"
+          },
+          "clusterUuid": {
+            "type": "string",
+            "description": "Cluster UUID",
+            "example": "1"
+          },
+          "host": {
+            "type": "string",
+            "description": "Host",
+            "example": "test-db.querypie.com"
+          },
+          "roleMapUuid": {
+            "type": "string",
+            "description": "Role Mapping UUID (Access Control UUID)"
+          },
+          "roleName": {
+            "type": "string",
+            "description": "Role Name",
+            "example": "Default Role"
+          },
+          "roleUuid": {
+            "type": "string",
+            "description": "Role UUID",
+            "example": "15"
+          },
+          "type": {
+            "type": "string",
+            "description": "Cluster Replication Type",
+            "example": "MASTER"
+          }
+        },
+        "description": "Cluster Information"
+      },
+      "com.querypie.dbam.controller.dto.ExternalAccessControlDto$GrantResponse": {
+        "required": [
+          "grantedClusterCount",
+          "grantedUserCount",
+          "totalGrantedRoles"
+        ],
+        "type": "object",
+        "properties": {
+          "clusterUuids": {
+            "type": "array",
+            "description": "Granted Cluster UUID List",
+            "items": {
+              "type": "string",
+              "description": "Granted Cluster UUID List"
+            }
+          },
+          "grantedClusterCount": {
+            "type": "integer",
+            "description": "Granted Cluster Count",
+            "format": "int32",
+            "example": 15
+          },
+          "grantedUserCount": {
+            "type": "integer",
+            "description": "Granted User Count",
+            "format": "int32",
+            "example": 10
+          },
+          "roleUuid": {
+            "type": "string",
+            "description": "Granted Role UUID"
+          },
+          "totalGrantedRoles": {
+            "type": "integer",
+            "description": "Total Granted Roles ( Users x Clusters )",
+            "format": "int32",
+            "example": 150
+          },
+          "userUuids": {
+            "type": "array",
+            "description": "Granted User UUID List",
+            "items": {
+              "type": "string",
+              "description": "Granted User UUID List"
+            }
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalAccessControlDto$GrantRoleRequest": {
+        "type": "object",
+        "properties": {
+          "clusterUuids": {
+            "type": "array",
+            "description": "List of Cluster UUID",
+            "items": {
+              "type": "string",
+              "description": "List of Cluster UUID"
+            }
+          },
+          "roleUuid": {
+            "type": "string",
+            "description": "Role UUID"
+          },
+          "userUuids": {
+            "type": "array",
+            "description": "List of User UUID",
+            "items": {
+              "type": "string",
+              "description": "List of User UUID"
+            }
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalAccessControlDto$RevokeResponse": {
+        "type": "object",
+        "properties": {
+          "revokedCount": {
+            "type": "integer",
+            "description": "Revoked Count",
+            "format": "int64",
+            "example": 15
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalAccessControlDto$RevokeRoleRequest": {
+        "type": "object",
+        "properties": {
+          "clusterUuids": {
+            "type": "array",
+            "description": "List of Cluster UUID",
+            "items": {
+              "type": "string",
+              "description": "List of Cluster UUID"
+            }
+          },
+          "userUuids": {
+            "type": "array",
+            "description": "List of User ID",
+            "items": {
+              "type": "string",
+              "description": "List of User ID"
+            }
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalAccessControlDto$UserInformation": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "Email",
+            "example": "brant@querypie.com"
+          },
+          "loginId": {
+            "type": "string",
+            "description": "Login ID",
+            "example": "brant"
+          },
+          "roleMapUuid": {
+            "type": "string",
+            "description": "Role Map UUID",
+            "example": "3"
+          },
+          "roleName": {
+            "type": "string",
+            "description": "Role Name",
+            "example": "Default Role"
+          },
+          "roleUuid": {
+            "type": "string",
+            "description": "Role UUID",
+            "example": "15"
+          },
+          "userName": {
+            "type": "string",
+            "description": "User Name",
+            "example": "Brant Hwang"
+          },
+          "userUuid": {
+            "type": "string",
+            "description": "User UUID",
+            "example": "1"
+          }
+        },
+        "description": "List of Users"
+      },
+      "com.querypie.dbam.controller.dto.ExternalCloudProviderDto$CreateRequest": {
+        "required": [
+          "cloudProvider",
+          "credentialOption",
+          "defaultTags",
+          "name",
+          "replicationMode"
+        ],
+        "type": "object",
+        "properties": {
+          "awsAccountId": {
+            "type": "string",
+            "description": "Aws account id for `CROSS_ACCOUNT_ROLE`"
+          },
+          "cloudProvider": {
+            "type": "string",
+            "description": "Cloud Provider",
+            "example": "AWS",
+            "enum": [
+              "AWS",
+              "AZURE",
+              "GCP"
+            ]
+          },
+          "cloudRegion": {
+            "type": "string",
+            "description": "Region for AWS, Required when cloud provider is AWS",
+            "example": "ap-northeast-2"
+          },
+          "credentialOption": {
+            "type": "string",
+            "description": "Credential option",
+            "example": "INSTANCE_PROFILE",
+            "enum": [
+              "INSTANCE_PROFILE",
+              "CROSS_ACCOUNT_ROLE",
+              "KEY",
+              "SERVICE_ACCOUNT",
+              "WORKLOAD_IDENTITY",
+              "CLIENT_SECRET",
+              "PROFILE_CREDENTIAL"
+            ]
+          },
+          "cronExpression": {
+            "type": "string",
+            "description": "Cron expression",
+            "example": "0 0 6 * * ?"
+          },
+          "defaultTags": {
+            "type": "array",
+            "description": "default tags",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalCloudProviderDto$DefaultTag"
+            }
+          },
+          "externalId": {
+            "type": "string",
+            "description": "External id for `CROSS_ACCOUNT_ROLE`"
+          },
+          "gcpProjectName": {
+            "type": "string",
+            "description": "Google cloud platform project id"
+          },
+          "name": {
+            "type": "string",
+            "description": "Cloud Provider Display Name",
+            "example": "AWS"
+          },
+          "proxyAuthType": {
+            "type": "string",
+            "description": "Proxy Authentication Type",
+            "deprecated": true,
+            "enum": [
+              "QUERYPIE",
+              "MANUAL"
+            ]
+          },
+          "proxyEnabled": {
+            "type": "boolean",
+            "description": "Proxy usage",
+            "deprecated": true
+          },
+          "replicationMode": {
+            "type": "string",
+            "description": "Scheduling mode",
+            "example": "MANUAL",
+            "enum": [
+              "MANUAL",
+              "SCHEDULING"
+            ]
+          },
+          "serviceAccountJson": {
+            "type": "string",
+            "description": "Google cloud platform service account json"
+          },
+          "sourceArn": {
+            "type": "string",
+            "description": "Role arn of assigned to the pod for `PROFILE_CREDENTIAL`"
+          },
+          "subscriptionId": {
+            "type": "string",
+            "description": "Azure subscription id"
+          },
+          "synchronizableDatabaseTypes": {
+            "minLength": 1,
+            "type": "array",
+            "description": "Synchronizable Database Type",
+            "items": {
+              "minLength": 1,
+              "type": "string",
+              "description": "Synchronizable Database Type",
+              "enum": [
+                "AURORA_MY_SQL",
+                "AURORA_POSTGRESQL",
+                "MY_SQL",
+                "POSTGRESQL",
+                "MARIA_DB",
+                "ORACLE",
+                "SQL_SERVER",
+                "DYNAMO_DB",
+                "DOCUMENT_DB",
+                "REDSHIFT",
+                "ATHENA",
+                "REDIS",
+                "BIG_QUERY"
+              ]
+            }
+          },
+          "targetArn": {
+            "type": "string",
+            "description": "Role arn of assigned to the target account for `CROSS_ACCOUNT_ROLE` / `PROFILE_CREDENTIAL`"
+          },
+          "tenantId": {
+            "type": "string",
+            "description": "Azure tenant id"
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalCloudProviderDto$DefaultTag": {
+        "required": [
+          "isParameterizedValue",
+          "key",
+          "value"
+        ],
+        "type": "object",
+        "properties": {
+          "isParameterizedValue": {
+            "type": "boolean",
+            "description": "Default tag value is parameterized",
+            "default": false
+          },
+          "key": {
+            "type": "string",
+            "description": "Default tag key"
+          },
+          "value": {
+            "type": "string",
+            "description": "Default tag value"
+          }
+        },
+        "description": "default tags"
+      },
+      "com.querypie.dbam.controller.dto.ExternalCloudProviderDto$Response": {
+        "required": [
+          "cloudProvider",
+          "createdAt",
+          "createdUser",
+          "isDeleted",
+          "isEnabled",
+          "replicationMode",
+          "updatedAt",
+          "updatedUser"
+        ],
+        "type": "object",
+        "properties": {
+          "awsAccountId": {
+            "type": "string",
+            "description": "Aws account id for `CROSS_ACCOUNT_ROLE`"
+          },
+          "cloudProvider": {
+            "type": "string",
+            "description": "Cloud Provider",
+            "example": "AWS",
+            "enum": [
+              "NONE",
+              "AWS",
+              "AZURE",
+              "GCP"
+            ]
+          },
+          "cloudRegion": {
+            "type": "string",
+            "description": "Region for aws",
+            "example": "ap-northeast-2"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Approval Updated At",
+            "format": "date-time"
+          },
+          "createdUser": {
+            "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserResponse"
+          },
+          "credentialOption": {
+            "type": "string",
+            "description": "Credential option",
+            "example": "INSTANCE_PROFILE",
+            "enum": [
+              "INSTANCE_PROFILE",
+              "CROSS_ACCOUNT_ROLE",
+              "KEY",
+              "SERVICE_ACCOUNT",
+              "WORKLOAD_IDENTITY",
+              "CLIENT_SECRET",
+              "PROFILE_CREDENTIAL"
+            ]
+          },
+          "cronExpression": {
+            "type": "string",
+            "description": "Cron expression",
+            "example": "0 0 6 * * ?"
+          },
+          "deleted": {
+            "type": "boolean",
+            "writeOnly": true
+          },
+          "enabled": {
+            "type": "boolean",
+            "writeOnly": true
+          },
+          "externalId": {
+            "type": "string",
+            "description": "External id for `CROSS_ACCOUNT_ROLE`"
+          },
+          "gcpProjectName": {
+            "type": "string",
+            "description": "Google cloud platform project id"
+          },
+          "isDeleted": {
+            "type": "boolean"
+          },
+          "isEnabled": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string",
+            "description": "Cloud Provider Name",
+            "example": "Cloud Provider Name"
+          },
+          "replicationMode": {
+            "type": "string",
+            "description": "Scheduling mode",
+            "example": "MANUAL",
+            "enum": [
+              "MANUAL",
+              "SCHEDULING"
+            ]
+          },
+          "serviceAccountJson": {
+            "type": "string",
+            "description": "Google cloud platform service account json"
+          },
+          "sourceArn": {
+            "type": "string",
+            "description": "Role arn of assigned to the pod for `PROFILE_CREDENTIAL`"
+          },
+          "subscriptionId": {
+            "type": "string",
+            "description": "Azure subscription id"
+          },
+          "synchronizableDatabaseTypes": {
+            "type": "array",
+            "description": "Synchronizable Database Type",
+            "items": {
+              "type": "string",
+              "description": "Synchronizable Database Type",
+              "enum": [
+                "AURORA_MY_SQL",
+                "AURORA_POSTGRESQL",
+                "MY_SQL",
+                "POSTGRESQL",
+                "MARIA_DB",
+                "ORACLE",
+                "SQL_SERVER",
+                "DYNAMO_DB",
+                "DOCUMENT_DB",
+                "REDSHIFT",
+                "ATHENA",
+                "REDIS",
+                "BIG_QUERY"
+              ]
+            }
+          },
+          "targetArn": {
+            "type": "string",
+            "description": "Role arn of assigned to the target account for `CROSS_ACCOUNT_ROLE` / `PROFILE_CREDENTIAL`"
+          },
+          "tenantId": {
+            "type": "string",
+            "description": "Azure tenant id"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Approval Updated At",
+            "format": "date-time"
+          },
+          "updatedUser": {
+            "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserResponse"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "Cloud Provider UUID",
+            "example": "UUID"
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalCloudProviderDto$UpdateRequest": {
+        "required": [
+          "name",
+          "replicationMode",
+          "synchronizableDatabaseTypes"
+        ],
+        "type": "object",
+        "properties": {
+          "cronExpression": {
+            "type": "string",
+            "description": "Cron expression",
+            "example": "0 0 6 * * ?"
+          },
+          "name": {
+            "type": "string",
+            "description": "Cloud Provider Display Name",
+            "example": "AWS"
+          },
+          "proxyAuthType": {
+            "type": "string",
+            "description": "Proxy Authentication Type",
+            "deprecated": true,
+            "enum": [
+              "QUERYPIE",
+              "MANUAL"
+            ]
+          },
+          "proxyEnabled": {
+            "type": "boolean",
+            "description": "Proxy usage",
+            "deprecated": true
+          },
+          "replicationMode": {
+            "type": "string",
+            "description": "Scheduling mode",
+            "example": "MANUAL",
+            "enum": [
+              "MANUAL",
+              "SCHEDULING"
+            ]
+          },
+          "synchronizableDatabaseTypes": {
+            "type": "array",
+            "description": "Synchronizable Database Type",
+            "items": {
+              "type": "string",
+              "description": "Synchronizable Database Type",
+              "enum": [
+                "AURORA_MY_SQL",
+                "AURORA_POSTGRESQL",
+                "MY_SQL",
+                "POSTGRESQL",
+                "MARIA_DB",
+                "ORACLE",
+                "SQL_SERVER",
+                "DYNAMO_DB",
+                "DOCUMENT_DB",
+                "REDSHIFT",
+                "ATHENA",
+                "REDIS",
+                "BIG_QUERY"
+              ]
+            }
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalConnectionDto$AddClusterRequest": {
+        "required": [
+          "host",
+          "port"
+        ],
+        "type": "object",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "Host",
+            "example": "test-db.querypie.com"
+          },
+          "port": {
+            "type": "integer",
+            "description": "Port",
+            "format": "int32",
+            "example": 1521
+          },
+          "type": {
+            "pattern": "Primary|Secondary|Single",
+            "type": "string",
+            "description": "Host Replication [`Primary`,`Secondary`,`Single`]",
+            "example": "Primary"
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalConnectionDto$ClusterResponse": {
+        "required": [
+          "deleted",
+          "host",
+          "port",
+          "type",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "deleted": {
+            "type": "boolean",
+            "description": "Delete Status",
+            "example": false
+          },
+          "host": {
+            "type": "string",
+            "description": "Host",
+            "example": "test-db.querypie.com"
+          },
+          "port": {
+            "type": "integer",
+            "description": "Port",
+            "format": "int32",
+            "example": 1521
+          },
+          "type": {
+            "type": "string",
+            "description": "Host Replication [`Primary`,`Secondary`,`Single`]",
+            "example": "Primary"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "Cluster UUID",
+            "example": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3"
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalConnectionDto$ConnectionAccount": {
+        "type": "object",
+        "properties": {
+          "kerberosProtocols": {
+            "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$KerberosProtocols"
+          },
+          "type": {
+            "type": "string",
+            "description": "Database Connection Accounts",
+            "enum": [
+              "NOAUTH",
+              "SASL_KERBEROS",
+              "SASL_PLAIN_UID",
+              "UIDPWD",
+              "SASL_PLAIN_UIDPWD_SSL",
+              "NOAUTH_SSL",
+              "DELEGATION_TOKEN",
+              "O_AUTH_CLIENT_CREDENTIALS",
+              "UIDPWD",
+              "SASL_KERBEROS"
+            ],
+            "default": "UIDPWD"
+          },
+          "useMultipleDatabaseAccount": {
+            "type": "boolean",
+            "writeOnly": true
+          },
+          "usernamePasswords": {
+            "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$UsernamePasswords"
+          }
+        },
+        "description": "Database Connection Accounts"
+      },
+      "com.querypie.dbam.controller.dto.ExternalConnectionDto$ConnectionAccountResponse": {
+        "type": "object",
+        "properties": {
+          "kerberosProtocols": {
+            "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$KerberosProtocolsResponse"
+          },
+          "type": {
+            "type": "string",
+            "description": "Database Connection Accounts",
+            "enum": [
+              "NOAUTH",
+              "SASL_KERBEROS",
+              "SASL_PLAIN_UID",
+              "UIDPWD",
+              "SASL_PLAIN_UIDPWD_SSL",
+              "NOAUTH_SSL",
+              "DELEGATION_TOKEN",
+              "O_AUTH_CLIENT_CREDENTIALS",
+              "UIDPWD",
+              "SASL_KERBEROS"
+            ],
+            "default": "UIDPWD"
+          },
+          "useMultipleDatabaseAccount": {
+            "type": "boolean",
+            "description": "Use Multiple Database Account",
+            "default": false
+          },
+          "usernamePasswords": {
+            "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$UsernamePasswordsResponse"
+          }
+        },
+        "description": "Database Connection Accounts"
+      },
+      "com.querypie.dbam.controller.dto.ExternalConnectionDto$CreateClusterRequest": {
+        "required": [
+          "host",
+          "port",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "Host",
+            "example": "test-db.querypie.com"
+          },
+          "port": {
+            "type": "integer",
+            "description": "Port",
+            "format": "int32",
+            "example": 1521
+          },
+          "type": {
+            "type": "string",
+            "description": "Host Replication [`Primary`,`Secondary`,`Single`]",
+            "example": "Primary"
+          }
+        },
+        "description": "Cluster List"
+      },
+      "com.querypie.dbam.controller.dto.ExternalConnectionDto$CreateInstanceRequest": {
+        "required": [
+          "exposed",
+          "host",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "exposed": {
+            "type": "boolean",
+            "description": "Exposed",
+            "example": true,
+            "default": true
+          },
+          "host": {
+            "type": "string",
+            "description": "Host",
+            "example": "test-db.querypie.com"
+          },
+          "name": {
+            "type": "string",
+            "description": "Instance name",
+            "example": "querypie-instance"
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalConnectionDto$CreateRequest": {
+        "required": [
+          "databaseType",
+          "hideCredential",
+          "maxDisplayRows",
+          "maxExportRows",
+          "name",
+          "useFixedCredentialForAgent",
+          "useProxy"
+        ],
+        "type": "object",
+        "properties": {
+          "audited": {
+            "type": "boolean",
+            "description": "Audit Enabled (Default : True)",
+            "example": true
+          },
+          "authenticationDb": {
+            "type": "string",
+            "description": "Authentication DB (MongoDB Only)"
+          },
+          "awsRegionValue": {
+            "type": "string",
+            "description": "AWS Region, Ref https://docs.aws.amazon.com/ko_kr/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html (DynamoDB Only)",
+            "example": "ap-northeast-2"
+          },
+          "clusters": {
+            "type": "array",
+            "description": "Cluster List",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$CreateClusterRequest"
+            }
+          },
+          "connectionAccount": {
+            "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$ConnectionAccount"
+          },
+          "connectionOwners": {
+            "type": "array",
+            "description": "Connection Owner",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.iam.controller.dto.UserRoleDto$CreateRequest"
+            }
+          },
+          "databaseType": {
+            "type": "string",
+            "description": "Database Type",
+            "example": "MySQL",
+            "enum": [
+              "Mysql",
+              "MariaDB",
+              "PostgreSQL",
+              "Redshift",
+              "SQLServer",
+              "AzureSQL",
+              "Oracle",
+              "Tibero",
+              "MongoDB",
+              "BigQuery",
+              "Presto",
+              "Trino",
+              "Hive",
+              "Cassandra",
+              "DynamoDB",
+              "Snowflake",
+              "Impala",
+              "Redis",
+              "SingleStore",
+              "Hana",
+              "CustomDataSource"
+            ]
+          },
+          "databaseVersion": {
+            "type": "string",
+            "description": "Database Version",
+            "example": "5.7.10"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description",
+            "example": "QueryPie Connection description"
+          },
+          "dmlSnapshot": {
+            "type": "boolean",
+            "description": "DML Snapshot Enabled (Default : False)",
+            "example": false
+          },
+          "fixedCredentialForAgent": {
+            "type": "string",
+            "description": "Fixed credential for Agent (Only for when proxyAuthType is QueryPie)"
+          },
+          "gcpCredentialType": {
+            "type": "string",
+            "description": "GCP Credential Type",
+            "example": "ServiceAccount",
+            "enum": [
+              "ServiceAccount",
+              "GoogleOAuth"
+            ]
+          },
+          "googleOAuthUuid": {
+            "type": "string",
+            "description": "Google OAuth UUID (BigQuery Only)"
+          },
+          "hideCredential": {
+            "type": "boolean",
+            "description": "Hide this credential from Connection List page"
+          },
+          "hostnameForLookup": {
+            "type": "string",
+            "description": "The domain for looking up MongoDB cluster's actual member host and port information via DNS SRV (Service Record) records.",
+            "example": "cluster-atlas.example.mongodb.net"
+          },
+          "listenerType": {
+            "type": "string",
+            "description": "Oracle Listener Type (Oracle Only)",
+            "example": "SID",
+            "enum": [
+              "SID",
+              "SERVICE_NAME"
+            ]
+          },
+          "maxDisplayRows": {
+            "type": "integer",
+            "description": "Max Display allowed Row Count (-1 is unlimited), Default : -1",
+            "format": "int32",
+            "example": 1000
+          },
+          "maxExportRows": {
+            "type": "integer",
+            "description": "Max Allowed Export Row Count (-1 is unlimited), Default: -1",
+            "format": "int32",
+            "example": 1000
+          },
+          "mongoDbSchemeType": {
+            "type": "string",
+            "description": "MongoDb Scheme Type(Only for when using MongoDB exclusively).<br>MONGODB='mongodb://'<br>MONGODB_SRV='mongodb+srv://'<br>",
+            "enum": [
+              "MONGODB",
+              "MONGODB_SRV"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Connection Name",
+            "example": "QueryPie Connection"
+          },
+          "otherOptions": {
+            "type": "string",
+            "description": "String added to the Connection String.",
+            "example": "ssl=true"
+          },
+          "password": {
+            "type": "string",
+            "description": "Database Connection User Password",
+            "example": "p@ssword"
+          },
+          "proxyAuthType": {
+            "type": "string",
+            "description": "Proxy authentication type",
+            "enum": [
+              "QUERYPIE",
+              "MANUAL"
+            ]
+          },
+          "roleName": {
+            "type": "string",
+            "description": "Role Name"
+          },
+          "schemaName": {
+            "type": "string",
+            "description": "Schema Name for RDBMS / Keyspace Name for Cassandra",
+            "example": "test_db"
+          },
+          "secretStoreUuid": {
+            "type": "string",
+            "description": "Secret Store UUID",
+            "example": "fee872bc-d281-4e20-9ed8-405545c7abc4"
+          },
+          "serviceAccount": {
+            "type": "string",
+            "description": "Service Account (BigQuery Only)"
+          },
+          "tags": {
+            "type": "array",
+            "description": "Connection Tags",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.dac.connection.tag.model.ConnectionTagDto"
+            }
+          },
+          "useFixedCredentialForAgent": {
+            "type": "boolean",
+            "description": "Use fixed credential for Agent (Only for when proxyAuthType is QueryPie)"
+          },
+          "useProxy": {
+            "type": "boolean",
+            "description": "Proxy usage"
+          },
+          "userName": {
+            "type": "string",
+            "description": "Database Connection User Name",
+            "example": "db_user"
+          },
+          "warehouseName": {
+            "type": "string",
+            "description": "Warehouse Name"
+          },
+          "zoneUuids": {
+            "type": "array",
+            "description": "List of Zone UUID (Default : Default NetworkZone)",
+            "example": [
+              "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3"
+            ],
+            "items": {
+              "type": "string",
+              "description": "List of Zone UUID (Default : Default NetworkZone)",
+              "example": "[\"63d2cc6d-dd83-4a31-a817-fc13f1fc57a3\"]"
+            }
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalConnectionDto$InstanceResponse": {
+        "required": [
+          "deleted",
+          "host",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "deleted": {
+            "type": "boolean",
+            "description": "Delete Status",
+            "example": false
+          },
+          "exposed": {
+            "type": "boolean",
+            "description": "Expose status",
+            "example": false
+          },
+          "host": {
+            "type": "string",
+            "description": "Host",
+            "example": "test-db.querypie.com"
+          },
+          "name": {
+            "type": "string",
+            "description": "Instance name",
+            "example": "querypie-instance"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "Instance UUID",
+            "example": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3"
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalConnectionDto$KerberosProtocol": {
+        "type": "object",
+        "properties": {
+          "keytabUuid": {
+            "type": "string",
+            "description": "Kerberos Account Ketyab Uuid"
+          },
+          "principal": {
+            "type": "string",
+            "description": "Kerberos Account Principal"
+          },
+          "realm": {
+            "type": "string",
+            "description": "Kerberos Account Realm"
+          },
+          "serviceName": {
+            "type": "string",
+            "description": "Kerberos Account Service Name"
+          }
+        },
+        "description": "Database Connection Kerberos Common Account"
+      },
+      "com.querypie.dbam.controller.dto.ExternalConnectionDto$KerberosProtocolResponse": {
+        "required": [
+          "principal",
+          "realm",
+          "serviceName"
+        ],
+        "type": "object",
+        "properties": {
+          "principal": {
+            "type": "string",
+            "description": "Kerberos Account Principal"
+          },
+          "realm": {
+            "type": "string",
+            "description": "Kerberos Account Realm"
+          },
+          "serviceName": {
+            "type": "string",
+            "description": "Kerberos Account Service Name"
+          }
+        },
+        "description": "Database Connection Kerberos Common Account"
+      },
+      "com.querypie.dbam.controller.dto.ExternalConnectionDto$KerberosProtocols": {
+        "type": "object",
+        "properties": {
+          "common": {
+            "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$KerberosProtocol"
+          }
+        },
+        "description": "Database Connection Kerberos Accounts"
+      },
+      "com.querypie.dbam.controller.dto.ExternalConnectionDto$KerberosProtocolsResponse": {
+        "type": "object",
+        "properties": {
+          "common": {
+            "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$KerberosProtocolResponse"
+          }
+        },
+        "description": "Database Connection Kerberos Accounts"
+      },
+      "com.querypie.dbam.controller.dto.ExternalConnectionDto$ProxyPortMappingRequest": {
+        "type": "object",
+        "properties": {
+          "clusterGroupUuids": {
+            "type": "array",
+            "description": "Cluster group uuids",
+            "items": {
+              "type": "string",
+              "description": "Cluster group uuids"
+            }
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalConnectionDto$Response": {
+        "required": [
+          "cloudProviderUuid",
+          "deleted",
+          "hideCredential",
+          "ledger",
+          "maxDisplayRows",
+          "maxExportRows",
+          "name",
+          "useFixedCredentialForAgent",
+          "useProxy",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "audited": {
+            "type": "boolean",
+            "description": "Audit Enabled",
+            "example": true
+          },
+          "authenticationDb": {
+            "type": "string",
+            "description": "Authentication DB (MongoDB Only)"
+          },
+          "awsRegionValue": {
+            "type": "string",
+            "description": "AWS Region, Ref https://docs.aws.amazon.com/ko_kr/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html (DynamoDB Only)",
+            "example": "ap-northeast-2"
+          },
+          "cloudProviderUuid": {
+            "type": "string",
+            "description": "Cloud Provider UUID",
+            "example": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3"
+          },
+          "clusters": {
+            "type": "array",
+            "description": "Cluster List",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$ClusterResponse"
+            }
+          },
+          "connectionAccount": {
+            "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$ConnectionAccountResponse"
+          },
+          "connectionOwners": {
+            "type": "array",
+            "description": "Connection Owners",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.iam.controller.dto.UserRoleDto$Response"
+            }
+          },
+          "databaseType": {
+            "type": "string",
+            "description": "DatabaseType",
+            "example": "MySQL"
+          },
+          "databaseVersion": {
+            "type": "string",
+            "description": "Database Version",
+            "example": "5.7.10"
+          },
+          "deleted": {
+            "type": "boolean",
+            "description": "Delete Status",
+            "example": false
+          },
+          "dmlSnapshot": {
+            "type": "boolean",
+            "description": "DML Snapshot Enabled",
+            "example": false
+          },
+          "fixedCredentialForAgent": {
+            "type": "string",
+            "description": "Fixed credential for Agent (Only for when proxyAuthType is QueryPie)"
+          },
+          "hideCredential": {
+            "type": "boolean",
+            "description": "Hide this credential from Connection List page"
+          },
+          "ledger": {
+            "type": "boolean",
+            "description": "Ledger"
+          },
+          "listenerType": {
+            "type": "string",
+            "description": "Oracle Listener Type (Oracle Only)",
+            "example": "SID",
+            "enum": [
+              "SID",
+              "SERVICE_NAME"
+            ]
+          },
+          "maxDisplayRows": {
+            "type": "integer",
+            "description": "Max Display allowed Row Count (-1 is unlimited)",
+            "format": "int32",
+            "example": 1000
+          },
+          "maxExportRows": {
+            "type": "integer",
+            "description": "Max Allowed Export Row Count (-1 is unlimited)",
+            "format": "int32",
+            "example": 1000
+          },
+          "mongoDbSchemeType": {
+            "type": "string",
+            "description": "MongoDb Scheme Type(Only for when using MongoDB exclusively).<br>MONGODB='mongodb://'<br>MONGODB_SRV='mongodb+srv://'<br>",
+            "enum": [
+              "MONGODB",
+              "MONGODB_SRV"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Connection Name",
+            "example": "QueryPie Connection"
+          },
+          "networkId": {
+            "type": "string",
+            "description": "Network ID"
+          },
+          "proxyAuthType": {
+            "type": "string",
+            "description": "Proxy authentication type",
+            "enum": [
+              "QUERYPIE",
+              "MANUAL"
+            ]
+          },
+          "roleName": {
+            "type": "string",
+            "description": "Role Name"
+          },
+          "schemaName": {
+            "type": "string",
+            "description": "Schema Name for RDBMS / Keyspace Name for Cassandra",
+            "example": "test_db"
+          },
+          "tags": {
+            "type": "array",
+            "description": "Tags",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.dac.connection.tag.model.ConnectionTagDto"
+            }
+          },
+          "useFixedCredentialForAgent": {
+            "type": "boolean",
+            "description": "Use fixed credential for Agent (Only for when proxyAuthType is QueryPie)"
+          },
+          "useProxy": {
+            "type": "boolean",
+            "description": "Proxy usage"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "Cluster Group UUID",
+            "example": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3"
+          },
+          "warehouseName": {
+            "type": "string",
+            "description": "Warehouse Name"
+          },
+          "zones": {
+            "type": "array",
+            "description": "Zones",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalNetworkZoneDto$ZoneInfoResponse"
+            }
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalConnectionDto$SecretStore": {
+        "type": "object",
+        "properties": {
+          "uuid": {
+            "type": "string",
+            "description": "Secret Store UUID",
+            "example": "fee872bc-d281-4e20-9ed8-405545c7abc4"
+          }
+        },
+        "description": "Secret Store Wrapper",
+        "example": {
+          "uuid": "fee872bc-d281-4e20-9ed8-405545c7abc4"
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalConnectionDto$UpdateClusterRequest": {
+        "required": [
+          "port",
+          "type",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "Host",
+            "example": "test-db.querypie.com"
+          },
+          "port": {
+            "type": "integer",
+            "description": "Port",
+            "format": "int32",
+            "example": 1521
+          },
+          "type": {
+            "type": "string",
+            "description": "Host Replication [`Primary`,`Secondary`,`Single`]",
+            "example": "Primary"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "Cluster UUID",
+            "example": "10"
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalConnectionDto$UpdateInstanceRequest": {
+        "required": [
+          "exposed",
+          "host",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "exposed": {
+            "type": "boolean",
+            "description": "Exposed",
+            "example": true,
+            "default": true
+          },
+          "host": {
+            "type": "string",
+            "description": "Host",
+            "example": "test-db.querypie.com"
+          },
+          "name": {
+            "type": "string",
+            "description": "Instance name",
+            "example": "querypie-instance"
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalConnectionDto$UpdateRequest": {
+        "required": [
+          "hideCredential",
+          "maxDisplayRows",
+          "maxExportRows",
+          "useFixedCredentialForAgent"
+        ],
+        "type": "object",
+        "properties": {
+          "audited": {
+            "type": "boolean",
+            "description": "Audit Enabled",
+            "example": true
+          },
+          "authenticationDb": {
+            "type": "string",
+            "description": "Authentication DB (MongoDB Only)"
+          },
+          "awsRegionValue": {
+            "type": "string",
+            "description": "AWS Region, Ref https://docs.aws.amazon.com/ko_kr/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html (DynamoDB Only)",
+            "example": "ap-northeast-2"
+          },
+          "clusters": {
+            "type": "array",
+            "description": "Cluster List",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$UpdateClusterRequest"
+            }
+          },
+          "connectionAccount": {
+            "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$ConnectionAccount"
+          },
+          "connectionOwners": {
+            "type": "array",
+            "description": "Connection Owner",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.iam.controller.dto.UserRoleDto$UpdateRequest"
+            }
+          },
+          "databaseVersion": {
+            "type": "string",
+            "description": "Database Version",
+            "example": "5.7.10"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description",
+            "example": "QueryPie Connection description"
+          },
+          "dmlSnapshot": {
+            "type": "boolean",
+            "description": "DML Snapshot Enabled",
+            "example": false
+          },
+          "fixedCredentialForAgent": {
+            "type": "string",
+            "description": "Fixed credential for Agent (Only for when proxyAuthType is QueryPie)"
+          },
+          "googleOAuthUuid": {
+            "type": "string",
+            "description": "Google OAuth UUID (BigQuery Only)"
+          },
+          "hideCredential": {
+            "type": "boolean",
+            "description": "Hide this credential from Connection List page"
+          },
+          "listenerType": {
+            "type": "string",
+            "description": "Oracle Listener Type (Oracle Only)",
+            "example": "SID",
+            "enum": [
+              "SID",
+              "SERVICE_NAME"
+            ]
+          },
+          "maxDisplayRows": {
+            "type": "integer",
+            "description": "Max Display allowed Row Count (-1 is unlimited)",
+            "format": "int32",
+            "example": 1000
+          },
+          "maxExportRows": {
+            "type": "integer",
+            "description": "Max Allowed Export Row Count (-1 is unlimited)",
+            "format": "int32",
+            "example": 1000
+          },
+          "name": {
+            "type": "string",
+            "description": "Connection Name",
+            "example": "QueryPie Connection"
+          },
+          "proxyAuthType": {
+            "type": "string",
+            "description": "Proxy authentication type",
+            "enum": [
+              "QUERYPIE",
+              "MANUAL"
+            ]
+          },
+          "roleName": {
+            "type": "string",
+            "description": "Role Name"
+          },
+          "schemaName": {
+            "type": "string",
+            "description": "Schema Name for RDBMS / Keyspace Name for Cassandra",
+            "example": "test_db"
+          },
+          "secretStore": {
+            "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$SecretStore"
+          },
+          "serviceAccount": {
+            "type": "string",
+            "description": "Service Account (BigQuery Only)"
+          },
+          "useFixedCredentialForAgent": {
+            "type": "boolean",
+            "description": "Use fixed credential for Agent (Only for when proxyAuthType is QueryPie)"
+          },
+          "useProxy": {
+            "type": "boolean",
+            "description": "Proxy usage"
+          },
+          "warehouseName": {
+            "type": "string",
+            "description": "Warehouse Name"
+          },
+          "zoneUuids": {
+            "type": "array",
+            "description": "List of Zone UUID",
+            "example": "UUID",
+            "items": {
+              "type": "string",
+              "description": "List of Zone UUID",
+              "example": "UUID"
+            }
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalConnectionDto$UsernamePassword": {
+        "type": "object",
+        "properties": {
+          "password": {
+            "type": "string",
+            "description": "Username-Password password"
+          },
+          "username": {
+            "type": "string",
+            "description": "Username-Password username"
+          },
+          "vaultDatabaseEngineAccount": {
+            "type": "string",
+            "description": "Vault database engine account"
+          }
+        },
+        "description": "Database Connection Username-Password Proxy Accounts"
+      },
+      "com.querypie.dbam.controller.dto.ExternalConnectionDto$UsernamePasswordResponse": {
+        "required": [
+          "username"
+        ],
+        "type": "object",
+        "properties": {
+          "username": {
+            "type": "string",
+            "description": "Username-Password username"
+          }
+        },
+        "description": "Database Connection Username-Password Proxy Accounts"
+      },
+      "com.querypie.dbam.controller.dto.ExternalConnectionDto$UsernamePasswords": {
+        "type": "object",
+        "properties": {
+          "admin": {
+            "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$UsernamePassword"
+          },
+          "common": {
+            "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$UsernamePassword"
+          },
+          "proxy": {
+            "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$UsernamePassword"
+          }
+        },
+        "description": "Database Connection Username-Password Accounts"
+      },
+      "com.querypie.dbam.controller.dto.ExternalConnectionDto$UsernamePasswordsResponse": {
+        "type": "object",
+        "properties": {
+          "admin": {
+            "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$UsernamePasswordResponse"
+          },
+          "common": {
+            "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$UsernamePasswordResponse"
+          },
+          "proxy": {
+            "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalConnectionDto$UsernamePasswordResponse"
+          }
+        },
+        "description": "Database Connection Username-Password Accounts"
+      },
+      "com.querypie.dbam.controller.dto.ExternalMaskingPatternDto$Response": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Masking Description",
+            "example": "Masking Description"
+          },
+          "detectingPattern": {
+            "type": "string",
+            "description": "Masking Detecting Pattern",
+            "example": "(?:^|\\b)\\d{6}\\p{Pd}\\d{7}(?:$|\\b)"
+          },
+          "maskingPattern": {
+            "type": "string",
+            "description": "Masking Pattern",
+            "example": "(?:^|\\b)\\d{6}\\p{Pd}\\d{7}(?:$|\\b)"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "Masking Pattern UUID",
+            "example": "5063396b-5047-44ca-833a-61c0e4f6dcd9"
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalNetworkZoneDto$CreateRequest": {
+        "required": [
+          "ipBands",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "ipBands": {
+            "type": "string",
+            "description": "IP Address Range(CIDR)",
+            "example": "0.0.0.0/0"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name"
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalNetworkZoneDto$UpdateRequest": {
+        "required": [
+          "ipBands",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "ipBands": {
+            "type": "string",
+            "description": "IP Address Range(CIDR)",
+            "example": "0.0.0.0/0"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name"
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalNetworkZoneDto$ZoneInfoResponse": {
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "description": "Created At",
+            "format": "date-time"
+          },
+          "ipBands": {
+            "type": "string",
+            "description": "IP Address Range",
+            "example": "CIDR or IP"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name",
+            "example": "Name"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Updated At",
+            "format": "date-time"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "UUID",
+            "example": "UUID"
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalPolicyDto$CreateRequest": {
+        "type": "object",
+        "properties": {
+          "clusterGroupUuid": {
+            "type": "string",
+            "description": "Cluster Group UUID",
+            "example": "35cfa847-165c-48b5-bb4e-af271e490f19"
+          },
+          "policyType": {
+            "type": "string",
+            "description": "Policy Type",
+            "example": "DATA_ACCESS",
+            "enum": [
+              "DATA_LEVEL",
+              "DATA_ACCESS",
+              "DATA_MASKING",
+              "NOTIFICATION",
+              "LEDGER"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "description": "Title",
+            "example": "Policy Title"
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalPolicyDto$DataAccessCreateRequest": {
+        "type": "object",
+        "properties": {
+          "allowedUserUuids": {
+            "type": "array",
+            "description": "White List User UUID List",
+            "example": [
+              "5063396b-5047-44ca-833a-61c0e4f6dcd9",
+              "16238493-5047-44ca-833a-61c0e4f6dcd1"
+            ],
+            "items": {
+              "type": "string",
+              "description": "White List User UUID List",
+              "example": "[\"5063396b-5047-44ca-833a-61c0e4f6dcd9\",\"16238493-5047-44ca-833a-61c0e4f6dcd1\"]"
+            }
+          },
+          "objectPath": {
+            "type": "array",
+            "description": "Object Path",
+            "example": [
+              "table",
+              "column"
+            ],
+            "items": {
+              "type": "string",
+              "description": "Object Path",
+              "example": "[\"table\",\"column\"]"
+            }
+          },
+          "objectType": {
+            "type": "string",
+            "description": "Object Type",
+            "example": "COLUMN",
+            "enum": [
+              "TABLE",
+              "COLUMN"
+            ]
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalPolicyDto$DataAccessResponse": {
+        "required": [
+          "allowedUserUuids",
+          "objectPath",
+          "policyUuid",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "accessRule": {
+            "$ref": "#/components/schemas/com.querypie.dbam.domain.policy.data.access.AccessRule"
+          },
+          "allowedUserUuids": {
+            "type": "array",
+            "description": "White List User UUID List",
+            "example": [
+              "5063396b-5047-44ca-833a-61c0e4f6dcd9",
+              "16238493-5047-44ca-833a-61c0e4f6dcd1"
+            ],
+            "items": {
+              "type": "string",
+              "description": "White List User UUID List",
+              "example": "[\"5063396b-5047-44ca-833a-61c0e4f6dcd9\",\"16238493-5047-44ca-833a-61c0e4f6dcd1\"]"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Updated At",
+            "format": "date-time"
+          },
+          "objectPath": {
+            "type": "array",
+            "description": "Object Path",
+            "example": [
+              "table",
+              "column"
+            ],
+            "items": {
+              "type": "string",
+              "description": "Object Path",
+              "example": "[\"table\",\"column\"]"
+            }
+          },
+          "objectType": {
+            "type": "string",
+            "description": "Object Type",
+            "example": "COLUMN",
+            "enum": [
+              "TABLE",
+              "COLUMN"
+            ]
+          },
+          "policyUuid": {
+            "type": "string",
+            "description": "Policy UUID",
+            "example": "35cfa847-165c-48b5-bb4e-af271e490f19"
+          },
+          "qualifiedObjectPath": {
+            "$ref": "#/components/schemas/com.querypie.dbam.domain.policy.objects.path.LegacyQualifiedObjectPath"
+          },
+          "ruleUsers": {
+            "type": "array",
+            "writeOnly": true,
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.dbam.domain.policy.rule.user.PolicyRuleUser"
+            }
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Updated At",
+            "format": "date-time"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "Rule UUID",
+            "example": "35cfa847-165c-48b5-bb4e-af271e490f19"
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalPolicyDto$DataAccessUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "allowedUserUuids": {
+            "type": "array",
+            "description": "White List User UUID List",
+            "example": [
+              "5063396b-5047-44ca-833a-61c0e4f6dcd9",
+              "16238493-5047-44ca-833a-61c0e4f6dcd1"
+            ],
+            "items": {
+              "type": "string",
+              "description": "White List User UUID List",
+              "example": "[\"5063396b-5047-44ca-833a-61c0e4f6dcd9\",\"16238493-5047-44ca-833a-61c0e4f6dcd1\"]"
+            }
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalPolicyDto$DataLevelCreateRequest": {
+        "required": [
+          "level"
+        ],
+        "type": "object",
+        "properties": {
+          "level": {
+            "maximum": 3,
+            "minimum": 1,
+            "type": "integer",
+            "description": "Sensitive Level (1~3)",
+            "format": "int32",
+            "example": 1
+          },
+          "objectPath": {
+            "type": "array",
+            "description": "Object Path",
+            "example": [
+              "table",
+              "column"
+            ],
+            "items": {
+              "type": "string",
+              "description": "Object Path",
+              "example": "[\"table\",\"column\"]"
+            }
+          },
+          "objectType": {
+            "type": "string",
+            "description": "Object Type",
+            "example": "COLUMN",
+            "enum": [
+              "TABLE",
+              "COLUMN"
+            ]
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalPolicyDto$DataLevelResponse": {
+        "required": [
+          "level",
+          "objectPath",
+          "policyUuid",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "description": "Updated At",
+            "format": "date-time"
+          },
+          "dataLevel": {
+            "$ref": "#/components/schemas/com.querypie.dbam.domain.policy.data.level.PolicyDataLevel"
+          },
+          "level": {
+            "type": "integer",
+            "description": "Sensitive Level (1~3)",
+            "format": "int32",
+            "example": 1
+          },
+          "objectPath": {
+            "type": "array",
+            "description": "Object Path",
+            "example": [
+              "table",
+              "column"
+            ],
+            "items": {
+              "type": "string",
+              "description": "Object Path",
+              "example": "[\"table\",\"column\"]"
+            }
+          },
+          "objectType": {
+            "type": "string",
+            "description": "Object Type",
+            "example": "COLUMN",
+            "enum": [
+              "TABLE",
+              "COLUMN"
+            ]
+          },
+          "policyUuid": {
+            "type": "string",
+            "description": "Policy UUID",
+            "example": "35cfa847-165c-48b5-bb4e-af271e490f19"
+          },
+          "qualifiedObjectPath": {
+            "$ref": "#/components/schemas/com.querypie.dbam.domain.policy.objects.path.LegacyQualifiedObjectPath"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Updated At",
+            "format": "date-time"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "Rule UUID",
+            "example": "35cfa847-165c-48b5-bb4e-af271e490f19"
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalPolicyDto$DataLevelUpdateRequest": {
+        "required": [
+          "level"
+        ],
+        "type": "object",
+        "properties": {
+          "level": {
+            "maximum": 3,
+            "minimum": 1,
+            "type": "integer",
+            "description": "Sensitive Level (1~3)",
+            "format": "int32",
+            "example": 1
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalPolicyDto$DataMaskingCreateRequest": {
+        "type": "object",
+        "properties": {
+          "objectPath": {
+            "type": "array",
+            "description": "Object Path",
+            "example": [
+              "table",
+              "column"
+            ],
+            "items": {
+              "type": "string",
+              "description": "Object Path",
+              "example": "[\"table\",\"column\"]"
+            }
+          },
+          "objectType": {
+            "type": "string",
+            "description": "Object Type",
+            "example": "COLUMN",
+            "enum": [
+              "TABLE",
+              "COLUMN"
+            ]
+          },
+          "patternUuid": {
+            "type": "string",
+            "description": "Masking Pattern UUID",
+            "example": "5063396b-5047-44ca-833a-61c0e4f6dcd9"
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalPolicyDto$DataMaskingResponse": {
+        "required": [
+          "objectPath",
+          "patternUuid",
+          "policyUuid",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "description": "Updated At",
+            "format": "date-time"
+          },
+          "maskingRule": {
+            "$ref": "#/components/schemas/com.querypie.dbam.domain.policy.data.masking.rules.MaskingRule"
+          },
+          "objectPath": {
+            "type": "array",
+            "description": "Object Path",
+            "example": [
+              "table",
+              "column"
+            ],
+            "items": {
+              "type": "string",
+              "description": "Object Path",
+              "example": "[\"table\",\"column\"]"
+            }
+          },
+          "objectType": {
+            "type": "string",
+            "description": "Object Type",
+            "example": "COLUMN",
+            "enum": [
+              "TABLE",
+              "COLUMN"
+            ]
+          },
+          "patternUuid": {
+            "type": "string",
+            "description": "Masking Pattern UUID",
+            "example": "5063396b-5047-44ca-833a-61c0e4f6dcd9"
+          },
+          "policyUuid": {
+            "type": "string",
+            "description": "Policy UUID",
+            "example": "35cfa847-165c-48b5-bb4e-af271e490f19"
+          },
+          "qualifiedObjectPath": {
+            "$ref": "#/components/schemas/com.querypie.dbam.domain.policy.objects.path.LegacyQualifiedObjectPath"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Updated At",
+            "format": "date-time"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "Rule UUID",
+            "example": "35cfa847-165c-48b5-bb4e-af271e490f19"
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalPolicyDto$DataMaskingUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "patternUuid": {
+            "type": "string",
+            "description": "Masking Pattern UUID",
+            "example": "5063396b-5047-44ca-833a-61c0e4f6dcd9"
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalPolicyDto$Response": {
+        "required": [
+          "enabled",
+          "numberOfRules"
+        ],
+        "type": "object",
+        "properties": {
+          "clusterGroupUuid": {
+            "type": "string",
+            "description": "Cluster Group UUID",
+            "example": "35cfa847-165c-48b5-bb4e-af271e490f19"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Created At",
+            "format": "date-time"
+          },
+          "createdUser": {
+            "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserResponse"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Enabled",
+            "example": true
+          },
+          "numberOfRules": {
+            "type": "integer",
+            "description": "Number of rules",
+            "format": "int64",
+            "example": 10
+          },
+          "policyType": {
+            "type": "string",
+            "description": "Policy Type",
+            "example": "DATA_LEVEL, DATA_ACCESS, DATA_MASKING, NOTIFICATION, or LEDGER",
+            "enum": [
+              "DATA_LEVEL",
+              "DATA_ACCESS",
+              "DATA_MASKING",
+              "NOTIFICATION",
+              "LEDGER"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "description": "Title",
+            "example": "Policy Title"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Updated At",
+            "format": "date-time"
+          },
+          "updatedUser": {
+            "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserResponse"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "Policy UUID",
+            "example": "35cfa847-165c-48b5-bb4e-af271e490f19"
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalPolicyDto$RuleResponse": {
+        "required": [
+          "objectPath",
+          "policyUuid",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "description": "Updated At",
+            "format": "date-time"
+          },
+          "objectPath": {
+            "type": "array",
+            "description": "Object Path",
+            "example": [
+              "table",
+              "column"
+            ],
+            "items": {
+              "type": "string",
+              "description": "Object Path",
+              "example": "[\"table\",\"column\"]"
+            }
+          },
+          "objectType": {
+            "type": "string",
+            "description": "Object Type",
+            "example": "COLUMN",
+            "enum": [
+              "TABLE",
+              "COLUMN"
+            ]
+          },
+          "policyUuid": {
+            "type": "string",
+            "description": "Policy UUID",
+            "example": "35cfa847-165c-48b5-bb4e-af271e490f19"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Updated At",
+            "format": "date-time"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "Rule UUID",
+            "example": "35cfa847-165c-48b5-bb4e-af271e490f19"
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalPolicyDto$UpdateRequest": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Title",
+            "example": "Policy Title"
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalPolicyNotificationDto$Response": {
+        "required": [
+          "alertType",
+          "lastStatus",
+          "name",
+          "template",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "alertType": {
+            "type": "string",
+            "description": "Alert Type",
+            "example": "SQL Execution"
+          },
+          "lastAt": {
+            "type": "string",
+            "description": "Last Event Time",
+            "format": "date-time"
+          },
+          "lastStatus": {
+            "type": "string",
+            "description": "Last Event Status",
+            "example": "SUCCESS",
+            "enum": [
+              "UNDEFINED",
+              "SUCCESS",
+              "FAIL"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Name",
+            "example": "SQL Execution Alert"
+          },
+          "template": {
+            "type": "string",
+            "description": "Message Template",
+            "example": "{{userName}} executed {{expRows}} rows."
+          },
+          "uuid": {
+            "type": "string",
+            "description": "Alert UUID",
+            "example": "a5ac2279-b715-4819-a00d-daba81739057"
+          }
+        },
+        "description": "Object list per entry"
+      },
+      "com.querypie.dbam.controller.dto.ExternalProxyDto$CreateRequest": {
+        "required": [
+          "host",
+          "name",
+          "portFrom",
+          "portTo"
+        ],
+        "type": "object",
+        "properties": {
+          "agentPort": {
+            "type": "integer",
+            "description": "Agent port",
+            "format": "int32",
+            "example": 9000
+          },
+          "host": {
+            "type": "string",
+            "description": "Proxy host name",
+            "example": "proxy.querypie.com"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name",
+            "example": "PROXY"
+          },
+          "networkId": {
+            "type": "string",
+            "description": "Network ID",
+            "nullable": true,
+            "example": "41abc"
+          },
+          "portFrom": {
+            "type": "integer",
+            "description": "Port from",
+            "format": "int32",
+            "example": 50000
+          },
+          "portTo": {
+            "type": "integer",
+            "description": "Port to",
+            "format": "int32",
+            "example": 51000
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalProxyDto$ProxyResponse": {
+        "required": [
+          "enabled",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "agentPort": {
+            "type": "integer",
+            "description": "Agent port",
+            "format": "int32",
+            "example": 9000
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Proxy enabled",
+            "example": true
+          },
+          "host": {
+            "type": "string",
+            "description": "Proxy host name",
+            "example": "proxy.querypie.com"
+          },
+          "networkId": {
+            "type": "string",
+            "description": "Network ID",
+            "example": "41abc"
+          },
+          "portFrom": {
+            "type": "integer",
+            "description": "Port from",
+            "format": "int32",
+            "example": 50000
+          },
+          "portTo": {
+            "type": "integer",
+            "description": "Port to",
+            "format": "int32",
+            "example": 51000
+          },
+          "proxy": {
+            "$ref": "#/components/schemas/com.querypie.proxy.persistence.Proxy"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "Proxy UUID",
+            "example": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3"
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalProxyDto$Response": {
+        "type": "object",
+        "properties": {
+          "otlEnabled": {
+            "type": "boolean",
+            "description": "OTL enabled",
+            "example": true
+          },
+          "proxies": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.dbam.controller.dto.ExternalProxyDto$ProxyResponse"
+            }
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalRoleDto$CreateRoleRequest": {
+        "required": [
+          "canCopyClipboard",
+          "canExport",
+          "canImport",
+          "name",
+          "privilegeTypes",
+          "privilegeVendor",
+          "used"
+        ],
+        "type": "object",
+        "properties": {
+          "canCopyClipboard": {
+            "type": "boolean",
+            "description": "Can Copy Clipboard",
+            "example": true
+          },
+          "canExport": {
+            "type": "boolean",
+            "description": "Can Export",
+            "example": true
+          },
+          "canImport": {
+            "type": "boolean",
+            "description": "Can Import",
+            "example": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Description",
+            "example": "Default Role Description"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name",
+            "example": "Default Role"
+          },
+          "privilegeTypes": {
+            "type": "array",
+            "description": "Privilege Type",
+            "writeOnly": true,
+            "example": "SELECT,INSERT",
+            "items": {
+              "type": "string",
+              "description": "Privilege Type",
+              "example": "SELECT,INSERT"
+            }
+          },
+          "privilegeVendor": {
+            "type": "string",
+            "description": "Privilege vendor",
+            "writeOnly": true,
+            "example": "SQL",
+            "enum": [
+              "SQL",
+              "REDIS"
+            ]
+          },
+          "used": {
+            "type": "boolean",
+            "description": "Used or Not",
+            "example": true
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalRoleDto$RoleResponse": {
+        "required": [
+          "canCopyClipboard",
+          "canExport",
+          "canImport",
+          "name",
+          "privilegeTypes",
+          "privilegeVendor",
+          "used",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "canCopyClipboard": {
+            "type": "boolean",
+            "description": "Can Copy Clipboard",
+            "example": true
+          },
+          "canExport": {
+            "type": "boolean",
+            "description": "Can Export",
+            "example": true
+          },
+          "canImport": {
+            "type": "boolean",
+            "description": "Can Import",
+            "example": true
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Created At",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description",
+            "example": "Default Role Description"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name",
+            "example": "Default Role"
+          },
+          "privilegeTypes": {
+            "type": "array",
+            "description": "Privilege Type",
+            "writeOnly": true,
+            "example": "SELECT,INSERT",
+            "items": {
+              "type": "string",
+              "description": "Privilege Type",
+              "example": "SELECT,INSERT"
+            }
+          },
+          "privilegeVendor": {
+            "type": "string",
+            "description": "Privilege vendor",
+            "writeOnly": true,
+            "example": "SQL",
+            "enum": [
+              "SQL",
+              "REDIS"
+            ]
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Updated At",
+            "format": "date-time"
+          },
+          "used": {
+            "type": "boolean",
+            "description": "Used or Not",
+            "example": true
+          },
+          "uuid": {
+            "type": "string",
+            "description": "UUID",
+            "example": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3"
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalRoleDto$UpdateRoleRequest": {
+        "required": [
+          "canCopyClipboard",
+          "canExport",
+          "canImport",
+          "name",
+          "privilegeTypes",
+          "privilegeVendor",
+          "used"
+        ],
+        "type": "object",
+        "properties": {
+          "canCopyClipboard": {
+            "type": "boolean",
+            "description": "Can Copy Clipboard",
+            "example": true
+          },
+          "canExport": {
+            "type": "boolean",
+            "description": "Can Export",
+            "example": true
+          },
+          "canImport": {
+            "type": "boolean",
+            "description": "Can Import",
+            "example": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Description",
+            "example": "Default Role Description"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name",
+            "example": "Default Role"
+          },
+          "privilegeTypes": {
+            "type": "array",
+            "description": "Privilege Type",
+            "writeOnly": true,
+            "example": "SELECT,INSERT",
+            "items": {
+              "type": "string",
+              "description": "Privilege Type",
+              "example": "SELECT,INSERT"
+            }
+          },
+          "privilegeVendor": {
+            "type": "string",
+            "description": "Privilege vendor",
+            "writeOnly": true,
+            "example": "SQL",
+            "enum": [
+              "SQL",
+              "REDIS"
+            ]
+          },
+          "used": {
+            "type": "boolean",
+            "description": "Used or Not",
+            "example": true
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalSqlAuditLogDto$AuditLogResponse": {
+        "required": [
+          "isExecResult",
+          "isPrevented"
+        ],
+        "type": "object",
+        "properties": {
+          "actionType": {
+            "type": "string",
+            "description": "ActionType",
+            "example": "CONNECTION"
+          },
+          "clusterGroupId": {
+            "type": "integer",
+            "description": "Cluster Group ID",
+            "format": "int64",
+            "example": 1
+          },
+          "clusterGroupName": {
+            "type": "string",
+            "description": "Cluster Group Name",
+            "example": "Test Cluster"
+          },
+          "clusterId": {
+            "type": "integer",
+            "description": "ClusterID",
+            "format": "int64",
+            "example": 1
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Created At",
+            "format": "date-time"
+          },
+          "databaseType": {
+            "type": "string",
+            "description": "DatabaseType",
+            "example": "MySQL",
+            "enum": [
+              "ALL",
+              "MySQL",
+              "MariaDB",
+              "PostgreSQL",
+              "Hana",
+              "Snowflake",
+              "Redshift",
+              "BigQuery",
+              "Presto",
+              "SQLServer",
+              "AzureSQL",
+              "Oracle",
+              "Tibero",
+              "Hive",
+              "MongoDB",
+              "HBase",
+              "Cassandra",
+              "DynamoDB",
+              "Trino",
+              "Impala",
+              "Greenplum",
+              "EnterpriseDB",
+              "DocumentDB",
+              "ScyllaDB",
+              "Athena",
+              "Redis",
+              "SingleStore",
+              "Vertica",
+              "OpenSearch",
+              "Spanner",
+              "DrSum",
+              "Teradata",
+              "CustomDataSource",
+              "ClickHouse",
+              "ShardingSphereMySql"
+            ]
+          },
+          "dbHost": {
+            "type": "string",
+            "description": "DB Host",
+            "example": "db.host.com"
+          },
+          "dbName": {
+            "type": "string",
+            "description": "Database Name",
+            "example": "information_schema"
+          },
+          "dbUser": {
+            "type": "string",
+            "description": "Database User Name",
+            "example": "system"
+          },
+          "email": {
+            "type": "string",
+            "description": "Email",
+            "example": "brant@querypie.com"
+          },
+          "execIp": {
+            "type": "string",
+            "description": "Executed Machine IP",
+            "example": "192.168.0.1"
+          },
+          "execMillis": {
+            "type": "integer",
+            "description": "Execution Time (Millis)",
+            "format": "int32",
+            "example": 200
+          },
+          "execResult": {
+            "type": "boolean",
+            "writeOnly": true,
+            "deprecated": true
+          },
+          "executedAt": {
+            "type": "string",
+            "description": "Executed At",
+            "format": "date-time"
+          },
+          "expRows": {
+            "type": "integer",
+            "description": "Executed Rows",
+            "format": "int64",
+            "example": 200
+          },
+          "hostName": {
+            "type": "string",
+            "description": "Executor's Host Name",
+            "example": "Desktop-PC-No-1"
+          },
+          "id": {
+            "type": "integer",
+            "description": "ID",
+            "format": "int64"
+          },
+          "isExecResult": {
+            "type": "boolean",
+            "deprecated": true
+          },
+          "isPrevented": {
+            "type": "boolean"
+          },
+          "prevented": {
+            "type": "boolean",
+            "writeOnly": true
+          },
+          "privilegeTypes": {
+            "type": "string",
+            "description": "Privilege Types",
+            "example": "SELECT, DDL_ALTER"
+          },
+          "reasonComment": {
+            "type": "string",
+            "description": "Reason Comment",
+            "example": "..."
+          },
+          "replicationType": {
+            "type": "string",
+            "description": "Replication Type",
+            "example": "MASTER / SLAVE / SINGLE"
+          },
+          "sqlText": {
+            "type": "string",
+            "description": "DML Text",
+            "example": "DML Statement"
+          },
+          "sqlType": {
+            "type": "string",
+            "description": "DML Type",
+            "example": "select / update / delete ..."
+          },
+          "state": {
+            "type": "string",
+            "description": "State",
+            "example": "SUCCESS, FAILURE, STOPPED, PREVENTED, RUNNING, ABORTED",
+            "enum": [
+              "SUCCESS",
+              "FAILURE",
+              "STOPPED",
+              "RUNNING",
+              "ABORTED"
+            ]
+          },
+          "userId": {
+            "type": "integer",
+            "description": "User ID",
+            "format": "int64",
+            "example": 1
+          },
+          "userName": {
+            "type": "string",
+            "description": "User Name",
+            "example": "Brant"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "UUID",
+            "example": "UUID"
+          }
+        }
+      },
+      "com.querypie.dbam.controller.dto.ExternalUserAuthHistoryDto$Response": {
+        "required": [
+          "error",
+          "id"
+        ],
+        "type": "object",
+        "properties": {
+          "actionAt": {
+            "type": "string",
+            "description": "액션 생성일자",
+            "format": "date-time"
+          },
+          "actionType": {
+            "type": "string",
+            "description": "액션 종류",
+            "example": "CONNECT",
+            "enum": [
+              "CONNECT",
+              "DISCONNECT"
+            ]
+          },
+          "authType": {
+            "type": "string",
+            "description": "인증 종류 (LDAP, DB, ETC)",
+            "example": "LDAP"
+          },
+          "clientIp": {
+            "type": "string",
+            "description": "클라이언트 IP",
+            "example": "192.168.0.1"
+          },
+          "cloudProviderName": {
+            "type": "string",
+            "description": "Cloud Provider Name",
+            "example": "Dev"
+          },
+          "cloudProviderType": {
+            "type": "string",
+            "description": "Cloud Provider Type",
+            "example": "AWS | GCP | AZURE",
+            "enum": [
+              "NONE",
+              "AWS",
+              "AZURE",
+              "GCP"
+            ]
+          },
+          "cloudProviderUuid": {
+            "type": "string",
+            "description": "Cloud Provider UUID",
+            "example": "UUID"
+          },
+          "clusterGroupName": {
+            "type": "string",
+            "description": "클러스터 그룹 이름",
+            "example": "QueryPie Cluster Group"
+          },
+          "dbHost": {
+            "type": "string",
+            "description": "DB Host",
+            "example": "user01"
+          },
+          "dbUser": {
+            "type": "string",
+            "description": "DB 사용자 ID",
+            "example": "user01"
+          },
+          "error": {
+            "type": "boolean",
+            "description": "에러 여부",
+            "example": false
+          },
+          "errorMessage": {
+            "type": "string",
+            "description": "에러 메시지",
+            "example": "SQLException"
+          },
+          "hostName": {
+            "type": "string",
+            "description": "인스턴스 호스트 이름",
+            "example": "cluster.chequer.com"
+          },
+          "id": {
+            "type": "integer",
+            "description": "사용자 인증 히스토리 ID",
+            "format": "int64",
+            "example": 1
+          },
+          "replicationType": {
+            "type": "string",
+            "description": "Replication Type",
+            "example": "MASTER",
+            "enum": [
+              "MASTER",
+              "SLAVE",
+              "SINGLE"
+            ]
+          },
+          "userId": {
+            "type": "integer",
+            "description": "사용자 ID",
+            "format": "int64",
+            "example": 1
+          },
+          "userLoginId": {
+            "type": "string",
+            "description": "사용자 아이디",
+            "example": "brant"
+          },
+          "userName": {
+            "type": "string",
+            "description": "사용자 이름",
+            "example": "Brant Hwang"
+          }
+        },
+        "description": "Object list per entry"
+      },
+      "com.querypie.dbam.domain.policy.Policy": {
+        "required": [
+          "deleted",
+          "enabled",
+          "isDeleted",
+          "objectType",
+          "objectUuid",
+          "policyUuid",
+          "title",
+          "type",
+          "uuid",
+          "version"
+        ],
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "deleted": {
+            "type": "boolean"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "isDeleted": {
+            "type": "boolean"
+          },
+          "objectType": {
+            "type": "string",
+            "enum": [
+              "UNDEFINED",
+              "SYSTEM",
+              "CLUSTER_GROUP",
+              "CLUSTER",
+              "INSTANCE",
+              "CLOUD_PROVIDER",
+              "NETWORK_ZONE",
+              "SERVER",
+              "SERVER_GROUP",
+              "SERVER_PROVIDER",
+              "K8S_CLUSTER",
+              "KUBE_CLUSTER_PROVIDER",
+              "DISCOVERY_JOB",
+              "SERVER_PASSWORD_PROVISION_JOB",
+              "SERVER_AD_PASSWORD_PROVISION_JOB",
+              "SERVER_AD_PASSWORD_PROVISION_STATUS_UPDATE_JOB",
+              "REPORT_FILE_DELETE_JOB",
+              "WEB_APP"
+            ]
+          },
+          "objectUuid": {
+            "type": "string"
+          },
+          "policyUuid": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "DATA_LEVEL",
+              "DATA_ACCESS",
+              "DATA_MASKING",
+              "NOTIFICATION",
+              "LEDGER"
+            ]
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedBy": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "uuid": {
+            "type": "string"
+          },
+          "version": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "com.querypie.dbam.domain.policy.data.access.AccessRule": {
+        "required": [
+          "deleted",
+          "isDeleted",
+          "objectPathUuid",
+          "policyType",
+          "policyUuid",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "deleted": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "isDeleted": {
+            "type": "boolean"
+          },
+          "objectPathUuid": {
+            "type": "string"
+          },
+          "policy": {
+            "$ref": "#/components/schemas/com.querypie.dbam.domain.policy.Policy"
+          },
+          "policyType": {
+            "type": "string",
+            "enum": [
+              "DATA_LEVEL",
+              "DATA_ACCESS",
+              "DATA_MASKING",
+              "NOTIFICATION",
+              "LEDGER"
+            ]
+          },
+          "policyUuid": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedBy": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "uuid": {
+            "type": "string"
+          }
+        }
+      },
+      "com.querypie.dbam.domain.policy.data.level.PolicyDataLevel": {
+        "required": [
+          "deleted",
+          "events",
+          "isDeleted",
+          "level",
+          "objectPathUuid",
+          "policyType",
+          "policyUuid",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "deleted": {
+            "type": "boolean"
+          },
+          "events": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "isDeleted": {
+            "type": "boolean"
+          },
+          "level": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "objectPath": {
+            "$ref": "#/components/schemas/com.querypie.dbam.domain.policy.objects.path.ObjectPathEntity"
+          },
+          "objectPathUuid": {
+            "type": "string"
+          },
+          "policy": {
+            "$ref": "#/components/schemas/com.querypie.dbam.domain.policy.Policy"
+          },
+          "policyType": {
+            "type": "string",
+            "enum": [
+              "DATA_LEVEL",
+              "DATA_ACCESS",
+              "DATA_MASKING",
+              "NOTIFICATION",
+              "LEDGER"
+            ]
+          },
+          "policyUuid": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedBy": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "uuid": {
+            "type": "string"
+          }
+        }
+      },
+      "com.querypie.dbam.domain.policy.data.masking.pattern.MaskingPattern": {
+        "required": [
+          "deleted",
+          "description",
+          "detectingPattern",
+          "isDeleted",
+          "maskingPattern",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "deleted": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string"
+          },
+          "detectingPattern": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "isDeleted": {
+            "type": "boolean"
+          },
+          "maskingPattern": {
+            "type": "string"
+          },
+          "rawData": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedBy": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "uuid": {
+            "type": "string"
+          }
+        }
+      },
+      "com.querypie.dbam.domain.policy.data.masking.rules.MaskingRule": {
+        "required": [
+          "deleted",
+          "isDeleted",
+          "objectPathUuid",
+          "patternId",
+          "policyRuleUsersAsList",
+          "policyType",
+          "policyUuid",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "deleted": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "isDeleted": {
+            "type": "boolean"
+          },
+          "objectPath": {
+            "$ref": "#/components/schemas/com.querypie.dbam.domain.policy.objects.path.ObjectPathEntity"
+          },
+          "objectPathUuid": {
+            "type": "string"
+          },
+          "pattern": {
+            "$ref": "#/components/schemas/com.querypie.dbam.domain.policy.data.masking.pattern.MaskingPattern"
+          },
+          "patternId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "policy": {
+            "$ref": "#/components/schemas/com.querypie.dbam.domain.policy.Policy"
+          },
+          "policyRuleUsers": {
+            "uniqueItems": true,
+            "type": "array",
+            "writeOnly": true,
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.dbam.domain.policy.rule.user.PolicyRuleUser"
+            }
+          },
+          "policyRuleUsersAsList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.dbam.domain.policy.rule.user.PolicyRuleUser"
+            }
+          },
+          "policyType": {
+            "type": "string",
+            "enum": [
+              "DATA_LEVEL",
+              "DATA_ACCESS",
+              "DATA_MASKING",
+              "NOTIFICATION",
+              "LEDGER"
+            ]
+          },
+          "policyUuid": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedBy": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "uuid": {
+            "type": "string"
+          }
+        }
+      },
+      "com.querypie.dbam.domain.policy.objects.path.LegacyQualifiedObjectPath": {
+        "required": [
+          "databaseName",
+          "databaseObjectType",
+          "objectPath",
+          "objectPathItems",
+          "tableName"
+        ],
+        "type": "object",
+        "properties": {
+          "columnName": {
+            "type": "string"
+          },
+          "databaseName": {
+            "type": "string"
+          },
+          "databaseObjectType": {
+            "type": "string",
+            "enum": [
+              "TABLE",
+              "COLUMN"
+            ]
+          },
+          "objectPath": {
+            "$ref": "#/components/schemas/com.querypie.dbam.domain.policy.objects.path.ObjectPathEntity"
+          },
+          "objectPathItems": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.dbam.domain.policy.objects.path.ObjectPathItemEntity"
+            }
+          },
+          "tableName": {
+            "type": "string"
+          }
+        }
+      },
+      "com.querypie.dbam.domain.policy.objects.path.ObjectPathEntity": {
+        "required": [
+          "fullPathHash",
+          "objectPathItemsAsList",
+          "type",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "fullPathHash": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "objectPathItemsAsList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.dbam.domain.policy.objects.path.ObjectPathItemEntity"
+            }
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "DATABASE",
+              "SCHEMA",
+              "TABLE",
+              "COLUMN"
+            ]
+          },
+          "uuid": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "com.querypie.dbam.domain.policy.objects.path.ObjectPathItemEntity": {
+        "required": [
+          "objectPathUuid",
+          "type",
+          "value"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "objectPath": {
+            "$ref": "#/components/schemas/com.querypie.dbam.domain.policy.objects.path.ObjectPathEntity"
+          },
+          "objectPathUuid": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "DATABASE",
+              "SCHEMA",
+              "TABLE",
+              "COLUMN"
+            ]
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "com.querypie.dbam.domain.policy.rule.user.PolicyRuleUser": {
+        "required": [
+          "isDeleted",
+          "policyType",
+          "ruleUuid",
+          "userUuid",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "deleted": {
+            "type": "boolean",
+            "writeOnly": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "isDeleted": {
+            "type": "boolean"
+          },
+          "maskingRule": {
+            "$ref": "#/components/schemas/com.querypie.dbam.domain.policy.data.masking.rules.MaskingRule"
+          },
+          "policyType": {
+            "type": "string",
+            "enum": [
+              "DATA_LEVEL",
+              "DATA_ACCESS",
+              "DATA_MASKING",
+              "NOTIFICATION",
+              "LEDGER"
+            ]
+          },
+          "ruleUuid": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedBy": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "userUuid": {
+            "type": "string"
+          },
+          "uuid": {
+            "type": "string"
+          }
+        }
+      },
+      "com.querypie.iam.controller.dto.ExternalUserDto$CreateRequest": {
+        "required": [
+          "email",
+          "loginId",
+          "name",
+          "password"
+        ],
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "Email",
+            "example": "brant@querypie.com"
+          },
+          "loginId": {
+            "type": "string",
+            "description": "Login ID",
+            "example": "brant"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name",
+            "example": "Brant"
+          },
+          "password": {
+            "type": "string",
+            "description": "Password"
+          }
+        }
+      },
+      "com.querypie.iam.controller.dto.ExternalUserDto$Response": {
+        "required": [
+          "deleted",
+          "expired",
+          "locked"
+        ],
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "description": "Created At",
+            "format": "date-time"
+          },
+          "deleted": {
+            "type": "boolean",
+            "description": "Deleted",
+            "example": false
+          },
+          "email": {
+            "type": "string",
+            "description": "Email",
+            "example": "brant@querypie.com"
+          },
+          "expired": {
+            "type": "boolean",
+            "description": "Expired",
+            "example": false
+          },
+          "lastLoginAt": {
+            "type": "string",
+            "description": "Last Login At",
+            "format": "date-time"
+          },
+          "locked": {
+            "type": "boolean",
+            "description": "Locked",
+            "example": false
+          },
+          "loginId": {
+            "type": "string",
+            "description": "Login ID",
+            "example": "brant"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name",
+            "example": "Brant"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Updated At",
+            "format": "date-time"
+          },
+          "userRoles": {
+            "type": "array",
+            "description": "UserRoles",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.iam.controller.dto.UserRoleDto$Response"
+            }
+          },
+          "uuid": {
+            "type": "string",
+            "description": "UUID",
+            "example": "UUID"
+          }
+        }
+      },
+      "com.querypie.iam.controller.dto.ExternalUserDto$UpdateRequest": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "Email",
+            "example": "brant@querypie.com"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name",
+            "example": "Brant"
+          },
+          "password": {
+            "type": "string",
+            "description": "Password"
+          }
+        }
+      },
+      "com.querypie.iam.controller.dto.ExternalUserDto$UserChangeStatusRequest": {
+        "required": [
+          "reasonForChangeStatus",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "reasonForChangeStatus": {
+            "type": "string",
+            "description": "Reason for change"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "Target user uuid"
+          }
+        }
+      },
+      "com.querypie.iam.controller.dto.ExternalUserGroupDto$CreateRequest": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name",
+            "example": "Brant"
+          }
+        }
+      },
+      "com.querypie.iam.controller.dto.ExternalUserGroupDto$Response": {
+        "required": [
+          "createdAt",
+          "name",
+          "updatedAt",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "description": "Created At",
+            "format": "date-time"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name",
+            "example": "Brant"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Updated At",
+            "format": "date-time"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "UUID",
+            "example": "UUID"
+          }
+        }
+      },
+      "com.querypie.iam.controller.dto.ExternalUserGroupDto$UpdateRequest": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name",
+            "example": "Brant"
+          }
+        }
+      },
+      "com.querypie.iam.controller.dto.ExternalUserResponse": {
+        "required": [
+          "loginId",
+          "name",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "loginId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "uuid": {
+            "type": "string"
+          }
+        },
+        "description": "Updated User",
+        "example": "User Information"
+      },
+      "com.querypie.iam.controller.dto.RoleDto$Response": {
+        "required": [
+          "name",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Role Name"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "Role UUID"
+          }
+        },
+        "description": "Role"
+      },
+      "com.querypie.iam.controller.dto.UserRoleDto$CreateRequest": {
+        "required": [
+          "roleUuid",
+          "userUuid"
+        ],
+        "type": "object",
+        "properties": {
+          "roleUuid": {
+            "type": "string",
+            "description": "Role UUID",
+            "example": "UUID"
+          },
+          "userUuid": {
+            "type": "string",
+            "description": "User UUID",
+            "example": "UUID"
+          }
+        },
+        "description": "Connection Owner"
+      },
+      "com.querypie.iam.controller.dto.UserRoleDto$Response": {
+        "required": [
+          "objectType",
+          "objectUuid",
+          "role",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "objectType": {
+            "type": "string",
+            "description": "Object Type",
+            "example": "COMPANY",
+            "enum": [
+              "UNDEFINED",
+              "SYSTEM",
+              "CLUSTER_GROUP",
+              "CLUSTER",
+              "INSTANCE",
+              "CLOUD_PROVIDER",
+              "NETWORK_ZONE",
+              "SERVER",
+              "SERVER_GROUP",
+              "SERVER_PROVIDER",
+              "K8S_CLUSTER",
+              "KUBE_CLUSTER_PROVIDER",
+              "DISCOVERY_JOB",
+              "SERVER_PASSWORD_PROVISION_JOB",
+              "SERVER_AD_PASSWORD_PROVISION_JOB",
+              "SERVER_AD_PASSWORD_PROVISION_STATUS_UPDATE_JOB",
+              "REPORT_FILE_DELETE_JOB",
+              "WEB_APP"
+            ]
+          },
+          "objectUuid": {
+            "type": "string",
+            "description": "Object UUID"
+          },
+          "role": {
+            "$ref": "#/components/schemas/com.querypie.iam.controller.dto.RoleDto$Response"
+          },
+          "user": {
+            "$ref": "#/components/schemas/com.querypie.iam.interfaces.client.UserModel"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "UserRole UUID"
+          }
+        },
+        "description": "Object list per entry"
+      },
+      "com.querypie.iam.controller.dto.UserRoleDto$UpdateRequest": {
+        "required": [
+          "roleUuid",
+          "userUuid"
+        ],
+        "type": "object",
+        "properties": {
+          "roleUuid": {
+            "type": "string",
+            "description": "Role UUID",
+            "example": "UUID"
+          },
+          "userUuid": {
+            "type": "string",
+            "description": "User UUID",
+            "example": "UUID"
+          }
+        },
+        "description": "Connection Owner"
+      },
+      "com.querypie.iam.controller.dto.UserRoleDto$UserAccessLevelUpdateRequest": {
+        "required": [
+          "roleUuids"
+        ],
+        "type": "object",
+        "properties": {
+          "roleUuids": {
+            "type": "array",
+            "description": "Role UUID",
+            "example": "UUID",
+            "items": {
+              "type": "string",
+              "description": "Role UUID",
+              "example": "UUID"
+            }
+          }
+        }
+      },
+      "com.querypie.iam.interfaces.client.UserModel": {
+        "required": [
+          "active",
+          "authProvider",
+          "deleted",
+          "email",
+          "id",
+          "isGroup",
+          "loginId",
+          "master",
+          "status",
+          "type",
+          "userName",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "active": {
+            "type": "boolean"
+          },
+          "authProvider": {
+            "type": "string",
+            "enum": [
+              "swivelsecure",
+              "db",
+              "ldap",
+              "okta",
+              "onelogin",
+              "saml",
+              "custom"
+            ]
+          },
+          "deleted": {
+            "type": "boolean"
+          },
+          "email": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "isGroup": {
+            "type": "boolean"
+          },
+          "loginId": {
+            "type": "string"
+          },
+          "master": {
+            "type": "boolean"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "ACCOUNT_LOCK",
+              "NORMAL",
+              "INVITED",
+              "EXPIRED",
+              "INACTIVE"
+            ]
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "USER",
+              "GROUP",
+              "API"
+            ]
+          },
+          "userName": {
+            "type": "string"
+          },
+          "uuid": {
+            "type": "string"
+          }
+        },
+        "description": "User"
+      },
+      "com.querypie.newworkflow.interfaces.external.v1.ExternalAccessApprovalDto$Response": {
+        "required": [
+          "approvalStatus",
+          "createdAt",
+          "createdUser",
+          "id",
+          "type",
+          "updatedAt",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "approvalStatus": {
+            "type": "string",
+            "description": "Approval Status",
+            "example": "PENDING",
+            "enum": [
+              "PENDING",
+              "IN_PROGRESS",
+              "APPROVED",
+              "REJECTED",
+              "CANCELED",
+              "EXPIRED"
+            ]
+          },
+          "connections": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v1.ExternalApprovalConnectionDto$Response"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Approval Created At",
+            "format": "date-time"
+          },
+          "createdUser": {
+            "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserResponse"
+          },
+          "description": {
+            "type": "string",
+            "description": "Approval Description",
+            "example": "Approval Description"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Approval ID",
+            "format": "int64"
+          },
+          "lines": {
+            "type": "array",
+            "description": "Assignees",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v1.ExternalApprovalLineDto$Response"
+            }
+          },
+          "title": {
+            "type": "string",
+            "description": "Approval Title",
+            "example": "Approval Title"
+          },
+          "type": {
+            "type": "string",
+            "description": "Approval Type",
+            "example": "ACCESS",
+            "enum": [
+              "SQL",
+              "ACCESS",
+              "EXPORT"
+            ]
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Approval Updated At",
+            "format": "date-time"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "Approval UUID",
+            "example": "UUID"
+          }
+        },
+        "description": "Object list per entry"
+      },
+      "com.querypie.newworkflow.interfaces.external.v1.ExternalApprovalConnectionDto$Response": {
+        "required": [
+          "clusterGroupUuid",
+          "clusterUuid"
+        ],
+        "type": "object",
+        "properties": {
+          "clusterGroupDescription": {
+            "type": "string",
+            "description": "Cluster Group Description",
+            "example": "Cluster Group description"
+          },
+          "clusterGroupName": {
+            "type": "string",
+            "description": "Cluster Group Name",
+            "example": "Cluster Group Name"
+          },
+          "clusterGroupUuid": {
+            "type": "string",
+            "description": "Cluster Group UUID",
+            "example": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3"
+          },
+          "clusterHost": {
+            "type": "string",
+            "description": "Cluster Host",
+            "example": "Cluster Host"
+          },
+          "clusterReplicationType": {
+            "type": "string",
+            "description": "Cluster Replication Type",
+            "example": "`MASTER`, `SLAVE`, `SINGLE`"
+          },
+          "clusterUuid": {
+            "type": "string",
+            "description": "Cluster UUID",
+            "example": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3"
+          },
+          "databaseName": {
+            "type": "string",
+            "description": "Database Name",
+            "example": "Database Name"
+          },
+          "roleName": {
+            "type": "string",
+            "description": "Role Name",
+            "example": "Role Name"
+          },
+          "roleUuid": {
+            "type": "string",
+            "description": "Role UUID",
+            "example": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3"
+          },
+          "schemaName": {
+            "type": "string",
+            "description": "Schema Name",
+            "example": "Schema Name"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "UUID",
+            "example": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3"
+          }
+        }
+      },
+      "com.querypie.newworkflow.interfaces.external.v1.ExternalApprovalDto$Response": {
+        "required": [
+          "approvalStatus",
+          "createdAt",
+          "createdUser",
+          "id",
+          "type",
+          "updatedAt",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "approvalStatus": {
+            "type": "string",
+            "description": "Approval Status",
+            "example": "PENDING",
+            "enum": [
+              "PENDING",
+              "IN_PROGRESS",
+              "APPROVED",
+              "REJECTED",
+              "CANCELED",
+              "EXPIRED"
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Approval Created At",
+            "format": "date-time"
+          },
+          "createdUser": {
+            "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserResponse"
+          },
+          "description": {
+            "type": "string",
+            "description": "Approval Description",
+            "example": "Approval Description"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Approval ID",
+            "format": "int64"
+          },
+          "lines": {
+            "type": "array",
+            "description": "Assignees",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v1.ExternalApprovalLineDto$Response"
+            }
+          },
+          "title": {
+            "type": "string",
+            "description": "Approval Title",
+            "example": "Approval Title"
+          },
+          "type": {
+            "type": "string",
+            "description": "Approval Type",
+            "example": "ACCESS",
+            "enum": [
+              "SQL",
+              "ACCESS",
+              "EXPORT"
+            ]
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Approval Updated At",
+            "format": "date-time"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "Approval UUID",
+            "example": "UUID"
+          }
+        },
+        "description": "Object list per entry"
+      },
+      "com.querypie.newworkflow.interfaces.external.v1.ExternalApprovalDto$ReviewRequest": {
+        "type": "object",
+        "properties": {
+          "connectionUuids": {
+            "type": "array",
+            "description": "Approval Connection UUID",
+            "example": [
+              "97b155ec-a280-11eb-beef-0ad7e958898e",
+              "b05e480e-b7bc-4f7e-82fe-d23d805c51bf"
+            ],
+            "items": {
+              "type": "string",
+              "description": "Approval Connection UUID",
+              "example": "[\"97b155ec-a280-11eb-beef-0ad7e958898e\",\"b05e480e-b7bc-4f7e-82fe-d23d805c51bf\"]"
+            }
+          }
+        }
+      },
+      "com.querypie.newworkflow.interfaces.external.v1.ExternalApprovalLineDto$Response": {
+        "required": [
+          "actionAt",
+          "status",
+          "step",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "actionAt": {
+            "type": "string",
+            "description": "Approval action At",
+            "format": "date-time"
+          },
+          "comment": {
+            "type": "string",
+            "description": "Approval Line Comment",
+            "example": "comment"
+          },
+          "status": {
+            "type": "string",
+            "description": "Approval Line Status",
+            "example": "APPROVED",
+            "enum": [
+              "NONE",
+              "PENDING",
+              "CANCELED",
+              "APPROVED",
+              "REJECTED",
+              "EXECUTED",
+              "UNREAD",
+              "CONFIRMED"
+            ]
+          },
+          "step": {
+            "type": "integer",
+            "description": "Approval Line Step",
+            "format": "int32",
+            "example": 1
+          },
+          "type": {
+            "type": "string",
+            "description": "Approval Line Type",
+            "example": "APPROVER",
+            "enum": [
+              "APPROVER",
+              "EXECUTOR",
+              "REVIEWER"
+            ]
+          },
+          "userDepartment": {
+            "type": "string"
+          },
+          "userEmail": {
+            "type": "string"
+          },
+          "userLoginId": {
+            "type": "string"
+          },
+          "userName": {
+            "type": "string"
+          },
+          "userType": {
+            "type": "string",
+            "enum": [
+              "USER",
+              "GROUP",
+              "API"
+            ]
+          },
+          "userUuid": {
+            "type": "string"
+          }
+        },
+        "description": "Assignees"
+      },
+      "com.querypie.newworkflow.interfaces.external.v1.ExternalApprovalRuleDto$PartialResponse": {
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "description": "Created At",
+            "format": "date-time"
+          },
+          "name": {
+            "type": "string",
+            "description": "NAME",
+            "example": "Default Rule"
+          },
+          "requestType": {
+            "type": "string",
+            "description": "Request Type",
+            "example": "SQL",
+            "enum": [
+              "SQL",
+              "ACCESS",
+              "EXPORT"
+            ]
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Updated At",
+            "format": "date-time"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "UUID",
+            "example": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3"
+          }
+        },
+        "description": "Object list per entry"
+      },
+      "com.querypie.newworkflow.interfaces.external.v1.ExternalApprovalRuleDto$Response": {
+        "required": [
+          "urgentMode"
+        ],
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "description": "Created At",
+            "format": "date-time"
+          },
+          "executionCondition": {
+            "type": "string",
+            "description": "Execution Condition",
+            "example": "ADMIN_ONLY",
+            "enum": [
+              "ADMIN_ONLY",
+              "ALL_USERS",
+              "FIXED",
+              "CONNECTION_OWNER",
+              "SERVER_GROUP_OWNER",
+              "WEB_APP_OWNER",
+              "ATTRIBUTE_BASED"
+            ]
+          },
+          "lines": {
+            "type": "array",
+            "description": "Approval Lines",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v1.ExternalApprovalRuleLineDto$Response"
+            }
+          },
+          "name": {
+            "type": "string",
+            "description": "NAME",
+            "example": "Default Rule"
+          },
+          "requestType": {
+            "type": "string",
+            "description": "Request Type",
+            "example": "SQL",
+            "enum": [
+              "SQL",
+              "ACCESS",
+              "EXPORT"
+            ]
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Updated At",
+            "format": "date-time"
+          },
+          "urgentMode": {
+            "type": "boolean",
+            "description": "Urgent Mode"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "UUID",
+            "example": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3"
+          }
+        }
+      },
+      "com.querypie.newworkflow.interfaces.external.v1.ExternalApprovalRuleLineDto$Response": {
+        "required": [
+          "step"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string",
+            "description": "Resource Type",
+            "example": "USER",
+            "enum": [
+              "USER",
+              "GROUP"
+            ]
+          },
+          "resourceUuid": {
+            "type": "string",
+            "description": "UUID of Resource Type",
+            "example": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3"
+          },
+          "step": {
+            "type": "integer",
+            "description": "Step",
+            "format": "int32",
+            "example": 1,
+            "default": 0
+          },
+          "type": {
+            "type": "string",
+            "description": "Approval Line Type",
+            "example": "APPROVER",
+            "enum": [
+              "APPROVER",
+              "EXECUTOR",
+              "REVIEWER"
+            ]
+          }
+        },
+        "description": "Approval Lines"
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$AccessRequestResponse": {
+        "required": [
+          "accessControls",
+          "urgent"
+        ],
+        "type": "object",
+        "properties": {
+          "accessControls": {
+            "type": "array",
+            "description": "Approval accesses",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$AccessRequestResponse$AccessControl"
+            }
+          },
+          "approvalStatus": {
+            "type": "string",
+            "description": "Approval status",
+            "enum": [
+              "PENDING",
+              "IN_PROGRESS",
+              "APPROVED",
+              "REJECTED",
+              "CANCELED",
+              "EXPIRED"
+            ]
+          },
+          "approvalSteps": {
+            "type": "array",
+            "description": "Steps",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$StepResponse"
+            }
+          },
+          "canceledAt": {
+            "type": "string",
+            "description": "Canceled at",
+            "format": "date-time"
+          },
+          "comments": {
+            "type": "string",
+            "description": "Comments"
+          },
+          "executionStatus": {
+            "type": "string",
+            "description": "Execution status",
+            "enum": [
+              "NONE",
+              "PENDING",
+              "EXECUTING",
+              "SUCCESS",
+              "FAILURE",
+              "CANCELED",
+              "EXPIRED"
+            ]
+          },
+          "expiryAt": {
+            "type": "string",
+            "description": "Expiry at(Due Date)",
+            "format": "date-time"
+          },
+          "requestType": {
+            "type": "string",
+            "description": "Request type",
+            "enum": [
+              "IP_REGISTRATION",
+              "DB_ACCESS_CONTROL",
+              "SQL_EXECUTION",
+              "DATA_EXPORT",
+              "SERVER_ACCESS_CONTROL",
+              "ACCESS_ROLE",
+              "UNMASKING",
+              "SERVER_PRIVILEGE",
+              "WEB_APP_JUST_IN_TIME_ACCESS_CONTROL",
+              "DECRYPTION",
+              "RESTRICTED_DATA_ACCESS",
+              "DB_POLICY_EXCEPTION"
+            ]
+          },
+          "requestedAt": {
+            "type": "string",
+            "description": "Requested at",
+            "format": "date-time"
+          },
+          "requestedBy": {
+            "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserResponse"
+          },
+          "reviewAssignees": {
+            "type": "array",
+            "description": "Reviewers",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$ReviewAssigneeResponse"
+            }
+          },
+          "rule": {
+            "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$WorkflowRequestResponse$Rule"
+          },
+          "title": {
+            "type": "string",
+            "description": "Title"
+          },
+          "urgent": {
+            "type": "boolean",
+            "description": "Urgent mode"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "UUID",
+            "format": "uuid"
+          }
+        }
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$AccessRequestResponse$AccessControl": {
+        "required": [
+          "clusterRoleDeleted",
+          "clusterRoleName",
+          "clusterRoleUuid",
+          "connectionResponse",
+          "granted"
+        ],
+        "type": "object",
+        "properties": {
+          "clusterRoleDeleted": {
+            "type": "boolean",
+            "description": "Cluster role deleted flag"
+          },
+          "clusterRoleName": {
+            "type": "string",
+            "description": "Cluster role name"
+          },
+          "clusterRoleUuid": {
+            "type": "string",
+            "description": "Cluster role UUID",
+            "format": "uuid"
+          },
+          "connectionResponse": {
+            "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$ConnectionResponse"
+          },
+          "granted": {
+            "type": "boolean",
+            "description": "Granted"
+          }
+        },
+        "description": "Approval accesses"
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$ConnectionResponse": {
+        "required": [
+          "cluster",
+          "clusterGroup",
+          "deleted",
+          "objectType"
+        ],
+        "type": "object",
+        "properties": {
+          "cluster": {
+            "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$ConnectionResponse$Cluster"
+          },
+          "clusterGroup": {
+            "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$ConnectionResponse$ClusterGroup"
+          },
+          "deleted": {
+            "type": "boolean",
+            "description": "Deleted"
+          },
+          "objectType": {
+            "type": "string",
+            "description": "Object type",
+            "enum": [
+              "UNDEFINED",
+              "SYSTEM",
+              "CLUSTER_GROUP",
+              "CLUSTER",
+              "INSTANCE",
+              "CLOUD_PROVIDER",
+              "NETWORK_ZONE",
+              "SERVER",
+              "SERVER_GROUP",
+              "SERVER_PROVIDER",
+              "K8S_CLUSTER",
+              "KUBE_CLUSTER_PROVIDER",
+              "DISCOVERY_JOB",
+              "SERVER_PASSWORD_PROVISION_JOB",
+              "SERVER_AD_PASSWORD_PROVISION_JOB",
+              "SERVER_AD_PASSWORD_PROVISION_STATUS_UPDATE_JOB",
+              "REPORT_FILE_DELETE_JOB",
+              "WEB_APP"
+            ]
+          }
+        },
+        "description": "Connection"
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$ConnectionResponse$Cluster": {
+        "required": [
+          "name",
+          "replicationType",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name"
+          },
+          "replicationType": {
+            "type": "string",
+            "description": "Replication type",
+            "enum": [
+              "MASTER",
+              "SLAVE",
+              "SINGLE"
+            ]
+          },
+          "uuid": {
+            "type": "string",
+            "description": "UUID",
+            "format": "uuid"
+          }
+        },
+        "description": "Cluster"
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$ConnectionResponse$ClusterGroup": {
+        "required": [
+          "databaseType",
+          "name",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "databaseType": {
+            "type": "string",
+            "description": "Database type",
+            "enum": [
+              "ALL",
+              "MySQL",
+              "MariaDB",
+              "PostgreSQL",
+              "Hana",
+              "Snowflake",
+              "Redshift",
+              "BigQuery",
+              "Presto",
+              "SQLServer",
+              "AzureSQL",
+              "Oracle",
+              "Tibero",
+              "Hive",
+              "MongoDB",
+              "HBase",
+              "Cassandra",
+              "DynamoDB",
+              "Trino",
+              "Impala",
+              "Greenplum",
+              "EnterpriseDB",
+              "DocumentDB",
+              "ScyllaDB",
+              "Athena",
+              "Redis",
+              "SingleStore",
+              "Vertica",
+              "OpenSearch",
+              "Spanner",
+              "DrSum",
+              "Teradata",
+              "CustomDataSource",
+              "ClickHouse",
+              "ShardingSphereMySql"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Name"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "UUID",
+            "format": "uuid"
+          }
+        },
+        "description": "Cluster group"
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$ExecutionAssigneeResponse": {
+        "required": [
+          "assignedUser"
+        ],
+        "type": "object",
+        "properties": {
+          "actionAt": {
+            "type": "string",
+            "description": "Action at",
+            "format": "date-time"
+          },
+          "actionBy": {
+            "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserResponse"
+          },
+          "assignedUser": {
+            "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserResponse"
+          },
+          "comments": {
+            "type": "string",
+            "description": "Comments"
+          },
+          "status": {
+            "type": "string",
+            "description": "Status",
+            "enum": [
+              "NONE",
+              "PENDING",
+              "EXECUTED",
+              "CANCELED"
+            ]
+          },
+          "user": {
+            "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserResponse"
+          }
+        },
+        "description": "Execution assignees"
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$ExportRequestResponse": {
+        "required": [
+          "connection",
+          "contentType",
+          "contentValue",
+          "database",
+          "executionAssignees",
+          "targetDate",
+          "urgent"
+        ],
+        "type": "object",
+        "properties": {
+          "approvalStatus": {
+            "type": "string",
+            "description": "Approval status",
+            "enum": [
+              "PENDING",
+              "IN_PROGRESS",
+              "APPROVED",
+              "REJECTED",
+              "CANCELED",
+              "EXPIRED"
+            ]
+          },
+          "approvalSteps": {
+            "type": "array",
+            "description": "Steps",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$StepResponse"
+            }
+          },
+          "canceledAt": {
+            "type": "string",
+            "description": "Canceled at",
+            "format": "date-time"
+          },
+          "comments": {
+            "type": "string",
+            "description": "Comments"
+          },
+          "connection": {
+            "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$ConnectionResponse"
+          },
+          "contentType": {
+            "type": "string",
+            "description": "Export type. Query Result or Table",
+            "enum": [
+              "TABLE",
+              "QUERY"
+            ]
+          },
+          "contentValue": {
+            "type": "string",
+            "description": "Content value"
+          },
+          "database": {
+            "type": "string",
+            "description": "Database"
+          },
+          "executionAssignees": {
+            "type": "array",
+            "description": "Execution assignees",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$ExecutionAssigneeResponse"
+            }
+          },
+          "executionStatus": {
+            "type": "string",
+            "description": "Execution status",
+            "enum": [
+              "NONE",
+              "PENDING",
+              "EXECUTING",
+              "SUCCESS",
+              "FAILURE",
+              "CANCELED",
+              "EXPIRED"
+            ]
+          },
+          "expiryAt": {
+            "type": "string",
+            "description": "Expiry at(Due Date)",
+            "format": "date-time"
+          },
+          "requestType": {
+            "type": "string",
+            "description": "Request type",
+            "enum": [
+              "IP_REGISTRATION",
+              "DB_ACCESS_CONTROL",
+              "SQL_EXECUTION",
+              "DATA_EXPORT",
+              "SERVER_ACCESS_CONTROL",
+              "ACCESS_ROLE",
+              "UNMASKING",
+              "SERVER_PRIVILEGE",
+              "WEB_APP_JUST_IN_TIME_ACCESS_CONTROL",
+              "DECRYPTION",
+              "RESTRICTED_DATA_ACCESS",
+              "DB_POLICY_EXCEPTION"
+            ]
+          },
+          "requestedAt": {
+            "type": "string",
+            "description": "Requested at",
+            "format": "date-time"
+          },
+          "requestedBy": {
+            "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserResponse"
+          },
+          "reviewAssignees": {
+            "type": "array",
+            "description": "Reviewers",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$ReviewAssigneeResponse"
+            }
+          },
+          "rule": {
+            "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$WorkflowRequestResponse$Rule"
+          },
+          "targetDate": {
+            "type": "string",
+            "description": "Target date",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string",
+            "description": "Title"
+          },
+          "urgent": {
+            "type": "boolean",
+            "description": "Urgent mode"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "UUID",
+            "format": "uuid"
+          }
+        }
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$PageResponse": {
+        "required": [
+          "approvalStatus",
+          "executionStatus",
+          "requestType",
+          "requestedAt",
+          "requester",
+          "title",
+          "updatedAt",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "approvalStatus": {
+            "type": "string",
+            "description": "Approval status",
+            "enum": [
+              "PENDING",
+              "IN_PROGRESS",
+              "APPROVED",
+              "REJECTED",
+              "CANCELED",
+              "EXPIRED"
+            ]
+          },
+          "executionStatus": {
+            "type": "string",
+            "description": "Execution status",
+            "enum": [
+              "NONE",
+              "PENDING",
+              "EXECUTING",
+              "SUCCESS",
+              "FAILURE",
+              "CANCELED",
+              "EXPIRED"
+            ]
+          },
+          "requestType": {
+            "type": "string",
+            "description": "Request type",
+            "enum": [
+              "IP_REGISTRATION",
+              "DB_ACCESS_CONTROL",
+              "SQL_EXECUTION",
+              "DATA_EXPORT",
+              "SERVER_ACCESS_CONTROL",
+              "ACCESS_ROLE",
+              "UNMASKING",
+              "SERVER_PRIVILEGE",
+              "WEB_APP_JUST_IN_TIME_ACCESS_CONTROL",
+              "DECRYPTION",
+              "RESTRICTED_DATA_ACCESS",
+              "DB_POLICY_EXCEPTION"
+            ]
+          },
+          "requestedAt": {
+            "type": "string",
+            "description": "Requested at",
+            "format": "date-time"
+          },
+          "requester": {
+            "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserResponse"
+          },
+          "title": {
+            "type": "string",
+            "description": "Title"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Updated at",
+            "format": "date-time"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "UUID",
+            "format": "uuid"
+          }
+        },
+        "description": "Object list per entry"
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$ReviewAssigneeResponse": {
+        "required": [
+          "assignedUser"
+        ],
+        "type": "object",
+        "properties": {
+          "actionAt": {
+            "type": "string",
+            "description": "Action at",
+            "format": "date-time"
+          },
+          "actionBy": {
+            "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserResponse"
+          },
+          "assignedUser": {
+            "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserResponse"
+          },
+          "comments": {
+            "type": "string",
+            "description": "Comments"
+          },
+          "status": {
+            "type": "string",
+            "description": "Status",
+            "enum": [
+              "NONE",
+              "UNREAD",
+              "CONFIRM"
+            ]
+          },
+          "user": {
+            "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserResponse"
+          }
+        },
+        "description": "Reviewers"
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$SqlRequestResponse": {
+        "required": [
+          "connection",
+          "contentType",
+          "contentValue",
+          "database",
+          "executionAssignees",
+          "targetDate",
+          "urgent"
+        ],
+        "type": "object",
+        "properties": {
+          "approvalStatus": {
+            "type": "string",
+            "description": "Approval status",
+            "enum": [
+              "PENDING",
+              "IN_PROGRESS",
+              "APPROVED",
+              "REJECTED",
+              "CANCELED",
+              "EXPIRED"
+            ]
+          },
+          "approvalSteps": {
+            "type": "array",
+            "description": "Steps",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$StepResponse"
+            }
+          },
+          "canceledAt": {
+            "type": "string",
+            "description": "Canceled at",
+            "format": "date-time"
+          },
+          "comments": {
+            "type": "string",
+            "description": "Comments"
+          },
+          "connection": {
+            "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$ConnectionResponse"
+          },
+          "contentType": {
+            "type": "string",
+            "description": "Content type",
+            "enum": [
+              "TEXT",
+              "FILE"
+            ]
+          },
+          "contentValue": {
+            "type": "string",
+            "description": "Content value. File path or Queries"
+          },
+          "database": {
+            "type": "string",
+            "description": "Database"
+          },
+          "executionAssignees": {
+            "type": "array",
+            "description": "Execution assignees",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$ExecutionAssigneeResponse"
+            }
+          },
+          "executionStatus": {
+            "type": "string",
+            "description": "Execution status",
+            "enum": [
+              "NONE",
+              "PENDING",
+              "EXECUTING",
+              "SUCCESS",
+              "FAILURE",
+              "CANCELED",
+              "EXPIRED"
+            ]
+          },
+          "expiryAt": {
+            "type": "string",
+            "description": "Expiry at(Due Date)",
+            "format": "date-time"
+          },
+          "requestType": {
+            "type": "string",
+            "description": "Request type",
+            "enum": [
+              "IP_REGISTRATION",
+              "DB_ACCESS_CONTROL",
+              "SQL_EXECUTION",
+              "DATA_EXPORT",
+              "SERVER_ACCESS_CONTROL",
+              "ACCESS_ROLE",
+              "UNMASKING",
+              "SERVER_PRIVILEGE",
+              "WEB_APP_JUST_IN_TIME_ACCESS_CONTROL",
+              "DECRYPTION",
+              "RESTRICTED_DATA_ACCESS",
+              "DB_POLICY_EXCEPTION"
+            ]
+          },
+          "requestedAt": {
+            "type": "string",
+            "description": "Requested at",
+            "format": "date-time"
+          },
+          "requestedBy": {
+            "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserResponse"
+          },
+          "reviewAssignees": {
+            "type": "array",
+            "description": "Reviewers",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$ReviewAssigneeResponse"
+            }
+          },
+          "rule": {
+            "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$WorkflowRequestResponse$Rule"
+          },
+          "targetDate": {
+            "type": "string",
+            "description": "Target data",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string",
+            "description": "Title"
+          },
+          "urgent": {
+            "type": "boolean",
+            "description": "Urgent mode"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "UUID",
+            "format": "uuid"
+          }
+        }
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$StepAssigneeResponse": {
+        "required": [
+          "assignedUser"
+        ],
+        "type": "object",
+        "properties": {
+          "actionAt": {
+            "type": "string",
+            "description": "Action at",
+            "format": "date-time"
+          },
+          "actionBy": {
+            "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserResponse"
+          },
+          "assignedUser": {
+            "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserResponse"
+          },
+          "comments": {
+            "type": "string",
+            "description": "Comments"
+          },
+          "status": {
+            "type": "string",
+            "description": "Status",
+            "enum": [
+              "NONE",
+              "PENDING",
+              "APPROVED",
+              "REJECTED"
+            ]
+          },
+          "user": {
+            "$ref": "#/components/schemas/com.querypie.iam.controller.dto.ExternalUserResponse"
+          }
+        },
+        "description": "Assignees"
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$StepResponse": {
+        "required": [
+          "approveCondition",
+          "assignees",
+          "order",
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "approveCondition": {
+            "type": "string",
+            "description": "Condition of Approval for step",
+            "enum": [
+              "ALL",
+              "ANY"
+            ]
+          },
+          "assignees": {
+            "type": "array",
+            "description": "Assignees",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$StepAssigneeResponse"
+            }
+          },
+          "order": {
+            "type": "integer",
+            "description": "Order of steps",
+            "format": "int32"
+          },
+          "status": {
+            "type": "string",
+            "description": "Status",
+            "enum": [
+              "NONE",
+              "IN_PROGRESS",
+              "APPROVED",
+              "REJECTED"
+            ]
+          }
+        },
+        "description": "Steps"
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.ExternalWorkflowRequestDto$WorkflowRequestResponse$Rule": {
+        "required": [
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "UUID",
+            "format": "uuid"
+          }
+        },
+        "description": "Rule"
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.access.ExternalAccessRequestDto$ApproveRequest": {
+        "type": "object",
+        "properties": {
+          "clusterUuids": {
+            "type": "array",
+            "description": "Cluster uuids to approve",
+            "items": {
+              "type": "string",
+              "description": "Cluster uuids to approve"
+            }
+          },
+          "comments": {
+            "type": "string",
+            "description": "Comments"
+          }
+        }
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.access.ExternalAccessRequestDto$RejectRequest": {
+        "type": "object",
+        "properties": {
+          "comments": {
+            "type": "string",
+            "description": "Comments"
+          }
+        }
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.export.ExternalExportRequestDto$ApproveRequest": {
+        "type": "object",
+        "properties": {
+          "comments": {
+            "type": "string",
+            "description": "Comments"
+          }
+        }
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.export.ExternalExportRequestDto$RejectRequest": {
+        "type": "object",
+        "properties": {
+          "comments": {
+            "type": "string",
+            "description": "Comments"
+          }
+        }
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.rule.ExternalWorkflowRuleDto$AddRequest": {
+        "required": [
+          "allowedSelfApproval",
+          "approvalSteps",
+          "enableDelegatedSubmission",
+          "executionAssignees",
+          "name",
+          "requestType",
+          "selectExecutionAssigneeCondition",
+          "urgent"
+        ],
+        "type": "object",
+        "properties": {
+          "allowedSelfApproval": {
+            "type": "boolean",
+            "description": "Whether self-approval is allowed"
+          },
+          "approvalSteps": {
+            "type": "array",
+            "description": "Approval Steps",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.rule.ExternalWorkflowRuleDto$RuleStepAddRequest"
+            }
+          },
+          "enableDelegatedSubmission": {
+            "type": "boolean",
+            "description": "Set to true to allow delegated submission for this workflow rule"
+          },
+          "executionAssignees": {
+            "type": "array",
+            "description": "Execution assignees",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.rule.ExternalWorkflowRuleDto$RuleAssigneeRequest"
+            }
+          },
+          "name": {
+            "type": "string",
+            "description": "Rule name",
+            "example": "Access control rule"
+          },
+          "requestType": {
+            "type": "string",
+            "description": "Request type",
+            "example": "DB_ACCESS_CONTROL",
+            "enum": [
+              "IP_REGISTRATION",
+              "DB_ACCESS_CONTROL",
+              "SQL_EXECUTION",
+              "DATA_EXPORT",
+              "SERVER_ACCESS_CONTROL",
+              "ACCESS_ROLE",
+              "UNMASKING",
+              "SERVER_PRIVILEGE",
+              "WEB_APP_JUST_IN_TIME_ACCESS_CONTROL",
+              "DECRYPTION",
+              "RESTRICTED_DATA_ACCESS",
+              "DB_POLICY_EXCEPTION"
+            ]
+          },
+          "selectExecutionAssigneeCondition": {
+            "type": "string",
+            "description": "select execution assignee condition",
+            "enum": [
+              "ADMIN_ONLY",
+              "ALL_USERS",
+              "FIXED",
+              "CONNECTION_OWNER",
+              "SERVER_GROUP_OWNER",
+              "WEB_APP_OWNER",
+              "ATTRIBUTE_BASED"
+            ]
+          },
+          "urgent": {
+            "type": "boolean",
+            "description": "urgent",
+            "example": false
+          }
+        }
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.rule.ExternalWorkflowRuleDto$DetailResponse": {
+        "required": [
+          "urgent"
+        ],
+        "type": "object",
+        "properties": {
+          "approvalSteps": {
+            "type": "array",
+            "description": "Approval steps",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.rule.ExternalWorkflowRuleDto$RuleStepResponse"
+            }
+          },
+          "executionAssignees": {
+            "type": "array",
+            "description": "Execution assignees",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.rule.ExternalWorkflowRuleDto$RuleAssignee"
+            }
+          },
+          "name": {
+            "type": "string",
+            "description": "Rule name",
+            "example": "Access control rule"
+          },
+          "requestType": {
+            "type": "string",
+            "description": "Request type",
+            "example": "SQL_EXECUTION",
+            "enum": [
+              "IP_REGISTRATION",
+              "DB_ACCESS_CONTROL",
+              "SQL_EXECUTION",
+              "DATA_EXPORT",
+              "SERVER_ACCESS_CONTROL",
+              "ACCESS_ROLE",
+              "UNMASKING",
+              "SERVER_PRIVILEGE",
+              "WEB_APP_JUST_IN_TIME_ACCESS_CONTROL",
+              "DECRYPTION",
+              "RESTRICTED_DATA_ACCESS",
+              "DB_POLICY_EXCEPTION"
+            ]
+          },
+          "selectExecutionAssigneeCondition": {
+            "type": "string",
+            "description": "select execution assignee condition",
+            "enum": [
+              "ADMIN_ONLY",
+              "ALL_USERS",
+              "FIXED",
+              "CONNECTION_OWNER",
+              "SERVER_GROUP_OWNER",
+              "WEB_APP_OWNER",
+              "ATTRIBUTE_BASED"
+            ]
+          },
+          "urgent": {
+            "type": "boolean",
+            "description": "urgent"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "UUID",
+            "example": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3"
+          }
+        }
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.rule.ExternalWorkflowRuleDto$EditRequest": {
+        "required": [
+          "allowedSelfApproval",
+          "approvalSteps",
+          "enableDelegatedSubmission",
+          "executionAssignees",
+          "name",
+          "selectExecutionAssigneeCondition",
+          "urgent"
+        ],
+        "type": "object",
+        "properties": {
+          "allowedSelfApproval": {
+            "type": "boolean",
+            "description": "Whether self-approval is allowed"
+          },
+          "approvalSteps": {
+            "type": "array",
+            "description": "Approval steps",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.rule.ExternalWorkflowRuleDto$RuleStepEditRequest"
+            }
+          },
+          "enableDelegatedSubmission": {
+            "type": "boolean",
+            "description": "Set to true to allow delegated submission for this workflow rule"
+          },
+          "executionAssignees": {
+            "type": "array",
+            "description": "Execution assignees",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.rule.ExternalWorkflowRuleDto$RuleAssigneeRequest"
+            }
+          },
+          "name": {
+            "type": "string",
+            "description": "name",
+            "example": "Data Export rule"
+          },
+          "selectExecutionAssigneeCondition": {
+            "type": "string",
+            "description": "select execution assignee condition",
+            "enum": [
+              "ADMIN_ONLY",
+              "ALL_USERS",
+              "FIXED",
+              "CONNECTION_OWNER",
+              "SERVER_GROUP_OWNER",
+              "WEB_APP_OWNER",
+              "ATTRIBUTE_BASED"
+            ]
+          },
+          "urgent": {
+            "type": "boolean",
+            "description": "urgent"
+          }
+        }
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.rule.ExternalWorkflowRuleDto$PageResponse": {
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "description": "Created At",
+            "format": "date-time"
+          },
+          "name": {
+            "type": "string",
+            "description": "Rule name",
+            "example": "Access control rule"
+          },
+          "requestType": {
+            "type": "string",
+            "description": "Request type",
+            "example": "SQL_EXECUTION",
+            "enum": [
+              "IP_REGISTRATION",
+              "DB_ACCESS_CONTROL",
+              "SQL_EXECUTION",
+              "DATA_EXPORT",
+              "SERVER_ACCESS_CONTROL",
+              "ACCESS_ROLE",
+              "UNMASKING",
+              "SERVER_PRIVILEGE",
+              "WEB_APP_JUST_IN_TIME_ACCESS_CONTROL",
+              "DECRYPTION",
+              "RESTRICTED_DATA_ACCESS",
+              "DB_POLICY_EXCEPTION"
+            ]
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Updated At",
+            "format": "date-time"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "UUID",
+            "example": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3"
+          }
+        },
+        "description": "Object list per entry"
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.rule.ExternalWorkflowRuleDto$RuleAssignee": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "Assignee user email"
+          },
+          "name": {
+            "type": "string",
+            "description": "Assignee user name"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "User UUID",
+            "example": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3"
+          }
+        },
+        "description": "Execution assignees"
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.rule.ExternalWorkflowRuleDto$RuleAssigneeRequest": {
+        "type": "object",
+        "properties": {
+          "uuid": {
+            "type": "string",
+            "description": "User UUID",
+            "example": "63d2cc6d-dd83-4a31-a817-fc13f1fc57a3"
+          }
+        },
+        "description": "Execution assignees"
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.rule.ExternalWorkflowRuleDto$RuleStepAddRequest": {
+        "required": [
+          "selectAssigneeCondition",
+          "stepApproveCondition"
+        ],
+        "type": "object",
+        "properties": {
+          "ruleAssignees": {
+            "type": "array",
+            "description": "Assignees",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.rule.ExternalWorkflowRuleDto$RuleAssigneeRequest"
+            }
+          },
+          "selectAssigneeCondition": {
+            "type": "string",
+            "description": "Assignee for Approval",
+            "example": "ADMIN_ONLY",
+            "enum": [
+              "ADMIN_ONLY",
+              "ALL_USERS",
+              "FIXED",
+              "CONNECTION_OWNER",
+              "SERVER_GROUP_OWNER",
+              "WEB_APP_OWNER",
+              "ATTRIBUTE_BASED"
+            ]
+          },
+          "stepApproveCondition": {
+            "type": "string",
+            "description": "Condition of Approval",
+            "enum": [
+              "ALL",
+              "ANY"
+            ]
+          }
+        },
+        "description": "Approval Steps"
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.rule.ExternalWorkflowRuleDto$RuleStepEditRequest": {
+        "required": [
+          "selectAssigneeCondition",
+          "stepApproveCondition"
+        ],
+        "type": "object",
+        "properties": {
+          "ruleAssignees": {
+            "type": "array",
+            "description": "Assignees",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.rule.ExternalWorkflowRuleDto$RuleAssigneeRequest"
+            }
+          },
+          "selectAssigneeCondition": {
+            "type": "string",
+            "description": "Assignee for Approval",
+            "example": "ADMIN_ONLY",
+            "enum": [
+              "ADMIN_ONLY",
+              "ALL_USERS",
+              "FIXED",
+              "CONNECTION_OWNER",
+              "SERVER_GROUP_OWNER",
+              "WEB_APP_OWNER",
+              "ATTRIBUTE_BASED"
+            ]
+          },
+          "stepApproveCondition": {
+            "type": "string",
+            "description": "Condition of Approval",
+            "enum": [
+              "ALL",
+              "ANY"
+            ]
+          }
+        },
+        "description": "Approval steps"
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.rule.ExternalWorkflowRuleDto$RuleStepResponse": {
+        "required": [
+          "selectAssigneeCondition",
+          "stepApproveCondition"
+        ],
+        "type": "object",
+        "properties": {
+          "ruleAssignees": {
+            "type": "array",
+            "description": "Assignees",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.newworkflow.interfaces.external.v2.rule.ExternalWorkflowRuleDto$RuleAssignee"
+            }
+          },
+          "selectAssigneeCondition": {
+            "type": "string",
+            "description": "Assignee for Approval",
+            "example": "ADMIN_ONLY",
+            "enum": [
+              "ADMIN_ONLY",
+              "ALL_USERS",
+              "FIXED",
+              "CONNECTION_OWNER",
+              "SERVER_GROUP_OWNER",
+              "WEB_APP_OWNER",
+              "ATTRIBUTE_BASED"
+            ]
+          },
+          "stepApproveCondition": {
+            "type": "string",
+            "description": "Condition of Approval",
+            "enum": [
+              "ALL",
+              "ANY"
+            ]
+          }
+        },
+        "description": "Approval steps"
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.sql.ExternalSqlRequestDto$ApproveRequest": {
+        "type": "object",
+        "properties": {
+          "comments": {
+            "type": "string",
+            "description": "Comments"
+          }
+        }
+      },
+      "com.querypie.newworkflow.interfaces.external.v2.sql.ExternalSqlRequestDto$RejectRequest": {
+        "type": "object",
+        "properties": {
+          "comments": {
+            "type": "string",
+            "description": "Comments"
+          }
+        }
+      },
+      "com.querypie.notification.controller.dto.ExternalNotificationAgitDto": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "Webhook URL"
+          }
+        }
+      },
+      "com.querypie.notification.controller.dto.ExternalNotificationChannelDto$CreateRequest": {
+        "required": [
+          "title",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "agit": {
+            "$ref": "#/components/schemas/com.querypie.notification.controller.dto.ExternalNotificationAgitDto"
+          },
+          "email": {
+            "$ref": "#/components/schemas/com.querypie.notification.controller.dto.ExternalNotificationEmailDto"
+          },
+          "http": {
+            "$ref": "#/components/schemas/com.querypie.notification.controller.dto.ExternalNotificationHttpDto"
+          },
+          "slack": {
+            "$ref": "#/components/schemas/com.querypie.notification.controller.dto.ExternalNotificationSlackDto"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "HTTP",
+              "AGIT",
+              "SLACK",
+              "EMAIL"
+            ]
+          }
+        }
+      },
+      "com.querypie.notification.controller.dto.ExternalNotificationChannelDto$ListUserResponse": {
+        "required": [
+          "list",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "list": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/com.querypie.notification.controller.dto.ExternalNotificationChannelDto$ListUserResponse$User"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "com.querypie.notification.controller.dto.ExternalNotificationChannelDto$ListUserResponse$User": {
+        "required": [
+          "email",
+          "name",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "uuid": {
+            "type": "string"
+          }
+        }
+      },
+      "com.querypie.notification.controller.dto.ExternalNotificationChannelDto$Response": {
+        "required": [
+          "enabled"
+        ],
+        "type": "object",
+        "properties": {
+          "agit": {
+            "$ref": "#/components/schemas/com.querypie.notification.controller.dto.ExternalNotificationAgitDto"
+          },
+          "email": {
+            "$ref": "#/components/schemas/com.querypie.notification.controller.dto.ExternalNotificationEmailDto"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "http": {
+            "$ref": "#/components/schemas/com.querypie.notification.controller.dto.ExternalNotificationHttpDto"
+          },
+          "slack": {
+            "$ref": "#/components/schemas/com.querypie.notification.controller.dto.ExternalNotificationSlackDto"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "HTTP",
+              "AGIT",
+              "SLACK",
+              "EMAIL"
+            ]
+          },
+          "uuid": {
+            "type": "string"
+          }
+        }
+      },
+      "com.querypie.notification.controller.dto.ExternalNotificationChannelDto$UpdateRequest": {
+        "required": [
+          "title"
+        ],
+        "type": "object",
+        "properties": {
+          "agit": {
+            "$ref": "#/components/schemas/com.querypie.notification.controller.dto.ExternalNotificationAgitDto"
+          },
+          "email": {
+            "$ref": "#/components/schemas/com.querypie.notification.controller.dto.ExternalNotificationEmailDto"
+          },
+          "http": {
+            "$ref": "#/components/schemas/com.querypie.notification.controller.dto.ExternalNotificationHttpDto"
+          },
+          "slack": {
+            "$ref": "#/components/schemas/com.querypie.notification.controller.dto.ExternalNotificationSlackDto"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      },
+      "com.querypie.notification.controller.dto.ExternalNotificationEmailDto": {
+        "type": "object",
+        "properties": {
+          "userUuids": {
+            "type": "array",
+            "description": "User UUIDs",
+            "example": [
+              "123e4567-e89b-12d3-a456-426614174000"
+            ],
+            "items": {
+              "type": "string",
+              "description": "User UUIDs",
+              "format": "uuid"
+            }
+          }
+        }
+      },
+      "com.querypie.notification.controller.dto.ExternalNotificationHttpDto": {
+        "type": "object",
+        "properties": {
+          "bodyTemplate": {
+            "type": "string",
+            "description": "BodyTemplate",
+            "example": "{{ message }}"
+          },
+          "headers": {
+            "type": "string",
+            "description": "Headers",
+            "example": "{\"Authroization\":\"Bearer ABCDEF\"}"
+          },
+          "url": {
+            "type": "string",
+            "description": "URL",
+            "example": "https://www.abc.com/"
+          }
+        }
+      },
+      "com.querypie.notification.controller.dto.ExternalNotificationSlackDto": {
+        "type": "object",
+        "properties": {
+          "apiChannelId": {
+            "type": "string",
+            "description": "Channel ID",
+            "example": "C027PJGS3A"
+          },
+          "apiOAuthToken": {
+            "type": "string",
+            "description": "User / Bot OAuth Token",
+            "example": "xoxb-xxxxxxx"
+          },
+          "type": {
+            "type": "string",
+            "description": "type",
+            "enum": [
+              "WEBHOOK",
+              "API"
+            ]
+          },
+          "webhookUrl": {
+            "type": "string",
+            "description": "Webhook URL",
+            "example": "https://www.abc.com/"
+          }
+        }
+      },
+      "com.querypie.proxy.persistence.Proxy": {
+        "required": [
+          "deleted",
+          "enabled",
+          "host",
+          "portFrom",
+          "portTo",
+          "uuid"
+        ],
+        "type": "object",
+        "properties": {
+          "agentPort": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "deleted": {
+            "type": "boolean"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "host": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "networkId": {
+            "type": "string"
+          },
+          "portFrom": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "portTo": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedBy": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "uuid": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "API Token": {
+        "in": "header",
+        "name": "Authorization",
+        "type": "apiKey"
+      }
+    }
+  }
+}

--- a/public/openapi-specification/11.4.1/v2.json
+++ b/public/openapi-specification/11.4.1/v2.json
@@ -76338,7 +76338,7 @@
             "description": "Vault database engine account"
           }
         },
-        "description": "Database Connection Username-Password Admin Accounts"
+        "description": "Database Connection Username-Password Proxy Accounts"
       },
       "com.querypie.dbam.controller.dto.ExternalConnectionDto$UsernamePasswordResponse": {
         "required": [
@@ -76351,7 +76351,7 @@
             "description": "Username-Password username"
           }
         },
-        "description": "Database Connection Username-Password Admin Accounts"
+        "description": "Database Connection Username-Password Proxy Accounts"
       },
       "com.querypie.dbam.controller.dto.ExternalConnectionDto$UsernamePasswords": {
         "type": "object",

--- a/scripts/fetch-openapi-spec/README.md
+++ b/scripts/fetch-openapi-spec/README.md
@@ -1,0 +1,133 @@
+# fetch-openapi-spec
+
+QueryPie 인스턴스에서 OpenAPI Specification을 다운로드하고 저장하는 TypeScript 스크립트입니다.
+
+## 개요
+
+이 스크립트는 사내 QueryPie 인스턴스의 OpenAPI Specification 엔드포인트에서 JSON 파일을 다운로드하여, 버전별로 정리하여 저장합니다.
+
+## 기능
+
+- URL에서 OpenAPI Spec JSON 파일 다운로드
+- API 버전 자동 감지 (v0.9 또는 v2)
+- QueryPie 버전 정보 추출 (`x-querypie-version` 필드)
+- JSON 포맷팅 (가독성 향상)
+- 버전별 디렉토리 자동 생성 및 파일 저장
+- 변경 감지 (기존 파일과 비교)
+- 에러 처리 및 상세 로깅
+
+## 설치
+
+프로젝트 루트에서 의존성을 설치합니다:
+
+```bash
+npm install
+```
+
+## 사용 방법
+
+### 기본 사용법
+
+```bash
+# V2 API Spec 다운로드 (URL에서 버전 자동 감지)
+npm run fetch-openapi-spec -- https://internal.dev.querypie.io/api/docs/specification/external-v2
+
+# V0.9 API Spec 다운로드
+npm run fetch-openapi-spec -- https://internal.dev.querypie.io/api/docs/specification/external
+```
+
+### 옵션
+
+- `--api-version <version>`: API 버전 명시적 지정 (v0.9 또는 v2)
+- `--auth-token <token>`: 인증 토큰 (보호된 엔드포인트용)
+- `--timeout <ms>`: 요청 타임아웃 (밀리초, 기본값: 30000)
+- `--no-overwrite`: 기존 파일 덮어쓰기 방지
+- `--help`, `-h`: 도움말 표시
+
+### 예제
+
+```bash
+# 명시적 API 버전 지정
+npm run fetch-openapi-spec -- https://example.com/api/spec --api-version v2
+
+# 인증 토큰 사용
+npm run fetch-openapi-spec -- https://example.com/api/spec --auth-token <your-token>
+
+# 타임아웃 설정
+npm run fetch-openapi-spec -- https://example.com/api/spec --timeout 60000
+
+# 기존 파일 덮어쓰기 방지
+npm run fetch-openapi-spec -- https://example.com/api/spec --no-overwrite
+```
+
+## 출력 디렉토리 구조
+
+다운로드한 파일은 다음 구조로 저장됩니다:
+
+```
+public/openapi-specification/
+  {querypie-version}/          # 예: 11.4.1, 11.5.0
+    v0.9.json                  # V0.9 API Specification
+    v2.json                     # V2 API Specification
+```
+
+버전 정보는 OpenAPI Spec JSON의 `info.x-querypie-version` 필드에서 추출됩니다.
+
+## API 버전 감지
+
+URL 경로를 분석하여 API 버전을 자동으로 감지합니다:
+
+- `/external-v2` 또는 `/v2` 포함 → `v2.json`
+- `/external` 포함 → `v0.9.json`
+
+명시적으로 `--api-version` 옵션을 사용하여 지정할 수도 있습니다.
+
+## 에러 처리
+
+스크립트는 다음 상황에서 에러를 발생시킵니다:
+
+- 네트워크 연결 실패
+- HTTP 에러 상태 코드
+- JSON 파싱 실패
+- 버전 정보 누락 또는 잘못된 형식
+- 파일 쓰기 권한 오류
+
+모든 에러는 상세한 메시지와 함께 로그에 기록됩니다.
+
+## 로깅
+
+스크립트는 진행 상황을 다음과 같이 로깅합니다:
+
+- `[INFO]`: 정상 진행 상황
+- `[WARN]`: 경고 사항 (기존 파일 덮어쓰기 등)
+- `[ERROR]`: 에러 발생
+
+## 개발
+
+### 파일 구조
+
+```
+scripts/fetch-openapi-spec/
+  index.ts                      # 메인 진입점, CLI 인자 처리
+  downloader.ts                 # HTTP 다운로드 로직
+  version-parser.ts             # 버전 정보 추출 및 파싱
+  json-formatter.ts             # JSON 포맷팅 로직
+  file-manager.ts               # 디렉토리 생성 및 파일 저장
+  types.ts                      # TypeScript 타입 정의
+  utils.ts                      # 유틸리티 함수
+  README.md                     # 이 파일
+```
+
+### 로컬 개발
+
+TypeScript 파일을 직접 실행하려면 `tsx`를 사용합니다:
+
+```bash
+npx tsx scripts/fetch-openapi-spec/index.ts <url>
+```
+
+## 참고
+
+- OpenAPI Specification: https://swagger.io/specification/
+- QueryPie API 문서: https://docs.querypie.com
+

--- a/scripts/fetch-openapi-spec/downloader.ts
+++ b/scripts/fetch-openapi-spec/downloader.ts
@@ -1,0 +1,97 @@
+/**
+ * HTTP downloader for OpenAPI specifications
+ */
+
+import type { DownloadOptions, DownloadResult, ApiVersion } from './types';
+import { detectApiVersionFromUrl, extractVersionInfo, getApiVersionFilename } from './version-parser';
+import { Logger } from './utils';
+
+/**
+ * Default timeout for HTTP requests (30 seconds)
+ */
+const DEFAULT_TIMEOUT = 30000;
+
+/**
+ * Download OpenAPI specification from URL
+ */
+export async function downloadOpenAPISpec(options: DownloadOptions): Promise<DownloadResult> {
+  const { url, apiVersion, authToken, timeout = DEFAULT_TIMEOUT } = options;
+  
+  Logger.info(`Starting OpenAPI Spec download from: ${url}`);
+  
+  // Detect API version if not provided
+  const detectedVersion: ApiVersion = apiVersion || detectApiVersionFromUrl(url);
+  Logger.info(`Detected API version: ${detectedVersion}`);
+  
+  // Prepare fetch options
+  const fetchOptions: RequestInit = {
+    method: 'GET',
+    headers: {
+      'Accept': 'application/json',
+      'User-Agent': 'querypie-docs-fetch-openapi-spec/1.0',
+    },
+    signal: AbortSignal.timeout(timeout),
+  };
+  
+  // Add authentication token if provided
+  if (authToken) {
+    fetchOptions.headers = {
+      ...fetchOptions.headers,
+      'Authorization': `Bearer ${authToken}`,
+    };
+  }
+  
+  try {
+    Logger.info('Downloading JSON file...');
+    const response = await fetch(url, fetchOptions);
+    
+    if (!response.ok) {
+      throw new Error(
+        `HTTP error! status: ${response.status}, statusText: ${response.statusText}`
+      );
+    }
+    
+    const content = await response.text();
+    
+    // Validate JSON
+    let json: unknown;
+    try {
+      json = JSON.parse(content);
+    } catch (parseError) {
+      throw new Error(
+        `Failed to parse JSON response: ${parseError instanceof Error ? parseError.message : 'Unknown error'}`
+      );
+    }
+    
+    // Validate OpenAPI spec structure
+    if (typeof json !== 'object' || json === null) {
+      throw new Error('Downloaded content is not a valid JSON object');
+    }
+    
+    const spec = json as Record<string, unknown>;
+    if (!spec.info || typeof spec.info !== 'object') {
+      throw new Error('Downloaded JSON does not contain required "info" field');
+    }
+    
+    // Extract version information
+    Logger.info('Extracting version information...');
+    const versionInfo = extractVersionInfo(spec as { info?: { 'x-querypie-version'?: string } });
+    Logger.info(`Extracted QueryPie version: ${versionInfo.full}`);
+    
+    return {
+      content,
+      json: spec as Parameters<typeof extractVersionInfo>[0],
+      apiVersion: detectedVersion,
+      versionInfo,
+    };
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.name === 'AbortError' || error.message.includes('timeout')) {
+        throw new Error(`Request timeout after ${timeout}ms`);
+      }
+      throw new Error(`Download failed: ${error.message}`);
+    }
+    throw new Error(`Download failed: ${String(error)}`);
+  }
+}
+

--- a/scripts/fetch-openapi-spec/file-manager.ts
+++ b/scripts/fetch-openapi-spec/file-manager.ts
@@ -1,0 +1,94 @@
+/**
+ * File management utilities
+ */
+
+import * as path from 'path';
+import * as fs from 'fs';
+import type { SaveOptions, Config } from './types';
+import { Logger, ensureDirectory, fileExists, calculateHash, getRelativePath } from './utils';
+import { getApiVersionFilename } from './version-parser';
+
+/**
+ * Default configuration
+ */
+const DEFAULT_CONFIG: Config = {
+  baseDir: path.join(process.cwd(), 'public', 'openapi-specification'),
+  defaultTimeout: 30000,
+  formatOptions: {
+    indent: 2,
+    sortKeys: false,
+  },
+};
+
+/**
+ * Get full file path for OpenAPI spec
+ */
+export function getSpecFilePath(versionDirectory: string, apiVersion: string): string {
+  const config = DEFAULT_CONFIG;
+  const filename = getApiVersionFilename(apiVersion as 'v0.9' | 'v2');
+  return path.join(config.baseDir, versionDirectory, filename);
+}
+
+/**
+ * Save formatted JSON to file
+ */
+export function saveSpecFile(options: SaveOptions): string {
+  const { versionDirectory, apiVersion, content, overwrite = true } = options;
+  const config = DEFAULT_CONFIG;
+  
+  // Create version directory
+  const versionDir = path.join(config.baseDir, versionDirectory);
+  ensureDirectory(versionDir);
+  
+  // Get file path
+  const filename = getApiVersionFilename(apiVersion);
+  const filePath = path.join(versionDir, filename);
+  const relativePath = getRelativePath(filePath);
+  
+  // Check if file exists
+  if (fileExists(filePath)) {
+    if (!overwrite) {
+      throw new Error(`File already exists and overwrite is disabled: ${relativePath}`);
+    }
+    
+    // Check if content has changed
+    const existingContent = fs.readFileSync(filePath, 'utf-8');
+    const existingHash = calculateHash(existingContent);
+    const newHash = calculateHash(content);
+    
+    if (existingHash === newHash) {
+      Logger.warn(`File content unchanged, skipping save: ${relativePath}`);
+      return filePath;
+    }
+    
+    Logger.warn(`Overwriting existing file: ${relativePath}`);
+  }
+  
+  // Validate JSON before saving
+  try {
+    JSON.parse(content);
+  } catch (error) {
+    throw new Error(
+      `Invalid JSON content cannot be saved: ${error instanceof Error ? error.message : 'Unknown error'}`
+    );
+  }
+  
+  // Write file
+  try {
+    fs.writeFileSync(filePath, content, 'utf-8');
+    Logger.info(`Saved file: ${relativePath}`);
+    return filePath;
+  } catch (error) {
+    throw new Error(
+      `Failed to write file: ${error instanceof Error ? error.message : 'Unknown error'}`
+    );
+  }
+}
+
+/**
+ * Get configuration
+ */
+export function getConfig(): Config {
+  return DEFAULT_CONFIG;
+}
+

--- a/scripts/fetch-openapi-spec/index.ts
+++ b/scripts/fetch-openapi-spec/index.ts
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+
+/**
+ * Main entry point for fetch-openapi-spec
+ * 
+ * Downloads OpenAPI specification from QueryPie instance and saves it to the repository.
+ * 
+ * Usage:
+ *   npm run fetch-openapi-spec -- <url>
+ *   npm run fetch-openapi-spec -- https://internal.dev.querypie.io/api/docs/specification/external-v2
+ * 
+ * Options:
+ *   --api-version <version>  Specify API version (v0.9 or v2). Auto-detected from URL if not provided.
+ *   --auth-token <token>      Authentication token for protected endpoints.
+ *   --timeout <ms>            Request timeout in milliseconds (default: 30000).
+ *   --no-overwrite           Do not overwrite existing files.
+ *   --help                   Show this help message.
+ */
+
+import * as process from 'process';
+import type { DownloadOptions } from './types';
+import { downloadOpenAPISpec } from './downloader';
+import { formatJSON } from './json-formatter';
+import { saveSpecFile } from './file-manager';
+import { Logger } from './utils';
+import { validateOpenAPISpec } from './json-formatter';
+
+/**
+ * Parse command line arguments
+ */
+function parseArgs(): {
+  url?: string;
+  apiVersion?: 'v0.9' | 'v2';
+  authToken?: string;
+  timeout?: number;
+  overwrite: boolean;
+  help: boolean;
+} {
+  const args = process.argv.slice(2);
+  const result: {
+    url?: string;
+    apiVersion?: 'v0.9' | 'v2';
+    authToken?: string;
+    timeout?: number;
+    overwrite: boolean;
+    help: boolean;
+  } = {
+    overwrite: true,
+    help: false,
+  };
+  
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    
+    if (arg === '--help' || arg === '-h') {
+      result.help = true;
+      return result;
+    }
+    
+    if (arg === '--api-version' && i + 1 < args.length) {
+      const version = args[++i];
+      if (version === 'v0.9' || version === 'v2') {
+        result.apiVersion = version;
+      } else {
+        throw new Error(`Invalid API version: ${version}. Must be 'v0.9' or 'v2'`);
+      }
+    } else if (arg === '--auth-token' && i + 1 < args.length) {
+      result.authToken = args[++i];
+    } else if (arg === '--timeout' && i + 1 < args.length) {
+      const timeout = parseInt(args[++i], 10);
+      if (isNaN(timeout) || timeout <= 0) {
+        throw new Error(`Invalid timeout value: ${args[i]}. Must be a positive number`);
+      }
+      result.timeout = timeout;
+    } else if (arg === '--no-overwrite') {
+      result.overwrite = false;
+    } else if (!arg.startsWith('--') && !result.url) {
+      result.url = arg;
+    }
+  }
+  
+  return result;
+}
+
+/**
+ * Print help message
+ */
+function printHelp(): void {
+  console.log(`
+Usage: npm run fetch-openapi-spec -- <url> [options]
+
+Downloads OpenAPI specification from QueryPie instance and saves it to the repository.
+
+Arguments:
+  <url>                    URL to download OpenAPI spec from
+                           Example: https://internal.dev.querypie.io/api/docs/specification/external-v2
+
+Options:
+  --api-version <version>   Specify API version (v0.9 or v2). Auto-detected from URL if not provided.
+  --auth-token <token>      Authentication token for protected endpoints.
+  --timeout <ms>            Request timeout in milliseconds (default: 30000).
+  --no-overwrite           Do not overwrite existing files.
+  --help, -h               Show this help message.
+
+Examples:
+  # Download V2 API spec (auto-detect version from URL)
+  npm run fetch-openapi-spec -- https://internal.dev.querypie.io/api/docs/specification/external-v2
+
+  # Download V0.9 API spec
+  npm run fetch-openapi-spec -- https://internal.dev.querypie.io/api/docs/specification/external
+
+  # Download with explicit API version
+  npm run fetch-openapi-spec -- https://example.com/api/spec --api-version v2
+
+  # Download with authentication
+  npm run fetch-openapi-spec -- https://example.com/api/spec --auth-token <token>
+`);
+}
+
+/**
+ * Main function
+ */
+async function main(): Promise<void> {
+  try {
+    const args = parseArgs();
+    
+    if (args.help) {
+      printHelp();
+      process.exit(0);
+    }
+    
+    if (!args.url) {
+      Logger.error('URL argument is required');
+      printHelp();
+      process.exit(1);
+    }
+    
+    // Download OpenAPI spec
+    const downloadOptions: DownloadOptions = {
+      url: args.url,
+      apiVersion: args.apiVersion,
+      authToken: args.authToken,
+      timeout: args.timeout,
+    };
+    
+    const result = await downloadOpenAPISpec(downloadOptions);
+    
+    // Validate OpenAPI spec structure
+    if (!validateOpenAPISpec(result.json)) {
+      throw new Error('Downloaded content is not a valid OpenAPI specification');
+    }
+    
+    // Format JSON
+    const formattedContent = formatJSON(result.json);
+    
+    // Save file
+    const filePath = saveSpecFile({
+      versionDirectory: result.versionInfo.directory,
+      apiVersion: result.apiVersion,
+      content: formattedContent,
+      overwrite: args.overwrite,
+    });
+    
+    Logger.info('Download completed successfully!');
+    Logger.info(`File saved to: ${filePath}`);
+    
+    process.exit(0);
+  } catch (error) {
+    Logger.error(
+      error instanceof Error ? error.message : String(error)
+    );
+    
+    if (error instanceof Error && error.stack) {
+      Logger.error(`Stack trace: ${error.stack}`);
+    }
+    
+    process.exit(1);
+  }
+}
+
+// Run main function
+main();
+

--- a/scripts/fetch-openapi-spec/json-formatter.ts
+++ b/scripts/fetch-openapi-spec/json-formatter.ts
@@ -1,0 +1,57 @@
+/**
+ * JSON formatting utilities
+ */
+
+import type { OpenAPISpec, Config } from './types';
+import { Logger } from './utils';
+
+/**
+ * Default formatting options
+ */
+const DEFAULT_FORMAT_OPTIONS = {
+  indent: 2,
+  sortKeys: false, // Keep original key order for better diff readability
+};
+
+/**
+ * Format JSON content with proper indentation
+ */
+export function formatJSON(
+  json: OpenAPISpec | unknown,
+  options: Config['formatOptions'] = DEFAULT_FORMAT_OPTIONS
+): string {
+  Logger.info('Formatting JSON file...');
+  
+  try {
+    const formatted = JSON.stringify(json, null, options.indent);
+    // Add trailing newline to match common file conventions
+    return formatted + '\n';
+  } catch (error) {
+    throw new Error(
+      `Failed to format JSON: ${error instanceof Error ? error.message : 'Unknown error'}`
+    );
+  }
+}
+
+/**
+ * Validate JSON structure
+ */
+export function validateOpenAPISpec(json: unknown): json is OpenAPISpec {
+  if (typeof json !== 'object' || json === null) {
+    return false;
+  }
+  
+  const spec = json as Record<string, unknown>;
+  
+  // Check for required OpenAPI fields
+  if (!spec.openapi && !spec.swagger) {
+    return false;
+  }
+  
+  if (!spec.info || typeof spec.info !== 'object') {
+    return false;
+  }
+  
+  return true;
+}
+

--- a/scripts/fetch-openapi-spec/types.ts
+++ b/scripts/fetch-openapi-spec/types.ts
@@ -1,0 +1,97 @@
+/**
+ * Type definitions for fetch-openapi-spec
+ */
+
+/**
+ * API version type
+ */
+export type ApiVersion = 'v0.9' | 'v2';
+
+/**
+ * OpenAPI Specification info object with QueryPie extension
+ */
+export interface OpenAPIInfo {
+  title?: string;
+  version?: string;
+  'x-querypie-version'?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * OpenAPI Specification structure
+ */
+export interface OpenAPISpec {
+  openapi?: string;
+  info?: OpenAPIInfo;
+  [key: string]: unknown;
+}
+
+/**
+ * Parsed version information
+ */
+export interface VersionInfo {
+  /** Full version string (e.g., "11.4.1-eee1211") */
+  full: string;
+  /** Major.minor.patch version (e.g., "11.4.1") */
+  directory: string;
+  /** Commit hash (e.g., "eee1211") */
+  commit?: string;
+}
+
+/**
+ * Download options
+ */
+export interface DownloadOptions {
+  /** URL to download from */
+  url: string;
+  /** API version (auto-detected if not provided) */
+  apiVersion?: ApiVersion;
+  /** Authentication token (optional) */
+  authToken?: string;
+  /** Request timeout in milliseconds */
+  timeout?: number;
+}
+
+/**
+ * Download result
+ */
+export interface DownloadResult {
+  /** Downloaded JSON content */
+  content: string;
+  /** Parsed JSON object */
+  json: OpenAPISpec;
+  /** Detected API version */
+  apiVersion: ApiVersion;
+  /** Extracted version information */
+  versionInfo: VersionInfo;
+}
+
+/**
+ * File save options
+ */
+export interface SaveOptions {
+  /** QueryPie version directory name (e.g., "11.4.1") */
+  versionDirectory: string;
+  /** API version (v0.9 or v2) */
+  apiVersion: ApiVersion;
+  /** Formatted JSON content */
+  content: string;
+  /** Whether to overwrite existing file */
+  overwrite?: boolean;
+}
+
+/**
+ * Program configuration
+ */
+export interface Config {
+  /** Base directory for OpenAPI specs */
+  baseDir: string;
+  /** Default timeout for HTTP requests */
+  defaultTimeout: number;
+  /** JSON formatting options */
+  formatOptions: {
+    indent: number;
+    sortKeys: boolean;
+  };
+}
+

--- a/scripts/fetch-openapi-spec/utils.ts
+++ b/scripts/fetch-openapi-spec/utils.ts
@@ -1,0 +1,100 @@
+/**
+ * Utility functions for fetch-openapi-spec
+ */
+
+import * as path from 'path';
+import * as fs from 'fs';
+
+/**
+ * Log levels
+ */
+export enum LogLevel {
+  INFO = 'INFO',
+  WARN = 'WARN',
+  ERROR = 'ERROR',
+}
+
+/**
+ * Logger utility
+ */
+export class Logger {
+  /**
+   * Log a message with specified level
+   */
+  static log(level: LogLevel, message: string, ...args: unknown[]): void {
+    const timestamp = new Date().toISOString();
+    const prefix = `[${timestamp}] [${level}]`;
+    const formattedMessage = args.length > 0 
+      ? `${prefix} ${message} ${args.map(arg => JSON.stringify(arg)).join(' ')}`
+      : `${prefix} ${message}`;
+    
+    console.log(formattedMessage);
+  }
+
+  /**
+   * Log info message
+   */
+  static info(message: string, ...args: unknown[]): void {
+    this.log(LogLevel.INFO, message, ...args);
+  }
+
+  /**
+   * Log warning message
+   */
+  static warn(message: string, ...args: unknown[]): void {
+    this.log(LogLevel.WARN, message, ...args);
+  }
+
+  /**
+   * Log error message
+   */
+  static error(message: string, ...args: unknown[]): void {
+    this.log(LogLevel.ERROR, message, ...args);
+  }
+}
+
+/**
+ * Ensure directory exists, create if not
+ */
+export function ensureDirectory(dirPath: string): void {
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true });
+    Logger.info(`Created directory: ${dirPath}`);
+  }
+}
+
+/**
+ * Calculate file hash (simple implementation)
+ */
+export function calculateHash(content: string): string {
+  // Simple hash function for change detection
+  let hash = 0;
+  for (let i = 0; i < content.length; i++) {
+    const char = content.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash = hash & hash; // Convert to 32-bit integer
+  }
+  return Math.abs(hash).toString(16);
+}
+
+/**
+ * Check if file exists
+ */
+export function fileExists(filePath: string): boolean {
+  return fs.existsSync(filePath);
+}
+
+/**
+ * Read file content
+ */
+export function readFile(filePath: string): string {
+  return fs.readFileSync(filePath, 'utf-8');
+}
+
+/**
+ * Get relative path from project root
+ */
+export function getRelativePath(filePath: string): string {
+  return path.relative(process.cwd(), filePath);
+}
+

--- a/scripts/fetch-openapi-spec/version-parser.ts
+++ b/scripts/fetch-openapi-spec/version-parser.ts
@@ -1,0 +1,68 @@
+/**
+ * Version parsing utilities
+ */
+
+import type { ApiVersion, VersionInfo, OpenAPISpec } from './types';
+import { Logger } from './utils';
+
+/**
+ * Detect API version from URL
+ */
+export function detectApiVersionFromUrl(url: string): ApiVersion {
+  const lowerUrl = url.toLowerCase();
+  
+  // Check for v2 indicators
+  if (lowerUrl.includes('/external-v2') || lowerUrl.includes('/v2') || lowerUrl.includes('/specification/external-v2')) {
+    return 'v2';
+  }
+  
+  // Default to v0.9
+  if (lowerUrl.includes('/external') || lowerUrl.includes('/specification/external')) {
+    return 'v0.9';
+  }
+  
+  // If no clear indicator, default to v0.9
+  Logger.warn(`Could not detect API version from URL, defaulting to v0.9: ${url}`);
+  return 'v0.9';
+}
+
+/**
+ * Extract version information from OpenAPI spec
+ */
+export function extractVersionInfo(spec: OpenAPISpec): VersionInfo {
+  const versionString = spec.info?.['x-querypie-version'];
+  
+  if (!versionString || typeof versionString !== 'string') {
+    throw new Error(
+      'Missing or invalid x-querypie-version field in OpenAPI spec. ' +
+      'Expected format: {major}.{minor}.{patch}-{commit-hash}'
+    );
+  }
+
+  // Parse version string: "11.4.1-eee1211" -> { major: "11", minor: "4", patch: "1", commit: "eee1211" }
+  const versionMatch = versionString.match(/^(\d+)\.(\d+)\.(\d+)(?:-(.+))?$/);
+  
+  if (!versionMatch) {
+    throw new Error(
+      `Invalid version format: ${versionString}. ` +
+      'Expected format: {major}.{minor}.{patch}-{commit-hash}'
+    );
+  }
+
+  const [, major, minor, patch, commit] = versionMatch;
+  const directory = `${major}.${minor}.${patch}`;
+
+  return {
+    full: versionString,
+    directory,
+    commit: commit || undefined,
+  };
+}
+
+/**
+ * Get filename for API version
+ */
+export function getApiVersionFilename(apiVersion: ApiVersion): string {
+  return `${apiVersion}.json`;
+}
+


### PR DESCRIPTION
QueryPie 인스턴스에서 OpenAPI Specification을 자동으로 다운로드하고 버전별로 저장하는 TypeScript 스크립트를 구현했습니다.

## 주요 기능
- OpenAPI Spec JSON 파일 다운로드
- API 버전 자동 감지 (v0.9 또는 v2)
- QueryPie 버전 정보 추출 및 버전별 디렉토리 자동 생성
- JSON 포맷팅 및 변경 감지
- CLI 옵션 지원 (인증 토큰, 타임아웃, 덮어쓰기 방지 등)

## 변경사항
- `scripts/fetch-openapi-spec/` 디렉토리에 새로운 스크립트 추가
- `docs/plan-to-migrate-openapi-spec.md` 문서 업데이트

