### PR TITLE
fix(ci): Confluence 워크플로우에서 첨부파일도 PR에 포함되도록 수정

### DIFF
--- a/.github/workflows/generate-mdx-from-confluence.yml
+++ b/.github/workflows/generate-mdx-from-confluence.yml
@@ -57,7 +57,7 @@ jobs:
           echo "=== Git Status ==="
           git status
 
-      - name: Create Pull Request for src/content changes
+      - name: Create Pull Request for src/content and public changes
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -74,9 +74,9 @@ jobs:
             git config user.email "${{ github.actor }}@users.noreply.github.com"
           fi
           
-          # src/content/ 변경사항 확인 (unstaged 상태)
-          if ! git status --porcelain src/content/ | grep -q "[AM]"; then
-            echo "No changes in src/content/ directory"
+          # src/content/ 및 public/ 변경사항 확인 (unstaged 상태)
+          if ! git status --porcelain src/content/ public/ | grep -q "[AM]"; then
+            echo "No changes in src/content/ or public/ directory"
             exit 0
           fi
           
@@ -86,18 +86,18 @@ jobs:
           # 브랜치 생성 및 체크아웃
           git checkout -b "$BRANCH_NAME"
           
-          # src/content/ 변경사항만 스테이징
-          git add src/content/
-          
+          # src/content/ 및 public/ 변경사항 스테이징
+          git add src/content/ public/
+
           # 스테이징된 변경사항 확인
           STAGED_FILES=$(git diff --cached --name-only)
           if [[ -z "$STAGED_FILES" ]]; then
-            echo "No staged changes in src/content/"
+            echo "No staged changes in src/content/ or public/"
             exit 0
           fi
-          
+
           # 변경사항 정보 수집 (스테이징 후)
-          CHANGES_STATUS=$(git status --short src/content/)
+          CHANGES_STATUS=$(git status --short src/content/ public/)
           CHANGES_STAT=$(git diff --cached --stat HEAD)
           
           # 커밋


### PR DESCRIPTION
## Description
- `src/content/` 디렉토리만 스테이징하던 것을 `public/` 디렉토리도 함께 스테이징하도록 변경
- `--attachments` 옵션 사용 시 다운로드된 첨부파일(이미지 등)이 PR에 포함됨

## Changes
- `.github/workflows/generate-mdx-from-confluence.yml`: 변경사항 확인 및 스테이징 시 `public/` 디렉토리 추가

## Related tickets & links
- Closes #498

## Added/updated tests?
- [x] No, and this is why: GitHub Actions 워크플로우 변경으로, 실제 워크플로우 실행을 통해 검증 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)