### PR TITLE
refactor: QueryPie 로고를 재사용 가능한 컴포넌트로 분리

### DIFF
--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -8,6 +8,7 @@ import { Metadata } from 'next';
 import React from 'react';
 import { LastUpdated } from '@/components/last-updated';
 import LanguageSelector2 from "@/components/language-selector2";
+import { QueryPieLogo } from '@/components/querypie-logo';
 
 const defaultMetadata: Metadata = {
   title: {
@@ -46,16 +47,7 @@ export default async function RootLayout({ children, params }) {
 
   const navbar = (
     <Navbar
-      logo={
-        <div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '7px' }}>
-            <img src="/icon-32.png" alt="QueryPie Logo" width={18} height={18} />
-            <div>
-              <b>QueryPie</b> <span style={{ opacity: '60%' }}>ACP</span>
-            </div>
-          </div>
-        </div>
-      }
+      logo={<QueryPieLogo />}
       logoLink={`/${lang}/`}
     />
   );

--- a/src/components/querypie-logo.tsx
+++ b/src/components/querypie-logo.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+/**
+ * QueryPieLogo HTML structure as string
+ * Used for DOM manipulation scenarios (e.g., Redoc logo replacement)
+ */
+export const QUERYPIE_LOGO_HTML = `
+  <div style="display: flex; align-items: center; gap: 7px;">
+    <img src="/icon-32.png" alt="QueryPie Logo" width="18" height="18" />
+    <div>
+      <b>QueryPie</b> <span style="opacity: 60%;">ACP</span>
+    </div>
+  </div>
+`;
+
+/**
+ * QueryPieLogo Component
+ *
+ * Reusable logo component for QueryPie ACP.
+ * Displays the QueryPie logo with icon and text.
+ *
+ * @example
+ * ```tsx
+ * <QueryPieLogo />
+ * ```
+ */
+export function QueryPieLogo() {
+  return (
+    <div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '7px' }}>
+        <img src="/icon-32.png" alt="QueryPie Logo" width={18} height={18} />
+        <div>
+          <b>QueryPie</b> <span style={{ opacity: '60%' }}>ACP</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Description
QueryPie 로고를 재사용 가능한 컴포넌트로 분리했습니다.
- `QueryPieLogo` 컴포넌트를 새로 생성하여 로고 UI를 재사용 가능하도록 개선
- `QUERYPIE_LOGO_HTML` 상수를 export하여 DOM 조작 시나리오(예: Redoc 로고 교체)에서도 사용 가능하도록 지원
- `layout.tsx`에서 인라인으로 작성된 로고 JSX를 `QueryPieLogo` 컴포넌트로 교체하여 코드 간소화

## Changes
- `src/components/querypie-logo.tsx`: QueryPieLogo 컴포넌트 및 QUERYPIE_LOGO_HTML 상수 추가
- `src/app/[lang]/layout.tsx`: 인라인 로고 JSX를 QueryPieLogo 컴포넌트로 교체

