### PR TITLE
feat(confluence-mdx): skeleton 변환 시 img 태그의 alt 속성을 _TEXT_로 변환

### DIFF
--- a/confluence-mdx/bin/mdx_to_skeleton.py
+++ b/confluence-mdx/bin/mdx_to_skeleton.py
@@ -968,7 +968,7 @@ def process_text_line(line: str, text_processor: TextProcessor) -> str:
 def _process_html_line(line: str, text_processor: TextProcessor) -> str:
     """
     Process HTML tags structure but replace text content using regex.
-    
+
     IMPORTANT: Leading whitespace (indentation) MUST be preserved.
     The function preserves leading whitespace at the beginning of the line.
     """
@@ -977,13 +977,26 @@ def _process_html_line(line: str, text_processor: TextProcessor) -> str:
     stripped = line.lstrip()
     if stripped != line:
         leading_whitespace = line[:len(line) - len(stripped)]
-    
+
+    # Process <img> tags to replace alt attribute text with _TEXT_
+    # Pattern: <img ... alt="some text" ... />
+    # Replace alt attribute content with _TEXT_
+    def replace_img_alt(match):
+        tag = match.group(0)
+        # Replace alt="..." with alt="_TEXT_"
+        # Handle both alt="..." and alt='...'
+        tag = re.sub(r'alt="[^"]*"', 'alt="_TEXT_"', tag)
+        tag = re.sub(r"alt='[^']*'", "alt='_TEXT_'", tag)
+        return tag
+
+    stripped = re.sub(r'<img[^>]*>', replace_img_alt, stripped)
+
     # Split by HTML tags, keeping the tags
     parts = re.split(r'(<[^>]+>|</[^>]+>)', stripped)
     result = []
     for i, part in enumerate(parts):
         if part.startswith('<'):
-            # HTML tag - keep as-is
+            # HTML tag - keep as-is (alt already processed for img tags)
             result.append(part)
         elif part.strip():
             # Text content - process it

--- a/confluence-mdx/tests/testcases/1454342158/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/1454342158/expected.skel.mdx
@@ -33,7 +33,7 @@ _TEXT_
 _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/1454342158/output/image-20251014-010700.png" alt="image-20251014-010700.png" width="760" />
+<img src="/1454342158/output/image-20251014-010700.png" alt="_TEXT_" width="760" />
 </figure>
 
 #### _TEXT_
@@ -43,7 +43,7 @@ _TEXT_
 * _TEXT_ **_TEXT_**
 
 <figure data-layout="center" data-align="center">
-<img src="/1454342158/output/image-20251014-011706.png" alt="Internal database의 상세 설정" width="532" />
+<img src="/1454342158/output/image-20251014-011706.png" alt="_TEXT_" width="532" />
 <figcaption>
 _TEXT_
 </figcaption>
@@ -65,7 +65,7 @@ _TEXT_ `_TEXT_`
 * _TEXT_ **_TEXT_**
 
 <figure data-layout="center" data-align="center">
-<img src="/1454342158/output/image-20251014-012049.png" alt="LDAP 상세설정" width="481" />
+<img src="/1454342158/output/image-20251014-012049.png" alt="_TEXT_" width="481" />
 <figcaption>
 _TEXT_
 </figcaption>
@@ -84,7 +84,7 @@ _TEXT_
 _TEXT_ **_TEXT_**
 
 <figure data-layout="center" data-align="center">
-<img src="/1454342158/output/image-20251014-075227.png" alt="image-20251014-075227.png" width="407" />
+<img src="/1454342158/output/image-20251014-075227.png" alt="_TEXT_" width="407" />
 </figure>
 
 
@@ -167,7 +167,7 @@ _TEXT_ `_TEXT_`
 _TEXT_ **_TEXT_**
 
 <figure data-layout="center" data-align="center">
-<img src="/1454342158/output/image-20251014-075127.png" alt="image-20251014-075127.png" width="408" />
+<img src="/1454342158/output/image-20251014-075127.png" alt="_TEXT_" width="408" />
 </figure>
 
 
@@ -206,7 +206,7 @@ _TEXT_ `_TEXT_`
 _TEXT_
 _TEXT_
 <figure data-layout="center" data-align="center">
-<img src="/1454342158/output/image-20251222-023912.png" alt="image-20251222-023912.png" width="491" />
+<img src="/1454342158/output/image-20251222-023912.png" alt="_TEXT_" width="491" />
 </figure>
 </Callout>
 
@@ -215,7 +215,7 @@ _TEXT_
 #### _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/1454342158/output/image-20240723-064242.png" alt="Okta Admin &gt; Applications &gt; Applications &gt; Browse App Catalog &gt; QueryPie 검색" width="760" />
+<img src="/1454342158/output/image-20240723-064242.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_ &gt; &gt; &gt; &gt;
 </figcaption>
@@ -231,7 +231,7 @@ _TEXT_ &gt; &gt; &gt; &gt;
 #### _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/1454342158/output/image-20240723-064424.png" alt="Okta Admin &gt; Directory &gt; Profile Editor &gt; QueryPie User &gt; Add Attribute" width="760" />
+<img src="/1454342158/output/image-20240723-064424.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_ &gt; &gt; &gt; &gt;
 </figcaption>
@@ -247,7 +247,7 @@ _TEXT_ &gt; &gt; &gt; &gt;
     * _TEXT_ `_TEXT_`
 
 <figure data-layout="center" data-align="center">
-<img src="/1454342158/output/image-20240723-064721.png" alt="Okta Admin &gt; Directory &gt; Profile Editor &gt; QueryPie User &gt; Mappings" width="760" />
+<img src="/1454342158/output/image-20240723-064721.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_ &gt; &gt; &gt; &gt;
 </figcaption>
@@ -265,7 +265,7 @@ _TEXT_ &gt; &gt; &gt; &gt;
 #### _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/1454342158/output/image-20240723-065134.png" alt="Okta Admin &gt; Applications &gt; Applications &gt; QueryPie App" width="760" />
+<img src="/1454342158/output/image-20240723-065134.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_ &gt; &gt; &gt;
 </figcaption>
@@ -283,7 +283,7 @@ _TEXT_ &gt; &gt; &gt;
 #### _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/1454342158/output/image-20240723-065346.png" alt="Okta Admin &gt; Applications &gt; Applications &gt; QueryPie App" width="760" />
+<img src="/1454342158/output/image-20240723-065346.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_ &gt; &gt; &gt;
 </figcaption>
@@ -306,7 +306,7 @@ _TEXT_
 _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/1454342158/output/image-20240110-042233.png" alt="Okta Admin Console &gt; Security &gt; Administrators &gt; Roles &gt; Create new role" width="762" />
+<img src="/1454342158/output/image-20240110-042233.png" alt="_TEXT_" width="762" />
 <figcaption>
 _TEXT_ &gt; &gt; &gt; &gt;
 </figcaption>
@@ -346,7 +346,7 @@ _TEXT_ &gt; &gt; &gt; &gt;
 _TEXT_ `_TEXT_`
 
 <figure data-layout="center" data-align="center">
-<img src="/1454342158/output/image-20251014-014729.png" alt="Okta 상세설정 (1)" width="481" />
+<img src="/1454342158/output/image-20251014-014729.png" alt="_TEXT_" width="481" />
 <figcaption>
 _TEXT_
 </figcaption>
@@ -395,14 +395,14 @@ _TEXT_
 _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/1454342158/output/screenshot-20250124-164255.png" alt="okta app 설정의 Audience URI(SP Entity ID) " width="690" />
+<img src="/1454342158/output/screenshot-20250124-164255.png" alt="_TEXT_" width="690" />
 <figcaption>
 _TEXT_
 </figcaption>
 </figure>
 
 <figure data-layout="center" data-align="center">
-<img src="/1454342158/output/screenshot-20250124-164553.png" alt="Other Requestable SSO URLs 의 Index" width="694" />
+<img src="/1454342158/output/screenshot-20250124-164553.png" alt="_TEXT_" width="694" />
 <figcaption>
 _TEXT_
 </figcaption>
@@ -410,7 +410,7 @@ _TEXT_
 </Callout>
 
 <figure data-layout="center" data-align="center">
-<img src="/1454342158/output/image-20251014-014805.png" alt="Okta 상세설정 (2)" width="481" />
+<img src="/1454342158/output/image-20251014-014805.png" alt="_TEXT_" width="481" />
 <figcaption>
 _TEXT_
 </figcaption>
@@ -440,7 +440,7 @@ _TEXT_ &gt;
 </Callout>
 
 <figure data-layout="center" data-align="center">
-<img src="/1454342158/output/Authentication-Okta-02.png" alt="Okta Admin &gt; Applications &gt; QueryPie App 상단 URL" width="760" />
+<img src="/1454342158/output/Authentication-Okta-02.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_ &gt; &gt;
 </figcaption>
@@ -453,7 +453,7 @@ _TEXT_ &gt; &gt;
 2. _TEXT_ `_TEXT_`
 
 <figure data-layout="center" data-align="center">
-<img src="/1454342158/output/image-20251014-082704.png" alt="image-20251014-082704.png" width="760" />
+<img src="/1454342158/output/image-20251014-082704.png" alt="_TEXT_" width="760" />
 </figure>
 
 <Callout type="info">
@@ -485,7 +485,7 @@ _TEXT_ [_TEXT_](https://onelogin.service-now.com/support?id=kb_article&sys_id=8a
 * _TEXT_ **_TEXT_**
 
 <figure data-layout="center" data-align="center">
-<img src="/1454342158/output/image-20251020-001435.png" alt="One Login 상세설정 (1)" width="480" />
+<img src="/1454342158/output/image-20251020-001435.png" alt="_TEXT_" width="480" />
 <figcaption>
 _TEXT_
 </figcaption>
@@ -495,7 +495,7 @@ _TEXT_
 * _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/1454342158/output/image-20251014-014949.png" alt="One Login 상세설정 (2)" width="481" />
+<img src="/1454342158/output/image-20251014-014949.png" alt="_TEXT_" width="481" />
 <figcaption>
 _TEXT_
 </figcaption>
@@ -520,7 +520,7 @@ _TEXT_
 * _TEXT_ **_TEXT_**
 
 <figure data-layout="center" data-align="center">
-<img src="/1454342158/output/image-20251014-015015.png" alt="image-20251014-015015.png" width="481" />
+<img src="/1454342158/output/image-20251014-015015.png" alt="_TEXT_" width="481" />
 </figure>
 
 _TEXT_ &lt; &gt; [_TEXT_](#target-title-not-found)
@@ -535,7 +535,7 @@ _TEXT_
 * _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/1454342158/output/image-20251014-015047.png" alt="image-20251014-015047.png" width="481" />
+<img src="/1454342158/output/image-20251014-015047.png" alt="_TEXT_" width="481" />
 </figure>
 
 * **_TEXT_**

--- a/confluence-mdx/tests/testcases/544112828/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544112828/expected.skel.mdx
@@ -16,7 +16,7 @@ _TEXT_
 1. _TEXT_ `_TEXT_`
 
 <figure data-layout="center" data-align="center">
-<img src="/544112828/output/screenshot-20240804-173002.png" alt="QueryPie Web &gt; 프로필 메뉴" width="760" />
+<img src="/544112828/output/screenshot-20240804-173002.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_ &gt;
 </figcaption>
@@ -25,7 +25,7 @@ _TEXT_ &gt;
 2. _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/544112828/output/image-20240723-154847.png" alt="QueryPie Web &gt; Agent Downloads 팝업창" width="760" />
+<img src="/544112828/output/image-20240723-154847.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_ &gt;
 </figcaption>
@@ -38,7 +38,7 @@ _TEXT_
 3. _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/544112828/output/screenshot-20240804-174002.png" alt="Mac OS 설치 프로그램" width="760" />
+<img src="/544112828/output/screenshot-20240804-174002.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_
 </figcaption>
@@ -48,7 +48,7 @@ _TEXT_
 _TEXT_ `_TEXT_`
 
 <figure data-layout="center" data-align="center">
-<img src="/544112828/output/agent-03.png" alt="Agent &gt; QueryPie Host 입력" width="760" />
+<img src="/544112828/output/agent-03.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_ &gt;
 </figcaption>
@@ -60,13 +60,13 @@ _TEXT_ &gt;
 1. _TEXT_ `_TEXT_`
 
 <figure data-layout="center" data-align="center">
-<img src="/544112828/output/screenshot-20240804-173713.png" alt="screenshot-20240804-173713.png" width="760" />
+<img src="/544112828/output/screenshot-20240804-173713.png" alt="_TEXT_" width="760" />
 </figure>
 
 2. _TEXT_ `_TEXT_`
 
 <figure data-layout="center" data-align="center">
-<img src="/544112828/output/screenshot-20240729-171236.png" alt="QueryPie Web &gt; Agent Login Page" width="760" />
+<img src="/544112828/output/screenshot-20240729-171236.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_ &gt;
 </figcaption>
@@ -75,7 +75,7 @@ _TEXT_ &gt;
 3. _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/544112828/output/screenshot-20240729-171314.png" alt="QueryPie Web &gt; Agent Login Success Page" width="764" />
+<img src="/544112828/output/screenshot-20240729-171314.png" alt="_TEXT_" width="764" />
 <figcaption>
 _TEXT_ &gt;
 </figcaption>
@@ -84,7 +84,7 @@ _TEXT_ &gt;
 4. _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/544112828/output/screenshot-20240804-174209.png" alt="Chrome - Agent App 열기 모달" width="760" />
+<img src="/544112828/output/screenshot-20240804-174209.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_
 </figcaption>
@@ -95,7 +95,7 @@ _TEXT_
 1. _TEXT_ `_TEXT_` <br/>
 
 <figure data-layout="center" data-align="center">
-<img src="/544112828/output/screenshot-20240730-151001.png" alt="Agent &gt; DB Connection Information" width="764" />
+<img src="/544112828/output/screenshot-20240730-151001.png" alt="_TEXT_" width="764" />
 <figcaption>
 _TEXT_ &gt;
 </figcaption>
@@ -104,7 +104,7 @@ _TEXT_ &gt;
 2. _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/544112828/output/agent-07.png" alt="3rd Party Client를 이용한 DB 커넥션 접속" width="764" />
+<img src="/544112828/output/agent-07.png" alt="_TEXT_" width="764" />
 <figcaption>
 _TEXT_
 </figcaption>
@@ -121,7 +121,7 @@ _TEXT_
 * _TEXT_ &gt;
 
 <figure data-layout="center" data-align="center">
-<img src="/544112828/output/screenshot-20240730-162653.png" alt="Agent &gt; Server &gt; Select a Role" width="764" />
+<img src="/544112828/output/screenshot-20240730-162653.png" alt="_TEXT_" width="764" />
 <figcaption>
 _TEXT_ &gt; &gt;
 </figcaption>
@@ -136,7 +136,7 @@ _TEXT_ <br/>
 * _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/544112828/output/screenshot-20240730-161729.png" alt="Agent &gt; Server &gt; Open Connection with" width="760" />
+<img src="/544112828/output/screenshot-20240730-161729.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_ &gt; &gt;
 </figcaption>
@@ -146,7 +146,7 @@ _TEXT_ &gt; &gt;
 * _TEXT_ `_TEXT_`
 
 <figure data-layout="center" data-align="center">
-<img src="/544112828/output/screenshot-20240730-162532.png" alt="Agent &gt; Server &gt; Open New Session" width="746" />
+<img src="/544112828/output/screenshot-20240730-162532.png" alt="_TEXT_" width="746" />
 <figcaption>
 _TEXT_ &gt; &gt;
 </figcaption>
@@ -194,7 +194,7 @@ $ ssh deploy@{{Server Name}}
 ### _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/544112828/output/kubernetes-agent-access-flow.png" alt="kubernetes-agent-access-flow.png" width="764" />
+<img src="/544112828/output/kubernetes-agent-access-flow.png" alt="_TEXT_" width="764" />
 </figure>
 
 * _TEXT_ `_TEXT_`
@@ -208,7 +208,7 @@ _TEXT_ `_TEXT_`
 _TEXT_ `_TEXT_`
 
 <figure data-layout="center" data-align="center">
-<img src="/544112828/output/screenshot-20240730-152705.png" alt="Agent &gt; Kubernetes &gt; Select a Role" width="760" />
+<img src="/544112828/output/screenshot-20240730-152705.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_ &gt; &gt;
 </figcaption>
@@ -225,7 +225,7 @@ _TEXT_
 _TEXT_ `_TEXT_`
 
 <figure data-layout="center" data-align="center">
-<img src="/544112828/output/screenshot-20240730-161141.png" alt="Agent &gt; Policy Information" width="760" />
+<img src="/544112828/output/screenshot-20240730-161141.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_ &gt;
 </figcaption>
@@ -236,7 +236,7 @@ _TEXT_ &gt;
 _TEXT_ `_TEXT_`
 
 <figure data-layout="center" data-align="center">
-<img src="/544112828/output/screenshot-20240730-154623.png" alt="Agent &gt; Settings &gt; Configure Kubeconfig Path" width="764" />
+<img src="/544112828/output/screenshot-20240730-154623.png" alt="_TEXT_" width="764" />
 <figcaption>
 _TEXT_ &gt; &gt;
 </figcaption>
@@ -248,7 +248,7 @@ _TEXT_ &gt; &gt;
 
 
 <figure data-layout="center" data-align="center">
-<img src="/544112828/output/screenshot-20240730-163530.png" alt="경로 지정 팝업" width="760" />
+<img src="/544112828/output/screenshot-20240730-163530.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_
 </figcaption>
@@ -287,7 +287,7 @@ _TEXT_
 _TEXT_ `_TEXT_`
 
 <figure data-layout="center" data-align="center">
-<img src="/544112828/output/screenshot-20240730-153518.png" alt="Agent &gt; Settings" width="361" />
+<img src="/544112828/output/screenshot-20240730-153518.png" alt="_TEXT_" width="361" />
 <figcaption>
 _TEXT_ &gt;
 </figcaption>
@@ -299,7 +299,7 @@ _TEXT_ &gt;
 _TEXT_ `_TEXT_`
 
 <figure data-layout="center" data-align="center">
-<img src="/544112828/output/screenshot-20240730-153524.png" alt="Agent &gt; App menu" width="363" />
+<img src="/544112828/output/screenshot-20240730-153524.png" alt="_TEXT_" width="363" />
 <figcaption>
 _TEXT_ &gt;
 </figcaption>

--- a/confluence-mdx/tests/testcases/544113141/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544113141/expected.skel.mdx
@@ -11,7 +11,7 @@ _TEXT_
 ### _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/544113141/output/image-20240730-070842.png" alt="Administrator &gt; Audit &gt; Databases &gt; DB Access History" width="760" />
+<img src="/544113141/output/image-20240730-070842.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_ &gt; &gt; &gt;
 </figcaption>
@@ -25,7 +25,7 @@ _TEXT_ &gt; &gt; &gt;
     3. _TEXT_ **_TEXT_**
 4. _TEXT_
   <figure data-layout="center" data-align="center">
-  <img src="/544113141/output/image-20240730-064139.png" alt="image-20240730-064139.png" width="736" />
+  <img src="/544113141/output/image-20240730-064139.png" alt="_TEXT_" width="736" />
   </figure>
     1. _TEXT_ **_TEXT_**
     2. _TEXT_ **_TEXT_**
@@ -60,7 +60,7 @@ _TEXT_ &gt; &gt; &gt;
 _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/544113141/output/image-20240730-065045.png" alt="Administrator &gt; Audit &gt; Databases &gt; DB Access History &gt; DB Access History Details" width="760" />
+<img src="/544113141/output/image-20240730-065045.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_ &gt; &gt; &gt; &gt;
 </figcaption>

--- a/confluence-mdx/tests/testcases/544145591/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544145591/expected.skel.mdx
@@ -11,7 +11,7 @@ import { Callout } from 'nextra/components'
 _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/544145591/output/image-20250822-103044.png" alt="Administrator &gt; General &gt; Company Management &gt; General" width="760" />
+<img src="/544145591/output/image-20250822-103044.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_ &gt; &gt; &gt;
 </figcaption>
@@ -33,7 +33,7 @@ _TEXT_ &gt; &gt; &gt;
 _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/544145591/output/image-20240805-014838.png" alt="Administrator &gt; General &gt; Company Management &gt; General &gt; System Properties" width="760" />
+<img src="/544145591/output/image-20240805-014838.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_ &gt; &gt; &gt; &gt;
 </figcaption>
@@ -45,7 +45,7 @@ _TEXT_ &gt; &gt; &gt; &gt;
 _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/544145591/output/Screenshot-2025-08-25-at-5.36.19-PM.png" alt="Screenshot-2025-08-25-at-5.36.19-PM.png" width="543" />
+<img src="/544145591/output/Screenshot-2025-08-25-at-5.36.19-PM.png" alt="_TEXT_" width="543" />
 </figure>
 
 ### _TEXT_
@@ -98,27 +98,27 @@ _TEXT_
 * _TEXT_
     * _TEXT_
       <figure data-layout="center" data-align="center">
-      <img src="/544145591/output/Screenshot-2025-06-12-at-1.33.58-PM.png" alt="Admin &gt; General &gt; Users &gt; Detail page &gt; Profile 탭&lt;br/&gt;" width="712" />
+      <img src="/544145591/output/Screenshot-2025-06-12-at-1.33.58-PM.png" alt="_TEXT_" width="712" />
       <figcaption>
       _TEXT_ &gt; &gt; &gt; &gt; <br/>
       </figcaption>
       </figure>
 * _TEXT_ &gt; &gt; &gt; <br/>
   <figure data-layout="center" data-align="center">
-  <img src="/544145591/output/image-20251110-030113.png" alt="image-20251110-030113.png" width="736" />
+  <img src="/544145591/output/image-20251110-030113.png" alt="_TEXT_" width="736" />
   </figure>
     * _TEXT_
 * _TEXT_
     * _TEXT_
         * _TEXT_
           <figure data-layout="center" data-align="center">
-          <img src="/544145591/output/image-20250508-022114.png" alt="image-20250508-022114.png" width="688" />
+          <img src="/544145591/output/image-20250508-022114.png" alt="_TEXT_" width="688" />
           </figure>
 * _TEXT_
     * _TEXT_
         * _TEXT_
           <figure data-layout="center" data-align="center">
-          <img src="/544145591/output/Screenshot-2025-06-16-at-10.30.14-AM.png" alt="Screenshot-2025-06-16-at-10.30.14-AM.png" width="615" />
+          <img src="/544145591/output/Screenshot-2025-06-16-at-10.30.14-AM.png" alt="_TEXT_" width="615" />
           </figure>
 
 ### _TEXT_
@@ -126,7 +126,7 @@ _TEXT_
 _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/544145591/output/Screenshot-2025-06-26-at-6.35.32-PM.png" alt="Screenshot-2025-06-26-at-6.35.32-PM.png" width="670" />
+<img src="/544145591/output/Screenshot-2025-06-26-at-6.35.32-PM.png" alt="_TEXT_" width="670" />
 </figure>
 
 _TEXT_
@@ -146,14 +146,14 @@ _TEXT_
 _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/544145591/output/image-20250926-112444.png" alt="Allow Delegated Approval 스위치" width="253" />
+<img src="/544145591/output/image-20250926-112444.png" alt="_TEXT_" width="253" />
 <figcaption>
 _TEXT_
 </figcaption>
 </figure>
 
 <figure data-layout="center" data-align="center">
-<img src="/544145591/output/image-20250926-112201.png" alt="대리결재 기능을 비활성화한 상태의 preference" width="516" />
+<img src="/544145591/output/image-20250926-112201.png" alt="_TEXT_" width="516" />
 <figcaption>
 _TEXT_
 </figcaption>
@@ -164,7 +164,7 @@ _TEXT_
 _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/544145591/output/Screenshot-2025-05-09-at-3.18.32-PM.png" alt="Screenshot-2025-05-09-at-3.18.32-PM.png" width="604" />
+<img src="/544145591/output/Screenshot-2025-05-09-at-3.18.32-PM.png" alt="_TEXT_" width="604" />
 </figure>
 
 
@@ -180,7 +180,7 @@ _TEXT_
 _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/544145591/output/Screenshot-2025-05-09-at-8.33.07-PM.png" alt="Screenshot-2025-05-09-at-8.33.07-PM.png" width="516" />
+<img src="/544145591/output/Screenshot-2025-05-09-at-8.33.07-PM.png" alt="_TEXT_" width="516" />
 </figure>
 
 _TEXT_ `_TEXT_`
@@ -198,7 +198,7 @@ _TEXT_
 _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/544145591/output/Screenshot-2025-05-09-at-8.40.28-PM.png" alt="Screenshot-2025-05-09-at-8.40.28-PM.png" width="352" />
+<img src="/544145591/output/Screenshot-2025-05-09-at-8.40.28-PM.png" alt="_TEXT_" width="352" />
 </figure>
 
 _TEXT_
@@ -224,7 +224,7 @@ _TEXT_
 _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/544145591/output/image-20250822-111454.png" alt="Use DB Privilege Type Based Approval" width="507" />
+<img src="/544145591/output/image-20250822-111454.png" alt="_TEXT_" width="507" />
 <figcaption>
 _TEXT_
 </figcaption>
@@ -233,7 +233,7 @@ _TEXT_
 _TEXT_ `_TEXT_`
 
 <figure data-layout="center" data-align="center">
-<img src="/544145591/output/image-20250822-112026.png" alt="image-20250822-112026.png" width="432" />
+<img src="/544145591/output/image-20250822-112026.png" alt="_TEXT_" width="432" />
 </figure>
 
 * _TEXT_ **_TEXT_**
@@ -259,7 +259,7 @@ _TEXT_ `_TEXT_`
 _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/544145591/output/image-20250825-002423.png" alt="image-20250825-002423.png" width="425" />
+<img src="/544145591/output/image-20250825-002423.png" alt="_TEXT_" width="425" />
 </figure>
 
 _TEXT_

--- a/confluence-mdx/tests/testcases/544178405/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544178405/expected.skel.mdx
@@ -14,7 +14,7 @@ _TEXT_ `_TEXT_`
 _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/544178405/output/screenshot-20240801-145006.png" alt="GNB 내 관리자 페이지 진입점" width="762" />
+<img src="/544178405/output/screenshot-20240801-145006.png" alt="_TEXT_" width="762" />
 <figcaption>
 _TEXT_
 </figcaption>

--- a/confluence-mdx/tests/testcases/544377869/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544377869/expected.skel.mdx
@@ -20,7 +20,7 @@ _TEXT_
 _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/544377869/output/image-20240725-070857.png" alt="Administrator &gt; Databases &gt; Connection Management &gt; DB Connections &gt; Connection Details &gt; Proxy Usage" width="760" />
+<img src="/544377869/output/image-20240725-070857.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_ &gt; &gt; &gt; &gt; &gt;
 </figcaption>
@@ -47,7 +47,7 @@ _TEXT_ [_TEXT_](../../administrator-manual/databases/monitoring/proxy-management
 </Callout>
 
 <figure data-layout="center" data-align="center">
-<img src="/544377869/output/image-20240725-071030.png" alt="Administrator &gt; Databases &gt; Connection Management &gt; DB Connections &gt; Proxy Management" width="760" />
+<img src="/544377869/output/image-20240725-071030.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_ &gt; &gt; &gt; &gt;
 </figcaption>

--- a/confluence-mdx/tests/testcases/544379140/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544379140/expected.skel.mdx
@@ -62,7 +62,7 @@ _TEXT_
 ### _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/544379140/output/image-20240714-063656.png" alt="Administrator &gt; Audit &gt; General &gt; Audit Log Export" width="760" />
+<img src="/544379140/output/image-20240714-063656.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_ &gt; &gt; &gt;
 </figcaption>
@@ -84,7 +84,7 @@ _TEXT_ `_TEXT_` &gt; &gt;
 _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/544379140/output/screenshot-20250116-131805.png" alt="Administrator &gt; Audit &gt; General &gt; Audit Log Export &gt; Create New Task" width="612" />
+<img src="/544379140/output/screenshot-20250116-131805.png" alt="_TEXT_" width="612" />
 <figcaption>
 _TEXT_ &gt; &gt; &gt; &gt;
 </figcaption>

--- a/confluence-mdx/tests/testcases/544381877/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544381877/expected.skel.mdx
@@ -14,7 +14,7 @@ _TEXT_
 _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/544381877/output/image-20240721-054859.png" alt="image-20240721-054859.png" width="760" />
+<img src="/544381877/output/image-20240721-054859.png" alt="_TEXT_" width="760" />
 </figure>
 
 1. _TEXT_ &gt; &gt; &gt;
@@ -63,7 +63,7 @@ _TEXT_
 ### _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/544381877/output/image-20240511-033842.png" alt="image-20240511-033842.png" width="760" />
+<img src="/544381877/output/image-20240511-033842.png" alt="_TEXT_" width="760" />
 </figure>
 
 * _TEXT_

--- a/confluence-mdx/tests/testcases/544384417/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544384417/expected.skel.mdx
@@ -685,7 +685,7 @@ _TEXT_
 
 
 <figure data-layout="center" data-align="center">
-<img src="/544384417/output/screenshot-20241223-112238.png" alt="Administrator &gt; Audit &gt; Reports &gt; Reports" width="760" />
+<img src="/544384417/output/screenshot-20241223-112238.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_ &gt; &gt; &gt;
 </figcaption>
@@ -724,7 +724,7 @@ _TEXT_
 
 
 <figure data-layout="center" data-align="center">
-<img src="/544384417/output/screenshot-20241223-112524.png" alt="Administrator &gt; Audit &gt; Reports &gt; Reports &gt; Report Detail" width="760" />
+<img src="/544384417/output/screenshot-20241223-112524.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_ &gt; &gt; &gt; &gt;
 </figcaption>
@@ -763,7 +763,7 @@ _TEXT_ `_TEXT_`
 _TEXT_ `_TEXT_`
 
 <figure data-layout="center" data-align="center">
-<img src="/544384417/output/screenshot-20241209-104337.png" alt="Administrator &gt; Audit &gt; Reports &gt; Reports &gt; Create" width="760" />
+<img src="/544384417/output/screenshot-20241209-104337.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_ &gt; &gt; &gt; &gt;
 </figcaption>
@@ -799,7 +799,7 @@ _TEXT_ `_TEXT_`
 _TEXT_<Badge color="grey">_TEXT_</Badge>
 
 <figure data-layout="center" data-align="center">
-<img src="/544384417/output/screenshot-20241223-104529.png" alt="Administrator &gt; Audit &gt; Reports &gt; Reports - Duplicate Task" width="589" />
+<img src="/544384417/output/screenshot-20241223-104529.png" alt="_TEXT_" width="589" />
 <figcaption>
 _TEXT_ &gt; &gt; &gt;
 </figcaption>

--- a/confluence-mdx/tests/testcases/568918170/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/568918170/expected.skel.mdx
@@ -14,7 +14,7 @@ _TEXT_
 ### _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/568918170/output/screenshot-20240802-114129.png" alt="Workflow &gt; Reviews &gt; All Reviews &gt; Review Details" width="760" />
+<img src="/568918170/output/screenshot-20240802-114129.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_ &gt; &gt; &gt;
 </figcaption>
@@ -37,7 +37,7 @@ _TEXT_
 #### _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/568918170/output/screenshot-20240802-120401.png" alt="User &gt; 상단 메뉴바에서 프로필 클릭 &gt; Preferences" width="760" />
+<img src="/568918170/output/screenshot-20240802-120401.png" alt="_TEXT_" width="760" />
 <figcaption>
 _TEXT_ &gt; &gt;
 </figcaption>
@@ -53,13 +53,13 @@ _TEXT_ &gt; &gt;
 
 _TEXT_
 <figure data-layout="center" data-align="center">
-<img src="/568918170/output/screenshot-20240802-120741.png" alt="원 결재자 기준 표시 내용" width="594" />
+<img src="/568918170/output/screenshot-20240802-120741.png" alt="_TEXT_" width="594" />
 <figcaption>
 _TEXT_
 </figcaption>
 </figure>
 <figure data-layout="center" data-align="center">
-<img src="/568918170/output/screenshot-20240802-120854.png" alt="대리 결재자 기준 표시 내용" width="594" />
+<img src="/568918170/output/screenshot-20240802-120854.png" alt="_TEXT_" width="594" />
 <figcaption>
 _TEXT_
 </figcaption>
@@ -77,7 +77,7 @@ _TEXT_
 * _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/568918170/output/screenshot-20240802-124638.png" alt="screenshot-20240802-124638.png" width="760" />
+<img src="/568918170/output/screenshot-20240802-124638.png" alt="_TEXT_" width="760" />
 </figure>
 
 #### _TEXT_
@@ -85,14 +85,14 @@ _TEXT_
 * _TEXT_
 **_TEXT_**
 <figure data-layout="center" data-align="center">
-<img src="/568918170/output/screenshot-20240725-153533.png" alt="대리 결재 관련 문구 없음" width="363" />
+<img src="/568918170/output/screenshot-20240725-153533.png" alt="_TEXT_" width="363" />
 <figcaption>
 _TEXT_
 </figcaption>
 </figure>
 **_TEXT_**
 <figure data-layout="center" data-align="center">
-<img src="/568918170/output/screenshot-20240725-152141.png" alt="대리 결재자가 Done by the delegate와 함께 표기됨" width="363" />
+<img src="/568918170/output/screenshot-20240725-152141.png" alt="_TEXT_" width="363" />
 <figcaption>
 _TEXT_
 </figcaption>
@@ -112,7 +112,7 @@ _TEXT_ [_TEXT_](../../administrator-manual/general/system/integrations/integrati
 _TEXT_
 
 <figure data-layout="center" data-align="center">
-<img src="/568918170/output/image-20230824-110815.png" alt="Workflow &gt; Sent Requests &gt; Done &gt; List Details" width="768" />
+<img src="/568918170/output/image-20230824-110815.png" alt="_TEXT_" width="768" />
 <figcaption>
 _TEXT_ &gt; &gt; &gt;
 </figcaption>

--- a/confluence-mdx/tests/testcases/692355151/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/692355151/expected.skel.mdx
@@ -36,7 +36,7 @@ _TEXT_
 </Callout>
 
 <figure data-layout="center" data-align="center">
-<img src="/692355151/output/image-20241029-234721.png" alt="image-20241029-234721.png" width="760" />
+<img src="/692355151/output/image-20241029-234721.png" alt="_TEXT_" width="760" />
 </figure>
 
 1. _TEXT_ `_TEXT_` <br/>
@@ -46,31 +46,31 @@ _TEXT_
         2. _TEXT_ **_TEXT_**
 
 <figure data-layout="center" data-align="center">
-<img src="/692355151/output/image-20241029-235845.png" alt="image-20241029-235845.png" width="682" />
+<img src="/692355151/output/image-20241029-235845.png" alt="_TEXT_" width="682" />
 </figure>
 
 <Callout type="important">
 * _TEXT_
 * _TEXT_
 <figure data-layout="center" data-align="center">
-<img src="/692355151/output/image-20241030-001252.png" alt="image-20241030-001252.png" width="682" />
+<img src="/692355151/output/image-20241030-001252.png" alt="_TEXT_" width="682" />
 </figure>
 </Callout>
 
 1. _TEXT_
     1. _TEXT_ <br/> <br/><br/>
       <figure data-layout="center" data-align="center">
-      <img src="/692355151/output/image-20241030-002325.png" alt="image-20241030-002325.png" width="712" />
+      <img src="/692355151/output/image-20241030-002325.png" alt="_TEXT_" width="712" />
       </figure>
     2. _TEXT_ `_TEXT_` <br/> <br/><br/><br/><br/><br/>
       <figure data-layout="center" data-align="center">
-      <img src="/692355151/output/image-20241030-003040.png" alt="`{JSON}` 을 클릭하면 전체 내용을 볼수 있습니다." width="712" />
+      <img src="/692355151/output/image-20241030-003040.png" alt="_TEXT_" width="712" />
       <figcaption>
       _TEXT_ `_TEXT_`
       </figcaption>
       </figure>
       <figure data-layout="center" data-align="center">
-      <img src="/692355151/output/image-20241030-003129.png" alt="JSON 결과의 복사와 내보내기가 가능합니다." width="560" />
+      <img src="/692355151/output/image-20241030-003129.png" alt="_TEXT_" width="560" />
       <figcaption>
       _TEXT_
       </figcaption>
@@ -80,7 +80,7 @@ _TEXT_
 
 1. _TEXT_ <br/>
   <figure data-layout="center" data-align="center">
-  <img src="/692355151/output/image-20241030-004258.png" alt="image-20241030-004258.png" width="736" />
+  <img src="/692355151/output/image-20241030-004258.png" alt="_TEXT_" width="736" />
   </figure>
 
 <Callout type="important">

--- a/confluence-mdx/tests/testcases/880181257/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/880181257/expected.skel.mdx
@@ -11,14 +11,14 @@ import { Callout } from 'nextra/components'
 1. _TEXT_
 2. _TEXT_ `_TEXT_` <br/>
   <figure data-layout="center" data-align="center">
-  <img src="/880181257/output/Screenshot-2025-03-06-at-1.19.24-PM.png" alt="Screenshot-2025-03-06-at-1.19.24-PM.png" width="712" />
+  <img src="/880181257/output/Screenshot-2025-03-06-at-1.19.24-PM.png" alt="_TEXT_" width="712" />
   </figure>
 3. _TEXT_
 4. _TEXT_
 5. _TEXT_
 6. _TEXT_ <br/>
   <figure data-layout="center" data-align="center">
-  <img src="/880181257/output/Screenshot-2025-03-06-at-1.22.28-PM.png" alt="Screenshot-2025-03-06-at-1.22.28-PM.png" width="712" />
+  <img src="/880181257/output/Screenshot-2025-03-06-at-1.22.28-PM.png" alt="_TEXT_" width="712" />
   </figure>
 7. _TEXT_ `_TEXT_`
 8. _TEXT_ &gt; &gt;
@@ -36,13 +36,13 @@ _TEXT_ <br/>
     * _TEXT_
     * _TEXT_ <br/>
       <figure data-layout="center" data-align="center">
-      <img src="/880181257/output/Screenshot-2025-03-06-at-2.05.26-PM.png" alt="Screenshot-2025-03-06-at-2.05.26-PM.png" width="400" />
+      <img src="/880181257/output/Screenshot-2025-03-06-at-2.05.26-PM.png" alt="_TEXT_" width="400" />
       </figure>
 2. **_TEXT_**
     * _TEXT_
     * _TEXT_ <br/>
       <figure data-layout="center" data-align="center">
-      <img src="/880181257/output/Screenshot-2025-03-06-at-2.08.11-PM.png" alt="Screenshot-2025-03-06-at-2.08.11-PM.png" width="712" />
+      <img src="/880181257/output/Screenshot-2025-03-06-at-2.08.11-PM.png" alt="_TEXT_" width="712" />
       </figure>
     * _TEXT_
     * _TEXT_
@@ -51,7 +51,7 @@ _TEXT_ <br/>
     * **_TEXT_**
     * _TEXT_
       <figure data-layout="center" data-align="center">
-      <img src="/880181257/output/Screenshot-2025-03-06-at-2.18.26-PM.png" alt="Screenshot-2025-03-06-at-2.18.26-PM.png" width="712" />
+      <img src="/880181257/output/Screenshot-2025-03-06-at-2.18.26-PM.png" alt="_TEXT_" width="712" />
       </figure>
 
 <Callout type="important">
@@ -65,11 +65,11 @@ _TEXT_ <br/>
     * _TEXT_
     * _TEXT_ <br/>
       <figure data-layout="center" data-align="center">
-      <img src="/880181257/output/Screenshot-2025-03-06-at-2.22.22-PM.png" alt="Screenshot-2025-03-06-at-2.22.22-PM.png" width="712" />
+      <img src="/880181257/output/Screenshot-2025-03-06-at-2.22.22-PM.png" alt="_TEXT_" width="712" />
       </figure>
 2. **_TEXT_**
     * _TEXT_
     * _TEXT_ <br/>
       <figure data-layout="center" data-align="center">
-      <img src="/880181257/output/Screenshot-2025-03-06-at-2.23.37-PM.png" alt="Screenshot-2025-03-06-at-2.23.37-PM.png" width="712" />
+      <img src="/880181257/output/Screenshot-2025-03-06-at-2.23.37-PM.png" alt="_TEXT_" width="712" />
       </figure>

--- a/confluence-mdx/tests/testcases/883654669/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/883654669/expected.skel.mdx
@@ -27,15 +27,15 @@ _TEXT_
 
 1. _TEXT_ `_TEXT_` [_TEXT_](https://api.slack.com/apps) <br/><br/>
   <figure data-layout="center" data-align="center">
-  <img src="/883654669/output/image-20231227-065658.png" alt="image-20231227-065658.png" width="760" />
+  <img src="/883654669/output/image-20231227-065658.png" alt="_TEXT_" width="760" />
   </figure>
 2. _TEXT_ `_TEXT_` <br/><br/>
   <figure data-layout="center" data-align="center">
-  <img src="/883654669/output/screenshot-20250218-131725.png" alt="screenshot-20250218-131725.png" width="712" />
+  <img src="/883654669/output/screenshot-20250218-131725.png" alt="_TEXT_" width="712" />
   </figure>
 3. _TEXT_ <br/><br/>
   <figure data-layout="center" data-align="center">
-  <img src="/883654669/output/image-20231227-065951.png" alt="image-20231227-065951.png" width="710" />
+  <img src="/883654669/output/image-20231227-065951.png" alt="_TEXT_" width="710" />
   </figure>
 4. _TEXT_ `_TEXT_` <br/> <br/> <br/>
   ```
@@ -70,7 +70,7 @@ _TEXT_
   ```
 5. _TEXT_ `_TEXT_` <br/><br/>
   <figure data-layout="center" data-align="center">
-  <img src="/883654669/output/image-20240115-220447.png" alt="image-20240115-220447.png" width="763" />
+  <img src="/883654669/output/image-20240115-220447.png" alt="_TEXT_" width="763" />
   </figure>
 
 ### _TEXT_
@@ -78,11 +78,11 @@ _TEXT_
 1. _TEXT_ `_TEXT_` &gt;
 2. _TEXT_ `_TEXT_` <br/>
   <figure data-layout="center" data-align="center">
-  <img src="/883654669/output/image-20240115-221520.png" alt="image-20240115-221520.png" width="760" />
+  <img src="/883654669/output/image-20240115-221520.png" alt="_TEXT_" width="760" />
   </figure>
 3. _TEXT_
   <figure data-layout="center" data-align="center">
-  <img src="/883654669/output/image-20240115-221618.png" alt="image-20240115-221618.png" width="760" />
+  <img src="/883654669/output/image-20240115-221618.png" alt="_TEXT_" width="760" />
   </figure>
 
 ### _TEXT_
@@ -90,7 +90,7 @@ _TEXT_
 _TEXT_ **_TEXT_** &gt;
 
 <figure data-layout="center" data-align="center">
-<img src="/883654669/output/image-20240418-022640.png" alt="image-20240418-022640.png" width="764" />
+<img src="/883654669/output/image-20240418-022640.png" alt="_TEXT_" width="764" />
 </figure>
 
 
@@ -106,11 +106,11 @@ _TEXT_
 
 1. _TEXT_ `_TEXT_` &gt; <br/><br/>
   <figure data-layout="center" data-align="center">
-  <img src="/883654669/output/screenshot-20250218-140951.png" alt="screenshot-20250218-140951.png" width="736" />
+  <img src="/883654669/output/screenshot-20250218-140951.png" alt="_TEXT_" width="736" />
   </figure>
 2. _TEXT_ `_TEXT_` <br/><br/>
   <figure data-layout="center" data-align="center">
-  <img src="/883654669/output/screenshot-20250218-141555.png" alt="screenshot-20250218-141555.png" width="736" />
+  <img src="/883654669/output/screenshot-20250218-141555.png" alt="_TEXT_" width="736" />
   </figure>
 3. _TEXT_ `_TEXT_`
 
@@ -118,7 +118,7 @@ _TEXT_
 
 1. _TEXT_ `_TEXT_` &gt; &gt; &gt; &gt; <br/><br/>
   <figure data-layout="center" data-align="center">
-  <img src="/883654669/output/screenshot-20250310-113509.png" alt="Administrator &gt; General &gt; System &gt; Integrations &gt; Slack &gt; Create a New Slack Configuration" width="736" />
+  <img src="/883654669/output/screenshot-20250310-113509.png" alt="_TEXT_" width="736" />
   <figcaption>
   _TEXT_ &gt; &gt; &gt; &gt; &gt;
   </figcaption>
@@ -128,7 +128,7 @@ _TEXT_
     * _TEXT_ **_TEXT_**
     * _TEXT_ **_TEXT_** <br/><br/>
       <figure data-layout="center" data-align="center">
-      <img src="/883654669/output/image-20231003-054240.png" alt="액션 허용타입 예시 (좌) / 액션 비허용 타입 예시 (우)" width="760" />
+      <img src="/883654669/output/image-20231003-054240.png" alt="_TEXT_" width="760" />
       <figcaption>
       _TEXT_
       </figcaption>
@@ -139,14 +139,14 @@ _TEXT_
 
 1. _TEXT_ <br/><br/>
   <figure data-layout="center" data-align="center">
-  <img src="/883654669/output/screenshot-20250310-113950.png" alt="Administrator &gt; General &gt; System &gt; Integrations &gt; Slack" width="736" />
+  <img src="/883654669/output/screenshot-20250310-113950.png" alt="_TEXT_" width="736" />
   <figcaption>
   _TEXT_ &gt; &gt; &gt; &gt;
   </figcaption>
   </figure>
 2. _TEXT_ `_TEXT_` <br/>
   <figure data-layout="center" data-align="center">
-  <img src="/883654669/output/screenshot-20250218-152840.png" alt="Administrator &gt; General &gt; System &gt; Integrations &gt; Slack &gt; Edit the Slack Configuration" width="736" />
+  <img src="/883654669/output/screenshot-20250218-152840.png" alt="_TEXT_" width="736" />
   <figcaption>
   _TEXT_ &gt; &gt; &gt; &gt; &gt;
   </figcaption>
@@ -159,13 +159,13 @@ _TEXT_
 
 1. _TEXT_ &gt; <br/>
   <figure data-layout="center" data-align="center">
-  <img src="/883654669/output/screenshot-20250218-151504.png" alt="screenshot-20250218-151504.png" width="736" />
+  <img src="/883654669/output/screenshot-20250218-151504.png" alt="_TEXT_" width="736" />
   </figure>
 2. _TEXT_ **_TEXT_** <br/> <br/><br/>
   <figure data-layout="center" data-align="center">
-  <img src="/883654669/output/screenshot-20250218-152238.png" alt="screenshot-20250218-152238.png" width="701" />
+  <img src="/883654669/output/screenshot-20250218-152238.png" alt="_TEXT_" width="701" />
   </figure>
 3. _TEXT_ `_TEXT_` <br/>
   <figure data-layout="center" data-align="center">
-  <img src="/883654669/output/screenshot-20250218-152527.png" alt="screenshot-20250218-152527.png" width="736" />
+  <img src="/883654669/output/screenshot-20250218-152527.png" alt="_TEXT_" width="736" />
   </figure>


### PR DESCRIPTION
## Summary
- `mdx_to_skeleton.py`의 `_process_html_line` 함수를 수정하여 `<img>` 태그의 `alt` 속성 값을 `_TEXT_`로 변환합니다.
- 모든 테스트 케이스의 `expected.skel.mdx` 파일을 업데이트하여 변경된 변환 결과를 반영했습니다.

## Changes
- `bin/mdx_to_skeleton.py`: img 태그의 alt 속성 처리 로직 추가
  - `alt="..."`와 `alt='...'` 형식을 모두 지원
  - 이미지의 src, width 등 다른 속성은 보존
- 13개 테스트 케이스의 `expected.skel.mdx` 파일 업데이트

## Test plan
- [x] `make test` - XHTML to MDX 변환 테스트 통과
- [x] `make test-skeleton` - skeleton 변환 테스트 통과 (18개 테스트 케이스)

## Related
Closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)