### PR TITLE
confluence-mdx: pages_of_confluence.py --recent 옵션 사용 시 list.txt가 전체 문서 목록을 포함하도록 수정

### DIFF
--- a/confluence-mdx/bin/pages_of_confluence.py
+++ b/confluence-mdx/bin/pages_of_confluence.py
@@ -914,20 +914,20 @@ class ConfluencePageProcessor:
                         continue
                 
                 # After downloading, process like local mode (hierarchical traversal from start_page_id)
-                # Generate pages.yaml with full hierarchical tree (like --local mode)
+                # Generate pages.yaml and list.txt with full hierarchical tree (like --local mode)
                 # No stdout output in this phase (like --local mode)
                 self.logger.warning(f"Processing page tree from start page ID {start_page_id} (local mode)")
                 page_count = 0
                 yaml_entries = []
+                list_lines = []
 
                 for page in self.fetch_page_tree_recursive(start_page_id, start_page_id, use_local=True):
                     if page:
+                        breadcrumbs_str = " />> ".join(page.breadcrumbs) if page.breadcrumbs else ""
                         # No stdout output in local mode
+                        list_lines.append(f"{page.page_id}\t{breadcrumbs_str}\n")
                         page_count += 1
                         yaml_entries.append(page.to_dict())
-                
-                # list.txt contains only downloaded pages
-                list_lines = downloaded_list_lines
 
             elif self.config.mode == "local":
                 # --local mode: Process existing local files hierarchically from start_page_id


### PR DESCRIPTION
## Summary
- `bin/pages_of_confluence.py` 스크립트의 `--recent` 옵션 사용 시 `list.txt`가 최근 수정된 페이지만 포함하던 버그를 수정
- 이제 `pages.yaml`과 동일하게 전체 문서 트리를 순회하여 `list.txt`를 생성

## 변경 내용
**수정 파일:** `confluence-mdx/bin/pages_of_confluence.py`

- `--recent` 모드의 로컬 처리 단계에서 `list_lines`를 전체 트리 순회 중에 생성하도록 수정
- 기존: `list_lines = downloaded_list_lines` (다운로드된 페이지만 포함)
- 변경: `yaml_entries`와 동일한 루프에서 `list_lines` 생성 (전체 페이지 포함)

## Test plan
- [x] `--recent` 옵션으로 스크립트 실행
- [x] `var/list.txt`와 `var/pages.yaml`의 페이지 수가 동일한지 확인 (287개)
- [x] `--local` 옵션으로 실행했을 때와 `list.txt` 결과가 동일한지 비교

Fixes #586

🤖 Generated with [Claude Code](https://claude.com/claude-code)