### PR TITLE
feat(confluence-mdx): Confluence status macro를 Badge 컴포넌트로 변환

### DIFF
--- a/confluence-mdx/tests/testcases/544384417/expected.mdx
+++ b/confluence-mdx/tests/testcases/544384417/expected.mdx
@@ -105,7 +105,7 @@ X
 </tr>
 <tr>
 <td>
-Group Status **[added-10.2.2]**<br/>그룹 현황
+Group Status <Badge color="green">added-10.2.2</Badge><br/>그룹 현황
 </td>
 <td>
 X
@@ -119,7 +119,7 @@ X
 </tr>
 <tr>
 <td>
-Group Membership History **[added-10.2.2]**<br/>그룹 멤버 추가/삭제 이력
+Group Membership History <Badge color="green">added-10.2.2</Badge><br/>그룹 멤버 추가/삭제 이력
 </td>
 <td>
 X
@@ -226,7 +226,7 @@ X
 </tr>
 <tr>
 <td>
-Security Configuration Stauts **[updated-10.2.2]**<br/>보안 설정 현황
+Security Configuration Stauts <Badge color="blue">updated-10.2.2</Badge><br/>보안 설정 현황
 </td>
 <td>
 X
@@ -243,7 +243,7 @@ X
 QueryPie DAC
 </td>
 <td rowspan="2">
-Databases **[added-10.2.2]**
+Databases <Badge color="green">added-10.2.2</Badge>
 </td>
 <td>
 DB Connection Status<br/>DB 커넥션 현황
@@ -336,7 +336,7 @@ O
 </tr>
 <tr>
 <td rowspan="2">
-Workflow Logs - DB **[added-10.2.2]**
+Workflow Logs - DB <Badge color="green">added-10.2.2</Badge>
 </td>
 <td>
 DAC Type Requests<br/>Workflow를 통해 진행된 DAC 유형 요청
@@ -353,7 +353,7 @@ O
 </tr>
 <tr>
 <td>
-DAC Unmasking Requests **[added-11.2.0]**
+DAC Unmasking Requests <Badge color="green">added-11.2.0</Badge>
 Workflow를 통해 진행된 Unmasking 요청
 </td>
 <td>
@@ -371,7 +371,7 @@ X
 QueryPie SAC
 </td>
 <td rowspan="2">
-Servers <br/>**[added-10.2.2]**
+Servers <br/><Badge color="green">added-10.2.2</Badge>
 </td>
 <td>
 Server Status<br/>서버 현황
@@ -402,7 +402,7 @@ O
 </tr>
 <tr>
 <td rowspan="2">
-Server Groups **[added-10.2.2]**
+Server Groups <Badge color="green">added-10.2.2</Badge>
 </td>
 <td>
 Server Group Status<br/>서버 그룹 현황
@@ -433,7 +433,7 @@ X
 </tr>
 <tr>
 <td rowspan="2">
-Server Account & Password **[added-10.2.2]**
+Server Account & Password <Badge color="green">added-10.2.2</Badge>
 </td>
 <td>
 Provisioned Server Account Status<br/>프로비저닝된 서버 계정 현황
@@ -467,7 +467,7 @@ O
 Server Access Control
 </td>
 <td>
-Direct Permission Status by User/Group **[updated-10.2.2]**<br/>사용자/그룹별 Direct Permission 현황
+Direct Permission Status by User/Group <Badge color="blue">updated-10.2.2</Badge><br/>사용자/그룹별 Direct Permission 현황
 </td>
 <td>
 O
@@ -495,7 +495,7 @@ O
 </tr>
 <tr>
 <td>
-*Server Role Status by User* **[deprecated-10.2.2]**<br/> *사용자별 서버 역할 현황*
+*Server Role Status by User* <Badge color="red">deprecated-10.2.2</Badge><br/> *사용자별 서버 역할 현황*
 </td>
 <td>
 *O*
@@ -509,7 +509,7 @@ O
 </tr>
 <tr>
 <td>
-Role-Granted Users by Role **[added-10.2.2]**<br/>역할별 역할 부여 사용자 현황
+Role-Granted Users by Role <Badge color="green">added-10.2.2</Badge><br/>역할별 역할 부여 사용자 현황
 </td>
 <td>
 O
@@ -523,7 +523,7 @@ X
 </tr>
 <tr>
 <td>
-Accessible Servers by Role **[added-10.2.2]**<br/>역할별 접근 가능 서버 현황
+Accessible Servers by Role <Badge color="green">added-10.2.2</Badge><br/>역할별 접근 가능 서버 현황
 </td>
 <td>
 X
@@ -537,7 +537,7 @@ O
 </tr>
 <tr>
 <td>
-Server Role & Policy Management History **[added-10.2.2]**<br/>서버 역할 및 정책 변경 이력
+Server Role & Policy Management History <Badge color="green">added-10.2.2</Badge><br/>서버 역할 및 정책 변경 이력
 </td>
 <td>
 X
@@ -657,7 +657,7 @@ O
 </tr>
 <tr>
 <td>
-Workflow Logs - Servers <br/>**[added-10.2.2]**
+Workflow Logs - Servers <br/><Badge color="green">added-10.2.2</Badge>
 </td>
 <td>
 SAC Type Requests<br/>SAC 유형 요청
@@ -796,7 +796,7 @@ Administrator &gt; Audit &gt; Reports &gt; Reports &gt; Create
 
 `Save` 버튼을 클릭하여 보고서 태스크를 저장하고 목록으로 돌아갑니다.
 
-### 보고서 복제하기**[10.2.2]**
+### 보고서 복제하기<Badge color="grey">10.2.2</Badge>
 
 <figure data-layout="center" data-align="center">
 <img src="/544384417/output/screenshot-20241223-104529.png" alt="Administrator &gt; Audit &gt; Reports &gt; Reports - Duplicate Task" width="589" />


### PR DESCRIPTION
## Summary
- Confluence XHTML의 `<ac:structured-macro name="status">` 요소를 Badge 컴포넌트로 변환합니다.
- 기존에는 `**[text]**` 형식으로 변환되었으나, 이제 `<Badge color="color">text</Badge>` 형식으로 변환됩니다.
- Confluence의 colour 속성(Green, Blue, Red, Yellow, Grey, Purple)을 Badge의 color 속성(green, blue, red, yellow, grey, purple)으로 자동 매핑합니다.

## Test plan
- [x] testcase 544384417을 실행하여 status macro가 Badge 컴포넌트로 올바르게 변환되는지 확인
- [x] Badge import가 자동으로 추가되는지 확인
- [x] 색상 매핑이 올바르게 동작하는지 확인 (Green → green, Blue → blue, Red → red 등)
- [ ] 로컬에서 변환된 MDX 파일이 올바르게 렌더링되는지 확인
- [ ] Badge 컴포넌트가 문서에서 기대한 대로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)