### PR TITLE
chore: 테스트용 sandbox 페이지를 추가

### DIFF
--- a/src/app/.well-known/[...path]/route.ts
+++ b/src/app/.well-known/[...path]/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * Route handler for .well-known paths
+ * 
+ * This handler prevents .well-known paths from being matched to [lang] route.
+ * Returns 404 for all .well-known requests to avoid routing errors.
+ */
+export async function GET(
+  _request: NextRequest,
+  _params: { params: Promise<{ path: string[] }> }
+) {
+  return new NextResponse('Not Found', { status: 404 });
+}

--- a/src/app/[lang]/sandbox/[version]/page.tsx
+++ b/src/app/[lang]/sandbox/[version]/page.tsx
@@ -1,0 +1,15 @@
+export default async function SandboxPage(props: {
+  params: Promise<{ lang: string; version: string }>;
+}) {
+  const params = await props.params;
+  
+  return (
+    <div>
+      <h1>hello, world!</h1>
+      <p>테스트용 페이지</p>
+      <p>Language: {params.lang}</p>
+      <p>Version: {params.version}</p>
+    </div>
+  );
+}
+

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -7,7 +7,8 @@ import { detectUserLanguage, supportedLanguages } from './lib/detect-user-langua
 const SKIP_MIDDLEWARE_URIS = new Map<string, string>([
   // slugs[0]
   ['_next', 'Handled by Next.js'],
-  ['robots.txt', 'Handled by static app route'],
+  ['robots.txt', 'Handled by route handler'],
+  ['.well-known', 'Handled by route handler'],
   // slugs[0] - Served in public
   ['BingSiteAuth.xml', 'Served in public'],
   ['google7b73baf7a3209e6f.html', 'Served in public'],


### PR DESCRIPTION
## Description
테스트용 sandbox 페이지를 추가했습니다.
- `src/app/[lang]/sandbox/[version]/page.tsx` 경로에 sandbox 페이지 구현
- 언어 및 버전 파라미터를 표시하는 간단한 테스트 페이지
- `.well-known` 경로 라우팅 처리 추가
  - Chrome Developer Tool 을 실행한 경우, `[lang]/layout.tsx`, `[lang]/[[...mdxPath]]/page.tsx` 에서 오류가 발생하는 현상을 해결합니다.
