### PR TITLE
refactor: logger 개선 및 middlewareLogger를 proxyLogger로 변경

### DIFF
--- a/src/lib/detect-user-language.ts
+++ b/src/lib/detect-user-language.ts
@@ -1,5 +1,5 @@
 import {NextRequest} from 'next/server';
-import {middlewareLogger} from './logger';
+import { proxyLogger } from './logger';
 
 // Supported languages
 export const supportedLanguages = ['en', 'ko', 'ja'];
@@ -15,7 +15,7 @@ function detectLanguageFromCookie(request: NextRequest): string | null {
   const cookieValue = request.cookies.get(cookieName)?.value;
   
   if (!cookieValue) {
-    middlewareLogger.debug('NEXT_LOCALE cookie not found');
+    proxyLogger.debug('NEXT_LOCALE cookie not found');
     return null;
   }
 
@@ -23,14 +23,14 @@ function detectLanguageFromCookie(request: NextRequest): string | null {
   const langCode = cookieValue.split('-')[0].toLowerCase();
   
   if (supportedLanguages.includes(langCode)) {
-    middlewareLogger.debug('Language detected from NEXT_LOCALE cookie', { 
+    proxyLogger.debug('Language detected from NEXT_LOCALE cookie', { 
       lang: langCode,
       cookieValue 
     });
     return langCode;
   }
 
-  middlewareLogger.debug('Invalid language in NEXT_LOCALE cookie', { 
+  proxyLogger.debug('Invalid language in NEXT_LOCALE cookie', { 
     cookieValue,
     langCode 
   });
@@ -46,7 +46,7 @@ function detectLanguageFromAcceptHeader(request: NextRequest): string | null {
   const acceptLanguage = request.headers.get('accept-language');
   
   if (!acceptLanguage) {
-    middlewareLogger.debug('Accept-Language header not found');
+    proxyLogger.debug('Accept-Language header not found');
     return null;
   }
 
@@ -65,7 +65,7 @@ function detectLanguageFromAcceptHeader(request: NextRequest): string | null {
   // Find the first supported language
   for (const lang of languages) {
     if (supportedLanguages.includes(lang.code)) {
-      middlewareLogger.debug('Language detected from Accept-Language header', { 
+      proxyLogger.debug('Language detected from Accept-Language header', { 
         lang: lang.code, 
         quality: lang.quality,
         acceptLanguage 
@@ -74,7 +74,7 @@ function detectLanguageFromAcceptHeader(request: NextRequest): string | null {
     }
   }
 
-  middlewareLogger.debug('No supported language found in Accept-Language header', { 
+  proxyLogger.debug('No supported language found in Accept-Language header', { 
     acceptLanguage 
   });
   return null;
@@ -100,7 +100,7 @@ export function detectUserLanguage(request: NextRequest): string {
   }
 
   // Default fallback
-  middlewareLogger.debug('Using default language', { lang: defaultLanguage });
+  proxyLogger.debug('Using default language', { lang: defaultLanguage });
   return defaultLanguage;
 }
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,111 +1,13 @@
-import {Logger as PinoLogger, pino} from 'pino';
+// Simple logger implementation for Next.js proxy and other modules
+// Uses console.log in development, structured JSON logging in production (Vercel)
 
-// Define proper types for request, response, and error objects
-interface LogRequest {
-  method?: string;
-  url?: string;
-  headers?: Record<string, string | string[] | undefined>;
-}
+import { pino } from 'pino';
 
-interface LogResponse {
-  statusCode?: number;
-  headers?: Record<string, string | string[] | undefined>;
-}
-
-interface LogError {
-  type?: string;
-  message?: string;
-  stack?: string;
-}
-
-// Detect Vercel environment
+// Environment detection
 const isVercel = process.env.VERCEL === '1';
-const isProduction = process.env.NODE_ENV === 'production';
 const isDevelopment = process.env.NODE_ENV === 'development';
 
-// Helper function for log formatting in development environment
-function formatLogForDevelopment(level: string, module: string, message: string, data?: Record<string, unknown>): string {
-  const timestamp = new Date().toLocaleTimeString('ko-KR', {
-    hour12: false,
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit'
-  });
-
-  const levelUpper = level.toUpperCase();
-
-  let formattedLog = `[${timestamp}] ${levelUpper} (${module}): ${message}`;
-
-  if (data && Object.keys(data).length > 0) {
-    // Compress data to single line for output
-    const dataStr = JSON.stringify(data).replace(/\s+/g, ' ');
-    formattedLog += ` ${dataStr}`;
-  }
-
-  return formattedLog;
-}
-
-// Pino configuration optimized for Vercel environment
-const logger = pino({
-  // Log level configuration
-  level: process.env.LOG_LEVEL || (isProduction ? 'info' : 'debug'),
-
-  // Use basic JSON output in development environment
-  transport: isDevelopment && !isVercel ? {
-    target: 'pino-pretty',
-    options: {
-      colorize: true,
-      translateTime: 'SYS:standard',
-      ignore: 'pid,hostname',
-      messageFormat: '[{time}] {level} ({module}/{service}): {msg}',
-      levelFirst: true,
-    }
-  } : undefined,
-
-  // Include Vercel environment information
-  base: {
-    env: process.env.NODE_ENV,
-    vercel: isVercel,
-    vercelEnv: process.env.VERCEL_ENV,
-    vercelRegion: process.env.VERCEL_REGION,
-    revision: process.env.VERCEL_GIT_COMMIT_SHA || 'unknown',
-    deploymentId: process.env.VERCEL_DEPLOYMENT_ID,
-  },
-
-  // Timestamp format
-  timestamp: () => `,"time":"${new Date().toISOString()}"`,
-
-  // Recommended settings for Vercel
-  serializers: {
-    req: (req: LogRequest) => ({
-      method: req.method,
-      url: req.url,
-      headers: req.headers,
-    }),
-    res: (res: LogResponse) => ({
-      statusCode: res.statusCode,
-      headers: res.headers,
-    }),
-    err: (err: LogError) => ({
-      type: err.type,
-      message: err.message,
-      stack: err.stack,
-    }),
-  },
-
-  // Log message format optimization
-  messageKey: 'msg',
-
-  // Performance optimization for Vercel environment
-  ...(isVercel && {
-    // Use sync flush in Vercel
-    sync: false,
-    // Log buffering optimization
-    buffer: true,
-  }),
-});
-
-// Define logger interface for better type safety
+// Logger interface for type safety
 interface LoggerInterface {
   debug: (message: string, data?: Record<string, unknown>) => void;
   info: (message: string, data?: Record<string, unknown>) => void;
@@ -113,45 +15,97 @@ interface LoggerInterface {
   error: (message: string, data?: Record<string, unknown>) => void;
 }
 
-// Custom logger wrapper for development environment
-function createDevLogger(baseLogger: PinoLogger, module: string): LoggerInterface {
-  return {
-    debug: (message: string, data?: Record<string, unknown>) => {
-      if (isDevelopment && !isVercel) {
+// Format log message for development environment
+function formatLogForDevelopment(
+  level: string,
+  module: string,
+  message: string,
+  data?: Record<string, unknown>,
+): string {
+  const timestamp = new Date().toLocaleTimeString('ko-KR', {
+    hour12: false,
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+
+  const levelUpper = level.toUpperCase();
+  let formattedLog = `[${timestamp}] ${levelUpper} (${module}): ${message}`;
+
+  if (data && Object.keys(data).length > 0) {
+    // Compress data to a single line for readability
+    const dataStr = JSON.stringify(data).replace(/\s+/g, ' ');
+    formattedLog += ` ${dataStr}`;
+  }
+
+  return formattedLog;
+}
+
+// Create a logger instance for a specific module
+// In development: uses console.log with formatted output
+// In production (Vercel): uses structured JSON logging via pino
+function createModuleLogger(module: string): LoggerInterface {
+  // In development, use simple console logging
+  if (isDevelopment && !isVercel) {
+    return {
+      debug: (message: string, data?: Record<string, unknown>) => {
         const formatted = formatLogForDevelopment('debug', module, message, data);
         console.log(formatted);
-      } else {
-        baseLogger.debug(data, message);
-      }
-    },
-    info: (message: string, data?: Record<string, unknown>) => {
-      if (isDevelopment && !isVercel) {
+      },
+      info: (message: string, data?: Record<string, unknown>) => {
         const formatted = formatLogForDevelopment('info', module, message, data);
         console.log(formatted);
-      } else {
-        baseLogger.info(data, message);
-      }
-    },
-    warn: (message: string, data?: Record<string, unknown>) => {
-      if (isDevelopment && !isVercel) {
+      },
+      warn: (message: string, data?: Record<string, unknown>) => {
         const formatted = formatLogForDevelopment('warn', module, message, data);
         console.warn(formatted);
-      } else {
-        baseLogger.warn(data, message);
-      }
-    },
-    error: (message: string, data?: Record<string, unknown>) => {
-      if (isDevelopment && !isVercel) {
+      },
+      error: (message: string, data?: Record<string, unknown>) => {
         const formatted = formatLogForDevelopment('error', module, message, data);
         console.error(formatted);
-      } else {
-        baseLogger.error(data, message);
-      }
+      },
+    };
+  }
+
+  // In production (Vercel), use pino for structured JSON logging
+  // This allows better log aggregation and analysis in Vercel's logging system
+  const logger = pino({
+    level: process.env.LOG_LEVEL || 'info',
+    base: {
+      env: process.env.NODE_ENV,
+      vercel: isVercel,
+      vercelEnv: process.env.VERCEL_ENV,
+      vercelRegion: process.env.VERCEL_REGION,
+      revision: process.env.VERCEL_GIT_COMMIT_SHA || 'unknown',
+      deploymentId: process.env.VERCEL_DEPLOYMENT_ID,
+      module,
+    },
+    messageKey: 'msg',
+    // Performance optimization for Vercel
+    ...(isVercel && {
+      sync: false,
+      buffer: true,
+    }),
+  });
+
+  return {
+    debug: (message: string, data?: Record<string, unknown>) => {
+      logger.debug(data || {}, message);
+    },
+    info: (message: string, data?: Record<string, unknown>) => {
+      logger.info(data || {}, message);
+    },
+    warn: (message: string, data?: Record<string, unknown>) => {
+      logger.warn(data || {}, message);
+    },
+    error: (message: string, data?: Record<string, unknown>) => {
+      logger.error(data || {}, message);
     },
   };
 }
 
-// Middleware-specific logger
-export const middlewareLogger = createDevLogger(logger, 'middleware');
+// Proxy-specific logger (renamed from middlewareLogger to reflect Next.js proxy naming)
+export const proxyLogger = createModuleLogger('proxy');
 
-export default logger;
+// Default export for backward compatibility (if needed elsewhere)
+export default createModuleLogger('app');

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,6 @@
 import { middleware as nextraMiddleware } from 'nextra/locales';
 import { NextRequest, NextResponse } from 'next/server';
-import { middlewareLogger } from './lib/logger';
+import { proxyLogger } from './lib/logger';
 import { detectUserLanguage, supportedLanguages } from './lib/detect-user-language';
 
 // URIs that should skip Nextra middleware and be handled by route handlers
@@ -43,14 +43,14 @@ export async function proxy(request: NextRequest) {
   if (skipBySlug || skipByPathname) {
     const reason = skipBySlug ? SKIP_MIDDLEWARE_URIS.get(slugs[0]) : SKIP_MIDDLEWARE_URIS.get(pathname);
 
-    middlewareLogger.debug('Skipping Nextra middleware', {
+    proxyLogger.debug('Skipping Nextra Proxy', {
       pathname,
       reason,
     });
     return NextResponse.next();
   }
 
-  middlewareLogger.debug('Middleware request', {
+  proxyLogger.debug('Proxy request', {
     method: request.method,
     pathname,
   });
@@ -64,14 +64,14 @@ export async function proxy(request: NextRequest) {
     const rewriteUrl = new URL(`/${detectedLanguage}${pathname}`, request.url);
 
     if (detectedLanguage === 'en') {
-      middlewareLogger.info('Root rewrite with dynamic language detection', {
+      proxyLogger.info('Root rewrite with dynamic language detection', {
         from: pathname,
         to: rewriteUrl,
         acceptLanguage: request.headers.get('accept-language'),
       });
       return NextResponse.rewrite(rewriteUrl);
     } else {
-      middlewareLogger.info('Root redirect with dynamic language detection', {
+      proxyLogger.info('Root redirect with dynamic language detection', {
         from: pathname,
         to: rewriteUrl,
         acceptLanguage: request.headers.get('accept-language'),
@@ -80,7 +80,7 @@ export async function proxy(request: NextRequest) {
     }
   }
 
-  middlewareLogger.debug('Handling with Nextra middleware');
+  proxyLogger.debug('Handling with Nextra middleware');
   return nextraMiddleware(request);
 }
 


### PR DESCRIPTION
## Description
- Next.js 16 프레임워크 업그레이드에 따라 middleware.ts가 proxy.ts로 변경됨에 따라 logger 이름을 middlewareLogger에서 proxyLogger로 변경
- logger.ts 리팩토링: pino 설정 간소화 및 불필요한 코드 제거
  - 사용하지 않는 LogRequest, LogResponse, LogError 인터페이스 제거
  - pino-pretty transport 제거 (worker thread 이슈 해결)
  - isProduction 변수 제거
  - 코드 간소화 및 주석 개선

## Changes
- `src/lib/logger.ts`: 리팩토링 (87줄 추가, 133줄 삭제)
- `src/proxy.ts`: middlewareLogger → proxyLogger로 변경
- `src/lib/detect-user-language.ts`: middlewareLogger → proxyLogger로 변경
