### PR TITLE
mdx: 첫 페이지에서 기술지원 섹션을 제거합니다

### DIFF
--- a/src/content/en/index.mdx
+++ b/src/content/en/index.mdx
@@ -117,14 +117,6 @@ When the validity period expires, you can extend the Community Edition license f
 
 * **[QueryPie ACP Community Edition Installation Guide](installation/querypie-acp-community-edition)** - Free installation and trial guide
 
-## Technical Support
-
-### Public Technical Support Resources
-* **[Customer Portal Technical Support Resources](https://querypie.atlassian.net/wiki/spaces/QCP/overview)** - Available for both Enterprise Plan and Community Edition users
-
-### Enterprise Plan Exclusive Support
-* **[Customer Exclusive Support Portal](https://help.support.querypie.com)** (requires customer user authentication)
-
 ## Previous Version Documentation
 
 * [QueryPie v11.0.0](https://querypie.atlassian.net/wiki/spaces/QM/pages/1129677677/)

--- a/src/content/ja/index.mdx
+++ b/src/content/ja/index.mdx
@@ -117,14 +117,6 @@ Dockerベースの簡単なインストールで7-10分以内にすぐに開始�
 
 * **[QueryPie ACP コミュニティエディション インストールガイド](installation/querypie-acp-community-edition)** - 無料インストールと体験ガイド
 
-## テクニカルサポート
-
-### 公開テクニカルサポート資料
-* **[Customer Portal テクニカルサポート資料](https://querypie.atlassian.net/wiki/spaces/QCP/overview)** - Enterprise PlanおよびCommunity Edition利用者すべてが利用可能
-
-### Enterprise Plan専用サポート
-* **[お客様専用サポートポータル](https://help.support.querypie.com)** （お客様ユーザー認証が必要）
-
 ## 旧バージョンドキュメント
 
 * [QueryPie v10.2.0](https://querypie.atlassian.net/wiki/spaces/QM/pages/834863167/)

--- a/src/content/ko/index.mdx
+++ b/src/content/ko/index.mdx
@@ -117,14 +117,6 @@ Docker 기반의 간단한 설치로 7-10분 내에 바로 시작할 수 있습�
 
 * **[QueryPie ACP 커뮤니티 에디션 설치 가이드](installation/querypie-acp-community-edition)** - 무료 설치 및 체험 가이드
 
-## 기술 지원
-
-### 공개 기술지원 자료
-* **[Customer Portal 기술지원 자료](https://querypie.atlassian.net/wiki/spaces/QCP/overview)** - Enterprise Plan 및 Community Edition 이용자 모두 이용 가능
-
-### Enterprise Plan 전용 지원
-* **[고객 전용 지원 포털](https://help.support.querypie.com)** (회원 인증 필요)
-
 ## 이전 버전 문서
 
 * [QueryPie v11.2.0](https://querypie.atlassian.net/wiki/spaces/QM/pages/1291125198/)


### PR DESCRIPTION
## Summary
- 한국어, 영어, 일본어 첫 페이지(index.mdx)에서 기술지원 섹션을 제거합니다
- 최근 `/support` 페이지가 도입되면서 기술지원 안내 내용이 중복되어, 첫 페이지의 기술지원 섹션을 삭제합니다
- 기술지원 관련 안내는 `/support` 및 `/support/premium-support` 페이지에서 확인할 수 있습니다

## Test plan
- [ ] 한국어 첫 페이지 `/ko` 에서 기술지원 섹션이 제거되었는지 확인
- [ ] 영어 첫 페이지 `/en` 에서 Technical Support 섹션이 제거되었는지 확인
- [ ] 일본어 첫 페이지 `/ja` 에서 テクニカルサポート 섹션이 제거되었는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)