### PR TITLE
chore(package.json): dev 스크립트에서 불필요한 --turbopack 플래그 제거

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "QueryPie Docs",
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev",
     "build": "next build",
     "postbuild": "npm run generate-pagefind && npm run generate-sitemap",
     "start": "next start",


### PR DESCRIPTION
## Summary
- Next.js 16에서 Turbopack이 기본 번들러이므로, dev 스크립트에서 --turbopack 플래그를 제거합니다
- dev와 build 모두 Turbopack을 기본으로 사용하여 일관성을 유지합니다

## Background
Next.js 16에서 Turbopack이 개발 및 프로덕션 빌드 모두의 기본 번들러가 되었습니다. 명시적인 플래그 없이도 Turbopack이 사용되므로, --turbopack 플래그는 불필요합니다.

## Test plan
- [x] npm run dev 실행하여 Turbopack 사용 확인 (Next.js 16.0.10 (Turbopack))
- [x] npm run build 실행하여 Turbopack 사용 확인 (874개 static pages 생성 성공)

## Related
- [Next.js 16 | Next.js](https://nextjs.org/blog/next-16)
- [Usage with Turbopack | Nextra](https://nextra.site/docs/guide/turbopack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)