### PR TITLE
fix(og): description 추출에서 멀티라인 import 구문을 올바르게 제거합니다

### DIFF
--- a/src/lib/extract-description.ts
+++ b/src/lib/extract-description.ts
@@ -59,7 +59,10 @@ export function extractDescriptionFromMdx(
   // 1. Frontmatter 제거
   let text = content.replace(/^---[\s\S]*?---\n*/m, '');
 
-  // 2. Import 문 제거
+  // 2. Import 문 제거 (멀티라인 포함)
+  // Multi-line: import { ... } from '...'
+  text = text.replace(/^import\s*\{[\s\S]*?\}\s*from\s*['"][^'"]*['"];?\s*/gm, '');
+  // Single-line: import ... from '...' or import '...'
   text = text.replace(/^import\s+.*$/gm, '');
 
   // 3. 모든 heading 제거 (#, ##, ### 등)


### PR DESCRIPTION
## Summary
- `extractDescriptionFromMdx()`에서 멀티라인 import 구문(`import { ... } from '...'`)이 완전히 제거되지 않아 OG 이미지 description에 import 잔여 텍스트가 노출되는 문제를 수정합니다.
- 기존 single-line regex 앞에 multi-line import regex를 추가하여 멀티라인 import를 먼저 제거합니다.

## Test plan
- [x] Preview Deployment에서 `/api/og/en` (index 페이지) OG 이미지 확인 — description에 `CircleStackIcon`, `heroicons` 등의 import 잔여 텍스트가 없어야 합니다.
  - ✅ "QueryPie ACP Product Documentation" 제목, "QueryPie Access Control Platform (ACP) is an integrated access control solution..." description 정상 표시. import 잔여 텍스트 없음.
- [x] Preview Deployment에서 `/api/og/ko` OG 이미지도 동일하게 확인합니다.
  - ✅ "QueryPie ACP 제품 문서" 제목, 한국어 description 정상 표시. import 잔여 텍스트 없음.
- [x] 기존 single-line import만 사용하는 페이지(예: `/api/og/en/administrator-manual/audit`)도 정상 동작 확인합니다.
  - ✅ "Audit" 제목, "All activities within QueryPie are recorded in audit logs..." description 정상 표시.

**Preview Deployment URL**: https://querypie-docs-git-jk-fix-og-description-import-removal-querypie.vercel.app

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)