### PR TITLE
fix(confluence-mdx): 이미지 변환 시 width 속성이 적용되도록 img 태그를 사용합니다

### DIFF
--- a/confluence-mdx/bin/confluence_xhtml_to_markdown.py
+++ b/confluence-mdx/bin/confluence_xhtml_to_markdown.py
@@ -119,22 +119,13 @@ class Attachment:
         if not caption:
             caption = self.filename
 
-        rehype_attr = []
-        if width:
-            rehype_attr.append(f'width={width}')
-
-        # Convert align to appropriate Tailwind CSS classes for rehype-attr
-        if align == 'left':
-            rehype_attr.append('class="float-left mr-4"')
-        elif align == 'right':
-            rehype_attr.append('class="float-right ml-4"')
-        elif align == 'center':
-            rehype_attr.append('class="mx-auto block"')
-
-        if self.filename.endswith('.png'):
-            # TODO(JK): For now, do not use rehype-attr for images.
-            # Otherwise, `npm run build` fails with 'Could not parse expression with acorn'
-            return f'![{caption}]({self.output_dir}/{self.filename})'
+        image_extensions = ('.png', '.gif', '.jpg', '.jpeg', '.webp', '.svg')
+        if self.filename.lower().endswith(image_extensions):
+            safe_caption = caption.replace('"', '&quot;').replace('<', '&lt;').replace('>', '&gt;')
+            attrs = [f'src="{self.output_dir}/{self.filename}"', f'alt="{safe_caption}"']
+            if width:
+                attrs.append(f'width="{width}"')
+            return f'<img {" ".join(attrs)} />'
         else:
             return f'[{caption}]({self.output_dir}/{self.filename})'
 

--- a/confluence-mdx/tests/testcases/1454342158/expected.mdx
+++ b/confluence-mdx/tests/testcases/1454342158/expected.mdx
@@ -33,7 +33,7 @@ Admin &gt; General &gt; System &gt; Integration 에서 Authentication 하위 항
 이 항목은 삭제 할 수 없습니다.
 
 <figure data-layout="center" data-align="center">
-![image-20251014-010700.png](/1454342158/output/image-20251014-010700.png)
+<img src="/1454342158/output/image-20251014-010700.png" alt="image-20251014-010700.png" width="760" />
 </figure>
 
 #### 기본 인증의 상세 설정
@@ -43,7 +43,7 @@ Admin &gt; General &gt; System &gt; Integration 에서 Authentication 하위 항
 *  **Multi-Factor Authentication Setting** : MFA 설정을 할 수 있습니다. Google Authenticator, Email을 지원합니다.
 
 <figure data-layout="center" data-align="center">
-![Internal database의 상세 설정](/1454342158/output/image-20251014-011706.png)
+<img src="/1454342158/output/image-20251014-011706.png" alt="Internal database의 상세 설정" width="532" />
 <figcaption>
 Internal database의 상세 설정
 </figcaption>
@@ -65,7 +65,7 @@ IdP를 변경하거나 삭제를 해야하는 경우 Customer Portal 을 통해 
 *  **Bind Password**  : BindDN의 암호를 입력합니다.
 
 <figure data-layout="center" data-align="center">
-![LDAP 상세설정](/1454342158/output/image-20251014-012049.png)
+<img src="/1454342158/output/image-20251014-012049.png" alt="LDAP 상세설정" width="481" />
 <figcaption>
 LDAP 상세설정
 </figcaption>
@@ -84,7 +84,7 @@ QueryPie 사용자 계정과 LDAP의 사용자 계정을 동기화하여 매핑�
 LDAP에서 사용자 그룹 정보 및 소속 정보를 동기화하려면  **Use Group 옵션** 을 활성화(체크)하고 필수로 지정된 정보들을 입력합니다.
 
 <figure data-layout="center" data-align="center">
-![image-20251014-075227.png](/1454342158/output/image-20251014-075227.png)
+<img src="/1454342158/output/image-20251014-075227.png" alt="image-20251014-075227.png" width="407" />
 </figure>
 
 
@@ -167,7 +167,7 @@ Membership Type
 LDAP 서버로부터 사용자 정보 동기화를 실행하려는 경우  **Use Synchronization with the Authentication System**  옵션을 활성화합니다.
 
 <figure data-layout="center" data-align="center">
-![image-20251014-075127.png](/1454342158/output/image-20251014-075127.png)
+<img src="/1454342158/output/image-20251014-075127.png" alt="image-20251014-075127.png" width="408" />
 </figure>
 
 
@@ -206,7 +206,7 @@ LDAP에서 관리 중인 사용자 속성을 QueryPie 내 Attribute와 매핑하
 Active Directory를 LDAP 연동할 경우 Anonymous 항목을 반드시 false로 설정해야합니다.
 AD는 기본적으로 익명 바인드 상태에서의 검색 작업을 허용하지 않습니다.
 <figure data-layout="center" data-align="center">
-![image-20251222-023912.png](/1454342158/output/image-20251222-023912.png)
+<img src="/1454342158/output/image-20251222-023912.png" alt="image-20251222-023912.png" width="491" />
 </figure>
 </Callout>
 
@@ -215,7 +215,7 @@ AD는 기본적으로 익명 바인드 상태에서의 검색 작업을 허용�
 #### Okta에서 QueryPie 를 애플리케이션으로 추가
 
 <figure data-layout="center" data-align="center">
-![Okta Admin &gt; Applications &gt; Applications &gt; Browse App Catalog &gt; QueryPie 검색](/1454342158/output/image-20240723-064242.png)
+<img src="/1454342158/output/image-20240723-064242.png" alt="Okta Admin &gt; Applications &gt; Applications &gt; Browse App Catalog &gt; QueryPie 검색" width="760" />
 <figcaption>
 Okta Admin &gt; Applications &gt; Applications &gt; Browse App Catalog &gt; QueryPie 검색
 </figcaption>
@@ -231,7 +231,7 @@ Okta Admin &gt; Applications &gt; Applications &gt; Browse App Catalog &gt; Quer
 #### Okta 계정 연동을 위한 Profile 설정
 
 <figure data-layout="center" data-align="center">
-![Okta Admin &gt; Directory &gt; Profile Editor &gt; QueryPie User &gt; Add Attribute](/1454342158/output/image-20240723-064424.png)
+<img src="/1454342158/output/image-20240723-064424.png" alt="Okta Admin &gt; Directory &gt; Profile Editor &gt; QueryPie User &gt; Add Attribute" width="760" />
 <figcaption>
 Okta Admin &gt; Directory &gt; Profile Editor &gt; QueryPie User &gt; Add Attribute
 </figcaption>
@@ -247,7 +247,7 @@ Okta Admin &gt; Directory &gt; Profile Editor &gt; QueryPie User &gt; Add Attrib
     * Display name : loginId / Variable name : loginId 항목 입력 후 `Save` 클릭
 
 <figure data-layout="center" data-align="center">
-![Okta Admin &gt; Directory &gt; Profile Editor &gt; QueryPie User &gt; Mappings](/1454342158/output/image-20240723-064721.png)
+<img src="/1454342158/output/image-20240723-064721.png" alt="Okta Admin &gt; Directory &gt; Profile Editor &gt; QueryPie User &gt; Mappings" width="760" />
 <figcaption>
 Okta Admin &gt; Directory &gt; Profile Editor &gt; QueryPie User &gt; Mappings
 </figcaption>
@@ -265,7 +265,7 @@ Okta Admin &gt; Directory &gt; Profile Editor &gt; QueryPie User &gt; Mappings
 #### Okta에 추가된 QueryPie 애플리케이션에 사용자 할당
 
 <figure data-layout="center" data-align="center">
-![Okta Admin &gt; Applications &gt; Applications &gt; QueryPie App](/1454342158/output/image-20240723-065134.png)
+<img src="/1454342158/output/image-20240723-065134.png" alt="Okta Admin &gt; Applications &gt; Applications &gt; QueryPie App" width="760" />
 <figcaption>
 Okta Admin &gt; Applications &gt; Applications &gt; QueryPie App
 </figcaption>
@@ -283,7 +283,7 @@ Okta Admin &gt; Applications &gt; Applications &gt; QueryPie App
 #### Okta에서 QueryPie 애플리케이션 연동 정보 설정
 
 <figure data-layout="center" data-align="center">
-![Okta Admin &gt; Applications &gt; Applications &gt; QueryPie App](/1454342158/output/image-20240723-065346.png)
+<img src="/1454342158/output/image-20240723-065346.png" alt="Okta Admin &gt; Applications &gt; Applications &gt; QueryPie App" width="760" />
 <figcaption>
 Okta Admin &gt; Applications &gt; Applications &gt; QueryPie App
 </figcaption>
@@ -306,7 +306,7 @@ QueryPie-Okta 간 사용자 및 그룹, 그룹 멤버십의 동기화를 위해 
 다만, 보안 수준 향상을 위해 Okta API 토큰의 권한을 최소한으로 부여하도록 조정해야 하는 경우, 이하의 권한 및 방법에 따라 API 토큰을 생성하실 것을 권장드립니다.
 
 <figure data-layout="center" data-align="center">
-![Okta Admin Console &gt; Security &gt; Administrators &gt; Roles &gt; Create new role](/1454342158/output/image-20240110-042233.png)
+<img src="/1454342158/output/image-20240110-042233.png" alt="Okta Admin Console &gt; Security &gt; Administrators &gt; Roles &gt; Create new role" width="762" />
 <figcaption>
 Okta Admin Console &gt; Security &gt; Administrators &gt; Roles &gt; Create new role
 </figcaption>
@@ -346,7 +346,7 @@ Okta Admin Console &gt; Security &gt; Administrators &gt; Roles &gt; Create new 
 목록 우측 상단의 `+ Add` 버튼을 누르고 팝업되는 화면에서 Type을 Okta로 선택하면 Okta를 IdP로 추가 할 수 있습니다.
 
 <figure data-layout="center" data-align="center">
-![Okta 상세설정 (1)](/1454342158/output/image-20251014-014729.png)
+<img src="/1454342158/output/image-20251014-014729.png" alt="Okta 상세설정 (1)" width="481" />
 <figcaption>
 Okta 상세설정 (1)
 </figcaption>
@@ -395,14 +395,14 @@ SP는 각 바인딩 방식에 따라 별도의 ACS URL을 운영할 수 있습�
 특정 상황이나 클라이언트의 요구에 따라 동적으로 생성된 ACS URL로 어설션을 받아야 할 때, 인덱스를 통해 정적으로 정의된 여러 URL 중 하나를 선택하도록 유도할 수 있습니다.
 
 <figure data-layout="center" data-align="center">
-![okta app 설정의 Audience URI(SP Entity ID) ](/1454342158/output/screenshot-20250124-164255.png)
+<img src="/1454342158/output/screenshot-20250124-164255.png" alt="okta app 설정의 Audience URI(SP Entity ID) " width="690" />
 <figcaption>
 okta app 설정의 Audience URI(SP Entity ID) 
 </figcaption>
 </figure>
 
 <figure data-layout="center" data-align="center">
-![Other Requestable SSO URLs 의 Index](/1454342158/output/screenshot-20250124-164553.png)
+<img src="/1454342158/output/screenshot-20250124-164553.png" alt="Other Requestable SSO URLs 의 Index" width="694" />
 <figcaption>
 Other Requestable SSO URLs 의 Index
 </figcaption>
@@ -410,7 +410,7 @@ Other Requestable SSO URLs 의 Index
 </Callout>
 
 <figure data-layout="center" data-align="center">
-![Okta 상세설정 (2)](/1454342158/output/image-20251014-014805.png)
+<img src="/1454342158/output/image-20251014-014805.png" alt="Okta 상세설정 (2)" width="481" />
 <figcaption>
 Okta 상세설정 (2)
 </figcaption>
@@ -440,7 +440,7 @@ Okta 상세설정 (2)
 </Callout>
 
 <figure data-layout="center" data-align="center">
-![Okta Admin &gt; Applications &gt; QueryPie App 상단 URL](/1454342158/output/Authentication-Okta-02.png)
+<img src="/1454342158/output/Authentication-Okta-02.png" alt="Okta Admin &gt; Applications &gt; QueryPie App 상단 URL" width="760" />
 <figcaption>
 Okta Admin &gt; Applications &gt; QueryPie App 상단 URL
 </figcaption>
@@ -453,7 +453,7 @@ Okta Admin &gt; Applications &gt; QueryPie App 상단 URL
 2. 이제 로그인 페이지에서 `Login with Okta` 버튼을 통해 Okta 계정으로 QueryPie에 로그인할 수 있습니다.
 
 <figure data-layout="center" data-align="center">
-![image-20251014-082704.png](/1454342158/output/image-20251014-082704.png)
+<img src="/1454342158/output/image-20251014-082704.png" alt="image-20251014-082704.png" width="760" />
 </figure>
 
 <Callout type="info">
@@ -485,7 +485,7 @@ One Login SAML Custom Connector 설정에 대한 자세한 내용은 [https://on
 *  **Identity Provider Metadata**  : One Login에서 다운로드한 XML 파일의 내용을 복사해서 붙여넣습니다.
 
 <figure data-layout="center" data-align="center">
-![One Login 상세설정 (1)](/1454342158/output/image-20251020-001435.png)
+<img src="/1454342158/output/image-20251020-001435.png" alt="One Login 상세설정 (1)" width="480" />
 <figcaption>
 One Login 상세설정 (1)
 </figcaption>
@@ -495,7 +495,7 @@ One Login 상세설정 (1)
 * 주기적인 동기화 기능을 사용하고자 할 경우 Replication Frequency 항목에서 Scheduling 을 설정합니다.
 
 <figure data-layout="center" data-align="center">
-![One Login 상세설정 (2)](/1454342158/output/image-20251014-014949.png)
+<img src="/1454342158/output/image-20251014-014949.png" alt="One Login 상세설정 (2)" width="481" />
 <figcaption>
 One Login 상세설정 (2)
 </figcaption>
@@ -520,7 +520,7 @@ One Login 상세설정 (2)
 *  **Identity Provider Metadata**  : IdP에서 확인한 SML metadata XML의 내용을 복사해서 붙여 넣습니다. 
 
 <figure data-layout="center" data-align="center">
-![image-20251014-015015.png](/1454342158/output/image-20251014-015015.png)
+<img src="/1454342158/output/image-20251014-015015.png" alt="image-20251014-015015.png" width="481" />
 </figure>
 
 &lt; 참고 &gt; [AWS SSO 연동](#target-title-not-found)
@@ -535,7 +535,7 @@ Custom Identity Provider는 인증 API서버를 사용하는 특수한 경우에
 *  사용자 정보 동기화를 실행하려는 경우 Use Synchronization with the Authentication System 옵션을 활성화합니다.
 
 <figure data-layout="center" data-align="center">
-![image-20251014-015047.png](/1454342158/output/image-20251014-015047.png)
+<img src="/1454342158/output/image-20251014-015047.png" alt="image-20251014-015047.png" width="481" />
 </figure>
 
 *  **Additional Settings** 

--- a/confluence-mdx/tests/testcases/544112828/expected.mdx
+++ b/confluence-mdx/tests/testcases/544112828/expected.mdx
@@ -16,7 +16,7 @@ QueryPie Agent를 설치하면, DataGrip, DBeaver와 같은 SQL Client, iTerm/Se
 1. QueryPie 로그인 후 우측 상단 프로필을 클릭하여 `Agent Download` 버튼을 클릭합니다.
 
 <figure data-layout="center" data-align="center">
-![QueryPie Web &gt; 프로필 메뉴](/544112828/output/screenshot-20240804-173002.png)
+<img src="/544112828/output/screenshot-20240804-173002.png" alt="QueryPie Web &gt; 프로필 메뉴" width="760" />
 <figcaption>
 QueryPie Web &gt; 프로필 메뉴
 </figcaption>
@@ -25,7 +25,7 @@ QueryPie Web &gt; 프로필 메뉴
 2. QueryPie Agent Downloads 팝업창이 실행되면 Step 1에서 사용 중인 PC 운영체제에 맞는 설치 파일을 다운로드한 후 Step 3에 있는 QueryPie URL을 복사해 둡니다.
 
 <figure data-layout="center" data-align="center">
-![QueryPie Web &gt; Agent Downloads 팝업창](/544112828/output/image-20240723-154847.png)
+<img src="/544112828/output/image-20240723-154847.png" alt="QueryPie Web &gt; Agent Downloads 팝업창" width="760" />
 <figcaption>
 QueryPie Web &gt; Agent Downloads 팝업창
 </figcaption>
@@ -38,7 +38,7 @@ QueryPie Agent는 Mac, Windows, Linux OS를 지원합니다.
 3. 다운로드받은 QueryPie Agent 설치 프로그램을 실행하여 설치를 완료합니다.
 
 <figure data-layout="center" data-align="center">
-![Mac OS 설치 프로그램](/544112828/output/screenshot-20240804-174002.png)
+<img src="/544112828/output/screenshot-20240804-174002.png" alt="Mac OS 설치 프로그램" width="760" />
 <figcaption>
 Mac OS 설치 프로그램
 </figcaption>
@@ -48,7 +48,7 @@ Mac OS 설치 프로그램
 QueryPie Host 입력란에 미리 복사해뒀던 QueryPie URL을 입력하고 `Next` 버튼을 클릭하면 로그인 화면으로 진입하게 됩니다.
 
 <figure data-layout="center" data-align="center">
-![Agent &gt; QueryPie Host 입력](/544112828/output/agent-03.png)
+<img src="/544112828/output/agent-03.png" alt="Agent &gt; QueryPie Host 입력" width="760" />
 <figcaption>
 Agent &gt; QueryPie Host 입력
 </figcaption>
@@ -60,13 +60,13 @@ Agent &gt; QueryPie Host 입력
 1. Agent 앱 내 로그인 화면에서 `Login` 버튼을 클릭합니다.
 
 <figure data-layout="center" data-align="center">
-![screenshot-20240804-173713.png](/544112828/output/screenshot-20240804-173713.png)
+<img src="/544112828/output/screenshot-20240804-173713.png" alt="screenshot-20240804-173713.png" width="760" />
 </figure>
 
 2. 웹 브라우저가 열리면, 로그인 페이지에서 인증정보를 입력하고, `Continue` 버튼을 클릭합니다.
 
 <figure data-layout="center" data-align="center">
-![QueryPie Web &gt; Agent Login Page](/544112828/output/screenshot-20240729-171236.png)
+<img src="/544112828/output/screenshot-20240729-171236.png" alt="QueryPie Web &gt; Agent Login Page" width="760" />
 <figcaption>
 QueryPie Web &gt; Agent Login Page
 </figcaption>
@@ -75,7 +75,7 @@ QueryPie Web &gt; Agent Login Page
 3. 로그인을 성공하면 아래와 같이 로그인 성공 화면이 표시되며 이후 Agent로 돌아갑니다.
 
 <figure data-layout="center" data-align="center">
-![QueryPie Web &gt; Agent Login Success Page](/544112828/output/screenshot-20240729-171314.png)
+<img src="/544112828/output/screenshot-20240729-171314.png" alt="QueryPie Web &gt; Agent Login Success Page" width="764" />
 <figcaption>
 QueryPie Web &gt; Agent Login Success Page
 </figcaption>
@@ -84,7 +84,7 @@ QueryPie Web &gt; Agent Login Success Page
 4. Agent 열기를 명시적으로 수행하여 인증정보를 Agent로 전달합니다.
 
 <figure data-layout="center" data-align="center">
-![Chrome - Agent App 열기 모달](/544112828/output/screenshot-20240804-174209.png)
+<img src="/544112828/output/screenshot-20240804-174209.png" alt="Chrome - Agent App 열기 모달" width="760" />
 <figcaption>
 Chrome - Agent App 열기 모달
 </figcaption>
@@ -95,7 +95,7 @@ Chrome - Agent App 열기 모달
 1. 로그인이 정상적으로 완료되면 Agent 앱 내 Databases 탭에서 권한 있는 커넥션들의 접속 정보를 확인할 수 있습니다.<br/>접속할 커넥션에 할당된 `Port` 를 클릭하면, 해당 커넥션의 `Proxy Credentials` 정보를 확인할 수 있습니다.
 
 <figure data-layout="center" data-align="center">
-![Agent &gt; DB Connection Information](/544112828/output/screenshot-20240730-151001.png)
+<img src="/544112828/output/screenshot-20240730-151001.png" alt="Agent &gt; DB Connection Information" width="764" />
 <figcaption>
 Agent &gt; DB Connection Information
 </figcaption>
@@ -104,7 +104,7 @@ Agent &gt; DB Connection Information
 2. 위의 접속 정보를 3rd Party 클라이언트에 입력하면 DB 커넥션 접속이 가능합니다.
 
 <figure data-layout="center" data-align="center">
-![3rd Party Client를 이용한 DB 커넥션 접속](/544112828/output/agent-07.png)
+<img src="/544112828/output/agent-07.png" alt="3rd Party Client를 이용한 DB 커넥션 접속" width="764" />
 <figcaption>
 3rd Party Client를 이용한 DB 커넥션 접속
 </figcaption>
@@ -121,7 +121,7 @@ Agent &gt; DB Connection Information
 * Default 역할 선택시, Workflow &gt; Server Access Request 요청에 의해 할당받은 서버 권한을 사용합니다. 
 
 <figure data-layout="center" data-align="center">
-![Agent &gt; Server &gt; Select a Role](/544112828/output/screenshot-20240730-162653.png)
+<img src="/544112828/output/screenshot-20240730-162653.png" alt="Agent &gt; Server &gt; Select a Role" width="764" />
 <figcaption>
 Agent &gt; Server &gt; Select a Role
 </figcaption>
@@ -136,7 +136,7 @@ Agent &gt; Server &gt; Select a Role
 * 접속할 서버를 우클릭 후 Open Connection with 메뉴를 선택하여, 사용하려는 터미널 툴을 선택합니다.
 
 <figure data-layout="center" data-align="center">
-![Agent &gt; Server &gt; Open Connection with](/544112828/output/screenshot-20240730-161729.png)
+<img src="/544112828/output/screenshot-20240730-161729.png" alt="Agent &gt; Server &gt; Open Connection with" width="760" />
 <figcaption>
 Agent &gt; Server &gt; Open Connection with
 </figcaption>
@@ -146,7 +146,7 @@ Agent &gt; Server &gt; Open Connection with
 * 사용하려는 계정을 선택하고 필요시 비밀번호를 입력한 뒤, `OK` 버튼을 클릭하여 세션을 엽니다.
 
 <figure data-layout="center" data-align="center">
-![Agent &gt; Server &gt; Open New Session](/544112828/output/screenshot-20240730-162532.png)
+<img src="/544112828/output/screenshot-20240730-162532.png" alt="Agent &gt; Server &gt; Open New Session" width="746" />
 <figcaption>
 Agent &gt; Server &gt; Open New Session
 </figcaption>
@@ -194,7 +194,7 @@ $ ssh deploy@{{Server Name}}
 ### 에이전트를 통한 쿠버네티스 접속
 
 <figure data-layout="center" data-align="center">
-![kubernetes-agent-access-flow.png](/544112828/output/kubernetes-agent-access-flow.png)
+<img src="/544112828/output/kubernetes-agent-access-flow.png" alt="kubernetes-agent-access-flow.png" width="764" />
 </figure>
 
 * 권한을 부여 받은 사용자는 에이전트 실행 시 현재 정책에 따른 `kubeconfig` 파일이 자동으로 수신됩니다.
@@ -208,7 +208,7 @@ $ ssh deploy@{{Server Name}}
 원하는 역할을 고르고 `OK` 버튼을 클릭하세요.
 
 <figure data-layout="center" data-align="center">
-![Agent &gt; Kubernetes &gt; Select a Role](/544112828/output/screenshot-20240730-152705.png)
+<img src="/544112828/output/screenshot-20240730-152705.png" alt="Agent &gt; Kubernetes &gt; Select a Role" width="760" />
 <figcaption>
 Agent &gt; Kubernetes &gt; Select a Role
 </figcaption>
@@ -225,7 +225,7 @@ Agent &gt; Kubernetes &gt; Select a Role
 각 클러스터 우측의 `🔍` 버튼을 누르면 Policy Information 팝업창이 나타나며 이곳에서 해당 클러스터에 적용된 정책 목록을 자세히 확인할 수 있습니다.
 
 <figure data-layout="center" data-align="center">
-![Agent &gt; Policy Information](/544112828/output/screenshot-20240730-161141.png)
+<img src="/544112828/output/screenshot-20240730-161141.png" alt="Agent &gt; Policy Information" width="760" />
 <figcaption>
 Agent &gt; Policy Information
 </figcaption>
@@ -236,7 +236,7 @@ Agent &gt; Policy Information
 Agent 설정 메뉴에서 `KubeConfig Path` 버튼을 클릭하여 Kubeconfig 경로 설정 모달을 엽니다.
 
 <figure data-layout="center" data-align="center">
-![Agent &gt; Settings &gt; Configure Kubeconfig Path](/544112828/output/screenshot-20240730-154623.png)
+<img src="/544112828/output/screenshot-20240730-154623.png" alt="Agent &gt; Settings &gt; Configure Kubeconfig Path" width="764" />
 <figcaption>
 Agent &gt; Settings &gt; Configure Kubeconfig Path
 </figcaption>
@@ -248,7 +248,7 @@ Agent &gt; Settings &gt; Configure Kubeconfig Path
 
 
 <figure data-layout="center" data-align="center">
-![경로 지정 팝업](/544112828/output/screenshot-20240730-163530.png)
+<img src="/544112828/output/screenshot-20240730-163530.png" alt="경로 지정 팝업" width="760" />
 <figcaption>
 경로 지정 팝업
 </figcaption>
@@ -287,7 +287,7 @@ export KUBECONFIG="${KUBECONFIG}:${HOME}/.kube/querypie-kubeconfig"
 프로필 영역 우측 `⚙️` 버튼을 클릭하여 설정 메뉴를 엽니다. `Reset All Settings` 버튼을 클릭합니다.
 
 <figure data-layout="center" data-align="center">
-![Agent &gt; Settings](/544112828/output/screenshot-20240730-153518.png)
+<img src="/544112828/output/screenshot-20240730-153518.png" alt="Agent &gt; Settings" width="361" />
 <figcaption>
 Agent &gt; Settings
 </figcaption>
@@ -299,7 +299,7 @@ Agent &gt; Settings
 메뉴 막대에서 QueryPie Agent 아이콘을 클릭하여 앱 메뉴를 엽니다. `Reset All Settings` 버튼을 클릭합니다.
 
 <figure data-layout="center" data-align="center">
-![Agent &gt; App menu](/544112828/output/screenshot-20240730-153524.png)
+<img src="/544112828/output/screenshot-20240730-153524.png" alt="Agent &gt; App menu" width="363" />
 <figcaption>
 Agent &gt; App menu
 </figcaption>

--- a/confluence-mdx/tests/testcases/544113141/expected.mdx
+++ b/confluence-mdx/tests/testcases/544113141/expected.mdx
@@ -11,7 +11,7 @@ title: 'DB Access History'
 ### DB Access History 조회하기
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; Audit &gt; Databases &gt; DB Access History](/544113141/output/image-20240730-070842.png)
+<img src="/544113141/output/image-20240730-070842.png" alt="Administrator &gt; Audit &gt; Databases &gt; DB Access History" width="760" />
 <figcaption>
 Administrator &gt; Audit &gt; Databases &gt; DB Access History
 </figcaption>
@@ -25,7 +25,7 @@ Administrator &gt; Audit &gt; Databases &gt; DB Access History
     3.  **Client IP**  : 사용자 IP
 4. 검색 필드 우측 필터 버튼을 클릭하여 AND/OR 조건으로 이하의 필터링이 가능합니다.
   <figure data-layout="center" data-align="center">
-  ![image-20240730-064139.png](/544113141/output/image-20240730-064139.png)
+  <img src="/544113141/output/image-20240730-064139.png" alt="image-20240730-064139.png" width="736" />
   </figure>
     1.  **Connection Name**  : 접속한 DB 커넥션명
     2.  **Database Type** : 데이터베이스 유형
@@ -60,7 +60,7 @@ Administrator &gt; Audit &gt; Databases &gt; DB Access History
 각 행을 클릭하면 세부 정보 조회가 가능합니다.
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; Audit &gt; Databases &gt; DB Access History &gt; DB Access History Details](/544113141/output/image-20240730-065045.png)
+<img src="/544113141/output/image-20240730-065045.png" alt="Administrator &gt; Audit &gt; Databases &gt; DB Access History &gt; DB Access History Details" width="760" />
 <figcaption>
 Administrator &gt; Audit &gt; Databases &gt; DB Access History &gt; DB Access History Details
 </figcaption>

--- a/confluence-mdx/tests/testcases/544145591/expected.mdx
+++ b/confluence-mdx/tests/testcases/544145591/expected.mdx
@@ -11,7 +11,7 @@ import { Callout } from 'nextra/components'
 General 페이지에서는 QueryPie 전체의 기본 설정을 변경할 수 있습니다.
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; General &gt; Company Management &gt; General](/544145591/output/image-20250822-103044.png)
+<img src="/544145591/output/image-20250822-103044.png" alt="Administrator &gt; General &gt; Company Management &gt; General" width="760" />
 <figcaption>
 Administrator &gt; General &gt; Company Management &gt; General
 </figcaption>
@@ -33,7 +33,7 @@ Administrator &gt; General &gt; Company Management &gt; General
 System Properties 페이지에서는 QueryPie 시스템 컴포넌트들의 설정값을 확인하고, 파일로 저장할 수 있습니다.
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; General &gt; Company Management &gt; General &gt; System Properties](/544145591/output/image-20240805-014838.png)
+<img src="/544145591/output/image-20240805-014838.png" alt="Administrator &gt; General &gt; Company Management &gt; General &gt; System Properties" width="760" />
 <figcaption>
 Administrator &gt; General &gt; Company Management &gt; General &gt; System Properties
 </figcaption>
@@ -45,7 +45,7 @@ Administrator &gt; General &gt; Company Management &gt; General &gt; System Prop
 Workflow Configurations에서는 결재 상신 및 승인 관련 설정을 변경합니다.
 
 <figure data-layout="center" data-align="center">
-![Screenshot-2025-08-25-at-5.36.19-PM.png](/544145591/output/Screenshot-2025-08-25-at-5.36.19-PM.png)
+<img src="/544145591/output/Screenshot-2025-08-25-at-5.36.19-PM.png" alt="Screenshot-2025-08-25-at-5.36.19-PM.png" width="543" />
 </figure>
 
 ### 최대 승인 기간 설정
@@ -98,27 +98,27 @@ Allow users to submit requests in Urgent mode 토글로 활성화합니다.
 * 중요: 
     * 선택된 Attribute의 값으로는 승인자의 QueryPie Login ID가 입력되어 있어야 합니다.
       <figure data-layout="center" data-align="center">
-      ![Admin &gt; General &gt; Users &gt; Detail page &gt; Profile 탭<br/>](/544145591/output/Screenshot-2025-06-12-at-1.33.58-PM.png)
+      <img src="/544145591/output/Screenshot-2025-06-12-at-1.33.58-PM.png" alt="Admin &gt; General &gt; Users &gt; Detail page &gt; Profile 탭&lt;br/&gt;" width="712" />
       <figcaption>
       Admin &gt; General &gt; Users &gt; Detail page &gt; Profile 탭<br/>
       </figcaption>
       </figure>
 * Administrator &gt; General &gt; Workflow Management &gt; Approval Rules 페이지에서 새로운 승인 규칙을 추가하거나 기존 규칙을 수정할 때, 'Assignee for Approval' 항목에 'Allow Assignee selection (Attribute-Based)'를 선택한 뒤 승인자와 매핑하기 위한 Attribute (예: teamLeader)를 지정합니다.<br/>
   <figure data-layout="center" data-align="center">
-  ![image-20251110-030113.png](/544145591/output/image-20251110-030113.png)
+  <img src="/544145591/output/image-20251110-030113.png" alt="image-20251110-030113.png" width="736" />
   </figure>
     * 자가 승인 비활성화 시 연동: 만약 Approval Rules 설정에서 'Self Approval (자가 승인)' 옵션이 비활성화된 경우, Attribute 기반으로 결정된 승인자가 요청자 자신일 경우에는 해당 요청자를 승인자로 자동 지정할 수 없습니다. 이 경우, 워크플로우 설정 또는 시스템 정책에 따라 승인자 지정이 실패하거나 다른 경로로 처리될 수 있으니 주의가 필요합니다.
 * Attribute 값 부재 시 알림
     * 만약 상신자 User Profile에 해당 Attribute 값이 비어 있는 경우(즉, 승인자의 Login ID가 지정되지 않은 경우), 워크플로우 상신 시 다음과 같은 내용의 알림 모달이 표시되며 요청 제출이 중단됩니다. 상신자는 관리자에게 문의하여 프로필의 Attribute 값을 설정해야 합니다.
         * 에러 메시지 예시: 
           <figure data-layout="center" data-align="center">
-          ![image-20250508-022114.png](/544145591/output/image-20250508-022114.png)
+          <img src="/544145591/output/image-20250508-022114.png" alt="image-20250508-022114.png" width="688" />
           </figure>
 * Attribute 값은 있지만 해당 사용자가 비활성화된 경우
     * 만약 상신자 User Profile에 해당 Attribute 값으로 지정된 승인자가 비활성화된 경우, 워크플로우 상신 시 Approver란에 지정된 승인자가 표기되지 않으며 아래와 같은 내용의 알림 모달이 표시되며 요청 제출이 중단됩니다.
         * 에러 메세지 예시:
           <figure data-layout="center" data-align="center">
-          ![Screenshot-2025-06-16-at-10.30.14-AM.png](/544145591/output/Screenshot-2025-06-16-at-10.30.14-AM.png)
+          <img src="/544145591/output/Screenshot-2025-06-16-at-10.30.14-AM.png" alt="Screenshot-2025-06-16-at-10.30.14-AM.png" width="615" />
           </figure>
 
 ### Attribute 기반 워크플로우 메뉴 숨김 기능 (Use User Attribute to Hide Workflow Menu)
@@ -126,7 +126,7 @@ Allow users to submit requests in Urgent mode 토글로 활성화합니다.
 Use User Attribute to Hide Workflow Menu 토글을 활성화합니다.
 
 <figure data-layout="center" data-align="center">
-![Screenshot-2025-06-26-at-6.35.32-PM.png](/544145591/output/Screenshot-2025-06-26-at-6.35.32-PM.png)
+<img src="/544145591/output/Screenshot-2025-06-26-at-6.35.32-PM.png" alt="Screenshot-2025-06-26-at-6.35.32-PM.png" width="670" />
 </figure>
 
 특정 사용자 속성(User Attribute)을 기준으로 사용자 대시보드에서 Workflow 메뉴를 보이지 않도록 설정하는 기능입니다.
@@ -146,14 +146,14 @@ Use User Attribute to Hide Workflow Menu 토글을 활성화합니다.
 만약 비활성화 할 경우 사용자 preference 화면에서 Approver setting 메뉴가 노출되지 않습니다.
 
 <figure data-layout="center" data-align="center">
-![Allow Delegated Approval 스위치](/544145591/output/image-20250926-112444.png)
+<img src="/544145591/output/image-20250926-112444.png" alt="Allow Delegated Approval 스위치" width="253" />
 <figcaption>
 Allow Delegated Approval 스위치
 </figcaption>
 </figure>
 
 <figure data-layout="center" data-align="center">
-![대리결재 기능을 비활성화한 상태의 preference](/544145591/output/image-20250926-112201.png)
+<img src="/544145591/output/image-20250926-112201.png" alt="대리결재 기능을 비활성화한 상태의 preference" width="516" />
 <figcaption>
 대리결재 기능을 비활성화한 상태의 preference
 </figcaption>
@@ -164,7 +164,7 @@ Allow Delegated Approval 스위치
 토글을 켜면 Workflow에서 상신된 SQL 요청 실행시 쓰로틀링을 적용합니다.
 
 <figure data-layout="center" data-align="center">
-![Screenshot-2025-05-09-at-3.18.32-PM.png](/544145591/output/Screenshot-2025-05-09-at-3.18.32-PM.png)
+<img src="/544145591/output/Screenshot-2025-05-09-at-3.18.32-PM.png" alt="Screenshot-2025-05-09-at-3.18.32-PM.png" width="604" />
 </figure>
 
 
@@ -180,7 +180,7 @@ Allow Delegated Approval 스위치
 Redirect to custom page for SQL Requests 토글을 활성화합니다.
 
 <figure data-layout="center" data-align="center">
-![Screenshot-2025-05-09-at-8.33.07-PM.png](/544145591/output/Screenshot-2025-05-09-at-8.33.07-PM.png)
+<img src="/544145591/output/Screenshot-2025-05-09-at-8.33.07-PM.png" alt="Screenshot-2025-05-09-at-8.33.07-PM.png" width="516" />
 </figure>
 
 이 옵션을 통해 User Agent에서 Ledger 테이블 대상으로 INSERT, UPDATE, DELETE 쿼리 실행으로 인해 워크플로 승인 요청이 발생할 경우, `Send Request` 버튼 클릭 시 사용자를 사전에 정의된 커스텀 URL 페이지로 리디렉션할지 여부를 결정합니다.
@@ -198,7 +198,7 @@ Redirect to custom page for SQL Requests 토글을 활성화합니다.
 Select Request Types Allowed for Users 토글을 활성화합니다.
 
 <figure data-layout="center" data-align="center">
-![Screenshot-2025-05-09-at-8.40.28-PM.png](/544145591/output/Screenshot-2025-05-09-at-8.40.28-PM.png)
+<img src="/544145591/output/Screenshot-2025-05-09-at-8.40.28-PM.png" alt="Screenshot-2025-05-09-at-8.40.28-PM.png" width="352" />
 </figure>
 
 이 옵션을 통해 관리자가 사용자가 접근하고 요청할 수 있는 워크플로우의 요청(Request) 타입을 선택적으로 제어할 수 있도록 합니다.
@@ -224,7 +224,7 @@ Select Request Types Allowed for Users 토글을 활성화합니다.
 Workflow를 통해 DB Access Request 를 상신할 경우 요청하는 권한에 따라 결재선 (Approval Rule)을 특정할 수 있도록 하려면 “Use DB Privilege Type Based Approval” 토글을 활성화합니다.
 
 <figure data-layout="center" data-align="center">
-![Use DB Privilege Type Based Approval](/544145591/output/image-20250822-111454.png)
+<img src="/544145591/output/image-20250822-111454.png" alt="Use DB Privilege Type Based Approval" width="507" />
 <figcaption>
 Use DB Privilege Type Based Approval
 </figcaption>
@@ -233,7 +233,7 @@ Use DB Privilege Type Based Approval
 `+Routing Rule` 버튼을 누르면 privilege 에 대한 조건을 지정하여 결재선에 대한 라우팅을 지정할 수 있습니다.
 
 <figure data-layout="center" data-align="center">
-![image-20250822-112026.png](/544145591/output/image-20250822-112026.png)
+<img src="/544145591/output/image-20250822-112026.png" alt="image-20250822-112026.png" width="432" />
 </figure>
 
 *  **Routing Rule Name**  : 식별하기 쉬운 라우팅 규칙의 이름을 입력합니다.
@@ -259,7 +259,7 @@ Use DB Privilege Type Based Approval
 Workflow의 SQL Request를 통해 수행할 쿼리를 상신할 때 실행 계획 결과를 첨부하는 “Attach Explain Results” 기능을 활성 또는 비활성화 할 수 있도록 옵션을 제공합니다.
 
 <figure data-layout="center" data-align="center">
-![image-20250825-002423.png](/544145591/output/image-20250825-002423.png)
+<img src="/544145591/output/image-20250825-002423.png" alt="image-20250825-002423.png" width="425" />
 </figure>
 
 관리자가 이 옵션을 활성화 하더라도 Workflow의 SQL Request 양식에서 “Attach Explain Results” 는 Off로 되어 있으므로 사용자가 필요시 명시적으로 “Attatch Explain Results” 토글 스위치를 On으로 변경해야 실행계획 결과가 첨부됩니다.

--- a/confluence-mdx/tests/testcases/544178405/expected.mdx
+++ b/confluence-mdx/tests/testcases/544178405/expected.mdx
@@ -14,7 +14,7 @@ QueryPie의 관리자는 QueryPie Web 또는 API를 통하여 리소스 및 권�
 이 버튼을 클릭하여 관리자 페이지를 새 탭으로 열 수 있습니다.
 
 <figure data-layout="center" data-align="center">
-![GNB 내 관리자 페이지 진입점](/544178405/output/screenshot-20240801-145006.png)
+<img src="/544178405/output/screenshot-20240801-145006.png" alt="GNB 내 관리자 페이지 진입점" width="762" />
 <figcaption>
 GNB 내 관리자 페이지 진입점
 </figcaption>

--- a/confluence-mdx/tests/testcases/544377869/expected.mdx
+++ b/confluence-mdx/tests/testcases/544377869/expected.mdx
@@ -20,7 +20,7 @@ import { Callout } from 'nextra/components'
 접속을 허용할 커넥션에서 Proxy 사용 여부를 활성화합니다.
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; Databases &gt; Connection Management &gt; DB Connections &gt; Connection Details &gt; Proxy Usage](/544377869/output/image-20240725-070857.png)
+<img src="/544377869/output/image-20240725-070857.png" alt="Administrator &gt; Databases &gt; Connection Management &gt; DB Connections &gt; Connection Details &gt; Proxy Usage" width="760" />
 <figcaption>
 Administrator &gt; Databases &gt; Connection Management &gt; DB Connections &gt; Connection Details &gt; Proxy Usage
 </figcaption>
@@ -47,7 +47,7 @@ Proxy Usage 옵션을 활성화하면 Proxy 로 접속할 수 있는 Port 가 �
 </Callout>
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; Databases &gt; Connection Management &gt; DB Connections &gt; Proxy Management](/544377869/output/image-20240725-071030.png)
+<img src="/544377869/output/image-20240725-071030.png" alt="Administrator &gt; Databases &gt; Connection Management &gt; DB Connections &gt; Proxy Management" width="760" />
 <figcaption>
 Administrator &gt; Databases &gt; Connection Management &gt; DB Connections &gt; Proxy Management
 </figcaption>

--- a/confluence-mdx/tests/testcases/544379140/expected.mdx
+++ b/confluence-mdx/tests/testcases/544379140/expected.mdx
@@ -62,7 +62,7 @@ Audit Log Export 기능 추가에 따라, 각 로그 화면에서 제공되던 �
 ### Audit Log Export 목록 조회하기
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; Audit &gt; General &gt; Audit Log Export](/544379140/output/image-20240714-063656.png)
+<img src="/544379140/output/image-20240714-063656.png" alt="Administrator &gt; Audit &gt; General &gt; Audit Log Export" width="760" />
 <figcaption>
 Administrator &gt; Audit &gt; General &gt; Audit Log Export
 </figcaption>
@@ -84,7 +84,7 @@ Administrator &gt; Audit &gt; General &gt; Audit Log Export
 해당 버튼 클릭시 아래와 같은 화면이 나타납니다.
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; Audit &gt; General &gt; Audit Log Export &gt; Create New Task](/544379140/output/screenshot-20250116-131805.png)
+<img src="/544379140/output/screenshot-20250116-131805.png" alt="Administrator &gt; Audit &gt; General &gt; Audit Log Export &gt; Create New Task" width="612" />
 <figcaption>
 Administrator &gt; Audit &gt; General &gt; Audit Log Export &gt; Create New Task
 </figcaption>

--- a/confluence-mdx/tests/testcases/544381877/expected.mdx
+++ b/confluence-mdx/tests/testcases/544381877/expected.mdx
@@ -14,7 +14,7 @@ QueryPie에서는 접근 제어를 적용할 온프레미스 등에 위치한 �
 개별 서버를 수동으로 등록하기 위해서는 서버의 기본적인 정보 입력이 필요합니다.
 
 <figure data-layout="center" data-align="center">
-![image-20240721-054859.png](/544381877/output/image-20240721-054859.png)
+<img src="/544381877/output/image-20240721-054859.png" alt="image-20240721-054859.png" width="760" />
 </figure>
 
 1. Administrator &gt; Kubernetes &gt; Connection Management &gt; Clusters 메뉴로 이동합니다.
@@ -63,7 +63,7 @@ QueryPie에서는 접근 제어를 적용할 온프레미스 등에 위치한 �
 ### 쿠버네티스 클러스터 연동용 스크립트 이용 안내
 
 <figure data-layout="center" data-align="center">
-![image-20240511-033842.png](/544381877/output/image-20240511-033842.png)
+<img src="/544381877/output/image-20240511-033842.png" alt="image-20240511-033842.png" width="760" />
 </figure>
 
 * 관리자는 사전에 해당 대상 쿠버네티스 클러스터에 접속이 가능하여야 합니다.

--- a/confluence-mdx/tests/testcases/544384417/expected.mdx
+++ b/confluence-mdx/tests/testcases/544384417/expected.mdx
@@ -685,7 +685,7 @@ Audit 메뉴에서 Reports &gt; Reports 메뉴로 진입하면 보고서 생성 
 
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; Audit &gt; Reports &gt; Reports](/544384417/output/screenshot-20241223-112238.png)
+<img src="/544384417/output/screenshot-20241223-112238.png" alt="Administrator &gt; Audit &gt; Reports &gt; Reports" width="760" />
 <figcaption>
 Administrator &gt; Audit &gt; Reports &gt; Reports
 </figcaption>
@@ -724,7 +724,7 @@ Administrator &gt; Audit &gt; Reports &gt; Reports
 
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; Audit &gt; Reports &gt; Reports &gt; Report Detail](/544384417/output/screenshot-20241223-112524.png)
+<img src="/544384417/output/screenshot-20241223-112524.png" alt="Administrator &gt; Audit &gt; Reports &gt; Reports &gt; Report Detail" width="760" />
 <figcaption>
 Administrator &gt; Audit &gt; Reports &gt; Reports &gt; Report Detail
 </figcaption>
@@ -763,7 +763,7 @@ Administrator &gt; Audit &gt; Reports &gt; Reports &gt; Report Detail
 태스크 이름, 보고서 유형, 스케줄링 관련 내용을 입력하고, 섹션 단위로 보고서 출력 항목 및 적용할 필터를 지정할 수 있습니다. `+ Add Section` 버튼을 클릭하여 섹션을 추가할 수 있습니다.
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; Audit &gt; Reports &gt; Reports &gt; Create](/544384417/output/screenshot-20241209-104337.png)
+<img src="/544384417/output/screenshot-20241209-104337.png" alt="Administrator &gt; Audit &gt; Reports &gt; Reports &gt; Create" width="760" />
 <figcaption>
 Administrator &gt; Audit &gt; Reports &gt; Reports &gt; Create
 </figcaption>
@@ -799,7 +799,7 @@ Administrator &gt; Audit &gt; Reports &gt; Reports &gt; Create
 ### 보고서 복제하기**[10.2.2]**
 
 <figure data-layout="center" data-align="center">
-![Administrator &gt; Audit &gt; Reports &gt; Reports - Duplicate Task](/544384417/output/screenshot-20241223-104529.png)
+<img src="/544384417/output/screenshot-20241223-104529.png" alt="Administrator &gt; Audit &gt; Reports &gt; Reports - Duplicate Task" width="589" />
 <figcaption>
 Administrator &gt; Audit &gt; Reports &gt; Reports - Duplicate Task
 </figcaption>

--- a/confluence-mdx/tests/testcases/568918170/expected.mdx
+++ b/confluence-mdx/tests/testcases/568918170/expected.mdx
@@ -14,7 +14,7 @@ Workflow 사용 시 편리함을 더해주는 부가 기능을 소개합니다.
 ### 참조된 요청 확인 처리하기
 
 <figure data-layout="center" data-align="center">
-![Workflow &gt; Reviews &gt; All Reviews &gt; Review Details](/568918170/output/screenshot-20240802-114129.png)
+<img src="/568918170/output/screenshot-20240802-114129.png" alt="Workflow &gt; Reviews &gt; All Reviews &gt; Review Details" width="760" />
 <figcaption>
 Workflow &gt; Reviews &gt; All Reviews &gt; Review Details
 </figcaption>
@@ -37,7 +37,7 @@ Workflow &gt; Reviews &gt; All Reviews &gt; Review Details
 #### 1. 대리 결재 사용 설정하기
 
 <figure data-layout="center" data-align="center">
-![User &gt; 상단 메뉴바에서 프로필 클릭 &gt; Preferences](/568918170/output/screenshot-20240802-120401.png)
+<img src="/568918170/output/screenshot-20240802-120401.png" alt="User &gt; 상단 메뉴바에서 프로필 클릭 &gt; Preferences" width="760" />
 <figcaption>
 User &gt; 상단 메뉴바에서 프로필 클릭 &gt; Preferences
 </figcaption>
@@ -53,13 +53,13 @@ User &gt; 상단 메뉴바에서 프로필 클릭 &gt; Preferences
 
 대리 결재 설정 기간에는 원 결재자와 대리 결재자의 접속 시 상단 메뉴바에 다음과 같이 표시됩니다.
 <figure data-layout="center" data-align="center">
-![원 결재자 기준 표시 내용](/568918170/output/screenshot-20240802-120741.png)
+<img src="/568918170/output/screenshot-20240802-120741.png" alt="원 결재자 기준 표시 내용" width="594" />
 <figcaption>
 원 결재자 기준 표시 내용
 </figcaption>
 </figure>
 <figure data-layout="center" data-align="center">
-![대리 결재자 기준 표시 내용](/568918170/output/screenshot-20240802-120854.png)
+<img src="/568918170/output/screenshot-20240802-120854.png" alt="대리 결재자 기준 표시 내용" width="594" />
 <figcaption>
 대리 결재자 기준 표시 내용
 </figcaption>
@@ -77,7 +77,7 @@ User &gt; 상단 메뉴바에서 프로필 클릭 &gt; Preferences
 * 상세 페이지에서 승인 또는 반려할 수 있으며, Comment 입력 시에는 대리 결재 중임을 알리는 문구가 표시됩니다. 
 
 <figure data-layout="center" data-align="center">
-![screenshot-20240802-124638.png](/568918170/output/screenshot-20240802-124638.png)
+<img src="/568918170/output/screenshot-20240802-124638.png" alt="screenshot-20240802-124638.png" width="760" />
 </figure>
 
 #### 4. 대리 결재 처리된 요청 건 확인하기
@@ -85,14 +85,14 @@ User &gt; 상단 메뉴바에서 프로필 클릭 &gt; Preferences
 * 다음과 같이 요청 상세페이지 내 승인 현황에서 원 결재자 또는 대리 결재자가 처리한 것인지를 확인할 수 있습니다. 
 **원 결재자가 처리한 경우**
 <figure data-layout="center" data-align="center">
-![대리 결재 관련 문구 없음](/568918170/output/screenshot-20240725-153533.png)
+<img src="/568918170/output/screenshot-20240725-153533.png" alt="대리 결재 관련 문구 없음" width="363" />
 <figcaption>
 대리 결재 관련 문구 없음
 </figcaption>
 </figure>
 **대리 결재자가 처리한 경우**
 <figure data-layout="center" data-align="center">
-![대리 결재자가 Done by the delegate와 함께 표기됨](/568918170/output/screenshot-20240725-152141.png)
+<img src="/568918170/output/screenshot-20240725-152141.png" alt="대리 결재자가 Done by the delegate와 함께 표기됨" width="363" />
 <figcaption>
 대리 결재자가 Done by the delegate와 함께 표기됨
 </figcaption>
@@ -112,7 +112,7 @@ Slack DM 알림 관련 자세한 내용은 [Slack DM 개인 알림 사용하기]
 동일한 내용으로 반복적인 결재 요청을 하거나 반려 처리된 결재 건에 대해 다음과 같이 재상신할 수 있습니다.
 
 <figure data-layout="center" data-align="center">
-![Workflow &gt; Sent Requests &gt; Done &gt; List Details](/568918170/output/image-20230824-110815.png)
+<img src="/568918170/output/image-20230824-110815.png" alt="Workflow &gt; Sent Requests &gt; Done &gt; List Details" width="768" />
 <figcaption>
 Workflow &gt; Sent Requests &gt; Done &gt; List Details
 </figcaption>

--- a/confluence-mdx/tests/testcases/692355151/expected.mdx
+++ b/confluence-mdx/tests/testcases/692355151/expected.mdx
@@ -36,7 +36,7 @@ Content Type은 “Text”만 지원합니다.
 </Callout>
 
 <figure data-layout="center" data-align="center">
-![image-20241029-234721.png](/692355151/output/image-20241029-234721.png)
+<img src="/692355151/output/image-20241029-234721.png" alt="image-20241029-234721.png" width="760" />
 </figure>
 
 1. 실행계획(Explain) 옵션 및 실행계획 수행<br/>쿼리 에디터 하단에 있는 옵션을 선택하고 `Explain` 버튼을 누릅니다.
@@ -46,31 +46,31 @@ Content Type은 “Text”만 지원합니다.
         2.  **JSON**  : JSON 형태로 결과가 표시됩니다. 
 
 <figure data-layout="center" data-align="center">
-![image-20241029-235845.png](/692355151/output/image-20241029-235845.png)
+<img src="/692355151/output/image-20241029-235845.png" alt="image-20241029-235845.png" width="682" />
 </figure>
 
 <Callout type="important">
 * 실행계획 대상이 되는 쿼리(세미콜론으로 끝나는 구문)는 100개로 제한됩니다. 
 * MySQL은 5.6 이후 부터 Explain의 결과를 JSON 포맷으로 출력할 수 있습니다. 따라서 5.6 이전 버전을 대상으로 Explain을 수행시 JSON으로 출력할 수 없습니다.
 <figure data-layout="center" data-align="center">
-![image-20241030-001252.png](/692355151/output/image-20241030-001252.png)
+<img src="/692355151/output/image-20241030-001252.png" alt="image-20241030-001252.png" width="682" />
 </figure>
 </Callout>
 
 1. 실행계획(Explain) 결과 확인
     1. Table 형태의 결과 확인<br/>아래 그림과 같은 결과가 표시됩니다. 각 필드의 의미는 MySQL reference 문서를 참고 바랍니다.<br/> <br/>  
       <figure data-layout="center" data-align="center">
-      ![image-20241030-002325.png](/692355151/output/image-20241030-002325.png)
+      <img src="/692355151/output/image-20241030-002325.png" alt="image-20241030-002325.png" width="712" />
       </figure>
     2. JSON 형태의 결과 확인<br/>JSON 을 선택하고 Explain 버튼을 누르면 아래 그림과 같은 결과가 표시됩니다. `{JSON}` 을 클릭하면 전체 JSON 내용을 확인 할 수 있습니다.<br/> <br/>  <br/> <br/>  <br/>내보내기(Export)를 할 때 관리자 설정에 따라 암호 입력을 요구하는 팝업이 출력될 수 있습니다.
       <figure data-layout="center" data-align="center">
-      ![`{JSON}`을 클릭하면 전체 내용을 볼수 있습니다.](/692355151/output/image-20241030-003040.png)
+      <img src="/692355151/output/image-20241030-003040.png" alt="`{JSON}`을 클릭하면 전체 내용을 볼수 있습니다." width="712" />
       <figcaption>
       `{JSON}`을 클릭하면 전체 내용을 볼수 있습니다.
       </figcaption>
       </figure>
       <figure data-layout="center" data-align="center">
-      ![JSON 결과의 복사와 내보내기가 가능합니다.](/692355151/output/image-20241030-003129.png)
+      <img src="/692355151/output/image-20241030-003129.png" alt="JSON 결과의 복사와 내보내기가 가능합니다." width="560" />
       <figcaption>
       JSON 결과의 복사와 내보내기가 가능합니다.
       </figcaption>
@@ -80,7 +80,7 @@ Content Type은 “Text”만 지원합니다.
 
 1. 결재자(Approver)의 실행계획(Explain)결과 확인<br/>결재자는 Explain Results 탭에서 첨부된 실행계획(Explain)결과를 확인하고 승인의 참고자료로 활용할 수 있습니다.
   <figure data-layout="center" data-align="center">
-  ![image-20241030-004258.png](/692355151/output/image-20241030-004258.png)
+  <img src="/692355151/output/image-20241030-004258.png" alt="image-20241030-004258.png" width="736" />
   </figure>
 
 <Callout type="important">

--- a/confluence-mdx/tests/testcases/880181257/expected.mdx
+++ b/confluence-mdx/tests/testcases/880181257/expected.mdx
@@ -11,14 +11,14 @@ import { Callout } from 'nextra/components'
 1. 사용자 화면 상단 Workflow 메뉴로 이동합니다.
 2. 좌측 상단 `Submit Request` 버튼 클릭후 DB Access Request 항목을 선택합니다. <br/> 
   <figure data-layout="center" data-align="center">
-  ![Screenshot-2025-03-06-at-1.19.24-PM.png](/880181257/output/Screenshot-2025-03-06-at-1.19.24-PM.png)
+  <img src="/880181257/output/Screenshot-2025-03-06-at-1.19.24-PM.png" alt="Screenshot-2025-03-06-at-1.19.24-PM.png" width="712" />
   </figure>
 3. Approval Rule을 상황에 맞게 설정하고 Title도 작성합니다.
 4. DB Connection 목록에서 Type이 'Custom Data Source'인 항목을 선택합니다.
 5. 다른 벤더들과 다르게 Privilege를 선택할 수 없기 때문에 “-”로 표기됩니다. 
 6. Expiration Date과 Reason for Request 항목도 상황에 맞게 설정 및 작성합니다. <br/> 
   <figure data-layout="center" data-align="center">
-  ![Screenshot-2025-03-06-at-1.22.28-PM.png](/880181257/output/Screenshot-2025-03-06-at-1.22.28-PM.png)
+  <img src="/880181257/output/Screenshot-2025-03-06-at-1.22.28-PM.png" alt="Screenshot-2025-03-06-at-1.22.28-PM.png" width="712" />
   </figure>
 7. 작성을 완료했다면 하단 `Submit`버튼을 클릭하여 신청을 완료합니다. 
 8. 관리자의 승인을 받았다면 좌측 Workflow &gt; Sent Request &gt; Done 메뉴에서 확인할 수 있습니다.
@@ -36,13 +36,13 @@ import { Callout } from 'nextra/components'
     * QueryPie Agent를 실행합니다.
     * Database 항목에서 Custom Data Source를 확인할 수 있습니다. <br/> 
       <figure data-layout="center" data-align="center">
-      ![Screenshot-2025-03-06-at-2.05.26-PM.png](/880181257/output/Screenshot-2025-03-06-at-2.05.26-PM.png)
+      <img src="/880181257/output/Screenshot-2025-03-06-at-2.05.26-PM.png" alt="Screenshot-2025-03-06-at-2.05.26-PM.png" width="400" />
       </figure>
 2.  **Connection Guide 확인** 
     * Agent에서 Custom Data Source 커넥션 행을 클릭하면 Port 정보를 담은 행이 보입니다.
     * 위 행을 우클릭을 한뒤 Connection Guide를 클릭하면 접속 정보를 확인할 수 있습니다. <br/> 
       <figure data-layout="center" data-align="center">
-      ![Screenshot-2025-03-06-at-2.08.11-PM.png](/880181257/output/Screenshot-2025-03-06-at-2.08.11-PM.png)
+      <img src="/880181257/output/Screenshot-2025-03-06-at-2.08.11-PM.png" alt="Screenshot-2025-03-06-at-2.08.11-PM.png" width="712" />
       </figure>
     * UID/PW는 수정할 수 없는 db username, db password로 표시됩니다.
     * Privileges는 "-"로 표시됩니다.
@@ -51,7 +51,7 @@ import { Callout } from 'nextra/components'
     *  **Host와 Port는 Connection Guide에 명시되어있는 정보를 입력해야합니다.**  
     * 벤더에 따라 추가 정보를 입력합니다.
       <figure data-layout="center" data-align="center">
-      ![Screenshot-2025-03-06-at-2.18.26-PM.png](/880181257/output/Screenshot-2025-03-06-at-2.18.26-PM.png)
+      <img src="/880181257/output/Screenshot-2025-03-06-at-2.18.26-PM.png" alt="Screenshot-2025-03-06-at-2.18.26-PM.png" width="712" />
       </figure>
 
 <Callout type="important">
@@ -65,11 +65,11 @@ import { Callout } from 'nextra/components'
     * 사용자 화면 상단 Databases를 클릭합니다. 
     * 좌측 커넥션 목록에서 QueryPie Connections를 클릭하면 접근 권한이 있는 Custom Data Source가 표시됩니다. <br/> 
       <figure data-layout="center" data-align="center">
-      ![Screenshot-2025-03-06-at-2.22.22-PM.png](/880181257/output/Screenshot-2025-03-06-at-2.22.22-PM.png)
+      <img src="/880181257/output/Screenshot-2025-03-06-at-2.22.22-PM.png" alt="Screenshot-2025-03-06-at-2.22.22-PM.png" width="712" />
       </figure>
 2.  **접속 불가 안내** 
     * Custom Data Source 선택 시 Connect 버튼이 비활성화됩니다.
     * 아래와 같은 툴팁이 표시되며 웹으로는 접속이 불가합니다.  <br/> "Access is only possible through a proxy and cannot be accessed through the web. Please open the QueryPie Agent to connect to the Custom Data Source."
       <figure data-layout="center" data-align="center">
-      ![Screenshot-2025-03-06-at-2.23.37-PM.png](/880181257/output/Screenshot-2025-03-06-at-2.23.37-PM.png)
+      <img src="/880181257/output/Screenshot-2025-03-06-at-2.23.37-PM.png" alt="Screenshot-2025-03-06-at-2.23.37-PM.png" width="712" />
       </figure>

--- a/confluence-mdx/tests/testcases/883654669/expected.mdx
+++ b/confluence-mdx/tests/testcases/883654669/expected.mdx
@@ -27,15 +27,15 @@ App Manifest를 이용하여 QueryPie DM 연동 전용 Slack App을 생성합니
 
 1. [https://api.slack.com/apps](https://api.slack.com/apps) 으로 이동하여 `Create an App` 을 클릭합니다.<br/> <br/> 
   <figure data-layout="center" data-align="center">
-  ![image-20231227-065658.png](/883654669/output/image-20231227-065658.png)
+  <img src="/883654669/output/image-20231227-065658.png" alt="image-20231227-065658.png" width="760" />
   </figure>
 2. Create an app 모달에서, App 생성 방식을 선택합니다. `From a manifest` 를 클릭합니다.<br/> <br/> 
   <figure data-layout="center" data-align="center">
-  ![screenshot-20250218-131725.png](/883654669/output/screenshot-20250218-131725.png)
+  <img src="/883654669/output/screenshot-20250218-131725.png" alt="screenshot-20250218-131725.png" width="712" />
   </figure>
 3. Pick a workspace 모달에서 QueryPie와 연동할 Slack Workspace를 선택한 뒤 다음 단계로 진행합니다.<br/> <br/> 
   <figure data-layout="center" data-align="center">
-  ![image-20231227-065951.png](/883654669/output/image-20231227-065951.png)
+  <img src="/883654669/output/image-20231227-065951.png" alt="image-20231227-065951.png" width="710" />
   </figure>
 4. Create app from manifest 모달에서 JSON 형식의 App Manifest를 입력합니다. <br/>미리 채워져 있는 내용들을 삭제하고 아래의 App Manifest를 붙여넣은 뒤 다음 단계로 진행합니다.<br/>:light_bulb_on: `{{..}}` 안의 값은 원하는 값으로 변경해 주세요. <br/> 
   ```
@@ -70,7 +70,7 @@ App Manifest를 이용하여 QueryPie DM 연동 전용 Slack App을 생성합니
   ```
 5. 설정 내용을 검토하고 `Create` 버튼을 클릭하여 App 생성을 완료합니다.<br/> <br/> 
   <figure data-layout="center" data-align="center">
-  ![image-20240115-220447.png](/883654669/output/image-20240115-220447.png)
+  <img src="/883654669/output/image-20240115-220447.png" alt="image-20240115-220447.png" width="763" />
   </figure>
 
 ### Slack Workspace에 Slack App 설치
@@ -78,11 +78,11 @@ App Manifest를 이용하여 QueryPie DM 연동 전용 Slack App을 생성합니
 1. Settings &gt; Install App에서 `Install to Workspace` 버튼을 클릭하여 생성된 앱을 Slack Workspace에 설치합니다. 
 2. 권한 요청 페이지에서, `허용`을 클릭합니다. <br/> 
   <figure data-layout="center" data-align="center">
-  ![image-20240115-221520.png](/883654669/output/image-20240115-221520.png)
+  <img src="/883654669/output/image-20240115-221520.png" alt="image-20240115-221520.png" width="760" />
   </figure>
 3. 설정한 Slack Workspace에서 Slack DM 전용 App이 생성된 것을 확인할 수 있습니다.
   <figure data-layout="center" data-align="center">
-  ![image-20240115-221618.png](/883654669/output/image-20240115-221618.png)
+  <img src="/883654669/output/image-20240115-221618.png" alt="image-20240115-221618.png" width="760" />
   </figure>
 
 ### Bot User OAuth Token 획득
@@ -90,7 +90,7 @@ App Manifest를 이용하여 QueryPie DM 연동 전용 Slack App을 생성합니
 Features &gt; OAuth & Permissions 메뉴 내 OAuth Tokens for Your Workspace 섹션에서,  **Bot User OAuth Token**  을 복사하여 기록해 둡니다.
 
 <figure data-layout="center" data-align="center">
-![image-20240418-022640.png](/883654669/output/image-20240418-022640.png)
+<img src="/883654669/output/image-20240418-022640.png" alt="image-20240418-022640.png" width="764" />
 </figure>
 
 
@@ -106,11 +106,11 @@ App manifest로 Slack app을 생성할 때 Socket Mode와 관련 권한들을 �
 
 1. 앱 설정 페이지의 Settings &gt; Basic Information 메뉴의 App-Level Tokens 섹션으로 이동하고, `Generate Token and Scope` 버튼을 클릭합니다.<br/> <br/> 
   <figure data-layout="center" data-align="center">
-  ![screenshot-20250218-140951.png](/883654669/output/screenshot-20250218-140951.png)
+  <img src="/883654669/output/screenshot-20250218-140951.png" alt="screenshot-20250218-140951.png" width="736" />
   </figure>
 2. Generate an app-level token 모달에서, Add Scope 버튼을 클릭한 뒤 `connections:write` 를 추가합니다.<br/> <br/> 
   <figure data-layout="center" data-align="center">
-  ![screenshot-20250218-141555.png](/883654669/output/screenshot-20250218-141555.png)
+  <img src="/883654669/output/screenshot-20250218-141555.png" alt="screenshot-20250218-141555.png" width="736" />
   </figure>
 3. 생성된 App-Level Token 모달에서, 앱 토큰을 복사하여 따로 기록해 둡니다. App-Level Token은 `xapp-` 으로 시작합니다.
 
@@ -118,7 +118,7 @@ App manifest로 Slack app을 생성할 때 Socket Mode와 관련 권한들을 �
 
 1. Admin &gt; General &gt; System &gt; Integrations &gt; Slack 메뉴로 진입한 뒤, `Configure` 버튼을 클릭하여 설정 모달을 엽니다.<br/> <br/> 
   <figure data-layout="center" data-align="center">
-  ![Administrator &gt; General &gt; System &gt; Integrations &gt; Slack &gt; Create a New Slack Configuration](/883654669/output/screenshot-20250310-113509.png)
+  <img src="/883654669/output/screenshot-20250310-113509.png" alt="Administrator &gt; General &gt; System &gt; Integrations &gt; Slack &gt; Create a New Slack Configuration" width="736" />
   <figcaption>
   Administrator &gt; General &gt; System &gt; Integrations &gt; Slack &gt; Create a New Slack Configuration
   </figcaption>
@@ -128,7 +128,7 @@ App manifest로 Slack app을 생성할 때 Socket Mode와 관련 권한들을 �
     *  **Send Workflow Notification via Slack DM**  : 워크플로우 요청에 대한 Slack DM 전송 활성화
     *  **Allow Users to approve or reject on Slack DM**  : Slack DM 내에서 승인 또는 거절 기능 활성화<br/> <br/> 
       <figure data-layout="center" data-align="center">
-      ![액션 허용타입 예시 (좌) / 액션 비허용 타입 예시 (우)](/883654669/output/image-20231003-054240.png)
+      <img src="/883654669/output/image-20231003-054240.png" alt="액션 허용타입 예시 (좌) / 액션 비허용 타입 예시 (우)" width="760" />
       <figcaption>
       액션 허용타입 예시 (좌) / 액션 비허용 타입 예시 (우)
       </figcaption>
@@ -139,14 +139,14 @@ App manifest로 Slack app을 생성할 때 Socket Mode와 관련 권한들을 �
 
 1. Slack Configuration을 등록한 뒤, 현재 설정 상태를 화면에서 확인할 수 있습니다.<br/> <br/> 
   <figure data-layout="center" data-align="center">
-  ![Administrator &gt; General &gt; System &gt; Integrations &gt; Slack](/883654669/output/screenshot-20250310-113950.png)
+  <img src="/883654669/output/screenshot-20250310-113950.png" alt="Administrator &gt; General &gt; System &gt; Integrations &gt; Slack" width="736" />
   <figcaption>
   Administrator &gt; General &gt; System &gt; Integrations &gt; Slack
   </figcaption>
   </figure>
 2. `Edit` 버튼을 클릭하여 입력한 설정을 변경할 수 있습니다.<br/>
   <figure data-layout="center" data-align="center">
-  ![Administrator &gt; General &gt; System &gt; Integrations &gt; Slack &gt; Edit the Slack Configuration](/883654669/output/screenshot-20250218-152840.png)
+  <img src="/883654669/output/screenshot-20250218-152840.png" alt="Administrator &gt; General &gt; System &gt; Integrations &gt; Slack &gt; Edit the Slack Configuration" width="736" />
   <figcaption>
   Administrator &gt; General &gt; System &gt; Integrations &gt; Slack &gt; Edit the Slack Configuration
   </figcaption>
@@ -159,13 +159,13 @@ DB Access Request를 예시로, Slack DM 기능이 정상적으로 작동하는�
 
 1. QueryPie User &gt; Workflow 페이지에서 Submit Request 버튼을 클릭한 뒤, DB Access Request를 선택하여 요청 작성 화면으로 진입합니다. 요청 작성 화면에서 필요한 정보를 입력하고, 요청을 상신합니다. <br/> 
   <figure data-layout="center" data-align="center">
-  ![screenshot-20250218-151504.png](/883654669/output/screenshot-20250218-151504.png)
+  <img src="/883654669/output/screenshot-20250218-151504.png" alt="screenshot-20250218-151504.png" width="736" />
   </figure>
 2. 승인자는 앞에서 추가한 Slack App과의 DM으로 승인해야 할 요청 알림을 수신할 수 있습니다.<br/> **Allow Users to approve or reject on Slack DM**  설정이 켜져 있으므로, DM에서 직접 사유를 입력하고 요청을 승인 또는 거절할 수 있습니다.<br/> <br/> 
   <figure data-layout="center" data-align="center">
-  ![screenshot-20250218-152238.png](/883654669/output/screenshot-20250218-152238.png)
+  <img src="/883654669/output/screenshot-20250218-152238.png" alt="screenshot-20250218-152238.png" width="701" />
   </figure>
 3. DM에서 `Details` 버튼을 클릭 시, QueryPie Admin에서 결재 요청에 대한 상세 내용을 확인하고 승인 또는 거절할 수 있습니다.<br/>
   <figure data-layout="center" data-align="center">
-  ![screenshot-20250218-152527.png](/883654669/output/screenshot-20250218-152527.png)
+  <img src="/883654669/output/screenshot-20250218-152527.png" alt="screenshot-20250218-152527.png" width="736" />
   </figure>


### PR DESCRIPTION
## Description
- Confluence에서 MDX로 변환 시 이미지의 width 속성이 누락되는 문제를 수정합니다.
- Markdown 이미지 문법(`![alt](src)`) 대신 HTML `<img>` 태그를 사용하여 width 속성을 명시적으로 지정합니다.
- png 외에도 gif, jpg, jpeg, webp, svg 확장자를 이미지로 인식하도록 확장합니다.
- 캡션 텍스트의 특수문자(`"`, `<`, `>`)를 이스케이프 처리합니다.

## Related tickets & links
- #518

## Added/updated tests?
- [ ] Yes
- [x] No, and this is why: 기존 테스트케이스의 expected 파일이 새로운 출력 형식에 맞게 업데이트되었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)