### PR TITLE
mdx: 테이블의 불필요한 속성 제거 - 번역문 동기화

### DIFF
--- a/src/content/en/administrator-manual.mdx
+++ b/src/content/en/administrator-manual.mdx
@@ -26,7 +26,7 @@ Admin page entry point in the GNB
 Before configuring services such as Databases, Servers, and Kubernetes, there are a few essential items to set up.
 In particular, we recommend configuring security settings, user settings, and assigning administrator roles first.
 
-<table data-table-width="760" data-layout="default" local-id="96d34ea4-8772-49af-9ba2-14ea36b1f3e1">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -36,10 +36,10 @@ In particular, we recommend configuring security settings, user settings, and as
 <tr>
 <th>
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Setup order**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Settings**
 </th>
 </tr>
@@ -142,7 +142,7 @@ Experience robust access control with QueryPie's fine‑grained permission model
 After completing the service configurations, you can review admin/user connection and activity history in the Audit menu.
 QueryPie also provides Discovery features to identify sensitive data—explore our next‑generation discovery capabilities.
 
-<table data-table-width="760" data-layout="default" local-id="1c770267-da7f-48dc-b1e3-817744eeec38">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -152,10 +152,10 @@ QueryPie also provides Discovery features to identify sensitive data—explore o
 <tr>
 <th>
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Setup order**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Settings**
 </th>
 </tr>

--- a/src/content/en/administrator-manual/audit.mdx
+++ b/src/content/en/administrator-manual/audit.mdx
@@ -27,7 +27,7 @@ User and administrator login/logout, permission grants and revocations, access t
 
 The types of auditable logs vary depending on the license you have, and the types of logs provided by license are as follows.
 
-<table data-table-width="760" data-layout="default" local-id="2eeba34f-b909-48ea-a011-5381931efcd4">
+<table>
 <tbody>
 <tr>
 <th>

--- a/src/content/en/administrator-manual/audit/database-logs.mdx
+++ b/src/content/en/administrator-manual/audit/database-logs.mdx
@@ -16,13 +16,13 @@ Additionally, you can view and release connection lock history due to DB connect
 
 In addition to the audit logs commonly provided by QueryPie, when you have a QueryPie Database Access Control (QueryPie DAC) license, the following log types are provided.
 
-<table data-table-width="507" data-layout="default" local-id="95470ac3-09e4-4695-80b7-6e7d4ff27bf8">
+<table>
 <tbody>
 <tr>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Common Logs**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **DAC-specific Logs**
 </th>
 </tr>

--- a/src/content/en/administrator-manual/audit/kubernetes-logs.mdx
+++ b/src/content/en/administrator-manual/audit/kubernetes-logs.mdx
@@ -14,7 +14,7 @@ Real-time recorded logs can be searched and filtered with various conditions.
 
 In addition to the audit logs commonly provided by QueryPie, when you have a QueryPie Kubernetes Access Control (QueryPie KAC) license, the following types of audit logs are provided.
 
-<table data-table-width="507" data-layout="default" local-id="2eeba34f-b909-48ea-a011-5381931efcd4">
+<table>
 <tbody>
 <tr>
 <th>

--- a/src/content/en/administrator-manual/audit/reports/reports.mdx
+++ b/src/content/en/administrator-manual/audit/reports/reports.mdx
@@ -24,7 +24,7 @@ As of version 11.2.0, reports can only be output in English.
 
 Please refer to the table below for report items and filters currently supported as of version 11.2.0.
 
-<table data-table-width="958" data-layout="center" local-id="cfcbf091-3775-4454-bff4-924bf43e88f4">
+<table>
 <a id="table-1"></a>
 <colgroup>
 <col/>

--- a/src/content/en/administrator-manual/audit/server-logs.mdx
+++ b/src/content/en/administrator-manual/audit/server-logs.mdx
@@ -16,13 +16,13 @@ Additionally, you can view the list of sessions connected through QueryPie or fo
 
 In addition to the audit logs commonly provided by QueryPie, when you have a QueryPie System Access Control (QueryPie SAC) license, the following types of audit logs are provided.
 
-<table data-table-width="507" data-layout="default" local-id="95470ac3-09e4-4695-80b7-6e7d4ff27bf8">
+<table>
 <tbody>
 <tr>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Common Logs**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **SAC-specific Logs**
 </th>
 </tr>

--- a/src/content/en/administrator-manual/audit/web-app-logs.mdx
+++ b/src/content/en/administrator-manual/audit/web-app-logs.mdx
@@ -14,24 +14,24 @@ Real-time recorded logs can be searched and filtered with various conditions.
 
 In addition to the audit logs commonly provided with web apps, when you have a QueryPie Web App Access Control (QueryPie WAC) license, the following types of audit logs are provided.
 
-<table data-table-width="507" data-layout="default" local-id="2f7b87af-5d13-428d-90c7-597153763bc3">
+<table>
 <tbody>
 <tr>
-<th data-highlight-colour="#f0f1f2">
+<th>
 **Common Logs**
 </th>
-<th data-highlight-colour="#f0f1f2">
+<th>
 **WAC-specific Logs**
 </th>
 </tr>
 <tr>
-<td data-highlight-colour="#ffffff">
+<td>
 **General**
 * User Access History
 * Activity Logs
 * Admin Role History
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 **Web Apps**
 * Web Access History
 * Web Event Audit

--- a/src/content/en/administrator-manual/databases.mdx
+++ b/src/content/en/administrator-manual/databases.mdx
@@ -24,7 +24,7 @@ If you are an administrator using QueryPie DAC (Database Access Controller) for 
 Clicking on linked items will take you to a page where you can immediately check the related guide.
 </Callout>
 
-<table data-table-width="760" data-layout="default" local-id="732b2fe2-d76c-4f02-aa32-1d192dd4db6e">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/en/administrator-manual/general/company-management/alerts.mdx
+++ b/src/content/en/administrator-manual/general/company-management/alerts.mdx
@@ -27,7 +27,7 @@ It supports general alerts as well as alerts specialized for DB access and syste
 
 The alert types supported by each service are as follows:
 
-<table data-table-width="760" data-layout="center" local-id="56383138-c970-42e6-869a-a74e4c473292">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/en/administrator-manual/general/company-management/alerts/new-request-template-variables-by-request-type.mdx
+++ b/src/content/en/administrator-manual/general/company-management/alerts/new-request-template-variables-by-request-type.mdx
@@ -12,7 +12,7 @@ List of variables supported in all request types.
 
 Common variables are also available when Request Type is set to all.
 
-<table data-table-width="811" data-layout="center" local-id="c749b9ca-9033-4c2b-b8fa-3880ad5a8736">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -194,7 +194,7 @@ Urgent request status
 
 ### DB Access Request
 
-<table data-table-width="808" data-layout="center" local-id="ee62ec7d-c9f6-4e28-b56e-747b6443c26d">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -281,7 +281,7 @@ Display requested privileges by connection as a list
 
 ### SQL Request
 
-<table data-table-width="814" data-layout="center" local-id="65178aed-8861-4dee-943a-42d33ce617bf">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -494,7 +494,7 @@ Execution expiration date
 
 ### SQL Export Request
 
-<table data-table-width="816" data-layout="center" local-id="a7dabd97-8ea6-4502-b876-197d927dd1dc">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -692,7 +692,7 @@ Execution expiration date
 
 ### Unmasking Request
 
-<table data-table-width="816" data-layout="center" local-id="212dceed-34bd-42c0-9cab-7b11a24950af">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -835,7 +835,7 @@ Approval expiration date
 
 ### Restricted Data Access Request
 
-<table data-table-width="816" data-layout="center" local-id="8d66df32-3ad9-473e-9876-a4c7fe8775e1">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -978,7 +978,7 @@ Approval expiration date
 
 ### DB Policy Exception Request
 
-<table data-table-width="816" data-layout="center" local-id="8fdf1d5c-786c-4147-8e56-bfd6d8dcdb0f">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -1135,7 +1135,7 @@ Approval expiration date
 
 ### Server Access Request
 
-<table data-table-width="820" data-layout="center" local-id="a4480e83-0193-4c46-ba7c-53a665a6ad03">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -1281,7 +1281,7 @@ Time in minutes that server access permission is valid
 
 ### Server Privilege Request
 
-<table data-table-width="820" data-layout="center" local-id="1ac8db57-f53b-4306-9a63-eabe504365d4">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -1427,7 +1427,7 @@ Time in minutes that server privilege is valid
 
 ### Access Role Request
 
-<table data-table-width="816" data-layout="center" local-id="e44f2beb-29c0-417c-b961-8a1b7946b510">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/en/administrator-manual/general/system/integrations/identity-providers.mdx
+++ b/src/content/en/administrator-manual/general/system/integrations/identity-providers.mdx
@@ -88,75 +88,75 @@ To synchronize user group information and membership information from LDAP, enab
 </figure>
 
 
-<table data-table-width="760" data-layout="default" local-id="56f8d1f8-9645-460d-a5cb-b6cce53606f2">
+<table>
 <colgroup>
 <col/>
 <col/>
 <col/>
 </colgroup>
 <tbody>
-<tr local-id="cfa528d4-7ee6-483e-8b39-8d8a70310476">
-<th data-highlight-colour="#f0f1f2" local-id="2cdeca85-1e14-4556-8faf-7e77b327d3b9">
+<tr>
+<th>
 **Attribute**
 </th>
-<th data-highlight-colour="#f0f1f2" local-id="53109c7a-a40d-4a4e-9d6a-73c4ddc826c4">
+<th>
 **Required**
 </th>
-<th data-highlight-colour="#f0f1f2" local-id="e24af88f-9192-424a-b43f-025bb31f869d">
+<th>
 **Description**
 </th>
 </tr>
-<tr local-id="75805077-450e-4657-bfe4-3cf78a4d5928">
-<td data-highlight-colour="#ffffff" local-id="ea2a1ab7-7f7f-496d-9a6c-da87bf25e27e">
+<tr>
+<td>
 Group Base DN
 </td>
-<td data-highlight-colour="#ffffff" local-id="b89474cb-0a96-449d-8a83-c1ca1e5a2b56">
+<td>
 Required
 </td>
-<td data-highlight-colour="#ffffff" local-id="45f67115-11f7-474d-b15e-7189fd10c205">
+<td>
 Enter the group Base DN value of the LDAP server.
 Only groups under this path are synchronized as Groups.
 * Example: `dc=example,dc=com`
 </td>
 </tr>
-<tr local-id="acfd3ac8-1ccf-4790-87fa-969d15cf52d6">
-<td data-highlight-colour="#ffffff" local-id="18032ff5-11ab-427f-85c6-a8246f91a155">
+<tr>
+<td>
 Group Search Filter
 </td>
-<td data-highlight-colour="#ffffff" local-id="646d1d8d-c6ab-4445-976e-a92acb4ad672">
+<td>
 Required
 </td>
-<td data-highlight-colour="#ffffff" local-id="51af7682-029c-474f-b1d7-9658042490f0">
+<td>
 Enter the filter value to fetch groups from the LDAP server.
 * Example: `objectclass=posixGroup`
 </td>
 </tr>
-<tr local-id="5c723610-073d-4379-a2fe-ee2392355478">
-<td local-id="ec5bca28-b3ec-4bdb-be11-90e106ad68b3">
+<tr>
+<td>
 Group ID
 </td>
-<td local-id="7ae2e57e-9b05-42b5-a721-e2289dc4a1ea">
+<td>
 Required
 </td>
-<td local-id="588d0912-0f58-4f46-9b25-c50c90650b50">
+<td>
 Enter the attribute value to use as the group identifier.
 * Example: `gidNumber`
 </td>
 </tr>
-<tr local-id="f6c5bd3a-d125-41ed-a76f-09b7ba17f1b1">
-<td data-highlight-colour="#ffffff" rowspan="2" local-id="22031ab0-9082-4f3f-bc9f-c375ce2a39a5">
+<tr>
+<td rowspan="2">
 Membership Type
 </td>
-<td data-highlight-colour="#ffffff" rowspan="2" local-id="7db6a6a6-8fcc-4a8f-b59e-544ccd580c72">
+<td rowspan="2">
 Required
 </td>
-<td data-highlight-colour="#ffffff" local-id="1dc8e309-8401-4397-ba11-1dfda8f45536">
+<td>
 If user entries contain group information, select `Include group information in user entries` and enter the attribute to reference in the field below.
 * Example: `member`, `uniqueMember`, `memberUid`, etc.
 </td>
 </tr>
-<tr local-id="97e7cec3-7328-4f30-8b01-295ca445a63f">
-<td data-highlight-colour="#ffffff" local-id="01bae4e3-5d99-4208-ba57-3880491c4780">
+<tr>
+<td>
 If group entries contain user information, select `Include user information in group entries` and enter the attribute to reference in the field below.
 * Example: `gidNumber`
 </td>

--- a/src/content/en/administrator-manual/general/user-management/authentication/integrating-with-ldap.mdx
+++ b/src/content/en/administrator-manual/general/user-management/authentication/integrating-with-ldap.mdx
@@ -45,7 +45,7 @@ For detailed descriptions, please refer to the items below.
 To synchronize user group information and membership information from LDAP, activate the **Use Group option** and enter the required information.
 For detailed descriptions, please refer to the items below.
 
-<table data-table-width="760" data-layout="default" local-id="b96b2197-17c2-48d3-98a7-93b37fc6260b">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -153,7 +153,7 @@ Click the `Add Row` button in the top right corner to add a new mapping row, and
 3. When deleting or changing mapping rows, you must click Save Changes for changes to be reflected in the UI, and you must additionally click Synchronize for actual synchronization with LDAP to be performed. That is, Save Changes means screen changes, and Synchronize means system reflection.
 </Callout>
 
-<table data-table-width="760" data-layout="default" local-id="a5c81338-6a96-4dc0-89e5-d0c7a08da012">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/en/administrator-manual/kubernetes.mdx
+++ b/src/content/en/administrator-manual/kubernetes.mdx
@@ -24,7 +24,7 @@ For administrators new to QueryPie KAC (Kubernetes Access Controller), we recomm
 Clicking on linked items will take you to pages where you can immediately check related guides.
 </Callout>
 
-<table data-table-width="760" data-layout="default" local-id="732b2fe2-d76c-4f02-aa32-1d192dd4db6e">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/en/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-yaml-code-syntax-guide.mdx
+++ b/src/content/en/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-yaml-code-syntax-guide.mdx
@@ -28,7 +28,7 @@ For Kubernetes policies, the specification was created as a comprehensive model 
 
 Wildcard ("*") and regular expression ([RE2 format](https://github.com/girishji/re2/wiki/Syntax): `^$` explicit required) patterns are supported in general policy code except for some items.
 
-<table data-table-width="760" data-layout="default" local-id="35831a4b-16f9-461f-96a1-0af983cbf59e">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -38,19 +38,19 @@ Wildcard ("*") and regular expression ([RE2 format](https://github.com/girishji/
 </colgroup>
 <tbody>
 <tr>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Category**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Property**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Required**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Description**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Valid Values**
 </th>
 </tr>

--- a/src/content/en/administrator-manual/servers.mdx
+++ b/src/content/en/administrator-manual/servers.mdx
@@ -26,7 +26,7 @@ Setting up essential resources like Account and SSH Key first, which are require
 Clicking on linked items will take you to pages where you can immediately check related guides.
 </Callout>
 
-<table data-table-width="760" data-layout="default" local-id="732b2fe2-d76c-4f02-aa32-1d192dd4db6e">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/en/administrator-manual/web-apps/wac-quickstart/1027-wac-role-policy-guide.mdx
+++ b/src/content/en/administrator-manual/web-apps/wac-quickstart/1027-wac-role-policy-guide.mdx
@@ -28,7 +28,7 @@ When all policies included in a role are combined, **at least 1 allow policy** m
 
 WAC policies are written in YAML format, and their basic structure is as follows.
 
-<table data-table-width="760" data-layout="default" local-id="35831a4b-16f9-461f-96a1-0af983cbf59e">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -38,19 +38,19 @@ WAC policies are written in YAML format, and their basic structure is as follows
 </colgroup>
 <tbody>
 <tr>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Category**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Property**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Required**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Description**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Valid Values**
 </th>
 </tr>

--- a/src/content/en/administrator-manual/web-apps/wac-quickstart/1028-wac-rbac-guide.mdx
+++ b/src/content/en/administrator-manual/web-apps/wac-quickstart/1028-wac-rbac-guide.mdx
@@ -58,7 +58,7 @@ spec:
 
 ### YAML Specification
 
-<table data-table-width="760" data-layout="default" local-id="bb2479df-82c8-474e-8723-247d4037944a">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -68,107 +68,107 @@ spec:
 </colgroup>
 <tbody>
 <tr>
-<th data-highlight-colour="#f0f1f2">
+<th>
 **Category**
 </th>
-<th data-highlight-colour="#f0f1f2">
+<th>
 **Property**
 </th>
-<th data-highlight-colour="#f0f1f2">
+<th>
 **Required**
 </th>
-<th data-highlight-colour="#f0f1f2">
+<th>
 **Description**
 </th>
-<th data-highlight-colour="#f0f1f2">
+<th>
 **Valid Values**
 </th>
 </tr>
 <tr>
-<td data-highlight-colour="#ffffff">
+<td>
 `apiVersion`
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 -
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 **[required]**
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 Version of the written YAML Code
 System-managed value, no modification needed
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 `webApp.rbac.querypie.com/v1`
 </td>
 </tr>
 <tr>
-<td data-highlight-colour="#ffffff">
+<td>
 `kind`
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 -
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 **[required]**
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 Type of the written YAML Code
 System-managed value, no modification needed
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 `WacPolicy`
 </td>
 </tr>
 <tr>
-<td data-highlight-colour="#ffffff">
+<td>
 `spec:`<br/> `&lt;effect&gt;`
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 -
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 **[required]**
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 Detailed rules within the policy (allow or deny)
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 `allow`, `deny`
 </td>
 </tr>
 <tr>
-<td data-highlight-colour="#ffffff">
+<td>
 
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 `resources`
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 **[required]**
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 Specify resources to allow/deny access
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 `webApp`, `urlPaths`, `urlPathTags` (urlPathTags can only be used in `spec: allow`)
 </td>
 </tr>
 <tr>
-<td data-highlight-colour="#ffffff">
+<td>
 
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 `conditions`
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 **[OPTIONAL]**
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 Detailed conditions for rule application targets
 (Currently only available in `spec: allow`)
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 `userAttributes`, `ipAddresses`
 </td>
 </tr>

--- a/src/content/en/installation/container-environment-variables.mdx
+++ b/src/content/en/installation/container-environment-variables.mdx
@@ -32,7 +32,7 @@ This document applies to QueryPie 10.3.0 or later versions.
 
 ### Deprecated Environment Variables
 
-<table data-table-width="1800" data-layout="default" local-id="c5fb16aa-9f97-493c-b628-440e4446f3b1">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -40,13 +40,13 @@ This document applies to QueryPie 10.3.0 or later versions.
 </colgroup>
 <tbody>
 <tr>
-<td data-highlight-colour="#f4f5f7">
+<td>
 **Environment Variable Name**
 </td>
-<td data-highlight-colour="#f4f5f7">
+<td>
 **Default Value**
 </td>
-<td data-highlight-colour="#f4f5f7">
+<td>
 **Description**
 </td>
 </tr>

--- a/src/content/en/installation/prerequisites/linux-distribution-and-docker-podman-support-status.mdx
+++ b/src/content/en/installation/prerequisites/linux-distribution-and-docker-podman-support-status.mdx
@@ -48,7 +48,7 @@ Docker and Podman support status is based on whether versions for running and ma
 
 For old versions of Podman 3.x, or cases where reliable packages are not provided, technical support is not provided by the QueryPie team, and it is classified as a condition where QueryPie cannot be used.
 
-<table data-table-width="760" data-layout="default" local-id="1e7d3698-ac8b-43f8-8fc8-c306e24dd14c">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/en/installation/querypie-acp-community-edition.mdx
+++ b/src/content/en/installation/querypie-acp-community-edition.mdx
@@ -21,7 +21,7 @@ QueryPie runs as a general web application and also includes proxy-based network
 
 For smooth installation and operation of QueryPie Community Edition, we recommend the following system environment.
 
-<table data-table-width="834" data-layout="center" local-id="7fd726e9-fc83-4263-a08f-8daf43a53c3b">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/en/release-notes/990-998/external-api-changes-9810-version-994-version.mdx
+++ b/src/content/en/release-notes/990-998/external-api-changes-9810-version-994-version.mdx
@@ -29,7 +29,7 @@ ______
 
 #### Changes/Improvements
 
-<table data-table-width="760" data-layout="default" local-id="dde603df-3268-4faf-a41d-602a0c651910">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -85,7 +85,7 @@ ______
 
 * For detailed request content, refer to Docs
 
-<table data-table-width="760" data-layout="default" local-id="07d79f85-952c-4830-a77e-c026ab9a37ca">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -178,7 +178,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="4a964f40-a620-417f-bd2f-52c24b38404e">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -268,7 +268,7 @@ ______
 
 * Query Parameter
 
-<table data-table-width="760" data-layout="default" local-id="177f70ea-ceb0-4cfd-bbf6-f23d470f037a">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -316,7 +316,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="932182bb-da8d-497f-a802-b0ac654a837a">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -391,7 +391,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="faa4a484-fb0f-47b7-978a-23feea65210e">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -446,7 +446,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="e34b740f-592e-49c5-b549-6f54500e8c83">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -505,7 +505,7 @@ ______
 
 * Query Parameter
 
-<table data-table-width="760" data-layout="default" local-id="9d2bd396-23e6-44cf-baa2-f17fc0dd9b55">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -585,7 +585,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="c43c1c7c-02dd-48b4-a04d-2c66bce49618">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -650,7 +650,7 @@ ______
 
 ##### Request
 
-<table data-table-width="760" data-layout="default" local-id="7f2d3d42-8253-404f-9149-10b318b6ca3d">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -697,7 +697,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="b16699b8-ecb0-4ee1-ac36-7ac7ea42eae9">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -748,7 +748,7 @@ ______
 
 ##### Request
 
-<table data-table-width="760" data-layout="default" local-id="f52a5751-3b5e-4888-b0bb-bb102080762d">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -800,7 +800,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="1b7cfa33-d4bb-4e89-a7c6-5add7e6663c3">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -861,7 +861,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="fea50ede-0255-4ec9-960a-1472523b2651">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -920,7 +920,7 @@ ______
 
 ##### Request & Response
 
-<table data-table-width="760" data-layout="default" local-id="56c6d3e7-3146-49ff-82ea-4aa792c89003">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -967,7 +967,7 @@ ______
 
 ##### Request & Response
 
-<table data-table-width="760" data-layout="default" local-id="85cd18b3-fa2c-4df3-a4b5-1b6e9a773256">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -1024,7 +1024,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="c8555215-eb77-4807-a123-8728d1377f19">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -1169,7 +1169,7 @@ None
 
 ##### Request
 
-<table data-table-width="760" data-layout="default" local-id="a91c0329-8458-4c75-a106-ccdd7a0e25e3">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -1287,7 +1287,7 @@ None
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="39575eab-8bc2-45f4-b145-a8b9d33bc1ef">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -1417,7 +1417,7 @@ None
 
 ##### Request
 
-<table data-table-width="760" data-layout="default" local-id="30d79d2b-4f9e-4cd9-82c4-3e3b2d040226">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -1534,7 +1534,7 @@ None
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="55b9a43a-b701-488d-8c41-38951410331d">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -1672,7 +1672,7 @@ ______
 
 * Query Parameter field addition
 
-<table data-table-width="760" data-layout="default" local-id="306ad9b1-6ed1-421e-b58c-42ed27d24672">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/en/release-notes/990-998/external-api-changes-994-version-995-version.mdx
+++ b/src/content/en/release-notes/990-998/external-api-changes-994-version-995-version.mdx
@@ -22,7 +22,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="729f4860-908e-453e-a2ce-586ef92bde21">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -60,7 +60,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="d1aedf57-9c7c-4ffd-abf3-d1381144dd7d">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -114,7 +114,7 @@ ______
 
 * Query Parameter
 
-<table data-table-width="760" data-layout="default" local-id="a8579e9b-bf3a-44ef-8dbe-bef487c68840">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/en/user-manual.mdx
+++ b/src/content/en/user-manual.mdx
@@ -14,7 +14,7 @@ This guide provides information on how QueryPie users can access QueryPie Web, r
 Follow the steps below to get started.
 Click on each item to see detailed usage instructions.
 
-<table data-table-width="760" data-layout="default" local-id="c53b8e8a-3f68-476f-aa0a-03f2f0eb700f">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -24,10 +24,10 @@ Click on each item to see detailed usage instructions.
 <tr>
 <th>
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Usage Steps**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Features**
 </th>
 </tr>
@@ -35,7 +35,7 @@ Click on each item to see detailed usage instructions.
 <td>
 1
 </td>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Login**
 </th>
 <td>
@@ -46,7 +46,7 @@ Click on each item to see detailed usage instructions.
 <td>
 2
 </td>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Explore Dashboard**
 </th>
 <td>
@@ -57,7 +57,7 @@ Click on each item to see detailed usage instructions.
 <td>
 3
 </td>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Get Permissions through Workflow**
 </th>
 <td>
@@ -77,7 +77,7 @@ Click on each item to see detailed usage instructions.
 <td>
 4
 </td>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Access from QueryPie Web**
 </th>
 <td>
@@ -100,7 +100,7 @@ Click on each item to see detailed usage instructions.
 <td>
 5
 </td>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Access with QueryPie Agent**
 </th>
 <td>
@@ -111,7 +111,7 @@ Click on each item to see detailed usage instructions.
 <td>
 6
 </td>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Explore Personal Settings**
 </th>
 <td>

--- a/src/content/en/user-manual/workflow.mdx
+++ b/src/content/en/user-manual/workflow.mdx
@@ -168,7 +168,7 @@ The Review menu is only displayed when the administrator has pre-configured its 
 
 The approval status list for requests is as follows.
 
-<table data-table-width="760" data-layout="default" local-id="7a620066-c0b8-4120-ad33-9894d8be7321">
+<table>
 <tbody>
 <tr>
 <th>

--- a/src/content/ja/administrator-manual.mdx
+++ b/src/content/ja/administrator-manual.mdx
@@ -26,7 +26,7 @@ GNB内の管理者ページアクセスポイント
 Databases、Servers、Kubernetesなど、各サービス設定を進める前に、基本的に設定しなければならない項目があります。
 特にセキュリティ設定、ユーザー設定、管理者役割割り当ては必須で設定することをお勧めします。
 
-<table data-table-width="760" data-layout="default" local-id="96d34ea4-8772-49af-9ba2-14ea36b1f3e1">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -36,10 +36,10 @@ Databases、Servers、Kubernetesなど、各サービス設定を進める前に
 <tr>
 <th>
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **設定順序**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **設定項目**
 </th>
 </tr>
@@ -142,7 +142,7 @@ QueryPieの細分化されたアクセス制御機能を通じて、強力な権
 サービス別設定が終わった後は、管理者/ユーザーの接続および実行履歴をAuditメニューで詳しく確認できます。
 また、機密情報を識別できるDiscovery機能も提供するので、次世代ディスカバリ機能を体験してみてください。
 
-<table data-table-width="760" data-layout="default" local-id="1c770267-da7f-48dc-b1e3-817744eeec38">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -152,10 +152,10 @@ QueryPieの細分化されたアクセス制御機能を通じて、強力な権
 <tr>
 <th>
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **設定順序**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **設定項目**
 </th>
 </tr>

--- a/src/content/ja/administrator-manual/audit.mdx
+++ b/src/content/ja/administrator-manual/audit.mdx
@@ -27,24 +27,24 @@ QueryPie内で起こるすべての活動は監査ログに記録されます。
 
 照会可能な監査ログの種類は保有しているライセンスに応じて構成が変わり、ライセンス別提供されるログの種類は以下の通りです。
 
-<table data-table-width="760" data-layout="default" local-id="2eeba34f-b909-48ea-a011-5381931efcd4">
+<table>
 <tbody>
-<tr local-id="84b3c86c-ab6d-43e6-844e-ee8e8565386e">
-<th local-id="4b5bfae2-bcbd-452a-82cf-2e340a8f9298">
+<tr>
+<th>
 **共通ログ**
 </th>
-<th local-id="56489574-e0c9-4e34-8829-6c68d3520e81">
+<th>
 **DAC専用ログ**
 </th>
-<th local-id="ebd3ff56-3b1b-42a9-bb8d-2e63484de5dd">
+<th>
 **SAC専用ログ**
 </th>
-<th local-id="e54d7e73-a09b-4000-9c43-b18546a06c24">
+<th>
 **KAC専用ログ**
 </th>
 </tr>
-<tr local-id="6069ea89-296f-43b1-8bf5-55dff52c0918">
-<td local-id="e27a7b6c-2d4e-49a9-b73d-51d7e79e6631">
+<tr>
+<td>
 **General**
 * User Access History
 * Activity Logs
@@ -52,7 +52,7 @@ QueryPie内で起こるすべての活動は監査ログに記録されます。
 * Workflow Logs
 * Reverse Tunnels
 </td>
-<td local-id="310ff96c-a206-4b06-81f4-24e823656e97">
+<td>
 **Databases**
 * DB Access History
 * Query Audit
@@ -61,7 +61,7 @@ QueryPie内で起こるすべての活動は監査ログに記録されます。
 * Account Lock History
 * Access Control Logs
 </td>
-<td local-id="1656db56-c136-4d6b-90c6-4f7b57ae184e">
+<td>
 **Servers**
 * Server Access History
 * Command Audit
@@ -71,7 +71,7 @@ QueryPie内で起こるすべての活動は監査ログに記録されます。
 * Server Role History
 * Account Lock History
 </td>
-<td local-id="8c0cace7-ea51-4f70-a2f5-69cd5117ce5c">
+<td>
 **Kubernetes**
 * Request Audit
 * Pod Session Recordings

--- a/src/content/ja/administrator-manual/audit/database-logs.mdx
+++ b/src/content/ja/administrator-manual/audit/database-logs.mdx
@@ -16,13 +16,13 @@ DB接続権限付与と回収、DBアクセス履歴、実行したクエリ、D
 
 クエリパイ共通で提供される監査ログに加えてクエリパイデータベースアクセス制御（QueryPie DAC）ライセンス保有時、以下のようなログタイプを提供します。
 
-<table data-table-width="507" data-layout="default" local-id="95470ac3-09e4-4695-80b7-6e7d4ff27bf8">
+<table>
 <tbody>
 <tr>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **共通ログ**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **DAC専用ログ**
 </th>
 </tr>

--- a/src/content/ja/administrator-manual/audit/kubernetes-logs.mdx
+++ b/src/content/ja/administrator-manual/audit/kubernetes-logs.mdx
@@ -14,7 +14,7 @@ QueryPieでのすべての活動は監査ログに記録されます。
 
 クエリパイ共通で提供される監査ログに加えて、クエリパイKubernetesアクセス制御（QueryPie KAC）ライセンス保有時、以下の監査ログの種類を提供します。
 
-<table data-table-width="507" data-layout="default" local-id="2eeba34f-b909-48ea-a011-5381931efcd4">
+<table>
 <tbody>
 <tr>
 <th>

--- a/src/content/ja/administrator-manual/audit/reports/reports.mdx
+++ b/src/content/ja/administrator-manual/audit/reports/reports.mdx
@@ -24,7 +24,7 @@ QueryPieレポートは監査対応に必要なデータをレポート形式で
 
 11.2.0バージョン現在サポートするレポート項目およびフィルターは以下の表を参照してください。
 
-<table data-table-width="958" data-layout="center" local-id="cfcbf091-3775-4454-bff4-924bf43e88f4">
+<table>
 <a id="table-1"></a>
 <colgroup>
 <col/>

--- a/src/content/ja/administrator-manual/audit/server-logs.mdx
+++ b/src/content/ja/administrator-manual/audit/server-logs.mdx
@@ -16,24 +16,24 @@ QueryPieのSystem Access Controlで発生するログをServer Logsで確認で�
 
 クエリパイ共通で提供される監査ログに加えてクエリパイシステムアクセス制御（QueryPie SAC）ライセンス保有時、以下の監査ログの種類を提供します。
 
-<table data-table-width="507" data-layout="default" local-id="95470ac3-09e4-4695-80b7-6e7d4ff27bf8">
+<table>
 <tbody>
-<tr local-id="8534186b-2033-4cc7-877e-dda79ee3b5b3">
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)" local-id="70f8197e-b83d-409e-bcbf-5e95dc6d6c13">
+<tr>
+<th>
 **共通ログ**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)" local-id="d3c87cc4-a023-4553-83b5-32808f0bcd35">
+<th>
 **SAC専用ログ**
 </th>
 </tr>
-<tr local-id="606bc709-5042-4fee-a00f-ad8452b791a9">
-<td local-id="33649f7e-f4b6-4a70-99c7-2aadea2b484f">
+<tr>
+<td>
 **General**
 * User Access History
 * Activity Logs
 * Admin Role History
 </td>
-<td local-id="a584fa3d-0929-4abe-8ac4-551670a70a00">
+<td>
 **Servers**
 * Server Access History
 * Command Audit

--- a/src/content/ja/administrator-manual/audit/web-app-logs.mdx
+++ b/src/content/ja/administrator-manual/audit/web-app-logs.mdx
@@ -14,24 +14,24 @@ QueryPieでのすべてのウェブアプリを監査ログに記録します。
 
 ウェブアプリと共通で提供される監査ログに加えて、ウェブアプリKubernetesアクセス制御（QueryPie WAC）ライセンス保有時、以下の監査ログの種類を提供します。
 
-<table data-table-width="507" data-layout="default" local-id="2f7b87af-5d13-428d-90c7-597153763bc3">
+<table>
 <tbody>
 <tr>
-<th data-highlight-colour="#f0f1f2">
+<th>
 **共通ログ**
 </th>
-<th data-highlight-colour="#f0f1f2">
+<th>
 **WAC専用ログ**
 </th>
 </tr>
 <tr>
-<td data-highlight-colour="#ffffff">
+<td>
 **General**
 * User Access History
 * Activity Logs
 * Admin Role History
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 **Web Apps**
 * Web Access History
 * Web Event Audit

--- a/src/content/ja/administrator-manual/databases.mdx
+++ b/src/content/ja/administrator-manual/databases.mdx
@@ -24,7 +24,7 @@ QueryPie DAC（Database Access Controller）を初めて使用する管理者な
 リンクされた項目をクリックすると関連ガイドをすぐに確認できるページに移動します。
 </Callout>
 
-<table data-table-width="760" data-layout="default" local-id="732b2fe2-d76c-4f02-aa32-1d192dd4db6e">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/ja/administrator-manual/general/company-management/alerts.mdx
+++ b/src/content/ja/administrator-manual/general/company-management/alerts.mdx
@@ -27,7 +27,7 @@ Administrator &gt; General &gt; Company Management &gt; Alerts
 
 サービス別にサポートする通知タイプは以下の通りです。
 
-<table data-table-width="760" data-layout="center" local-id="56383138-c970-42e6-869a-a74e4c473292">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/ja/administrator-manual/general/company-management/alerts/new-request-template-variables-by-request-type.mdx
+++ b/src/content/ja/administrator-manual/general/company-management/alerts/new-request-template-variables-by-request-type.mdx
@@ -12,7 +12,7 @@ Alert TypeをNew Requestで選択した場合、Request Typeによるテンプ�
 
 Request Typeを全体選択した場合でも共通変数は使用可能です。
 
-<table data-table-width="811" data-layout="center" local-id="c749b9ca-9033-4c2b-b8fa-3880ad5a8736">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -194,7 +194,7 @@ Urgent
 
 ### DB Access Request
 
-<table data-table-width="808" data-layout="center" local-id="ee62ec7d-c9f6-4e28-b56e-747b6443c26d">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -281,7 +281,7 @@ Requested Privilege per Connection
 
 ### SQL Request
 
-<table data-table-width="814" data-layout="center" local-id="65178aed-8861-4dee-943a-42d33ce617bf">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -494,7 +494,7 @@ Execution Expiration Date
 
 ### SQL Export Request
 
-<table data-table-width="816" data-layout="center" local-id="a7dabd97-8ea6-4502-b876-197d927dd1dc">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -692,7 +692,7 @@ Execution Expiration Date
 
 ### Unmasking Request
 
-<table data-table-width="816" data-layout="center" local-id="212dceed-34bd-42c0-9cab-7b11a24950af">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -835,7 +835,7 @@ Approval Expiration Date
 
 ### Restricted Data Access Request
 
-<table data-table-width="816" data-layout="center" local-id="8d66df32-3ad9-473e-9876-a4c7fe8775e1">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -978,7 +978,7 @@ Approval Expiration Date
 
 ### DB Policy Exception Request
 
-<table data-table-width="816" data-layout="center" local-id="8fdf1d5c-786c-4147-8e56-bfd6d8dcdb0f">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -1135,7 +1135,7 @@ Approval Expiration Date
 
 ### Server Access Request
 
-<table data-table-width="820" data-layout="center" local-id="a4480e83-0193-4c46-ba7c-53a665a6ad03">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -1281,7 +1281,7 @@ Duration
 
 ### Server Privilege Request
 
-<table data-table-width="820" data-layout="center" local-id="1ac8db57-f53b-4306-9a63-eabe504365d4">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -1427,7 +1427,7 @@ Duration
 
 ### Access Role Request
 
-<table data-table-width="816" data-layout="center" local-id="e44f2beb-29c0-417c-b961-8a1b7946b510">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/ja/administrator-manual/general/system/integrations/identity-providers.mdx
+++ b/src/content/ja/administrator-manual/general/system/integrations/identity-providers.mdx
@@ -88,75 +88,75 @@ LDAPからユーザーグループ情報および所属情報を同期するに�
 </figure>
 
 
-<table data-table-width="760" data-layout="default" local-id="56f8d1f8-9645-460d-a5cb-b6cce53606f2">
+<table>
 <colgroup>
 <col/>
 <col/>
 <col/>
 </colgroup>
 <tbody>
-<tr local-id="cfa528d4-7ee6-483e-8b39-8d8a70310476">
-<th data-highlight-colour="#f0f1f2" local-id="2cdeca85-1e14-4556-8faf-7e77b327d3b9">
+<tr>
+<th>
 **Attribute**
 </th>
-<th data-highlight-colour="#f0f1f2" local-id="53109c7a-a40d-4a4e-9d6a-73c4ddc826c4">
+<th>
 **必須**
 </th>
-<th data-highlight-colour="#f0f1f2" local-id="e24af88f-9192-424a-b43f-025bb31f869d">
+<th>
 **Description**
 </th>
 </tr>
-<tr local-id="75805077-450e-4657-bfe4-3cf78a4d5928">
-<td data-highlight-colour="#ffffff" local-id="ea2a1ab7-7f7f-496d-9a6c-da87bf25e27e">
+<tr>
+<td>
 Group Base DN
 </td>
-<td data-highlight-colour="#ffffff" local-id="b89474cb-0a96-449d-8a83-c1ca1e5a2b56">
+<td>
 必須
 </td>
-<td data-highlight-colour="#ffffff" local-id="45f67115-11f7-474d-b15e-7189fd10c205">
+<td>
 LDAPサーバーのグループBase DN値を入力します。
 このパスの下位にあるグループのみがGroupとして同期されます。
 * 例：`dc=example,dc=com`
 </td>
 </tr>
-<tr local-id="acfd3ac8-1ccf-4790-87fa-969d15cf52d6">
-<td data-highlight-colour="#ffffff" local-id="18032ff5-11ab-427f-85c6-a8246f91a155">
+<tr>
+<td>
 Group Search Filter
 </td>
-<td data-highlight-colour="#ffffff" local-id="646d1d8d-c6ab-4445-976e-a92acb4ad672">
+<td>
 必須
 </td>
-<td data-highlight-colour="#ffffff" local-id="51af7682-029c-474f-b1d7-9658042490f0">
+<td>
 LDAPサーバーのグループを取得するためのフィルター値を入力します。
 * 例：`objectclass=posixGroup`
 </td>
 </tr>
-<tr local-id="5c723610-073d-4379-a2fe-ee2392355478">
-<td local-id="ec5bca28-b3ec-4bdb-be11-90e106ad68b3">
+<tr>
+<td>
 Group ID
 </td>
-<td local-id="7ae2e57e-9b05-42b5-a721-e2289dc4a1ea">
+<td>
 必須
 </td>
-<td local-id="588d0912-0f58-4f46-9b25-c50c90650b50">
+<td>
 グループの識別子として使用する属性値を入力します。
 * 例：`gidNumber`
 </td>
 </tr>
-<tr local-id="f6c5bd3a-d125-41ed-a76f-09b7ba17f1b1">
-<td data-highlight-colour="#ffffff" rowspan="2" local-id="22031ab0-9082-4f3f-bc9f-c375ce2a39a5">
+<tr>
+<td rowspan="2">
 Membership Type
 </td>
-<td data-highlight-colour="#ffffff" rowspan="2" local-id="7db6a6a6-8fcc-4a8f-b59e-544ccd580c72">
+<td rowspan="2">
 必須
 </td>
-<td data-highlight-colour="#ffffff" local-id="1dc8e309-8401-4397-ba11-1dfda8f45536">
+<td>
 ユーザーにグループ情報が含まれている場合、`Include group information in user entries`を選択し、下位フィールドに参照するAttributeを入力します。
 * 例：`member`、`uniqueMember`、`memberUid`等
 </td>
 </tr>
-<tr local-id="97e7cec3-7328-4f30-8b01-295ca445a63f">
-<td data-highlight-colour="#ffffff" local-id="01bae4e3-5d99-4208-ba57-3880491c4780">
+<tr>
+<td>
 グループにユーザー情報が含まれている場合、`Include user information in group entries`を選択し、下位フィールドに参照するAttributeを入力します。
 * 例：`gidNumber`
 </td>

--- a/src/content/ja/administrator-manual/general/user-management/authentication/integrating-with-ldap.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/authentication/integrating-with-ldap.mdx
@@ -45,7 +45,7 @@ Attributeマッピングのための属性情報の場合、フィールド名�
 LDAPでユーザーグループ情報および所属情報を同期するには **Use Groupオプション** を有効化し必須で指定された情報を入力します。
 詳細説明は下部項目を参照してください。
 
-<table data-table-width="760" data-layout="default" local-id="b96b2197-17c2-48d3-98a7-93b37fc6260b">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -153,7 +153,7 @@ LDAPで管理中のユーザー属性をQueryPie内Attributeとマッピング�
 3. マッピング行削除または変更時、Save ChangesをクリックしなければUI上で変更事項が反映されず、Synchronizeを追加でクリックしなければLDAPと実際の同期が実行されます。つまり、Save Changesは画面上変更、Synchronizeはシステム反映を意味します。
 </Callout>
 
-<table data-table-width="760" data-layout="default" local-id="a5c81338-6a96-4dc0-89e5-d0c7a08da012">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/ja/administrator-manual/kubernetes.mdx
+++ b/src/content/ja/administrator-manual/kubernetes.mdx
@@ -24,7 +24,7 @@ QueryPie KAC(Kubernetes Access Controller)を初めて使用する管理者な�
 リンクされた項目をクリックすると関連ガイドをすぐに確認できるページに移動します。
 </Callout>
 
-<table data-table-width="760" data-layout="default" local-id="732b2fe2-d76c-4f02-aa32-1d192dd4db6e">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/ja/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-yaml-code-syntax-guide.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-yaml-code-syntax-guide.mdx
@@ -28,7 +28,7 @@ Kubernetesポリシーの場合、実際のKubernetesに存在するネームス
 
 一部項目を除いた全般ポリシーコードでワイルドカード("*")および正規表現([RE2形式](https://github.com/girishji/re2/wiki/Syntax): `^$`明示必須)パターンをサポートします。
 
-<table data-table-width="760" data-layout="default" local-id="35831a4b-16f9-461f-96a1-0af983cbf59e">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -38,19 +38,19 @@ Kubernetesポリシーの場合、実際のKubernetesに存在するネームス
 </colgroup>
 <tbody>
 <tr>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Category**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Property**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Required**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Description**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Valid Values**
 </th>
 </tr>

--- a/src/content/ja/administrator-manual/servers.mdx
+++ b/src/content/ja/administrator-manual/servers.mdx
@@ -26,7 +26,7 @@ Account、SSH Keyのようにサーバー登録に必須的に必要なリソー
 リンクされた項目をクリックすると関連ガイドをすぐに確認できるページに移動します。
 </Callout>
 
-<table data-table-width="760" data-layout="default" local-id="732b2fe2-d76c-4f02-aa32-1d192dd4db6e">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/ja/administrator-manual/web-apps/wac-quickstart/1027-wac-role-policy-guide.mdx
+++ b/src/content/ja/administrator-manual/web-apps/wac-quickstart/1027-wac-role-policy-guide.mdx
@@ -28,7 +28,7 @@ QueryPie WACは他のQueryPie製品と同様にRBAC（Role-Based Access Control�
 
 WACのポリシーはYAML形式で記述され、その基本構造は以下の通りです。
 
-<table data-table-width="760" data-layout="default" local-id="35831a4b-16f9-461f-96a1-0af983cbf59e">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -38,19 +38,19 @@ WACのポリシーはYAML形式で記述され、その基本構造は以下の�
 </colgroup>
 <tbody>
 <tr>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Category**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Property**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Required**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Description**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Valid Values**
 </th>
 </tr>

--- a/src/content/ja/administrator-manual/web-apps/wac-quickstart/1028-wac-rbac-guide.mdx
+++ b/src/content/ja/administrator-manual/web-apps/wac-quickstart/1028-wac-rbac-guide.mdx
@@ -58,7 +58,7 @@ spec:
 
 ### YAML仕様
 
-<table data-table-width="760" data-layout="default" local-id="bb2479df-82c8-474e-8723-247d4037944a">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -68,107 +68,107 @@ spec:
 </colgroup>
 <tbody>
 <tr>
-<th data-highlight-colour="#f0f1f2">
+<th>
 **Category**
 </th>
-<th data-highlight-colour="#f0f1f2">
+<th>
 **Property**
 </th>
-<th data-highlight-colour="#f0f1f2">
+<th>
 **Required**
 </th>
-<th data-highlight-colour="#f0f1f2">
+<th>
 **Description**
 </th>
-<th data-highlight-colour="#f0f1f2">
+<th>
 **Valid Values**
 </th>
 </tr>
 <tr>
-<td data-highlight-colour="#ffffff">
+<td>
 `apiVersion`
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 -
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 **[required]**
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 記述されたYAML Codeのバージョン
 システムで管理する値で、修正不要
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 `webApp.rbac.querypie.com/v1`
 </td>
 </tr>
 <tr>
-<td data-highlight-colour="#ffffff">
+<td>
 `kind`
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 -
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 **[required]**
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 記述されたYAML Codeの種類
 システムで管理する値で、修正不要
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 `WacPolicy`
 </td>
 </tr>
 <tr>
-<td data-highlight-colour="#ffffff">
+<td>
 `spec:`<br/>  `&lt;effect&gt;`
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 -
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 **[required]**
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 ポリシー内の詳細ルール（許可または拒否）
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 `allow`, `deny`
 </td>
 </tr>
 <tr>
-<td data-highlight-colour="#ffffff">
+<td>
 
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 `resources`
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 **[required]**
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 アクセスを許可/拒否するリソース指定
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 `webApp`, `urlPaths`, `urlPathTags` (urlPathTagsは `spec: allow` でのみ使用可能)
 </td>
 </tr>
 <tr>
-<td data-highlight-colour="#ffffff">
+<td>
 
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 `conditions`
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 **[OPTIONAL]**
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 ルール適用対象に対する詳細条件
 (現在 `spec: allow` でのみ使用可能)
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 `userAttributes`, `ipAddresses`
 </td>
 </tr>

--- a/src/content/ja/installation/container-environment-variables.mdx
+++ b/src/content/ja/installation/container-environment-variables.mdx
@@ -32,7 +32,7 @@ QueryPie ACPのServer Containerを実行するために必要な環境変数に�
 
 ### 使用されなくなった環境変数
 
-<table data-table-width="1800" data-layout="default" local-id="c5fb16aa-9f97-493c-b628-440e4446f3b1">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -40,13 +40,13 @@ QueryPie ACPのServer Containerを実行するために必要な環境変数に�
 </colgroup>
 <tbody>
 <tr>
-<td data-highlight-colour="#f4f5f7">
+<td>
 **Environment Variable Name**
 </td>
-<td data-highlight-colour="#f4f5f7">
+<td>
 **Default Value**
 </td>
-<td data-highlight-colour="#f4f5f7">
+<td>
 **Description**
 </td>
 </tr>

--- a/src/content/ja/installation/prerequisites/linux-distribution-and-docker-podman-support-status.mdx
+++ b/src/content/ja/installation/prerequisites/linux-distribution-and-docker-podman-support-status.mdx
@@ -48,7 +48,7 @@ Docker、Podmanサポート現況はQueryPieを実行、管理するためのバ
 
 Podman 3.xの旧バージョン、信頼できるパッケージが提供されない場合、QueryPieチームからの技術サポートを受けられず、QueryPieを使用できない条件と分類します。
 
-<table data-table-width="760" data-layout="default" local-id="1e7d3698-ac8b-43f8-8fc8-c306e24dd14c">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/ja/installation/querypie-acp-community-edition.mdx
+++ b/src/content/ja/installation/querypie-acp-community-edition.mdx
@@ -21,7 +21,7 @@ QueryPieは一般的なウェブアプリケーション形式で実行され、
 
 QueryPie Community Editionの円滑なインストールおよび運用のために以下のようなシステム環境を推奨します。
 
-<table data-table-width="834" data-layout="center" local-id="7fd726e9-fc83-4263-a08f-8daf43a53c3b">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/ja/release-notes/990-998/external-api-changes-9810-version-994-version.mdx
+++ b/src/content/ja/release-notes/990-998/external-api-changes-9810-version-994-version.mdx
@@ -29,7 +29,7 @@ ______
 
 #### 変更/改善事項
 
-<table data-table-width="760" data-layout="default" local-id="dde603df-3268-4faf-a41d-602a0c651910">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -85,7 +85,7 @@ ______
 
 * 詳細なリクエスト内容はDocs参照
 
-<table data-table-width="760" data-layout="default" local-id="07d79f85-952c-4830-a77e-c026ab9a37ca">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -178,7 +178,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="4a964f40-a620-417f-bd2f-52c24b38404e">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -268,7 +268,7 @@ ______
 
 * Query Parameter
 
-<table data-table-width="760" data-layout="default" local-id="177f70ea-ceb0-4cfd-bbf6-f23d470f037a">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -316,7 +316,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="932182bb-da8d-497f-a802-b0ac654a837a">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -391,7 +391,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="faa4a484-fb0f-47b7-978a-23feea65210e">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -446,7 +446,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="e34b740f-592e-49c5-b549-6f54500e8c83">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -505,7 +505,7 @@ ______
 
 * Query Parameter
 
-<table data-table-width="760" data-layout="default" local-id="9d2bd396-23e6-44cf-baa2-f17fc0dd9b55">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -585,7 +585,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="c43c1c7c-02dd-48b4-a04d-2c66bce49618">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -650,7 +650,7 @@ ______
 
 ##### Request
 
-<table data-table-width="760" data-layout="default" local-id="7f2d3d42-8253-404f-9149-10b318b6ca3d">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -697,7 +697,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="b16699b8-ecb0-4ee1-ac36-7ac7ea42eae9">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -748,7 +748,7 @@ ______
 
 ##### Request
 
-<table data-table-width="760" data-layout="default" local-id="f52a5751-3b5e-4888-b0bb-bb102080762d">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -800,7 +800,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="1b7cfa33-d4bb-4e89-a7c6-5add7e6663c3">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -861,7 +861,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="fea50ede-0255-4ec9-960a-1472523b2651">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -920,7 +920,7 @@ ______
 
 ##### Request & Response
 
-<table data-table-width="760" data-layout="default" local-id="56c6d3e7-3146-49ff-82ea-4aa792c89003">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -967,7 +967,7 @@ ______
 
 ##### Request & Response
 
-<table data-table-width="760" data-layout="default" local-id="85cd18b3-fa2c-4df3-a4b5-1b6e9a773256">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -1024,7 +1024,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="c8555215-eb77-4807-a123-8728d1377f19">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -1169,7 +1169,7 @@ ______
 
 ##### Request
 
-<table data-table-width="760" data-layout="default" local-id="a91c0329-8458-4c75-a106-ccdd7a0e25e3">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -1287,7 +1287,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="39575eab-8bc2-45f4-b145-a8b9d33bc1ef">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -1417,7 +1417,7 @@ ______
 
 ##### Request
 
-<table data-table-width="760" data-layout="default" local-id="30d79d2b-4f9e-4cd9-82c4-3e3b2d040226">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -1534,7 +1534,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="55b9a43a-b701-488d-8c41-38951410331d">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -1672,7 +1672,7 @@ ______
 
 * Query Parameterフィールド追加
 
-<table data-table-width="760" data-layout="default" local-id="306ad9b1-6ed1-421e-b58c-42ed27d24672">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/ja/release-notes/990-998/external-api-changes-994-version-995-version.mdx
+++ b/src/content/ja/release-notes/990-998/external-api-changes-994-version-995-version.mdx
@@ -22,7 +22,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="729f4860-908e-453e-a2ce-586ef92bde21">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -60,7 +60,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="d1aedf57-9c7c-4ffd-abf3-d1381144dd7d">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -114,7 +114,7 @@ ______
 
 * Query Parameter
 
-<table data-table-width="760" data-layout="default" local-id="a8579e9b-bf3a-44ef-8dbe-bef487c68840">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/ja/user-manual.mdx
+++ b/src/content/ja/user-manual.mdx
@@ -14,7 +14,7 @@ title: 'ユーザーガイド'
 以下の順に進めてみましょう。
 各項目をクリックすると、詳しい使い方が表示されます。
 
-<table data-table-width="760" data-layout="default" local-id="c53b8e8a-3f68-476f-aa0a-03f2f0eb700f">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -24,10 +24,10 @@ title: 'ユーザーガイド'
 <tr>
 <th>
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **利用の流れ**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **機能**
 </th>
 </tr>
@@ -35,7 +35,7 @@ title: 'ユーザーガイド'
 <td>
 1
 </td>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **ログイン**
 </th>
 <td>
@@ -46,7 +46,7 @@ title: 'ユーザーガイド'
 <td>
 2
 </td>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **ダッシュボードを見る**
 </th>
 <td>
@@ -57,7 +57,7 @@ title: 'ユーザーガイド'
 <td>
 3
 </td>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Workflow で権限申請**
 </th>
 <td>
@@ -77,7 +77,7 @@ title: 'ユーザーガイド'
 <td>
 4
 </td>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **QueryPie Web から接続**
 </th>
 <td>
@@ -100,7 +100,7 @@ title: 'ユーザーガイド'
 <td>
 5
 </td>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **QueryPie Agent で接続**
 </th>
 <td>
@@ -111,7 +111,7 @@ title: 'ユーザーガイド'
 <td>
 6
 </td>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **個人設定**
 </th>
 <td>

--- a/src/content/ja/user-manual/workflow.mdx
+++ b/src/content/ja/user-manual/workflow.mdx
@@ -168,7 +168,7 @@ Reviewメニューは管理者が事前に使用設定をした場合のみ表�
 
 要求の承認状態目録は以下の通りです。
 
-<table data-table-width="760" data-layout="default" local-id="7a620066-c0b8-4120-ad33-9894d8be7321">
+<table>
 <tbody>
 <tr>
 <th>

--- a/src/content/ko/administrator-manual.mdx
+++ b/src/content/ko/administrator-manual.mdx
@@ -26,7 +26,7 @@ GNB 내 관리자 페이지 진입점
 Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 기본적으로 설정해야하는 항목들이 있습니다.
 특히 보안 설정, 사용자 설정, 관리자 역할 할당은 필수적으로 설정하시는 것을 권장해 드립니다.
 
-<table data-table-width="760" data-layout="default" local-id="96d34ea4-8772-49af-9ba2-14ea36b1f3e1">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -36,10 +36,10 @@ Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 �
 <tr>
 <th>
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **설정 순서**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **설정 항목**
 </th>
 </tr>
@@ -142,7 +142,7 @@ QueryPie의 세분화된 접근 제어 기능을 통해 강력한 권한 관리�
 서비스별 설정이 끝난 후에는 관리자/사용자의 접속 및 실행 이력들을 Audit 메뉴에서 자세히 확인하실 수 있습니다.
 뿐만 아니라 민감 정보를 식별할 수 있는 Discovery 기능 또한 제공하니 차세대 디스커버리 기능을 경험해 보세요.
 
-<table data-table-width="760" data-layout="default" local-id="1c770267-da7f-48dc-b1e3-817744eeec38">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -152,10 +152,10 @@ QueryPie의 세분화된 접근 제어 기능을 통해 강력한 권한 관리�
 <tr>
 <th>
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **설정 순서**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **설정 항목**
 </th>
 </tr>

--- a/src/content/ko/administrator-manual/audit.mdx
+++ b/src/content/ko/administrator-manual/audit.mdx
@@ -27,24 +27,24 @@ QueryPie 안에서 일어나는 모든 활동은 감사 로그에 기록됩니�
 
 조회 가능한 감사 로그의 종류는 보유하고 계신 라이선스에 따라 구성이 달라지며, 라이선스별 제공되는 로그의 종류는 아래와 같습니다.
 
-<table data-table-width="760" data-layout="default" local-id="2eeba34f-b909-48ea-a011-5381931efcd4">
+<table>
 <tbody>
-<tr local-id="84b3c86c-ab6d-43e6-844e-ee8e8565386e">
-<th local-id="4b5bfae2-bcbd-452a-82cf-2e340a8f9298">
+<tr>
+<th>
 **공통 로그**
 </th>
-<th local-id="56489574-e0c9-4e34-8829-6c68d3520e81">
+<th>
 **DAC 전용 로그**
 </th>
-<th local-id="ebd3ff56-3b1b-42a9-bb8d-2e63484de5dd">
+<th>
 **SAC 전용 로그**
 </th>
-<th local-id="e54d7e73-a09b-4000-9c43-b18546a06c24">
+<th>
 **KAC 전용 로그**
 </th>
 </tr>
-<tr local-id="6069ea89-296f-43b1-8bf5-55dff52c0918">
-<td local-id="e27a7b6c-2d4e-49a9-b73d-51d7e79e6631">
+<tr>
+<td>
 **General**
 * User Access History
 * Activity Logs
@@ -52,7 +52,7 @@ QueryPie 안에서 일어나는 모든 활동은 감사 로그에 기록됩니�
 * Workflow Logs
 * Reverse Tunnels
 </td>
-<td local-id="310ff96c-a206-4b06-81f4-24e823656e97">
+<td>
 **Databases**
 * DB Access History
 * Query Audit
@@ -61,7 +61,7 @@ QueryPie 안에서 일어나는 모든 활동은 감사 로그에 기록됩니�
 * Account Lock History
 * Access Control Logs
 </td>
-<td local-id="1656db56-c136-4d6b-90c6-4f7b57ae184e">
+<td>
 **Servers**
 * Server Access History
 * Command Audit
@@ -71,7 +71,7 @@ QueryPie 안에서 일어나는 모든 활동은 감사 로그에 기록됩니�
 * Server Role History
 * Account Lock History
 </td>
-<td local-id="8c0cace7-ea51-4f70-a2f5-69cd5117ce5c">
+<td>
 **Kubernetes**
 * Request Audit
 * Pod Session Recordings

--- a/src/content/ko/administrator-manual/audit/database-logs.mdx
+++ b/src/content/ko/administrator-manual/audit/database-logs.mdx
@@ -16,13 +16,13 @@ DB 접속 권한 부여와 회수, DB 접근 이력, 수행한 쿼리, DML 쿼�
 
 쿼리파이 공통으로 제공되는 감사 로그에 더하여 쿼리파이 데이터베이스 접근제어 (QueryPie DAC) 라이선스 보유 시, 다음과 같은 로그 타입을 제공합니다.
 
-<table data-table-width="507" data-layout="default" local-id="95470ac3-09e4-4695-80b7-6e7d4ff27bf8">
+<table>
 <tbody>
 <tr>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **공통 로그**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **DAC 전용 로그**
 </th>
 </tr>

--- a/src/content/ko/administrator-manual/audit/kubernetes-logs.mdx
+++ b/src/content/ko/administrator-manual/audit/kubernetes-logs.mdx
@@ -14,7 +14,7 @@ QueryPie에서의 모든 활동은 감사 로그에 기록됩니다.
 
 쿼리파이 공통으로 제공되는 감사 로그에 더하여 쿼리파이 쿠버네티스 접근제어 (QueryPie KAC) 라이선스 보유 시, 이하의 감사 로그의 종류 제공합니다.
 
-<table data-table-width="507" data-layout="default" local-id="2eeba34f-b909-48ea-a011-5381931efcd4">
+<table>
 <tbody>
 <tr>
 <th>

--- a/src/content/ko/administrator-manual/audit/reports/reports.mdx
+++ b/src/content/ko/administrator-manual/audit/reports/reports.mdx
@@ -24,7 +24,7 @@ QueryPie 보고서는 감사 대응에 필요한 데이터를 보고서 형태�
 
 11.2.0 버전 현재 지원하는 보고서 항목 및 필터는 아래의 표를 참고하시기 바랍니다.
 
-<table data-table-width="958" data-layout="center" local-id="cfcbf091-3775-4454-bff4-924bf43e88f4">
+<table>
 <a id="table-1"></a>
 <colgroup>
 <col/>

--- a/src/content/ko/administrator-manual/audit/server-logs.mdx
+++ b/src/content/ko/administrator-manual/audit/server-logs.mdx
@@ -16,24 +16,24 @@ QueryPie의 System Access Control에서 발생하는 로그들을 Server Logs에
 
 쿼리파이 공통으로 제공되는 감사 로그에 더하여 쿼리파이 시스템 접근제어 (QueryPie SAC) 라이선스 보유 시, 이하의 감사 로그의 종류 제공합니다.
 
-<table data-table-width="507" data-layout="default" local-id="95470ac3-09e4-4695-80b7-6e7d4ff27bf8">
+<table>
 <tbody>
-<tr local-id="8534186b-2033-4cc7-877e-dda79ee3b5b3">
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)" local-id="70f8197e-b83d-409e-bcbf-5e95dc6d6c13">
+<tr>
+<th>
 **공통 로그**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)" local-id="d3c87cc4-a023-4553-83b5-32808f0bcd35">
+<th>
 **SAC 전용 로그**
 </th>
 </tr>
-<tr local-id="606bc709-5042-4fee-a00f-ad8452b791a9">
-<td local-id="33649f7e-f4b6-4a70-99c7-2aadea2b484f">
+<tr>
+<td>
 **General**
 * User Access History
 * Activity Logs
 * Admin Role History
 </td>
-<td local-id="a584fa3d-0929-4abe-8ac4-551670a70a00">
+<td>
 **Servers**
 * Server Access History
 * Command Audit

--- a/src/content/ko/administrator-manual/audit/web-app-logs.mdx
+++ b/src/content/ko/administrator-manual/audit/web-app-logs.mdx
@@ -14,24 +14,24 @@ QueryPie에서의 모든 웹앱을 감사 로그에 기록합니다.
 
 웹앱과 공통으로 제공되는 감사 로그에 더하여 웹앱 쿠버네티스 접근제어 (QueryPie WAC) 리이슨스 보류, 시, 아래와 감사 로그의 종류 제공합니다.
 
-<table data-table-width="507" data-layout="default" local-id="2f7b87af-5d13-428d-90c7-597153763bc3">
+<table>
 <tbody>
 <tr>
-<th data-highlight-colour="#f0f1f2">
+<th>
 **공통 로그**
 </th>
-<th data-highlight-colour="#f0f1f2">
+<th>
 **WAC 전용 로그**
 </th>
 </tr>
 <tr>
-<td data-highlight-colour="#ffffff">
+<td>
 **General**
 * User Access History
 * Activity Logs
 * Admin Role History
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 **Web Apps**
 * Web Access History
 * Web Event Audit

--- a/src/content/ko/administrator-manual/databases.mdx
+++ b/src/content/ko/administrator-manual/databases.mdx
@@ -24,7 +24,7 @@ QueryPie DAC(Database Access Controller)을 처음 사용하는 관리자라면 
 링크된 항목을 클릭하시면 연관 가이드를 바로 확인할 수 있는 페이지로 이동합니다.
 </Callout>
 
-<table data-table-width="760" data-layout="default" local-id="732b2fe2-d76c-4f02-aa32-1d192dd4db6e">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/ko/administrator-manual/general/company-management/alerts.mdx
+++ b/src/content/ko/administrator-manual/general/company-management/alerts.mdx
@@ -27,7 +27,7 @@ Administrator &gt; General &gt; Company Management &gt; Alerts
 
 서비스 별로 지원하는 알림 유형은 다음과 같습니다.
 
-<table data-table-width="760" data-layout="center" local-id="56383138-c970-42e6-869a-a74e4c473292">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/ko/administrator-manual/general/company-management/alerts/new-request-template-variables-by-request-type.mdx
+++ b/src/content/ko/administrator-manual/general/company-management/alerts/new-request-template-variables-by-request-type.mdx
@@ -12,7 +12,7 @@ Alert Type을 New Request로 선택한 경우, Request Type에 따른 템플릿 
 
 Request Type을 전체 선택한 경우에도 공통 변수는 사용 가능합니다.
 
-<table data-table-width="811" data-layout="center" local-id="c749b9ca-9033-4c2b-b8fa-3880ad5a8736">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -194,7 +194,7 @@ Urgent
 
 ### DB Access Request
 
-<table data-table-width="808" data-layout="center" local-id="ee62ec7d-c9f6-4e28-b56e-747b6443c26d">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -281,7 +281,7 @@ Requested Privilege per Connection
 
 ### SQL Request
 
-<table data-table-width="814" data-layout="center" local-id="65178aed-8861-4dee-943a-42d33ce617bf">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -494,7 +494,7 @@ Execution Expiration Date
 
 ### SQL Export Request
 
-<table data-table-width="816" data-layout="center" local-id="a7dabd97-8ea6-4502-b876-197d927dd1dc">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -692,7 +692,7 @@ Execution Expiration Date
 
 ### Unmasking Request
 
-<table data-table-width="816" data-layout="center" local-id="212dceed-34bd-42c0-9cab-7b11a24950af">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -835,7 +835,7 @@ Approval Expiration Date
 
 ### Restricted Data Access Request
 
-<table data-table-width="816" data-layout="center" local-id="8d66df32-3ad9-473e-9876-a4c7fe8775e1">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -978,7 +978,7 @@ Approval Expiration Date
 
 ### DB Policy Exception Request
 
-<table data-table-width="816" data-layout="center" local-id="8fdf1d5c-786c-4147-8e56-bfd6d8dcdb0f">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -1135,7 +1135,7 @@ Approval Expiration Date
 
 ### Server Access Request
 
-<table data-table-width="820" data-layout="center" local-id="a4480e83-0193-4c46-ba7c-53a665a6ad03">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -1281,7 +1281,7 @@ Duration
 
 ### Server Privilege Request
 
-<table data-table-width="820" data-layout="center" local-id="1ac8db57-f53b-4306-9a63-eabe504365d4">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -1427,7 +1427,7 @@ Duration
 
 ### Access Role Request
 
-<table data-table-width="816" data-layout="center" local-id="e44f2beb-29c0-417c-b961-8a1b7946b510">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/ko/administrator-manual/general/system/integrations/identity-providers.mdx
+++ b/src/content/ko/administrator-manual/general/system/integrations/identity-providers.mdx
@@ -88,75 +88,75 @@ LDAP에서 사용자 그룹 정보 및 소속 정보를 동기화하려면  **Us
 </figure>
 
 
-<table data-table-width="760" data-layout="default" local-id="56f8d1f8-9645-460d-a5cb-b6cce53606f2">
+<table>
 <colgroup>
 <col/>
 <col/>
 <col/>
 </colgroup>
 <tbody>
-<tr local-id="cfa528d4-7ee6-483e-8b39-8d8a70310476">
-<th data-highlight-colour="#f0f1f2" local-id="2cdeca85-1e14-4556-8faf-7e77b327d3b9">
+<tr>
+<th>
 **Attribute**
 </th>
-<th data-highlight-colour="#f0f1f2" local-id="53109c7a-a40d-4a4e-9d6a-73c4ddc826c4">
+<th>
 **필수 여부**
 </th>
-<th data-highlight-colour="#f0f1f2" local-id="e24af88f-9192-424a-b43f-025bb31f869d">
+<th>
 **Description**
 </th>
 </tr>
-<tr local-id="75805077-450e-4657-bfe4-3cf78a4d5928">
-<td data-highlight-colour="#ffffff" local-id="ea2a1ab7-7f7f-496d-9a6c-da87bf25e27e">
+<tr>
+<td>
 Group Base DN
 </td>
-<td data-highlight-colour="#ffffff" local-id="b89474cb-0a96-449d-8a83-c1ca1e5a2b56">
+<td>
 필수
 </td>
-<td data-highlight-colour="#ffffff" local-id="45f67115-11f7-474d-b15e-7189fd10c205">
+<td>
 LDAP 서버의 그룹 Base DN 값을 입력합니다.
 이 경로의 하위에 있는 그룹만 Group으로 동기화합니다.
 * 예: `dc=example,dc=com`
 </td>
 </tr>
-<tr local-id="acfd3ac8-1ccf-4790-87fa-969d15cf52d6">
-<td data-highlight-colour="#ffffff" local-id="18032ff5-11ab-427f-85c6-a8246f91a155">
+<tr>
+<td>
 Group Search Filter
 </td>
-<td data-highlight-colour="#ffffff" local-id="646d1d8d-c6ab-4445-976e-a92acb4ad672">
+<td>
 필수
 </td>
-<td data-highlight-colour="#ffffff" local-id="51af7682-029c-474f-b1d7-9658042490f0">
+<td>
 LDAP 서버의 그룹을 가져오기 위한 필터 값을 입력합니다.
 * 예: `objectclass=posixGroup`
 </td>
 </tr>
-<tr local-id="5c723610-073d-4379-a2fe-ee2392355478">
-<td local-id="ec5bca28-b3ec-4bdb-be11-90e106ad68b3">
+<tr>
+<td>
 Group ID
 </td>
-<td local-id="7ae2e57e-9b05-42b5-a721-e2289dc4a1ea">
+<td>
 필수
 </td>
-<td local-id="588d0912-0f58-4f46-9b25-c50c90650b50">
+<td>
 그룹의 식별자로 사용할 속성 값을 입력합니다.
 * 예: `gidNumber`
 </td>
 </tr>
-<tr local-id="f6c5bd3a-d125-41ed-a76f-09b7ba17f1b1">
-<td data-highlight-colour="#ffffff" rowspan="2" local-id="22031ab0-9082-4f3f-bc9f-c375ce2a39a5">
+<tr>
+<td rowspan="2">
 Membership Type
 </td>
-<td data-highlight-colour="#ffffff" rowspan="2" local-id="7db6a6a6-8fcc-4a8f-b59e-544ccd580c72">
+<td rowspan="2">
 필수
 </td>
-<td data-highlight-colour="#ffffff" local-id="1dc8e309-8401-4397-ba11-1dfda8f45536">
+<td>
 사용자에 그룹 정보가 포함된 경우, `Include group information in user entries` 를 선택하고, 하단 필드에 참조할 Attribute를 입력합니다.
 * 예: `member`, `uniqueMember`, `memberUid` 등
 </td>
 </tr>
-<tr local-id="97e7cec3-7328-4f30-8b01-295ca445a63f">
-<td data-highlight-colour="#ffffff" local-id="01bae4e3-5d99-4208-ba57-3880491c4780">
+<tr>
+<td>
 그룹에 사용자 정보가 포함된 경우, `Include user information in group entries` 를 선택하고, 하단 필드에 참조할 Attribute를 입력합니다.
 * 예: `gidNumber`
 </td>

--- a/src/content/ko/administrator-manual/general/user-management/authentication/integrating-with-ldap.mdx
+++ b/src/content/ko/administrator-manual/general/user-management/authentication/integrating-with-ldap.mdx
@@ -45,7 +45,7 @@ Attribute 매핑을 위한 속성 정보의 경우, 필드명은 QueryPie User�
 LDAP에서 사용자 그룹 정보 및 소속 정보를 동기화하려면  **Use Group 옵션** 을 활성화하고 필수로 지정된 정보들을 입력합니다.
 자세한 설명은 하단 항목을 참고해주세요.
 
-<table data-table-width="760" data-layout="default" local-id="b96b2197-17c2-48d3-98a7-93b37fc6260b">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -153,7 +153,7 @@ LDAP에서 관리 중인 사용자 속성을 QueryPie 내 Attribute와 매핑하
 3.  매핑 행 삭제 또는 변경 시, Save Changes를 클릭해야 UI 상에서 변경 사항이 반영되며, Synchronize를 추가로 클릭해야 LDAP과 실제 동기화가 수행됩니다. 즉, Save Changes는 화면상 변경, Synchronize는 시스템 반영을 의미합니다.
 </Callout>
 
-<table data-table-width="760" data-layout="default" local-id="a5c81338-6a96-4dc0-89e5-d0c7a08da012">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/ko/administrator-manual/kubernetes.mdx
+++ b/src/content/ko/administrator-manual/kubernetes.mdx
@@ -24,7 +24,7 @@ QueryPie KAC(Kubernetes Access Controller)을 처음 사용하는 관리자라�
 링크된 항목을 클릭하시면 연관 가이드를 바로 확인할 수 있는 페이지로 이동합니다.
 </Callout>
 
-<table data-table-width="760" data-layout="default" local-id="732b2fe2-d76c-4f02-aa32-1d192dd4db6e">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/ko/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-yaml-code-syntax-guide.mdx
+++ b/src/content/ko/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-yaml-code-syntax-guide.mdx
@@ -28,7 +28,7 @@ Role 설정은 GUI 로 하며, Policy 정의는 코드(YAML)로 관리합니다.
 
 일부 항목을 제외한 전반 정책 코드에서 와일드카드(“*”) 및 정규표현식([RE2 형식](https://github.com/girishji/re2/wiki/Syntax): `^$` 명시 필수) 패턴을 지원합니다.
 
-<table data-table-width="760" data-layout="default" local-id="35831a4b-16f9-461f-96a1-0af983cbf59e">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -38,19 +38,19 @@ Role 설정은 GUI 로 하며, Policy 정의는 코드(YAML)로 관리합니다.
 </colgroup>
 <tbody>
 <tr>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Category**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Property**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Required**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Description**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Valid Values**
 </th>
 </tr>

--- a/src/content/ko/administrator-manual/servers.mdx
+++ b/src/content/ko/administrator-manual/servers.mdx
@@ -26,7 +26,7 @@ Account, SSH Key 와 같이 서버 등록에 필수적으로 필요한 리소스
 링크된 항목을 클릭하시면 연관 가이드를 바로 확인할 수 있는 페이지로 이동합니다.
 </Callout>
 
-<table data-table-width="760" data-layout="default" local-id="732b2fe2-d76c-4f02-aa32-1d192dd4db6e">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/ko/administrator-manual/web-apps/wac-quickstart/1027-wac-role-policy-guide.mdx
+++ b/src/content/ko/administrator-manual/web-apps/wac-quickstart/1027-wac-role-policy-guide.mdx
@@ -28,7 +28,7 @@ QueryPie WAC은 다른 QueryPie 제품들과 마찬가지로 RBAC(Role-Based Acc
 
 WAC의 정책은 YAML 형식으로 작성되며, 그 기본 구조는 다음과 같습니다.
 
-<table data-table-width="760" data-layout="default" local-id="35831a4b-16f9-461f-96a1-0af983cbf59e">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -38,19 +38,19 @@ WAC의 정책은 YAML 형식으로 작성되며, 그 기본 구조는 다음과 
 </colgroup>
 <tbody>
 <tr>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Category**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Property**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Required**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Description**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Valid Values**
 </th>
 </tr>

--- a/src/content/ko/administrator-manual/web-apps/wac-quickstart/1028-wac-rbac-guide.mdx
+++ b/src/content/ko/administrator-manual/web-apps/wac-quickstart/1028-wac-rbac-guide.mdx
@@ -58,7 +58,7 @@ spec:
 
 ### YAML 명세
 
-<table data-table-width="760" data-layout="default" local-id="bb2479df-82c8-474e-8723-247d4037944a">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -68,107 +68,107 @@ spec:
 </colgroup>
 <tbody>
 <tr>
-<th data-highlight-colour="#f0f1f2">
+<th>
 **Category**
 </th>
-<th data-highlight-colour="#f0f1f2">
+<th>
 **Property**
 </th>
-<th data-highlight-colour="#f0f1f2">
+<th>
 **Required**
 </th>
-<th data-highlight-colour="#f0f1f2">
+<th>
 **Description**
 </th>
-<th data-highlight-colour="#f0f1f2">
+<th>
 **Valid Values**
 </th>
 </tr>
 <tr>
-<td data-highlight-colour="#ffffff">
+<td>
 `apiVersion`
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 -
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 **[required]**
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 작성된 YAML Code의 버전
 시스템에서 관리하는 값으로, 수정 불필요
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 `webApp.rbac.querypie.com/v1`
 </td>
 </tr>
 <tr>
-<td data-highlight-colour="#ffffff">
+<td>
 `kind`
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 -
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 **[required]**
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 작성된 YAML Code의 종류
 시스템에서 관리하는 값으로, 수정 불필요
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 `WacPolicy`
 </td>
 </tr>
 <tr>
-<td data-highlight-colour="#ffffff">
+<td>
 `spec:`<br/>  `&lt;effect&gt;`
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 -
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 **[required]**
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 정책 내 세부 규칙 (허용 또는 거부)
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 `allow`, `deny`
 </td>
 </tr>
 <tr>
-<td data-highlight-colour="#ffffff">
+<td>
 
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 `resources`
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 **[required]**
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 접근을 허용/거부할 리소스 지정
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 `webApp`, `urlPaths`, `urlPathTags` (urlPathTags는 `spec: allow` 에서만 사용 가능)
 </td>
 </tr>
 <tr>
-<td data-highlight-colour="#ffffff">
+<td>
 
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 `conditions`
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 **[OPTIONAL]**
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 규칙 적용 대상에 대한 세부 조건
 (현재 `spec: allow` 에서만 사용 가능)
 </td>
-<td data-highlight-colour="#ffffff">
+<td>
 `userAttributes`, `ipAddresses`
 </td>
 </tr>

--- a/src/content/ko/installation/container-environment-variables.mdx
+++ b/src/content/ko/installation/container-environment-variables.mdx
@@ -32,7 +32,7 @@ QueryPie ACP 의 Server Container 를 실행하는데 필요한 환경변수에 
 
 ### 더이상 사용되지 않는 환경변수
 
-<table data-table-width="1800" data-layout="default" local-id="c5fb16aa-9f97-493c-b628-440e4446f3b1">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -40,13 +40,13 @@ QueryPie ACP 의 Server Container 를 실행하는데 필요한 환경변수에 
 </colgroup>
 <tbody>
 <tr>
-<td data-highlight-colour="#f4f5f7">
+<td>
 **Environment Variable Name**
 </td>
-<td data-highlight-colour="#f4f5f7">
+<td>
 **Default Value**
 </td>
-<td data-highlight-colour="#f4f5f7">
+<td>
 **Description**
 </td>
 </tr>

--- a/src/content/ko/installation/prerequisites/linux-distribution-and-docker-podman-support-status.mdx
+++ b/src/content/ko/installation/prerequisites/linux-distribution-and-docker-podman-support-status.mdx
@@ -48,7 +48,7 @@ Docker, Podman 지원 현황은 QueryPie 를 실행, 관리하기 위한 버전�
 
 Podman 3.x 의 구버전, 신뢰할 수 있는 패키지가 제공되지 않는 경우, QueryPie 팀으로부터 기술지원되지 않으며, QueryPie 를 사용할 수 없는 조건이라고 분류합니다.
 
-<table data-table-width="760" data-layout="default" local-id="1e7d3698-ac8b-43f8-8fc8-c306e24dd14c">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/ko/installation/querypie-acp-community-edition.mdx
+++ b/src/content/ko/installation/querypie-acp-community-edition.mdx
@@ -21,7 +21,7 @@ QueryPie는 일반적인 웹 애플리케이션 형태로 실행되며, 프록�
 
 QueryPie Community Edition의 원활한 설치 및 운영을 위해 다음과 같은 시스템 환경을 권장합니다.
 
-<table data-table-width="834" data-layout="center" local-id="7fd726e9-fc83-4263-a08f-8daf43a53c3b">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/ko/release-notes/990-998/external-api-changes-9810-version-994-version.mdx
+++ b/src/content/ko/release-notes/990-998/external-api-changes-9810-version-994-version.mdx
@@ -29,7 +29,7 @@ ______
 
 #### 변경/개선 사항
 
-<table data-table-width="760" data-layout="default" local-id="dde603df-3268-4faf-a41d-602a0c651910">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -85,7 +85,7 @@ ______
 
 * 자세한 요청 내용은 Docs 참조
 
-<table data-table-width="760" data-layout="default" local-id="07d79f85-952c-4830-a77e-c026ab9a37ca">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -178,7 +178,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="4a964f40-a620-417f-bd2f-52c24b38404e">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -268,7 +268,7 @@ ______
 
 * Query Parameter
 
-<table data-table-width="760" data-layout="default" local-id="177f70ea-ceb0-4cfd-bbf6-f23d470f037a">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -316,7 +316,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="932182bb-da8d-497f-a802-b0ac654a837a">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -391,7 +391,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="faa4a484-fb0f-47b7-978a-23feea65210e">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -446,7 +446,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="e34b740f-592e-49c5-b549-6f54500e8c83">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -505,7 +505,7 @@ ______
 
 * Query Parameter
 
-<table data-table-width="760" data-layout="default" local-id="9d2bd396-23e6-44cf-baa2-f17fc0dd9b55">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -585,7 +585,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="c43c1c7c-02dd-48b4-a04d-2c66bce49618">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -650,7 +650,7 @@ ______
 
 ##### Request
 
-<table data-table-width="760" data-layout="default" local-id="7f2d3d42-8253-404f-9149-10b318b6ca3d">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -697,7 +697,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="b16699b8-ecb0-4ee1-ac36-7ac7ea42eae9">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -748,7 +748,7 @@ ______
 
 ##### Request
 
-<table data-table-width="760" data-layout="default" local-id="f52a5751-3b5e-4888-b0bb-bb102080762d">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -800,7 +800,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="1b7cfa33-d4bb-4e89-a7c6-5add7e6663c3">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -861,7 +861,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="fea50ede-0255-4ec9-960a-1472523b2651">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -920,7 +920,7 @@ ______
 
 ##### Request & Response
 
-<table data-table-width="760" data-layout="default" local-id="56c6d3e7-3146-49ff-82ea-4aa792c89003">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -967,7 +967,7 @@ ______
 
 ##### Request & Response
 
-<table data-table-width="760" data-layout="default" local-id="85cd18b3-fa2c-4df3-a4b5-1b6e9a773256">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -1024,7 +1024,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="c8555215-eb77-4807-a123-8728d1377f19">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -1169,7 +1169,7 @@ ______
 
 ##### Request
 
-<table data-table-width="760" data-layout="default" local-id="a91c0329-8458-4c75-a106-ccdd7a0e25e3">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -1287,7 +1287,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="39575eab-8bc2-45f4-b145-a8b9d33bc1ef">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -1417,7 +1417,7 @@ ______
 
 ##### Request
 
-<table data-table-width="760" data-layout="default" local-id="30d79d2b-4f9e-4cd9-82c4-3e3b2d040226">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -1534,7 +1534,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="55b9a43a-b701-488d-8c41-38951410331d">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -1672,7 +1672,7 @@ ______
 
 * Query Parameter 필드추가
 
-<table data-table-width="760" data-layout="default" local-id="306ad9b1-6ed1-421e-b58c-42ed27d24672">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/ko/release-notes/990-998/external-api-changes-994-version-995-version.mdx
+++ b/src/content/ko/release-notes/990-998/external-api-changes-994-version-995-version.mdx
@@ -22,7 +22,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="729f4860-908e-453e-a2ce-586ef92bde21">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -60,7 +60,7 @@ ______
 
 ##### Response
 
-<table data-table-width="760" data-layout="default" local-id="d1aedf57-9c7c-4ffd-abf3-d1381144dd7d">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -114,7 +114,7 @@ ______
 
 * Query Parameter
 
-<table data-table-width="760" data-layout="default" local-id="a8579e9b-bf3a-44ef-8dbe-bef487c68840">
+<table>
 <colgroup>
 <col/>
 <col/>

--- a/src/content/ko/user-manual.mdx
+++ b/src/content/ko/user-manual.mdx
@@ -14,7 +14,7 @@ title: '사용자 매뉴얼'
 아래 순서를 따라 사용해 보세요.
 각 항목을 클릭하면 자세한 사용 방법을 확인하실 수 있습니다.
 
-<table data-table-width="760" data-layout="default" local-id="c53b8e8a-3f68-476f-aa0a-03f2f0eb700f">
+<table>
 <colgroup>
 <col/>
 <col/>
@@ -24,10 +24,10 @@ title: '사용자 매뉴얼'
 <tr>
 <th>
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **사용 순서**
 </th>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **기능**
 </th>
 </tr>
@@ -35,7 +35,7 @@ title: '사용자 매뉴얼'
 <td>
 1
 </td>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **로그인**
 </th>
 <td>
@@ -46,7 +46,7 @@ title: '사용자 매뉴얼'
 <td>
 2
 </td>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **대시보드 둘러보기**
 </th>
 <td>
@@ -57,7 +57,7 @@ title: '사용자 매뉴얼'
 <td>
 3
 </td>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **Workflow로 권한 받기**
 </th>
 <td>
@@ -77,7 +77,7 @@ title: '사용자 매뉴얼'
 <td>
 4
 </td>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **QueryPie Web에서 접속하기**
 </th>
 <td>
@@ -100,7 +100,7 @@ title: '사용자 매뉴얼'
 <td>
 5
 </td>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **QueryPie Agent로 접속하기**
 </th>
 <td>
@@ -111,7 +111,7 @@ title: '사용자 매뉴얼'
 <td>
 6
 </td>
-<th data-highlight-colour="var(--ds-background-accent-gray-subtlest, #F4F5F7)">
+<th>
 **개인 설정 둘러보기**
 </th>
 <td>

--- a/src/content/ko/user-manual/workflow.mdx
+++ b/src/content/ko/user-manual/workflow.mdx
@@ -168,7 +168,7 @@ Review 메뉴는 관리자가 사전에 사용 설정을 한 경우에만 표시
 
 요청의 승인 상태 목록은 다음과 같습니다.
 
-<table data-table-width="760" data-layout="default" local-id="7a620066-c0b8-4120-ad33-9894d8be7321">
+<table>
 <tbody>
 <tr>
 <th>


### PR DESCRIPTION
## Description
- #481 의 한국어 원문 변경사항(테이블의 불필요한 속성 제거)에 대응하여 영어, 일본어 번역 파일을 동기화합니다.
- `<table>` 태그에서 `data-table-width`, `data-layout`, `local-id` 속성 제거
- `<th>`, `<td>` 태그에서 `data-highlight-colour` 속성 제거
- `<tr>`, `<th>`, `<td>` 태그에서 `local-id` 속성 제거
- `bin/mdx_to_skeleton.py --recursive=target/{en,ja} --max-diff=30` 명령에서 불일치가 발생하지 않도록 번역문을 수정합니다.

## Additional notes
- 총 72개 파일 변경 (457줄 추가, 457줄 삭제)
- 한국어 원문 24개 파일, 영어 번역 24개 파일, 일본어 번역 24개 파일 수정
