### PR TITLE
feat: Badge 컴포넌트 추가 (Confluence status 매크로 지원)

### DIFF
--- a/src/components/badge.tsx
+++ b/src/components/badge.tsx
@@ -1,0 +1,52 @@
+import type { FC, ReactNode } from 'react'
+
+type BadgeColor = 'grey' | 'blue' | 'green' | 'yellow' | 'red' | 'purple'
+
+const colorStyles: Record<BadgeColor, { background: string; color: string }> = {
+  grey: { background: '#DDDEE1', color: '#292A2E' },
+  blue: { background: '#8FB8F6', color: '#292A2E' },
+  green: { background: '#B3DF72', color: '#292A2E' },
+  yellow: { background: '#F9C84E', color: '#292A2E' },
+  red: { background: '#FD9891', color: '#292A2E' },
+  purple: { background: '#D8A0F7', color: '#292A2E' },
+}
+
+/**
+ * Badge component for displaying status labels with colored backgrounds.
+ * Renders as an inline element, matching Confluence's {status} macro appearance.
+ *
+ * @example
+ * <Badge color="blue">IN PROGRESS</Badge>
+ * <Badge color="green">DONE</Badge>
+ * <Badge color="red">AT RISK</Badge>
+ */
+const Badge: FC<{
+  /** The color variant of the badge */
+  color?: BadgeColor
+  /** The content to display inside the badge */
+  children: ReactNode
+}> = ({ color = 'grey', children }) => {
+  const styles = colorStyles[color] || colorStyles.grey
+
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        padding: '2px 8px',
+        borderRadius: '3px',
+        fontSize: '0.75em',
+        fontWeight: 700,
+        lineHeight: 1.4,
+        textTransform: 'uppercase',
+        whiteSpace: 'nowrap',
+        verticalAlign: 'middle',
+        backgroundColor: styles.background,
+        color: styles.color,
+      }}
+    >
+      {children}
+    </span>
+  )
+}
+
+export default Badge

--- a/src/mdx-components.js
+++ b/src/mdx-components.js
@@ -1,8 +1,10 @@
 import { useMDXComponents as getDocsMDXComponents } from 'nextra-theme-docs';
+import Badge from '@/components/badge';
 
 const docsComponents = getDocsMDXComponents();
 
 export const useMDXComponents = components => ({
   ...docsComponents,
+  Badge,
   ...components,
 });


### PR DESCRIPTION
## Summary

- Confluence의 `{status}` 매크로를 MDX에서 표현하기 위한 `<Badge>` 컴포넌트 추가
- 6가지 색상 지원 (grey, blue, green, yellow, red, purple)
- MDX에서 import 없이 바로 사용 가능

## 사용 예시

```jsx
<Badge color="blue">IN PROGRESS</Badge>
<Badge color="green">DONE</Badge>
<Badge color="red">AT RISK</Badge>
```

## 지원 색상

| 색상 | 배경색 | 텍스트 |
|------|--------|--------|
| `grey` | `#DDDEE1` | `#292A2E` |
| `blue` | `#8FB8F6` | `#292A2E` |
| `green` | `#B3DF72` | `#292A2E` |
| `yellow` | `#F9C84E` | `#292A2E` |
| `red` | `#FD9891` | `#292A2E` |
| `purple` | `#D8A0F7` | `#292A2E` |

## Test plan

- [ ] 빌드 성공 확인
- [ ] MDX 파일에서 `<Badge color="blue">텍스트</Badge>` 형식으로 사용 테스트
- [ ] 6가지 색상 모두 렌더링 확인

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)