### PR TITLE
docs(confluence-mdx): README.md에 venv 활성화 필수 안내 추가

### DIFF
--- a/confluence-mdx/README.md
+++ b/confluence-mdx/README.md
@@ -106,6 +106,12 @@ $ bin/xhtml2markdown.ko.sh
 
 ## 데이터 수집 및 변환 절차 상세 안내
 
+> **주의:** 아래의 모든 스크립트 실행 예시는 **venv 가상환경이 활성화된 상태**에서 실행해야 합니다.
+> ```bash
+> cd querypie-docs/confluence-mdx
+> source venv/bin/activate  # venv 활성화 필수
+> ```
+
 ### 1. Confluence 문서 데이터 수집 (pages_of_confluence.py)
 
 `pages_of_confluence.py`는 Confluence REST API를 이용하여 지정한 문서와 그 하위 페이지들을 수집하여 저장하는 스크립트입니다. 


### PR DESCRIPTION
## Summary
- `confluence-mdx/README.md`의 "데이터 수집 및 변환 절차 상세 안내" 섹션에 venv 가상환경 활성화 필수 안내를 추가

## 변경 이유
기존 문서에서 스크립트 실행 예시(`bin/pages_of_confluence.py` 등)가 venv 활성화 없이 바로 실행되는 것처럼 보여, 다음과 같은 혼란이 발생할 수 있었습니다:

1. 시스템 Python으로 실행 시도
2. `yaml`, `requests` 등 필수 모듈 미설치 오류 발생
3. venv 환경을 찾아서 활성화하는 데 불필요한 시간 소요

## 변경 내용
**수정 파일:** `confluence-mdx/README.md`

"데이터 수집 및 변환 절차 상세 안내" 섹션 상단에 다음 주의사항 추가:
```
> **주의:** 아래의 모든 스크립트 실행 예시는 **venv 가상환경이 활성화된 상태**에서 실행해야 합니다.
> ```bash
> cd querypie-docs/confluence-mdx
> source venv/bin/activate  # venv 활성화 필수
> ```
```

## Test plan
- [x] README.md 마크다운 문법 확인
- [x] 안내 내용이 기존 "Python 가상환경(venv) 생성" 섹션과 일관성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)