### PR TITLE
mdx(ko): Overview 메뉴 타이틀에서 'QueryPie' 접두어 제거

### DIFF
--- a/src/content/ko/_meta.ts
+++ b/src/content/ko/_meta.ts
@@ -4,7 +4,7 @@ export default {
   },
   'overview': {
     type: 'page',
-    title: 'QueryPie Overview',
+    title: 'Overview',
   },
   'user-manual': {
     type: 'page',


### PR DESCRIPTION
## Summary
- 한국어 top-level `_meta.ts`의 overview 메뉴 타이틀을 `QueryPie Overview`에서 `Overview`로 변경합니다.
- 영어(`Overview`), 일본어(`概要`)와 동일하게 제품명 접두어 없이 표시합니다.

## Test plan
- [ ] 한국어 메뉴에서 `Overview`로 표시되는지 확인
- [ ] 영어/일본어 메뉴에 영향이 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)