### PR TITLE
open-api: Redoc title/description 커스터마이징 및 페이지 레이아웃 개선

### DIFF
--- a/src/app/[lang]/api-reference/[acpVersion]/[apiVersion]/page.tsx
+++ b/src/app/[lang]/api-reference/[acpVersion]/[apiVersion]/page.tsx
@@ -85,33 +85,25 @@ function getLocalizedText(
 ): {
   title: string;
   description: string;
-  heading: string;
-  intro: string;
 } {
   const upperApiVersion = apiVersion.toUpperCase();
 
   switch (lang) {
     case 'ko':
       return {
-        title: `API 레퍼런스 - ${upperApiVersion}`,
-        description: `QueryPie API ${upperApiVersion} 명세서 (버전 ${acpVersion})`,
-        heading: `QueryPie API 레퍼런스 - ${upperApiVersion}`,
-        intro: `이 페이지는 QueryPie API ${upperApiVersion} (버전 ${acpVersion})의 전체 OpenAPI 명세서를 제공합니다.`,
+        title: `QueryPie ACP API 레퍼런스 - ${upperApiVersion}`,
+        description: `이 페이지는 QueryPie ACP API ${upperApiVersion} (버전 ${acpVersion})의 전체 OpenAPI 명세서를 제공합니다.`,
       };
     case 'ja':
       return {
-        title: `APIリファレンス - ${upperApiVersion}`,
-        description: `QueryPie API ${upperApiVersion} 仕様書 (バージョン ${acpVersion})`,
-        heading: `QueryPie APIリファレンス - ${upperApiVersion}`,
-        intro: `このページは、QueryPie API ${upperApiVersion} (バージョン ${acpVersion}) の完全なOpenAPI仕様書を提供します。`,
+        title: `QueryPie ACP APIリファレンス - ${upperApiVersion}`,
+        description: `このページは、QueryPie ACP API ${upperApiVersion} (バージョン ${acpVersion}) の完全なOpenAPI仕様書を提供します。`,
       };
     case 'en':
     default:
       return {
-        title: `API Reference - ${upperApiVersion}`,
-        description: `QueryPie API ${upperApiVersion} Specification (Version ${acpVersion})`,
-        heading: `QueryPie API Reference - ${upperApiVersion}`,
-        intro: `This page provides the complete OpenAPI specification for QueryPie API ${upperApiVersion} (Version ${acpVersion}).`,
+        title: `QueryPie ACP API Reference - ${upperApiVersion}`,
+        description: `This page provides the complete OpenAPI specification for QueryPie ACP API ${upperApiVersion} (Version ${acpVersion}).`,
       };
   }
 }
@@ -190,18 +182,16 @@ export default async function ApiReferencePage(props: {
     notFound();
   }
 
-  const { heading, intro } = getLocalizedText(lang, apiVersion, acpVersion);
+  const { title, description } = getLocalizedText(lang, apiVersion, acpVersion);
 
   return (
     <div className="api-reference-page">
-      <div className="mb-8">
-        <h1 className="mb-4 text-4xl font-bold">{heading}</h1>
-        <p className="text-lg text-gray-600 dark:text-gray-400">{intro}</p>
-      </div>
       <OpenApiViewer
         querypieVersion={acpVersion}
         apiVersion={apiVersion as 'v2' | 'v0.9'}
         lang={lang}
+        title={title}
+        description={description}
       />
     </div>
   );

--- a/src/components/openapi-viewer/OpenApiViewer.tsx
+++ b/src/components/openapi-viewer/OpenApiViewer.tsx
@@ -14,6 +14,10 @@ interface OpenApiViewerProps {
   apiVersion: 'v0.9' | 'v2';
   /** Language code (optional, defaults to "en") */
   lang?: string;
+  /** Custom title text to display in Redoc (optional) */
+  title?: string;
+  /** Custom description text to display in Redoc (optional) */
+  description?: string;
 }
 
 /**
@@ -55,6 +59,8 @@ export function OpenApiViewer({
   querypieVersion,
   apiVersion,
   lang: _lang = 'en',
+  title,
+  description,
 }: OpenApiViewerProps) {
   const [spec, setSpec] = useState<OpenApiSpec | null>(null);
   const [loading, setLoading] = useState(true);
@@ -79,9 +85,20 @@ export function OpenApiViewer({
       })
       .then((data: OpenApiSpec) => {
         // Remove x-logo from spec to prevent Redoc from rendering default logo
+        // Also update title and description if title/description props are provided
         const modifiedSpec = { ...data };
-        if (modifiedSpec.info?.['x-logo']) {
+        if (!modifiedSpec.info) {
+          modifiedSpec.info = {};
+        }
+        if (modifiedSpec.info['x-logo']) {
           delete modifiedSpec.info['x-logo'];
+        }
+        // Override title and description with props if provided
+        if (title) {
+          modifiedSpec.info.title = title;
+        }
+        if (description) {
+          modifiedSpec.info.description = description;
         }
         setSpec(modifiedSpec);
         setLoading(false);
@@ -90,7 +107,7 @@ export function OpenApiViewer({
         setError(err.message);
         setLoading(false);
       });
-  }, [querypieVersion, apiVersion]);
+  }, [querypieVersion, apiVersion, title, description]);
 
   // Loading state
   if (loading) {


### PR DESCRIPTION
## Description
Redoc에서 표시되는 title과 description을 커스터마이징할 수 있도록 개선하고, API Reference 페이지 레이아웃을 간소화했습니다.

- OpenApiViewer 컴포넌트에 `title`, `description` props 추가하여 Redoc 내부 표시 제목/설명 오버라이드 지원
- API Reference 페이지 상단의 중복된 heading/intro 영역 제거하여 Redoc 내부에 통합
- 다국어 지원을 위한 title/description 로컬라이제이션 유지

