### PR TITLE
feat(og): OpenGraph endpoint를 path 기반으로 개선

### DIFF
--- a/src/app/[lang]/[[...mdxPath]]/page.tsx
+++ b/src/app/[lang]/[[...mdxPath]]/page.tsx
@@ -4,7 +4,7 @@ import { Metadata } from 'next';
 import fs from 'fs';
 import path from 'path';
 import { getCanonicalUrl } from '@/lib/get-canonical-url';
-import { extractDescriptionFromMdx } from '@/lib/extract-description';
+import { buildOgMetadata } from '@/lib/og-metadata';
 
 export async function generateStaticParams() {
   const locales = ['en', 'ja', 'ko']; // Same as next.config.mjs
@@ -72,42 +72,16 @@ export async function generateMetadata(props: {
   // Generate canonical URL
   const canonicalUrl = await getCanonicalUrl(params);
 
-  // Generate OG image URL with query parameters
-  const title = metadata.title ? String(metadata.title) : '';
-  const extractedDescription = metadata.description
-    ? String(metadata.description)
-    : extractDescriptionFromMdx(mdxPath, lang);
+  // OG 이미지 메타데이터 생성
+  const ogMetadata = buildOgMetadata(metadata, mdxPath, lang);
 
-  // OG 이미지: title과 description 모두 유효한 경우에만 생성
-  const ogImage = title && extractedDescription
-    ? {
-        openGraph: {
-          ...metadata.openGraph,
-          images: [
-            {
-              url: `/api/og?lang=${lang}&title=${encodeURIComponent(title)}&description=${encodeURIComponent(extractedDescription)}`,
-              width: 1200,
-              height: 630,
-              alt: metadata.title ? String(metadata.title) : 'QueryPie Documentation',
-            },
-          ],
-        },
-        twitter: {
-          ...metadata.twitter,
-          card: 'summary_large_image' as const,
-          images: [`/api/og?lang=${lang}&title=${encodeURIComponent(title)}&description=${encodeURIComponent(extractedDescription)}`],
-        },
-      }
-    : {};
-
-  // Add canonical URL and OG image to metadata
   return {
     ...metadata,
     alternates: {
       ...metadata.alternates,
       canonical: canonicalUrl,
     },
-    ...ogImage,
+    ...ogMetadata,
   };
 }
 

--- a/src/app/api/og/[lang]/[[...mdxPath]]/route.tsx
+++ b/src/app/api/og/[lang]/[[...mdxPath]]/route.tsx
@@ -1,0 +1,22 @@
+import { NextRequest } from 'next/server';
+import { generateOgImage } from '@/lib/og-image';
+import { extractTitleFromMdx, extractDescriptionFromMdx } from '@/lib/extract-description';
+
+/**
+ * Path 기반 OG 이미지 생성 endpoint.
+ * MDX 파일을 내부에서 읽어 title/description을 추출합니다.
+ *
+ * 예: /api/og/en/administrator-manual/databases/monitoring
+ */
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ lang: string; mdxPath?: string[] }> }
+) {
+  const { lang, mdxPath = [] } = await params;
+  const { origin } = new URL(req.url);
+
+  const title = extractTitleFromMdx(mdxPath, lang) || 'QueryPie ACP Product Documentation';
+  const description = extractDescriptionFromMdx(mdxPath, lang) || '';
+
+  return generateOgImage(title, description, origin);
+}

--- a/src/lib/og-image.tsx
+++ b/src/lib/og-image.tsx
@@ -1,9 +1,4 @@
 import { ImageResponse } from 'next/og';
-import type { NextRequest } from 'next/server';
-
-export const config = {
-  runtime: 'edge',
-};
 
 const size = {
   width: 1200,
@@ -21,9 +16,6 @@ const FONT_URLS = {
     'https://fonts.gstatic.com/s/notosansjp/v53/-F6jfjtqLzI2JPCgQBnw7HFyzSD-AsregP8VFBEi75vY0rw-oME.ttf',
 };
 
-/**
- * 원격 폰트를 로드합니다.
- */
 async function loadFont(url: string): Promise<ArrayBuffer | null> {
   try {
     const response = await fetch(url);
@@ -36,11 +28,18 @@ async function loadFont(url: string): Promise<ArrayBuffer | null> {
   return null;
 }
 
-export default async function handler(req: NextRequest) {
-  const { searchParams, origin } = new URL(req.url);
-  const title = searchParams.get('title') || 'QueryPie Documentation';
-  const description = searchParams.get('description') || '';
-
+/**
+ * OG 이미지를 생성합니다.
+ *
+ * @param title - 페이지 제목
+ * @param description - 페이지 설명
+ * @param origin - 배경 이미지를 로드하기 위한 origin URL (예: https://docs.querypie.com)
+ */
+export async function generateOgImage(
+  title: string,
+  description: string,
+  origin: string
+): Promise<ImageResponse> {
   // 리소스 병렬 로드 (배경 이미지, 폰트)
   const [backgroundImageData, notoSansFont, notoSansJPFont] = await Promise.all([
     fetch(`${origin}/og-background.png`)

--- a/src/lib/og-metadata.ts
+++ b/src/lib/og-metadata.ts
@@ -1,0 +1,45 @@
+import type { Metadata } from 'next';
+import { extractDescriptionFromMdx } from '@/lib/extract-description';
+
+/**
+ * OG 이미지 메타데이터를 생성합니다.
+ *
+ * title과 description이 모두 유효한 경우에만 openGraph/twitter 메타데이터를 반환합니다.
+ * description은 Nextra metadata에 없으면 MDX 본문에서 자동 추출합니다.
+ */
+export function buildOgMetadata(
+  metadata: Metadata & { title?: string },
+  mdxPath: string[],
+  lang: string
+): Pick<Metadata, 'openGraph' | 'twitter'> {
+  const title = metadata.title ? String(metadata.title) : '';
+  const description = metadata.description
+    ? String(metadata.description)
+    : extractDescriptionFromMdx(mdxPath, lang);
+
+  if (!title || !description) {
+    return {};
+  }
+
+  const ogPath = mdxPath.length > 0 ? `/${mdxPath.join('/')}` : '';
+  const ogImageUrl = `/api/og/${lang}${ogPath}`;
+
+  return {
+    openGraph: {
+      ...metadata.openGraph,
+      images: [
+        {
+          url: ogImageUrl,
+          width: 1200,
+          height: 630,
+          alt: title || 'QueryPie ACP Product Documentation',
+        },
+      ],
+    },
+    twitter: {
+      ...metadata.twitter,
+      card: 'summary_large_image' as const,
+      images: [ogImageUrl],
+    },
+  };
+}

--- a/src/pages/api/test-opengraph.tsx
+++ b/src/pages/api/test-opengraph.tsx
@@ -1,0 +1,20 @@
+import type { NextRequest } from 'next/server';
+import { generateOgImage } from '@/lib/og-image';
+
+export const config = {
+  runtime: 'edge',
+};
+
+/**
+ * 테스트용 OG 이미지 생성 endpoint.
+ * query string으로 title, description을 전달받습니다.
+ *
+ * 예: /api/test-opengraph?title=Hello&description=World
+ */
+export default async function handler(req: NextRequest) {
+  const { searchParams, origin } = new URL(req.url);
+  const title = searchParams.get('title') || 'QueryPie ACP Product Documentation';
+  const description = searchParams.get('description') || '';
+
+  return generateOgImage(title, description, origin);
+}


### PR DESCRIPTION
## Summary
- 기존 `/api/og` query string 기반 endpoint를 `/api/test-opengraph`로 이름 변경하여 테스트용으로 유지합니다.
- 새로운 path 기반 endpoint `/api/og/[lang]/[[...mdxPath]]`를 추가합니다.
  - MDX 파일에서 title/description을 내부적으로 추출하여 OG 이미지를 생성합니다.
  - 브라우저 request/response에 query string으로 title, description이 노출되지 않습니다.
- OG 관련 로직을 모듈별로 분리합니다:
  - `src/lib/og-image.tsx`: OG 이미지 렌더링 (JSX → PNG)
  - `src/lib/og-metadata.ts`: OG 메타데이터 구성 (`buildOgMetadata()`)
  - `src/lib/extract-description.ts`: MDX 콘텐츠 추출 (`extractTitleFromMdx()`, `extractDescriptionFromMdx()`)
- 기본 title을 `QueryPie ACP Product Documentation`으로 통일합니다.

## Test plan
- [x] `/api/test-opengraph?title=Test&description=Hello` → HTTP 200, image/png 정상 생성
- [x] `/api/og/en/overview` → HTTP 200, image/png 정상 생성
- [x] `/api/og/ko/administrator-manual/databases/monitoring` → HTTP 200, image/png 정상 생성
- [x] 페이지 소스에서 `og:image` meta 태그 URL이 path 기반(`/api/og/en/...`)으로 변경 확인

## Related tickets & links
- Closes #553

🤖 Generated with [Claude Code](https://claude.com/claude-code)