### PR TITLE
docs: Commit 및 PR 작성 가이드 문서를 추가합니다

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -2,6 +2,8 @@
 
 querypie-docs 저장소의 commit 관습에 맞게 commit message를 작성합니다.
 
+> **상세 가이드**: [docs/commit-pr-guide.md](/docs/commit-pr-guide.md)
+
 ## 작업 순서
 
 1. `git branch --show-current`로 현재 브랜치 확인
@@ -12,288 +14,30 @@ querypie-docs 저장소의 commit 관습에 맞게 commit message를 작성합�
 6. 변경사항을 분석하여 commit message 초안 작성
 7. 사용자에게 확인 후 commit 실행
 
-## 브랜치 관리
+## 브랜치 이름 형식
 
-### 현재 브랜치 확인
-
-```bash
-git branch --show-current
-```
-
-### main 브랜치에서 작업 중인 경우
-
-main 브랜치에서 직접 커밋하지 않습니다. feature branch를 생성하고 checkout합니다.
-
-**브랜치 이름 형식:**
 ```
 <username>/<type>-<간단한-설명>
 ```
 
-**Username 목록:**
-- `jk`
-- `kelly`
-- `dave`
-- `jane`
+**Username**: `jk`, `kelly`, `dave`, `jane` (git config에서 유추)
 
-username은 git config user.name 또는 user.email에서 유추합니다.
+## 핵심 규칙
 
-**Type 종류:**
-- `feat-` : 새로운 기능
-- `fix-` : 버그 수정
-- `refactor-` : 리팩토링
-- `chore-` : 기타 작업
-- `docs-` : 문서 작업
-- `mdx-` : MDX 문서 작업
-- `open-api-` : OpenAPI/API Reference 작업
+- **제목**: `<type>(<scope>): <한국어 설명>` 또는 `<prefix>: <한국어 설명>`
+- **본문**: `## Summary`로 시작, 배경/이유/목적 한 문장 + bullet point로 변경사항 기술
+- **언어**: 한국어, 경어체(~합니다), 능동태
+- **제목 길이**: 50자 이내
 
-**브랜치 이름 규칙:**
-- 영어 소문자와 하이픈(`-`)만 사용
-- 간결하고 명확하게 작성 (2-4 단어)
-- 공백 대신 하이픈 사용
-- `/`는 username 구분에만 1회 사용
-
-**예시:**
-- `jk/mdx-update-korean-docs`
-- `kelly/fix-build-error`
-- `dave/open-api-add-endpoint`
-- `jane/confluence-mdx-improve-converter`
-
-**브랜치 생성 및 checkout:**
-```bash
-git checkout -b <username>/<type>-<간단한-설명>
-```
-
-### main 브랜치가 아닌 경우
-
-현재 브랜치에서 그대로 작업을 진행합니다. 별도의 브랜치 생성이 필요하지 않습니다.
-
-## Commit Message 형식
-
-### Title (제목)
-
-querypie-docs는 도메인 기반 prefix를 사용합니다:
+## Claude 사용 시
 
 ```
-<type>: <description>
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
 ```
 
-또는 scope가 필요한 경우:
+## 참조
 
-```
-<type>(<scope>): <description>
-```
-
-**Type 종류 (우선순위 순):**
-- `mdx`: MDX 문서 추가/수정/번역
-- `open-api`: OpenAPI/API Reference 관련 작업
-- `confluence-mdx`: Confluence 변환 도구 관련
-- `mdx_to_skeleton`: 스켈레톤 변환 도구 관련
-- `fix`: 버그 수정
-- `refactor`: 코드 리팩토링 (기능 변경 없음)
-- `chore`: 빌드, 패키지 등 기타 변경
-- `ci`: CI/CD 설정 변경
-- `tests`: 테스트 추가/수정
-
-**제목 작성 규칙:**
-- 한국어 사용 (영어도 가능)
-- 50자 이내 권장
-- 마침표 없이 작성
-- 명령형으로 작성 (예: "추가", "수정", "개선", "구현")
-- PR 번호는 작성하지 않음 (GitHub merge 시 자동 추가됨)
-
-**예시:**
-- `mdx: Confluence 한국어 문서 업데이트 (Community Edition 설치 가이드 개선)`
-- `mdx: 12월 15일 이후 매뉴얼 업데이트를 일본어로 번역`
-- `open-api: API Reference 동적 라우팅 페이지 구현`
-- `open-api: Redoc title/description 커스터마이징 및 페이지 레이아웃 개선`
-- `confluence-mdx: 테이블 변환 시 불필요한 속성 제거`
-- `fix: robots.txt에 Disallow 규칙 추가하여 불필요한 크롤링 차단`
-- `fix(ci): Confluence 워크플로우에서 첨부파일도 PR에 포함되도록 수정`
-- `refactor: QueryPie 로고를 재사용 가능한 컴포넌트로 분리`
-- `chore: 테스트용 sandbox 페이지를 추가`
-
-### Description (본문)
-
-querypie-docs는 **본문을 포함**하는 것이 관습입니다. 변경사항의 맥락과 세부 내용을 상세히 기술합니다.
-
-**기본 형식:**
-
-```markdown
-## Description
-- 변경 내용의 핵심 요약
-- 세부 변경사항 나열
-- 필요시 하위 항목으로 상세 설명
-  - 세부 항목 1
-  - 세부 항목 2
-
-## Additional notes
-- 추가 참고사항 (선택사항)
-- 후속 작업 안내 등
-```
-
-**변경된 파일이 많은 경우:**
-
-```markdown
-## Description
-- 변경 내용 요약
-
-## Changes
-- `path/to/file1.tsx`: 변경 내용 설명
-- `path/to/file2.ts`: 변경 내용 설명
-
-## Additional notes
-- 추가 참고사항
-```
-
-**관련 이슈가 있는 경우:**
-
-```markdown
-## Description
-- 변경 내용 설명
-
-## Related tickets & links
-- Closes #123
-
-## Added/updated tests?
-- [x] No, and this is why: 간단한 변경으로 로컬에서 검증 완료
-```
-
-**MDX 문서 업데이트의 경우:**
-
-```markdown
-## Description
-- Confluence에서 최근 수정된 문서 변경사항을 MDX로 업데이트합니다 (한국어)
-- 변경된 문서 내용 요약
-  - 세부 변경 항목 1
-  - 세부 변경 항목 2
-
-### 영어/일본어 번역 추가
-- 위 한국어 문서 변경사항에 대응하는 영어(en), 일본어(ja) 번역 수행
-- Skeleton MDX 비교를 통해 원문과 번역문의 문서 구조 일치 검증 완료
-
-## Additional notes
-- 총 N개 파일 변경 (X줄 추가, Y줄 삭제)
-```
-
-**코드 변경의 경우:**
-
-```markdown
-## Description
-변경 내용에 대한 간략한 설명을 작성합니다.
-
-- 구현 세부사항 1
-- 구현 세부사항 2
-- 구현 세부사항 3
-
-## Additional Notes
-- 아직 개선이 필요한 부분이나 후속 작업 안내
-```
-
-**취약점 수정의 경우:**
-
-```markdown
-## 취약점
-- CVE-XXXX-XXXXX 취약점 설명
-- CVE-YYYY-YYYYY 취약점 설명
-
-## 패치 방법
-- npx npm-check-updates
-- npx npm-check-updates --upgrade
-- npm install
-- npm audit
-```
-
-### 실제 commit 예시
-
-**예시 1: MDX 문서 업데이트**
-```
-mdx: Confluence 한국어 문서 업데이트 (Community Edition 설치 가이드 개선)
-
-## Description
-- Confluence에서 최근 수정된 문서 변경사항을 MDX로 업데이트합니다 (한국어)
-- Community Edition 설치 가이드 개선
-    - 라이선스 안내 재배치 및 상세화
-    - 초기 암호 변경 안내 추가
-    - 설치 위치 및 수동 시작/중지 방법 추가
-    - 스크린샷 업데이트
-- LDAP Identity Providers 문서에 Active Directory 연동 시 Anonymous 설정 주의사항 추가
-
-### 영어/일본어 번역 추가
-- 위 한국어 문서 변경사항에 대응하는 영어(en), 일본어(ja) 번역 수행
-- Skeleton MDX 비교를 통해 원문과 번역문의 문서 구조 일치 검증 완료
-
-## Additional notes
-- 한국어: 5개 파일 변경 (90줄 추가, 24줄 삭제)
-- 영어/일본어: 10개 파일 변경 (192줄 추가, 60줄 삭제)
-```
-
-**예시 2: 기능 구현**
-```
-open-api: API Reference 동적 라우팅 페이지 구현
-
-## Description
-버전별 API Reference 페이지를 동적 라우팅으로 구현했습니다.
-- `[lang]/api-reference/[acpVersion]/[apiVersion]` 경로로 버전별 API Reference 페이지 동적 생성
-- OpenApiViewer 컴포넌트를 사용하여 OpenAPI 명세서 표시
-- 다국어 지원 (en/ko/ja) 및 generateStaticParams로 정적 생성 지원
-- logger 개선: production 환경에서 debug/info 로그 비활성화 및 createModuleLogger export 추가
-
-## Additional notes
-- 로고 이미지가 깨어지는 부분, 페이지 상단 설명 문구 영역을 개선하여야 합니다.
-- 좌측 Sidebar, 우측 TOC 영역을 모두 사용하는 레이아웃이 적용되었습니다.
-```
-
-**예시 3: 버그 수정**
-```
-fix: robots.txt에 Disallow 규칙 추가하여 불필요한 크롤링 차단
-
-## Description
-- Google Search Console에서 보고된 404 오류 해결을 위해 robots.txt에 Disallow 규칙 추가
-- `/_next/` 경로 차단: 빌드마다 해시가 변경되는 static 파일(CSS, JS) 크롤링 방지
-- `/api/` 경로 차단: API Reference 동적 라우팅 경로 크롤링 방지
-
-## Changes
-- `src/app/robots.txt/route.ts`: 프로덕션 환경 robots.txt에 Disallow 규칙 추가
-
-## Related tickets & links
-- Closes #488
-
-## Added/updated tests?
-- [x] No, and this is why: robots.txt 동적 라우트의 단순 문자열 변경으로, 로컬 dev 서버에서 출력 검증 완료
-```
-
-**예시 4: 리팩토링**
-```
-refactor: QueryPie 로고를 재사용 가능한 컴포넌트로 분리
-
-## Description
-QueryPie 로고를 재사용 가능한 컴포넌트로 분리했습니다.
-- `QueryPieLogo` 컴포넌트를 새로 생성하여 로고 UI를 재사용 가능하도록 개선
-- `QUERYPIE_LOGO_HTML` 상수를 export하여 DOM 조작 시나리오(예: Redoc 로고 교체)에서도 사용 가능하도록 지원
-- `layout.tsx`에서 인라인으로 작성된 로고 JSX를 `QueryPieLogo` 컴포넌트로 교체하여 코드 간소화
-
-## Changes
-- `src/components/querypie-logo.tsx`: QueryPieLogo 컴포넌트 및 QUERYPIE_LOGO_HTML 상수 추가
-- `src/app/[lang]/layout.tsx`: 인라인 로고 JSX를 QueryPieLogo 컴포넌트로 교체
-```
-
-**예시 5: 도구 개선**
-```
-confluence-mdx: 테이블 변환 시 불필요한 속성 제거
-
-## Description
-- 테이블 변환 시 Confluence 전용 속성을 제거하도록 `get_html_attributes` 함수를 개선합니다.
-- `local-id` 속성 제거 (Confluence 내부 식별자)
-- `data-*` 속성 제거 (`data-table-width`, `data-layout`, `data-highlight-colour` 등)
-- testcases 의 expected.mdx 를 업데이트합니다.
-```
-
-## 주의사항
-
-- **본문은 필수입니다** - 단순한 변경이라도 `## Description` 섹션을 포함합니다
-- PR merge 시 GitHub에서 `(#xxx)` 번호가 자동 추가됨
-- Co-Authored-By 헤더는 자동으로 추가됨
-- 문서 관련 작업은 `mdx:` prefix 사용
-- API 관련 작업은 `open-api:` prefix 사용
-- 도구 관련 작업은 해당 도구명을 prefix로 사용 (예: `confluence-mdx:`)
-- 이미지 첨부가 필요한 경우 GitHub 이미지 링크 형식 사용 가능
+- Type/Prefix 종류: [docs/commit-pr-guide.md#type-종류](/docs/commit-pr-guide.md#type-종류)
+- 본문 형식: [docs/commit-pr-guide.md#본문-형식](/docs/commit-pr-guide.md#본문-형식)
+- 작성 지침: [docs/commit-pr-guide.md#작성-지침](/docs/commit-pr-guide.md#작성-지침)
+- 예시: [docs/commit-pr-guide.md#예시](/docs/commit-pr-guide.md#예시)

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -23,6 +23,7 @@
 | confluence-mdx.md | [confluence-mdx/README.md](/confluence-mdx/README.md) |
 | mdx-skeleton-comparison.md | [docs/translation.md](/docs/translation.md) |
 | documentation.md | [docs/DEVELOPMENT.md](/docs/DEVELOPMENT.md) |
+| commit.md (commands) | [docs/commit-pr-guide.md](/docs/commit-pr-guide.md) |
 
 ## 사용법
 

--- a/docs/commit-pr-guide.md
+++ b/docs/commit-pr-guide.md
@@ -1,0 +1,196 @@
+# Commit 및 PR 작성 가이드
+
+이 문서는 querypie-docs 프로젝트의 커밋 로그 및 PR 작성 관습을 정의합니다.
+
+## 제목 형식
+
+### 기본 형식
+
+```
+<type>(<scope>): <한국어 설명>
+```
+
+또는 도메인 기반 prefix를 사용합니다:
+
+```
+<prefix>: <한국어 설명>
+```
+
+### Type 종류
+
+| Type | 설명 | 예시 |
+|------|------|------|
+| `feat` | 새로운 기능 추가 | `feat(tests): Playwright 기반 이미지 렌더링 측정 도구 추가` |
+| `refactor` | 코드 리팩토링 | `refactor: QueryPie 로고를 재사용 가능한 컴포넌트로 분리` |
+| `fix` | 버그 수정 | `fix(src/lib): useLocale에서 pathname null 체크 추가` |
+| `ci` | CI/CD 관련 변경 | `ci(.github/workflows): fetch-openapi-spec 워크플로우 변경` |
+| `chore` | 기타 변경 (빌드, 패키지 등) | `chore: 보안 취약점 패치 및 의존성 업데이트` |
+
+### 도메인 기반 Prefix
+
+프로젝트 특성상 도메인 기반 prefix를 사용할 수 있습니다:
+
+| Prefix | 설명 | 예시                                             |
+|--------|------|------------------------------------------------|
+| `mdx:` | MDX 문서 변경 | `mdx: installation 문서 정리 및 support 분리`         |
+| `open-api:` | API Reference 관련 | `open-api: API Reference 동적 라우팅 페이지 구현`        |
+| `confluence-mdx:` | Confluence 변환기 관련 | `confluence-mdx: 테이블 변환 시 불필요한 속성 제거`          |
+| `skill:` | Claude Skills 관련 | `skill: Claude Skills 한국어 번역 및 docs 참조로 중복 제거` |
+| `docs` | 문서 변경 | `docs: 번역 가이드를 재작성`                            |
+
+### Scope 예시
+
+| Scope | 설명 |
+|-------|------|
+| `src/content` | 소스 콘텐츠 |
+| `src/lib`, `src/components` | 라이브러리, 컴포넌트 |
+| `.github/workflows` | CI/CD 워크플로우 |
+| `confluence-mdx` | Confluence 변환 도구 |
+| `tests` | 테스트 |
+| `deps` | 의존성 |
+
+## 본문 형식
+
+### 기본 구조
+
+```markdown
+## Summary
+PR을 작성하게 된 배경, 이유, 목적을 한 문장으로 기술합니다.
+
+- 변경사항을 bullet point로 설명합니다.
+- 추가 변경사항을 기술합니다.
+
+## Test plan
+- [ ] 테스트 항목 1
+- [ ] 테스트 항목 2
+
+## Related tickets & links
+- #123
+- Closes #456
+
+## Additional notes
+- 추가 참고사항을 기술합니다.
+```
+
+### 섹션별 설명
+
+| 섹션 | 필수 | 설명 |
+|------|------|------|
+| `## Summary` 또는 `## Description` | 권장 | 배경/이유/목적 한 문장 + 변경사항 요약 |
+| `## Test plan` | 권장 | 테스트 방법 체크리스트 |
+| `## Related tickets & links` | 선택 | 관련 이슈/티켓 |
+| `## Additional notes` | 선택 | 추가 참고사항 |
+
+## 작성 지침
+
+### 언어 및 톤
+
+1. **한국어로 작성합니다.**
+2. **경어체(~합니다)를 사용합니다.**
+3. **능동태를 사용하여 주체가 명확한 문장을 작성합니다.**
+   - 좋은 예: "캐시 로직을 개선합니다."
+   - 피할 예: "캐시 로직이 개선되었습니다."
+
+### 기술 용어
+
+1. **기술 용어는 원어 그대로 사용하되, 동사는 한국어로 작성합니다.**
+   - 좋은 예: "buildx를 설치합니다."
+   - 피할 예: "buildx install을 수행합니다."
+
+### 간결성
+
+1. **제목은 50자 이내로 간결하게 작성합니다.**
+2. **한 문장에 하나의 변경사항만 기술하여 가독성을 높입니다.**
+3. **불필요한 수식어나 부연 설명은 생략하고 핵심만 전달합니다.**
+   - 좋은 예: "ARM64 빌드 지원을 추가합니다."
+   - 피할 예: "더 나은 호환성을 위해 ARM64 아키텍처에 대한 빌드 지원 기능을 새롭게 추가합니다."
+
+### Claude 사용 시
+
+Claude Code를 사용하여 작업한 경우 다음을 포함합니다:
+
+```markdown
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+```
+
+## 예시
+
+### feat 예시
+
+```
+feat(tests): Playwright 기반 이미지 렌더링 측정 도구 추가 (#530)
+
+## Summary
+- Playwright를 사용한 이미지 렌더링 크기 측정 도구 추가
+- 단일 페이지 측정 (`measure.js`) 및 두 페이지 비교 (`compare.js`) 기능 제공
+- 독립 실행 가능한 프로젝트로 구성 (별도 `package.json`)
+
+## Test plan
+- [ ] `cd tests/image-rendering && npm install` 실행
+- [ ] `node measure.js <URL>` 실행하여 이미지 측정 확인
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-authored-by: Claude Opus 4.5 <noreply@anthropic.com>
+```
+
+### fix 예시
+
+```
+fix(src/lib): useLocale에서 pathname null 체크 추가 (#520)
+
+## Summary
+- `usePathname()`이 `null`을 반환할 수 있으므로 null 체크를 추가
+- TypeScript 빌드 에러 수정
+
+## Test plan
+- [ ] `npm run build` 성공 확인
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-authored-by: Claude Opus 4.5 <noreply@anthropic.com>
+```
+
+### docs 예시
+
+```
+docs(src/content): ko MDX 파일의 이미지를 img 태그로 변환합니다
+
+## Description
+- #528 에서 수정한 변환 프로그램을 적용하여 한국어 MDX 파일의 이미지를 재변환합니다.
+- Markdown 이미지 문법을 HTML `<img>` 태그로 변환하여 width 속성을 명시합니다.
+
+## Related tickets & links
+- #528
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+### mdx prefix 예시
+
+```
+mdx: Confluence 외부링크를 내부 링크로 수정합니다. (#505)
+
+## Description
+- identity-providers.mdx의 Okta Confluence edit-v2 URL을 일반 페이지 URL로 수정합니다.
+- installation-guide-setupv2sh.mdx의 Confluence 링크를 내부 문서 링크로 수정합니다.
+```
+
+### ci 예시
+
+```
+ci(.github/workflows): fetch-openapi-spec 워크플로우를 self-hosted runner에서 실행하도록 변경합니다. (#506)
+
+## Summary
+- fetch-openapi-spec 워크플로우를 GitHub-hosted runner 대신 self-hosted runner에서 실행하도록 변경합니다.
+- `os:ubuntu`, `purpose:ci` 레이블을 사용합니다.
+
+## Test plan
+- [ ] workflow_dispatch로 워크플로우 실행하여 self-hosted runner에서 정상 동작 확인
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-authored-by: Claude Opus 4.5 <noreply@anthropic.com>
+```


### PR DESCRIPTION
## Summary
프로젝트의 커밋/PR 작성 관습을 문서화하여 일관된 커밋 메시지 작성을 돕습니다.

- `docs/commit-pr-guide.md` 문서를 추가합니다.
- `/commit` skill을 간소화하고 docs 문서를 참조하도록 변경합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)