### PR TITLE
fix(confluence-mdx): Inline Code 내 <, > 문자가 인코딩되지 않도록 수정합니다

### DIFF
--- a/confluence-mdx/bin/confluence_xhtml_to_markdown.py
+++ b/confluence-mdx/bin/confluence_xhtml_to_markdown.py
@@ -436,14 +436,15 @@ def navigable_string_as_markdown(node):
         # This is a leaf node with text
         text = clean_text(node.text)
         text = text.replace('\n', ' ')  # Replace newlines with space
-        # Encode < and > to prevent conflict with JSX syntax.
-        text = text.replace('<', '&lt;').replace('>', '&gt;')
         # Normalize multiple spaces to a single space
         text = re.sub(r'\s+', ' ', text)
         if node.parent.name == 'code':
-            # Do not backtick_curly_braces if the parent node is `<code>`, as it is backticked already.
+            # Do not encode < and > or backtick_curly_braces if the parent node is `<code>`,
+            # as it is backticked already and characters will be displayed correctly.
             pass
         else:
+            # Encode < and > to prevent conflict with JSX syntax.
+            text = text.replace('<', '&lt;').replace('>', '&gt;')
             text = backtick_curly_braces(text)
         return text
     else:

--- a/confluence-mdx/tests/testcases/544379140/expected.mdx
+++ b/confluence-mdx/tests/testcases/544379140/expected.mdx
@@ -121,7 +121,7 @@ Administrator &gt; Audit &gt; General &gt; Audit Log Export &gt; Create New Task
 
 - Number Type
 
-지원하는 표현식 : `&gt;`, `&lt;`, `&lt;=`, `&gt;=`, `==`, `!=`<br/>예 : `x &gt; `10``, `x == `10``
+지원하는 표현식 : `>`, `<`, `<=`, `>=`, `==`, `!=`<br/>예 : `x > `10``, `x == `10``
 
 - String Type
 
@@ -129,11 +129,11 @@ Administrator &gt; Audit &gt; General &gt; Audit Log Export &gt; Create New Task
 
 - Boolean Type
 
-지원하는 표현식 : `== (equals)`, `!= (not equals)`, `&& (and)`, `|| (or)`<br/>예 : `x == `true``,`x && y`, `(x &gt; `0`) && (y == `0`)`
+지원하는 표현식 : `== (equals)`, `!= (not equals)`, `&& (and)`, `|| (or)`<br/>예 : `x == `true``,`x && y`, `(x > `0`) && (y == `0`)`
 
 - Array Type
 
-예 : `x[? @ == 'value']`, `list[? @ &gt; `10`]`
+예 : `x[? @ == 'value']`, `list[? @ > `10`]`
 
 
 (3) 여러 조건을 함께 사용하기 위해 아래의 문자를 활용할 수 있습니다.


### PR DESCRIPTION
## Summary
- Inline Code 내 `<`, `>` 문자가 `&lt;`, `&gt;`로 인코딩되어 표시되는 문제 수정
- `navigable_string_as_markdown()` 함수에서 `<code>` 태그 내부 텍스트의 HTML 인코딩을 건너뛰도록 변경
- Markdown/MDX에서 backtick 안의 내용은 JSX로 파싱되지 않으므로 HTML 인코딩이 불필요

## Test plan
- [x] `make test` 실행하여 모든 XHTML 테스트 통과 확인
- [x] `544379140` 테스트케이스에서 inline code 내 `>`, `<` 문자가 올바르게 변환되는지 확인

Closes #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)