### PR TITLE
fix(src/components): pathname null 체크 추가

### DIFF
--- a/src/components/last-updated.tsx
+++ b/src/components/last-updated.tsx
@@ -18,7 +18,7 @@ export const LastUpdated: FC<{
 
   // Bug fix: Extract locale from pathname more safely
   let dateLocale = locale
-  if (i18n.length) {
+  if (i18n.length && pathname) {
     const pathSegments = pathname.split('/').filter(Boolean) // Remove empty strings
     if (pathSegments.length > 0) {
       const firstSegment = pathSegments[0]


### PR DESCRIPTION
## Summary
- `usePathname()`이 `null`을 반환할 수 있으므로 null 체크를 추가
- TypeScript 빌드 에러 수정

## Changes
- `src/components/last-updated.tsx`: `if (i18n.length)` → `if (i18n.length && pathname)`

## Test plan
- [ ] `npm run build` 성공 확인
- [ ] 빌드된 사이트에서 Last Updated 날짜가 정상 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)