### PR TITLE
chore: 일시적으로 2019년 QueryPie 로고를 사용합니다.

### DIFF
--- a/src/components/querypie-logo.tsx
+++ b/src/components/querypie-logo.tsx
@@ -46,7 +46,7 @@ export const QUERYPIE_LOGO_HTML = `
 export function QueryPieLogo() {
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: '7px' }}>
-      <QueryPie2019 width={100} height={21} />
+      <QueryPie2019 width={85} height={18} style={{ position: 'relative', top: '2px' }} />
       <span style={{ opacity: '60%' }}>ACP</span>
     </div>
   );


### PR DESCRIPTION
## Summary
- 일시적으로 2019년 QueryPie 로고 SVG 컴포넌트를 사용하도록 변경합니다.
- `QueryPie2019` SVG 컴포넌트를 추가합니다.
- `QueryPieLogo` 컴포넌트에서 기존 아이콘+텍스트 대신 2019년 로고 SVG를 사용합니다.

## Test plan
- [ ] 로컬에서 로고가 정상적으로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)