### PR TITLE
fix(mdx): support 페이지 영어/일본어 번역문의 Confluence 링크 오류 수정

### DIFF
--- a/src/content/en/support.mdx
+++ b/src/content/en/support.mdx
@@ -22,7 +22,6 @@ For detailed technical support resources, please visit our [Confluence Space](ht
 * [QueryPie Architecture](https://querypie.atlassian.net/wiki/spaces/QCP/pages/887947488)
 * [Advanced Environment Setup](https://querypie.atlassian.net/wiki/spaces/QCP/pages/888078563)
 * [Advanced Integration Guide](https://querypie.atlassian.net/wiki/spaces/QCP/pages/897876290)
-* [Release Version Documents](https://querypie.atlassian.net/wiki/spaces/QCP/pages/841351486)
 * [Troubleshooting](https://querypie.atlassian.net/wiki/spaces/QCP/pages/1111916585)
 
 #### Product Demo - YouTube

--- a/src/content/ja/support.mdx
+++ b/src/content/ja/support.mdx
@@ -22,8 +22,6 @@ title: 'サポート'
 * [QueryPie Architecture](https://querypie.atlassian.net/wiki/spaces/QCP/pages/888176803)
 * [Advanced Environment Setup](https://querypie.atlassian.net/wiki/spaces/QCP/pages/888013101)
 * [Advanced Integration Guide](https://querypie.atlassian.net/wiki/spaces/QCP/pages/897679639)
-* [リリースバージョン別ドキュメント](https://querypie.atlassian.net/wiki/spaces/QCP/pages/841351486)
-* [Troubleshooting](https://querypie.atlassian.net/wiki/spaces/QCP/pages/1111916585)
 
 #### Product Demo - YouTube
 


### PR DESCRIPTION
## Description
- PR #579에서 추가된 Confluence 기술지원 링크가 영어/일본어 번역문에서 한국어 페이지를 가리키는 문제를 수정합니다.
- 각 언어별 Confluence 페이지로 올바르게 링크되도록 페이지 ID를 수정합니다.
- 영어/일본어 Confluence 페이지가 존재하지 않는 항목은 삭제합니다.

### 변경사항
**영어 번역문 (en/support.mdx):**
- QueryPie Architecture: 400064797 → 887947488
- Advanced Environment Setup: 887947577 → 888078563
- Advanced Integration Guide: 841449834 → 897876290
- Troubleshooting: 920486841 → 1111916585
- **Release Version Documents 항목 삭제** (영어 페이지 없음)

**일본어 번역문 (ja/support.mdx):**
- QueryPie Architecture: 400064797 → 888176803
- Advanced Environment Setup: 887947577 → 888013101
- Advanced Integration Guide: 841449834 → 897679639
- **リリースバージョン別ドキュメント 항목 삭제** (일본어 페이지 없음)
- **Troubleshooting 항목 삭제** (일본어 페이지 없음)

### Background
PR #579에서 한국어 번역문에 Confluence 기술지원 링크를 추가했으나, 영어/일본어 번역문에는 한국어 Confluence 페이지 ID가 사용되었습니다.
Confluence에는 각 언어별로 별도의 페이지가 존재하므로, 해당 언어의 페이지로 링크하도록 수정합니다.

또한, 각 언어별 페이지가 존재하지 않는 항목은 혼란을 방지하기 위해 삭제합니다.
사용자가 해당 언어로 문서를 열었을 때 한국어 페이지로 리다이렉트되는 것보다, 존재하는 페이지만 표시하는 것이 더 나은 사용자 경험을 제공합니다.

## Related tickets & links
- #579 (원본 PR)

## Added/updated tests?
- [ ] Yes
- [x] No, and this is why: 문서 링크 수정만 포함되어 있습니다.
- [ ] I need help with writing tests

## Additional notes
- Confluence API를 통해 각 언어별 페이지 ID를 확인하여 수정했습니다.
- 일본어 Troubleshooting 페이지는 Confluence에 존재하지 않아 항목을 삭제했습니다.
- 영어 Release Version Documents 페이지도 존재하지 않아 항목을 삭제했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)