### PR TITLE
fix(src/lib): useLocale에서 pathname null 체크 추가

### DIFF
--- a/src/lib/use-locale.ts
+++ b/src/lib/use-locale.ts
@@ -8,7 +8,7 @@ const useLocale = (defaultLocale: string = 'en'): string => {
   const pathname = usePathname();
 
   let locale = defaultLocale;
-  if (i18n.length) {
+  if (i18n.length && pathname) {
     const pathSegments = pathname.split('/').filter(Boolean); // Remove empty strings
 
     if (pathSegments.length > 0) {


### PR DESCRIPTION
## Summary
- `usePathname()`이 `null`을 반환할 수 있으므로 null 체크를 추가
- TypeScript 빌드 에러 수정
- PR #519 와 동일한 패턴의 버그 수정

## Changes
- `src/lib/use-locale.ts`: `if (i18n.length)` → `if (i18n.length && pathname)`

## Test plan
- [ ] `npm run build` 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)