### PR TITLE
fix: 리스트 내부 코드 블록 들여쓰기 문제 수정

### DIFF
--- a/confluence-mdx/bin/confluence_xhtml_to_markdown.py
+++ b/confluence-mdx/bin/confluence_xhtml_to_markdown.py
@@ -1225,20 +1225,6 @@ class MultiLineParser:
         return self.markdown_lines
 
     @property
-    def as_markdown_of_two(self):
-        """Convert the node to Markdown format for indented list."""
-        self.convert_recursively(self.node)
-
-        if len(self.markdown_lines) >= 2:
-            # Join all items except the last one into a single string
-            first_line = "".join(self.markdown_lines[:-1])
-            # Get the last item in the list
-            last_line = self.markdown_lines[-1]
-            return [first_line, last_line]
-        else:
-            return self.markdown_lines
-
-    @property
     def is_standalone_dash(self):
         """
         Check if the node contains only a plain standalone dash character.
@@ -1452,7 +1438,7 @@ class MultiLineParser:
             elif child.name in ['ul', 'ol']:
                 pass  # Will be processed later in this method
             elif child.name in ['ac:structured-macro'] and attr_name in ['code']:
-                code_markdown = MultiLineParser(child).as_markdown_of_two
+                code_markdown = MultiLineParser(child).as_markdown
                 child_markdown.extend(code_markdown)
             else:
                 child_markdown.append(f'(Unexpected node name="{child.name}" ac:name="{attr_name}")\n')
@@ -1462,10 +1448,8 @@ class MultiLineParser:
 
         itself = ' '.join(li_itself)
         self.markdown_lines.append(f'{prefix}{itself}\n')
-        if len(child_markdown) > 0:
-            for i in range(len(child_markdown)):
-                child_markdown[i] = prefix_for_children + child_markdown[i]
-            self.markdown_lines.extend(child_markdown)
+        for line in child_markdown:
+            self.markdown_lines.append(prefix_for_children + line)
 
         # Handle nested lists
         for child in node.children:
@@ -1568,7 +1552,8 @@ class MultiLineParser:
                 if isinstance(item, CData):
                     cdata = str(item)  # Convert CData object to string
                     break
-        self.markdown_lines.append(f"{cdata}\n")
+        for line in cdata.rstrip('\n').split('\n'):
+            self.markdown_lines.append(f"{line}\n")
         self.markdown_lines.append("```\n")
 
     def convert_structured_macro_expand(self, node):

--- a/confluence-mdx/tests/testcases/544381877/expected.html
+++ b/confluence-mdx/tests/testcases/544381877/expected.html
@@ -256,13 +256,10 @@ ${CA_CERT}&quot;
 </details>
 <ul>
 <li>스크립트 다운로드 이후 해당 경로에서 이하의 명령어를 수행하여 실행 권한을 부여한 뒤 사용합니다.
-<pre><code></code></pre>
+<pre><code>chmod +x generate_kubepie_sa.sh
+./generate_kubepie_sa.sh
+</code></pre>
 
 </li>
 
 </ul>
-
-<p>chmod +x generate_kubepie_sa.sh
-./generate_kubepie_sa.sh</p>
-
-<pre><code></code></pre>

--- a/confluence-mdx/tests/testcases/544381877/expected.mdx
+++ b/confluence-mdx/tests/testcases/544381877/expected.mdx
@@ -171,6 +171,6 @@ ${CA_CERT}"
 
 * 스크립트 다운로드 이후 해당 경로에서 이하의 명령어를 수행하여 실행 권한을 부여한 뒤 사용합니다. 
   ```
-chmod +x generate_kubepie_sa.sh
-./generate_kubepie_sa.sh
+  chmod +x generate_kubepie_sa.sh
+  ./generate_kubepie_sa.sh
   ```

--- a/confluence-mdx/tests/testcases/544381877/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544381877/expected.skel.mdx
@@ -171,6 +171,6 @@ ${CA_CERT}"
 
 * _TEXT_
   ```
-chmod +x generate_kubepie_sa.sh
-./generate_kubepie_sa.sh
+  chmod +x generate_kubepie_sa.sh
+  ./generate_kubepie_sa.sh
   ```

--- a/confluence-mdx/tests/testcases/544382364/expected.html
+++ b/confluence-mdx/tests/testcases/544382364/expected.html
@@ -194,44 +194,28 @@ Role 설정은 GUI 로 하며, Policy 정의는 코드(YAML)로 관리합니다.
 </li>
 
 <li>Resources에 명시된 리소스에 대한 권한 수행이 가능한 kubernetes 측 그룹(단일 또는 복수)을 정의합니다.
-<pre><code></code></pre>
+<pre><code>kubernetesGroups: 
+  - system:masters
+  - default-group-account
+</code></pre>
 
 </li>
 
-</ul>
-
-</li>
-
-</ul>
-
-</li>
-
-</ol>
-
-<p>kubernetesGroups:</p>
-
-<ul>
-<li>system:masters</li>
-
-<li>default-group-account
-<pre><code>* kubernetesGroups에는 Querypie User의 Group을 예약어 형태로 입력할 수 있습니다. 이 때, User의 Group은 쌍따옴표(“) 없이 입력 입력되어야 하며, 사용자가 Policy를 볼 땐 실제 user Group의 값이 표시됩니다.
+<li>kubernetesGroups에는 Querypie User의 Group을 예약어 형태로 입력할 수 있습니다. 이 때, User의 Group은 쌍따옴표(“) 없이 입력 입력되어야 하며, 사용자가 Policy를 볼 땐 실제 user Group의 값이 표시됩니다.
+<pre><code>kubernetesGroups: 
+  - $user.groups
 </code></pre>
 
 </li>
 
 </ul>
 
-<p>kubernetesGroups:</p>
-
-<ul>
-<li>$user.groups
-<pre><code></code></pre>
-
 </li>
 
 </ul>
 
-<ol start="2">
+</li>
+
 <li><code>impersonation</code>: <span style="display:inline-block;padding:2px 5px 2px 4px;margin:0 2px;border-radius:3px;font-size:0.75em;font-weight:700;line-height:1.1;letter-spacing:-0.3px;text-transform:uppercase;white-space:nowrap;position:relative;top:-1px;background-color:#F9C84E;color:#292A2E">OPTIONAL</span>
 <ul>
 <li>사용자가 클라이언트 단에서 kubernetes 내 특정 serviceaccount 등의 권한으로 kubectl 명령에 impersonation(--as, --as-group)을 시도하는 경우, 이에 대한 호출 허용 목록을 정의합니다.
@@ -239,9 +223,16 @@ Role 설정은 GUI 로 하며, Policy 정의는 코드(YAML)로 관리합니다.
 <li><code>users</code>: 쿠버네티스 내 존재하는 사용자/서비스 계정으로 &quot;--as&quot; 파라미터에 허용 가능한 값을 나열합니다.</li>
 
 <li><code>groups</code>: 쿠버네티스 내 존재하는 그룹 계정으로 &quot;--as-group&quot; 파라미터에 허용 가능한 값을 나열합니다.
-<pre><code></code></pre>
+<pre><code>impersonation: 
+  users: 
+    - &quot;system:serviceaccount:argocd&quot;
+  groups: 
+    - &quot;system:admin&quot;
+</code></pre>
 
 </li>
+
+<li>와일드카드를 허용합니다. (<code>&quot;*&quot;</code>)</li>
 
 </ul>
 
@@ -252,22 +243,6 @@ Role 설정은 GUI 로 하며, Policy 정의는 코드(YAML)로 관리합니다.
 </li>
 
 </ol>
-
-<p>impersonation:
-users:</p>
-
-<ul>
-<li>&quot;system:serviceaccount:argocd&quot;
-groups:</li>
-
-<li>&quot;system:admin&quot;
-<pre><code>* 와일드카드를 허용합니다. (`&quot;*&quot;`)
-
-</code></pre>
-
-</li>
-
-</ul>
 
 <h3>Actions 명시 방법</h3>
 
@@ -321,28 +296,18 @@ groups:</li>
 
 </ol>
 
-<pre><code></code></pre>
-
-</li>
-
-</ol>
-
-<p>resources:</p>
-
-<ul>
-<li>&quot;pods&quot;</li>
-
-<li>&quot;deployments&quot;</li>
-
-<li>&quot;configmaps&quot;
-<pre><code></code></pre>
-
-</li>
-
-</ul>
+<pre><code> resources:
+   - &quot;pods&quot;
+   - &quot;deployments&quot;
+   - &quot;configmaps&quot;
+</code></pre>
 
 <ol start="5">
 <li>와일드카드를 허용합니다. (<code>&quot;*&quot;</code>)</li>
+
+</ol>
+
+</li>
 
 <li><code>namespace</code> : 대상 네임스페이스를 정의합니다.
 <ol>
@@ -440,96 +405,70 @@ groups:</li>
 
 <ul>
 <li><code>resourceTags</code> : 태그 항목에서는 리소스 태그의 키와 값으로 필터링할 수 있습니다.
-<pre><code></code></pre>
-
-</li>
-
-</ul>
-
-<p>resourceTags:
-&quot;region&quot;: &quot;ap-northeast-1&quot;
-&quot;Owner&quot;: &quot;Brant&quot;</p>
-
-<pre><code>* `userAttributes` : 사용자의 속성(attribute)을 조건으로 지정하고 값이 매칭되는 사용자에 한해서만 해당 정책에서 정의된 권한의 사용을 제한합니다. 
+<pre><code>resourceTags: 
+  &quot;region&quot;: &quot;ap-northeast-1&quot;
+  &quot;Owner&quot;: &quot;Brant&quot;
 </code></pre>
 
-<p>userAttributes:
-&quot;countryCode&quot;: &quot;KR&quot;
-&quot;department&quot;: &quot;Infra&quot;</p>
+</li>
 
-<pre><code>* `ipAddresses` : 리소스에 대한 IP 접근 통제 조건 리스트를 단일IP, CIDR 형태으로 정의합니다. 
+<li><code>userAttributes</code> : 사용자의 속성(attribute)을 조건으로 지정하고 값이 매칭되는 사용자에 한해서만 해당 정책에서 정의된 권한의 사용을 제한합니다.
+<pre><code>userAttributes: 
+  &quot;countryCode&quot;: &quot;KR&quot;
+  &quot;department&quot;: &quot;Infra&quot;
 </code></pre>
 
-<p>ipAddresses: [&quot;10.10.0.0/24&quot;, &quot;10.11.10.1&quot;]</p>
+</li>
 
-<pre><code>
-
-### KAC Policy 예시
-
+<li><code>ipAddresses</code> : 리소스에 대한 IP 접근 통제 조건 리스트를 단일IP, CIDR 형태으로 정의합니다.
+<pre><code>ipAddresses: [&quot;10.10.0.0/24&quot;, &quot;10.11.10.1&quot;]
 </code></pre>
 
-<p>apiVersion: kubernetes.rbac.querypie.com/v1
-kind: KacPolicy</p>
-
-<p>spec:
-allow:
-resources:</p>
-
-<ul>
-<li>&quot;cluster:*&quot;
-subjects:
-kubernetesGroups:
-<ul>
-<li>&quot;system:masters&quot;
-impersonation:
-users: [&quot;system:serviceaccount:argocd&quot;]
-groups: [&quot;system:admin&quot;]<br/>
-actions:</li>
-
-</ul>
-
-</li>
-
-<li>apiGroups: [&quot;*&quot;]
-resources:
-<ul>
-<li>&quot;pods&quot;
-namespace: &quot;<em>&quot;
-name: &quot;</em>&quot;
-verbs: [&quot;get&quot;, &quot;list&quot;, &quot;watch&quot;]
-conditions:
-resourceTags:
-&quot;Owner&quot;: [&quot;Kenny&quot;, &quot;Brant&quot;]
-&quot;Team&quot;: &quot;DevSecOps&quot;
-userAttributes:
-&quot;countryCode&quot;: &quot;KR&quot;
-&quot;department&quot;: &quot;Infra&quot;
-ipAddresses: [&quot;10.10.0.0/24&quot;, &quot;10.11.10.1&quot;]
-deny:
-resources:</li>
-
-</ul>
-
-</li>
-
-<li>&quot;cluster:kubepie-*&quot;
-actions:</li>
-
-<li>apiGroups: [&quot;*&quot;]
-resources:
-<ul>
-<li>&quot;<em>&quot;
-namespace: &quot;production&quot;
-name: &quot;</em>&quot;
-verbs: [&quot;*&quot;]
-conditions:
-resourceTags:
-&quot;Owner&quot;: &quot;Brant&quot;</li>
-
-</ul>
-
 </li>
 
 </ul>
 
-<pre><code></code></pre>
+<h3>KAC Policy 예시</h3>
+
+<pre><code>apiVersion: kubernetes.rbac.querypie.com/v1 
+kind: KacPolicy
+
+spec:
+  allow: 
+    resources: 
+      - &quot;cluster:*&quot;
+    subjects: 
+      kubernetesGroups: 
+        - &quot;system:masters&quot;
+      impersonation: 
+        users: [&quot;system:serviceaccount:argocd&quot;] 
+        groups: [&quot;system:admin&quot;]  
+    actions: 
+      - apiGroups: [&quot;*&quot;] 
+        resources: 
+          - &quot;pods&quot;
+        namespace: &quot;*&quot; 
+        name: &quot;*&quot; 
+        verbs: [&quot;get&quot;, &quot;list&quot;, &quot;watch&quot;]
+    conditions: 
+      resourceTags: 
+        &quot;Owner&quot;: [&quot;Kenny&quot;, &quot;Brant&quot;]
+        &quot;Team&quot;: &quot;DevSecOps&quot; 
+      userAttributes: 
+        &quot;countryCode&quot;: &quot;KR&quot;
+        &quot;department&quot;: &quot;Infra&quot;
+      ipAddresses: [&quot;10.10.0.0/24&quot;, &quot;10.11.10.1&quot;] 
+  deny: 
+    resources: 
+      - &quot;cluster:kubepie-*&quot;
+    actions: 
+      - apiGroups: [&quot;*&quot;]
+        resources: 
+          - &quot;*&quot;
+        namespace: &quot;production&quot;
+        name: &quot;*&quot;
+        verbs: [&quot;*&quot;]
+    conditions: 
+      resourceTags: 
+        &quot;Owner&quot;: &quot;Brant&quot;
+</code></pre>

--- a/confluence-mdx/tests/testcases/544382364/expected.mdx
+++ b/confluence-mdx/tests/testcases/544382364/expected.mdx
@@ -229,25 +229,25 @@ O
             * Impersonation을 위한 해당 subjects는 다른 Policy들과 하나의 Role 내에서 중첩이 가능합니다.
         * Resources에 명시된 리소스에 대한 권한 수행이 가능한 kubernetes 측 그룹(단일 또는 복수)을 정의합니다.
           ```
-kubernetesGroups: 
-  - system:masters
-  - default-group-account
+          kubernetesGroups: 
+            - system:masters
+            - default-group-account
           ```
         * kubernetesGroups에는 Querypie User의 Group을 예약어 형태로 입력할 수 있습니다. 이 때, User의 Group은 쌍따옴표(“) 없이 입력 입력되어야 하며, 사용자가 Policy를 볼 땐 실제 user Group의 값이 표시됩니다.
           ```
-kubernetesGroups: 
-  - $user.groups
+          kubernetesGroups: 
+            - $user.groups
           ```
 2. `impersonation`: <Badge color="yellow">OPTIONAL</Badge>
     * 사용자가 클라이언트 단에서 kubernetes 내 특정 serviceaccount 등의 권한으로 kubectl 명령에 impersonation(--as, --as-group)을 시도하는 경우, 이에 대한 호출 허용 목록을 정의합니다.
         * `users`: 쿠버네티스 내 존재하는 사용자/서비스 계정으로 "--as" 파라미터에 허용 가능한 값을 나열합니다.
         * `groups`: 쿠버네티스 내 존재하는 그룹 계정으로 "--as-group" 파라미터에 허용 가능한 값을 나열합니다.
           ```
-impersonation: 
-  users: 
-    - "system:serviceaccount:argocd"
-  groups: 
-    - "system:admin"
+          impersonation: 
+            users: 
+              - "system:serviceaccount:argocd"
+            groups: 
+              - "system:admin"
           ```
         * 와일드카드를 허용합니다. (`"*"`)
 
@@ -272,10 +272,10 @@ impersonation:
     3. 네임스페이스 하위 리소스만 지정하여 권한을 부여하더라도, Namespace에 대한 ReadOnly 권한이 함께 부여됩니다. 따라서, 리소스 호출 시 매번 네임스페이스 명시해주어야 하는 사례가 발생되지 않습니다. 특정 네임스페이스에 대한 권한 부여를 방지하고자 하는 경우, `spec:deny` 에서 네임스페이스 리소스에 대한 접근 거부를 설정할 수 있습니다. 
     4. 단일 정책 액션에서 다중으로 리소스 지정이 가능합니다. 
       ```
- resources:
-   - "pods"
-   - "deployments"
-   - "configmaps"
+       resources:
+         - "pods"
+         - "deployments"
+         - "configmaps"
       ```
     5. 와일드카드를 허용합니다. (`"*"`)
 3. `namespace` : 대상 네임스페이스를 정의합니다. 
@@ -312,19 +312,19 @@ impersonation:
 
 * `resourceTags` : 태그 항목에서는 리소스 태그의 키와 값으로 필터링할 수 있습니다. 
   ```
-resourceTags: 
-  "region": "ap-northeast-1"
-  "Owner": "Brant"
+  resourceTags: 
+    "region": "ap-northeast-1"
+    "Owner": "Brant"
   ```
 * `userAttributes` : 사용자의 속성(attribute)을 조건으로 지정하고 값이 매칭되는 사용자에 한해서만 해당 정책에서 정의된 권한의 사용을 제한합니다. 
   ```
-userAttributes: 
-  "countryCode": "KR"
-  "department": "Infra"
+  userAttributes: 
+    "countryCode": "KR"
+    "department": "Infra"
   ```
 * `ipAddresses` : 리소스에 대한 IP 접근 통제 조건 리스트를 단일IP, CIDR 형태으로 정의합니다. 
   ```
-ipAddresses: ["10.10.0.0/24", "10.11.10.1"]
+  ipAddresses: ["10.10.0.0/24", "10.11.10.1"]
   ```
 
 

--- a/confluence-mdx/tests/testcases/883654669/expected.html
+++ b/confluence-mdx/tests/testcases/883654669/expected.html
@@ -48,32 +48,32 @@
 </ol>
 
 <pre><code>{
-  &quot;display_information&quot;: {
-      &quot;name&quot;: &quot;{{name}}&quot;
-  },
-  &quot;features&quot;: {
-      &quot;bot_user&quot;: {
-          &quot;display_name&quot;: &quot;{{display_name}}&quot;,
-          &quot;always_online&quot;: false
-      }
-  },
-  &quot;oauth_config&quot;: {
-      &quot;scopes&quot;: {
-          &quot;bot&quot;: [
-              &quot;chat:write&quot;,
-              &quot;users:read.email&quot;,
-              &quot;users:read&quot;
-          ]
-      }
-  },
-  &quot;settings&quot;: {
-      &quot;interactivity&quot;: {
-          &quot;is_enabled&quot;: true
-      },
-      &quot;org_deploy_enabled&quot;: false,
-      &quot;socket_mode_enabled&quot;: true,
-      &quot;token_rotation_enabled&quot;: false
-  }
+    &quot;display_information&quot;: {
+        &quot;name&quot;: &quot;{{name}}&quot;
+    },
+    &quot;features&quot;: {
+        &quot;bot_user&quot;: {
+            &quot;display_name&quot;: &quot;{{display_name}}&quot;,
+            &quot;always_online&quot;: false
+        }
+    },
+    &quot;oauth_config&quot;: {
+        &quot;scopes&quot;: {
+            &quot;bot&quot;: [
+                &quot;chat:write&quot;,
+                &quot;users:read.email&quot;,
+                &quot;users:read&quot;
+            ]
+        }
+    },
+    &quot;settings&quot;: {
+        &quot;interactivity&quot;: {
+            &quot;is_enabled&quot;: true
+        },
+        &quot;org_deploy_enabled&quot;: false,
+        &quot;socket_mode_enabled&quot;: true,
+        &quot;token_rotation_enabled&quot;: false
+    }
 }
 </code></pre>
 

--- a/confluence-mdx/tests/testcases/883654669/expected.mdx
+++ b/confluence-mdx/tests/testcases/883654669/expected.mdx
@@ -39,34 +39,34 @@ App Manifest를 이용하여 QueryPie DM 연동 전용 Slack App을 생성합니
   </figure>
 4. Create app from manifest 모달에서 JSON 형식의 App Manifest를 입력합니다. <br/>미리 채워져 있는 내용들을 삭제하고 아래의 App Manifest를 붙여넣은 뒤 다음 단계로 진행합니다.<br/>:light_bulb_on: `{{..}}` 안의 값은 원하는 값으로 변경해 주세요. <br/> 
   ```
-{
-    "display_information": {
-        "name": "{{name}}"
-    },
-    "features": {
-        "bot_user": {
-            "display_name": "{{display_name}}",
-            "always_online": false
-        }
-    },
-    "oauth_config": {
-        "scopes": {
-            "bot": [
-                "chat:write",
-                "users:read.email",
-                "users:read"
-            ]
-        }
-    },
-    "settings": {
-        "interactivity": {
-            "is_enabled": true
-        },
-        "org_deploy_enabled": false,
-        "socket_mode_enabled": true,
-        "token_rotation_enabled": false
-    }
-}
+  {
+      "display_information": {
+          "name": "{{name}}"
+      },
+      "features": {
+          "bot_user": {
+              "display_name": "{{display_name}}",
+              "always_online": false
+          }
+      },
+      "oauth_config": {
+          "scopes": {
+              "bot": [
+                  "chat:write",
+                  "users:read.email",
+                  "users:read"
+              ]
+          }
+      },
+      "settings": {
+          "interactivity": {
+              "is_enabled": true
+          },
+          "org_deploy_enabled": false,
+          "socket_mode_enabled": true,
+          "token_rotation_enabled": false
+      }
+  }
   ```
 5. 설정 내용을 검토하고 `Create` 버튼을 클릭하여 App 생성을 완료합니다.<br/> <br/> 
   <figure data-layout="center" data-align="center">

--- a/confluence-mdx/tests/testcases/883654669/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/883654669/expected.skel.mdx
@@ -39,34 +39,34 @@ _TEXT_
   </figure>
 4. _TEXT_ `_TEXT_` <br/> <br/> <br/>
   ```
-{
-    "display_information": {
-        "name": "{{name}}"
-    },
-    "features": {
-        "bot_user": {
-            "display_name": "{{display_name}}",
-            "always_online": false
-        }
-    },
-    "oauth_config": {
-        "scopes": {
-            "bot": [
-                "chat:write",
-                "users:read.email",
-                "users:read"
-            ]
-        }
-    },
-    "settings": {
-        "interactivity": {
-            "is_enabled": true
-        },
-        "org_deploy_enabled": false,
-        "socket_mode_enabled": true,
-        "token_rotation_enabled": false
-    }
-}
+  {
+      "display_information": {
+          "name": "{{name}}"
+      },
+      "features": {
+          "bot_user": {
+              "display_name": "{{display_name}}",
+              "always_online": false
+          }
+      },
+      "oauth_config": {
+          "scopes": {
+              "bot": [
+                  "chat:write",
+                  "users:read.email",
+                  "users:read"
+              ]
+          }
+      },
+      "settings": {
+          "interactivity": {
+              "is_enabled": true
+          },
+          "org_deploy_enabled": false,
+          "socket_mode_enabled": true,
+          "token_rotation_enabled": false
+      }
+  }
   ```
 5. _TEXT_ `_TEXT_` <br/><br/>
   <figure data-layout="center" data-align="center">


### PR DESCRIPTION
## Summary
- 리스트 항목 내 코드 블록에서 ` ``` ` 마커만 들여쓰기되고 코드 내용은 0열에서 시작하는 문제 수정
- `convert_structured_macro_code`에서 코드 내용을 줄 단위로 분리
- `convert_li`의 들여쓰기 로직 단순화
- 불필요한 `as_markdown_of_two` 메서드 제거

## 문제 상황
```markdown
* 리스트 항목
  ```
code line 1  ← 들여쓰기 없음
code line 2  ← 들여쓰기 없음
  ```
```
MDX 파서가 코드 블록을 인식 못해 내용이 일반 텍스트로 누출

## 해결 후
```markdown
* 리스트 항목
  ```
  code line 1  ← 들여쓰기 적용
  code line 2  ← 들여쓰기 적용
  ```
```

## 변경 내용
1. `convert_structured_macro_code`: 코드 내용을 줄 단위로 분리
2. `convert_li`: 들여쓰기 로직 단순화 (20줄 → 2줄)
3. `as_markdown_of_two` 메서드 제거 (더 이상 불필요)

## 영향받는 테스트케이스
- 544381877, 544382364, 883654669: 리스트 내 코드 블록 포함 문서

## Test plan
- [x] XHTML 변환 테스트 통과 (20/20)
- [x] Skeleton 테스트 통과 (18/18)
- [x] Render 테스트 통과 (20/20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)