### PR TITLE
fix: migrate middleware.ts to proxy.ts for Next.js 16

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -33,7 +33,7 @@ function getSlugs(pathname: string): string[] {
   return slugs.length > 0 ? slugs : [''];
 }
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
   const slugs = getSlugs(pathname);
 


### PR DESCRIPTION
## Description
- Next.js 16의 새로운 proxy 파일 컨벤션에 맞춰 `middleware.ts`를 `proxy.ts`로 마이그레이션합니다.
- 함수명을 `middleware`에서 `proxy`로 변경하여 deprecated 경고를 해결합니다.
- 기능은 동일하게 유지되며, Next.js 16의 새로운 파일 컨벤션을 따릅니다.

