### PR TITLE
docs(en): 영어 문서 제목을 "ACP Documentation"으로 단축

### DIFF
--- a/src/app/api/og/[lang]/[[...mdxPath]]/route.tsx
+++ b/src/app/api/og/[lang]/[[...mdxPath]]/route.tsx
@@ -15,7 +15,7 @@ export async function GET(
   const { lang, mdxPath = [] } = await params;
   const { origin } = new URL(req.url);
 
-  const title = extractTitleFromMdx(mdxPath, lang) || 'QueryPie ACP Product Documentation';
+  const title = extractTitleFromMdx(mdxPath, lang) || 'QueryPie ACP Documentation';
   const description = extractDescriptionFromMdx(mdxPath, lang) || '';
 
   return generateOgImage(title, description, origin);

--- a/src/content/en/index.mdx
+++ b/src/content/en/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'QueryPie ACP Product Documentation'
+title: 'QueryPie ACP Documentation'
 ---
 
 import DescriptionCards from '@/components/description-cards';
@@ -15,7 +15,7 @@ import {
   WrenchScrewdriverIcon
 } from '@heroicons/react/24/outline';
 
-# Welcome to QueryPie ACP Product Documentation
+# Welcome to QueryPie ACP Documentation
 
 ## What is QueryPie Access Control Platform (ACP)?
 

--- a/src/lib/og-metadata.ts
+++ b/src/lib/og-metadata.ts
@@ -32,7 +32,7 @@ export function buildOgMetadata(
           url: ogImageUrl,
           width: 1200,
           height: 630,
-          alt: title || 'QueryPie ACP Product Documentation',
+          alt: title || 'QueryPie ACP Documentation',
         },
       ],
     },

--- a/src/pages/api/test-opengraph.tsx
+++ b/src/pages/api/test-opengraph.tsx
@@ -13,7 +13,7 @@ export const config = {
  */
 export default async function handler(req: NextRequest) {
   const { searchParams, origin } = new URL(req.url);
-  const title = searchParams.get('title') || 'QueryPie ACP Product Documentation';
+  const title = searchParams.get('title') || 'QueryPie ACP Documentation';
   const description = searchParams.get('description') || '';
 
   return generateOgImage(title, description, origin);


### PR DESCRIPTION
## Description
- `QueryPie ACP Product Documentation`을 `QueryPie ACP Documentation`으로 변경합니다.
- 제목이 길어서 Preview 등에서 줄바꿈되는 문제를 해결하기 위함입니다.

### 변경된 위치 (5곳)

1. **src/content/en/index.mdx** (2곳)
   - Line 2: title 속성
   - Line 18: heading 텍스트

2. **src/pages/api/test-opengraph.tsx** (1곳)
   - Line 16: OG 이미지 테스트용 fallback title

3. **src/lib/og-metadata.ts** (1곳)
   - Line 35: OG 이미지 alt text fallback

4. **src/app/api/og/[lang]/[[...mdxPath]]/route.tsx** (1곳)
   - Line 18: OG 이미지 생성용 fallback title

### 참고사항
- 한국어(ko)와 일본어(ja)는 이미 "제품 문서" / "製品ドキュメント"로 짧게 표기되어 있어 변경하지 않았습니다.
- "Product" 단어가 없어 영어 버전만 변경 대상입니다.

## Related tickets & links
- Closes #560

## Stats
- 4 files changed
- 5 insertions(+), 5 deletions(-)