### PR TITLE
open-api: RedocStandalone 로고 숨김 처리

### DIFF
--- a/src/components/openapi-viewer/OpenApiViewer.tsx
+++ b/src/components/openapi-viewer/OpenApiViewer.tsx
@@ -27,6 +27,10 @@ interface OpenApiSpec {
     version?: string;
     'x-querypie-version'?: string;
     description?: string;
+    'x-logo'?: {
+      url?: string;
+      altText?: string;
+    };
   };
   [key: string]: unknown;
 }
@@ -74,7 +78,12 @@ export function OpenApiViewer({
         return res.json();
       })
       .then((data: OpenApiSpec) => {
-        setSpec(data);
+        // Remove x-logo from spec to prevent Redoc from rendering default logo
+        const modifiedSpec = { ...data };
+        if (modifiedSpec.info?.['x-logo']) {
+          delete modifiedSpec.info['x-logo'];
+        }
+        setSpec(modifiedSpec);
         setLoading(false);
       })
       .catch((err: Error) => {
@@ -129,6 +138,14 @@ export function OpenApiViewer({
     disableSearch: false,
     nativeScrollbars: false,
     pathInMiddlePanel: false,
+    // Hide default logo using theme option
+    theme: {
+      logo: {
+        maxHeight: '0px',
+        maxWidth: '0px',
+        gutter: '0px',
+      },
+    },
   };
 
   return (


### PR DESCRIPTION
## Description
RedocStandalone에서 기본 로고가 표시되지 않도록 간결하게 구현했습니다.
- OpenAPI 스펙에서 `x-logo` 필드를 제거하여 Redoc이 기본 로고를 렌더링하지 않도록 처리
- Redoc `theme.logo` 옵션으로 로고 크기를 0으로 설정하여 이중 방어 구현
- 복잡한 DOM 조작 로직 없이 Redoc 공식 API만 사용하여 안정성 확보

