### PR TITLE
ci(.github/workflows): fetch-openapi-spec 워크플로우를 self-hosted runner에서 실행하도록 변경합니다.

### DIFF
--- a/.github/workflows/fetch-openapi-spec.yml
+++ b/.github/workflows/fetch-openapi-spec.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   fetch-openapi-spec:
-    runs-on: ubuntu-latest
+    runs-on: ["os:ubuntu", "purpose:ci"]
     permissions:
       contents: write # to create a branch and push changes
       pull-requests: write # to create a PR


### PR DESCRIPTION
## Summary
- fetch-openapi-spec 워크플로우를 GitHub-hosted runner(ubuntu-latest) 대신 self-hosted runner에서 실행하도록 변경합니다.
  - `os:ubuntu`, `purpose:ci` 레이블을 사용합니다.
- Organization 의 Runner 설정을 추가하지 않도록, querypie organization 대신 chequer-io organization 에서 Workflow 를 실행합니다.
  - chequer-io organization 에서 실행하기 위해, querypie-docs repository 를 https://github.com/chequer-io/querypie-docs 에 fork 하였습니다.

## Test plan
- [ ] workflow_dispatch로 워크플로우 실행하여 self-hosted runner에서 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)