### PR TITLE
fix: Turbopack 빌드 경고 해결 - 중복된 fs.existsSync() 제거

### DIFF
--- a/src/app/[lang]/[[...mdxPath]]/page.tsx
+++ b/src/app/[lang]/[[...mdxPath]]/page.tsx
@@ -48,14 +48,12 @@ export async function generateStaticParams() {
       const mdxFiles = findMdxFiles(localeDir);
 
       for (const pathSegments of mdxFiles) {
-        const fullPath = path.join(localeDir, ...pathSegments) + '.mdx';
-
-        if (fs.existsSync(fullPath)) {
-          paramsList.push({
-            lang: locale,
-            mdxPath: pathSegments || [], // Set mdx file path
-          });
-        }
+        // findMdxFiles already returns only existing .mdx files
+        // No need to check fs.existsSync again
+        paramsList.push({
+          lang: locale,
+          mdxPath: pathSegments || [], // Set mdx file path
+        });
       }
     }
   }


### PR DESCRIPTION
## Summary
- generateStaticParams()에서 중복된 fs.existsSync() 호출을 제거하여 Turbopack 빌드 경고를 해결합니다
- findMdxFiles()가 이미 실제로 존재하는 .mdx 파일만 반환하므로, 추가적인 파일 존재 확인이 불필요합니다

## Background
Turbopack은 동적 파일 경로 생성 시 광범위한 파일 매칭 패턴을 감지하면 경고를 발생시킵니다. 

```
./src/app/[lang]/[[...mdxPath]]/page.tsx:50:26
The file pattern (...) matches 11050 files in [project]/
Overly broad patterns can lead to build performance issues and over bundling.
```

**문제의 원인:**
- line 51: `path.join(localeDir, ...pathSegments) + '.mdx'` - 동적 파일 경로 생성
- line 53: `fs.existsSync(fullPath)` - 파일 존재 확인

**해결 방법:**
findMdxFiles() 함수는 이미 `fs.readdirSync()`와 `file.isFile() && file.name.endsWith('.mdx')` 체크를 통해 실제로 존재하는 .mdx 파일만 찾아 반환합니다. 따라서 이후의 `fs.existsSync()` 체크는 중복이며, 이를 제거하면 Turbopack의 동적 패턴 감지를 피할 수 있습니다.

## Test plan
- [x] npm run build 실행하여 Turbopack 경고 감소 확인 (3개 → 2개)
- [x] page.tsx의 경고가 완전히 제거되었는지 확인
- [x] 빌드 성공 확인 (874개 static pages 생성 완료)

## Changes
**Before:**
```typescript
for (const pathSegments of mdxFiles) {
  const fullPath = path.join(localeDir, ...pathSegments) + '.mdx';
  
  if (fs.existsSync(fullPath)) {
    paramsList.push({
      lang: locale,
      mdxPath: pathSegments || [],
    });
  }
}
```

**After:**
```typescript
for (const pathSegments of mdxFiles) {
  // findMdxFiles already returns only existing .mdx files
  // No need to check fs.existsSync again
  paramsList.push({
    lang: locale,
    mdxPath: pathSegments || [],
  });
}
```

## Result
- ✅ Turbopack 경고: 3개 → 2개로 감소
- ✅ page.tsx의 경고 완전히 제거
- ℹ️ extract-description.ts의 2개 경고는 별도 이슈로 처리 필요

## Related
- Closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)