### PR TITLE
feat(reverse_sync): Forward converter 연동으로 round-trip 검증 완성

### DIFF
--- a/confluence-mdx/tests/test_reverse_sync_e2e.py
+++ b/confluence-mdx/tests/test_reverse_sync_e2e.py
@@ -1,13 +1,17 @@
+import os
+import shutil
+
 import pytest
 from pathlib import Path
 from mdx_block_parser import parse_mdx_blocks
 from block_diff import diff_blocks
 from mapping_recorder import record_mapping
 from xhtml_patcher import patch_xhtml
-from reverse_sync import _build_patches
+from reverse_sync import _build_patches, run_verify
 
 
 TESTCASE_DIR = Path(__file__).parent / "testcases" / "793608206"
+VAR_DIR = Path(__file__).parent.parent / "var" / "793608206"
 
 
 @pytest.fixture
@@ -86,3 +90,83 @@ def test_e2e_mapping_covers_mdx_blocks(testcase_data):
     # 매핑의 heading 수와 MDX heading 수가 비슷해야 함
     assert len(heading_mappings) > 0, "XHTML에서 heading 매핑이 추출되어야 함"
     assert len(heading_blocks) > 0, "MDX에서 heading 블록이 파싱되어야 함"
+
+
+class TestE2ERoundTrip:
+    """실제 forward converter를 사용한 round-trip 검증 테스트."""
+
+    @pytest.fixture
+    def setup_var_793608206(self, tmp_path, monkeypatch):
+        """var/793608206/ 구조를 tmp_path에 복사하고 작업 디렉토리 변경."""
+        if not VAR_DIR.exists():
+            pytest.skip("var/793608206 not found")
+        monkeypatch.chdir(tmp_path)
+        dest = tmp_path / "var" / "793608206"
+        shutil.copytree(VAR_DIR, dest)
+        # pages.yaml도 복사 (converter가 {input_dir}/../pages.yaml 을 참조)
+        pages_yaml = VAR_DIR.parent / "pages.yaml"
+        if pages_yaml.exists():
+            shutil.copy2(pages_yaml, tmp_path / "var" / "pages.yaml")
+        return dest
+
+    def test_roundtrip_no_changes(self, setup_var_793608206, tmp_path):
+        """변경 없으면 no_changes 상태."""
+        var_dir = setup_var_793608206
+        mdx_path = TESTCASE_DIR / "expected.mdx"
+        if not mdx_path.exists():
+            pytest.skip("expected.mdx not found")
+
+        original = tmp_path / "original.mdx"
+        improved = tmp_path / "improved.mdx"
+        mdx_content = mdx_path.read_text()
+        original.write_text(mdx_content)
+        improved.write_text(mdx_content)
+
+        result = run_verify(
+            page_id="793608206",
+            original_mdx_path=str(original),
+            improved_mdx_path=str(improved),
+        )
+        assert result['status'] == 'no_changes'
+
+    def test_roundtrip_with_text_change(self, setup_var_793608206, tmp_path):
+        """텍스트 변경 후 full round-trip: forward converter를 실제 호출."""
+        var_dir = setup_var_793608206
+        mdx_path = TESTCASE_DIR / "expected.mdx"
+        if not mdx_path.exists():
+            pytest.skip("expected.mdx not found")
+
+        original_mdx = mdx_path.read_text()
+
+        # paragraph 블록에서 텍스트 변경
+        original_blocks = parse_mdx_blocks(original_mdx)
+        paragraph_blocks = [b for b in original_blocks if b.type == 'paragraph']
+        if not paragraph_blocks:
+            pytest.skip("No paragraph blocks in test data")
+
+        target_text = paragraph_blocks[0].content.strip()
+        if '.' in target_text:
+            improved_mdx = original_mdx.replace(
+                target_text, target_text.replace('.', '!', 1), 1)
+        else:
+            improved_mdx = original_mdx.replace(
+                target_text, target_text + ' (수정됨)', 1)
+
+        if improved_mdx == original_mdx:
+            pytest.skip("변경 적용 불가")
+
+        original = tmp_path / "original.mdx"
+        improved = tmp_path / "improved.mdx"
+        original.write_text(original_mdx)
+        improved.write_text(improved_mdx)
+
+        result = run_verify(
+            page_id="793608206",
+            original_mdx_path=str(original),
+            improved_mdx_path=str(improved),
+        )
+        assert result['status'] in ('pass', 'fail')
+        assert result['changes_count'] > 0
+        assert result['verification']['exact_match'] is not None
+        # verify.mdx 파일이 생성되었는지 확인
+        assert (var_dir / "rsync" / "verify.mdx").exists()


### PR DESCRIPTION
## Summary
- `reverse_sync.py`의 verify 파이프라인에서 미구현이던 forward converter 호출(Step 6-7)을 완성합니다
- `_forward_convert()` 함수를 추가하여 subprocess로 `confluence_xhtml_to_markdown.py`를 호출, patched XHTML → MDX 변환을 수행합니다
- 임시 파일 복사 방식으로 기존 `page.v1.yaml`, `pages.yaml` 메타데이터를 그대로 활용합니다
- 기존 임시 상태 `patched`를 실제 `pass`/`fail` 상태로 대체하여 round-trip 검증이 동작합니다

## Test plan
- [x] 단위 테스트: forward converter mock으로 pass/fail 경로 검증 (test_reverse_sync.py)
- [x] E2E 테스트: 실제 testcase 793608206 데이터로 full round-trip 검증 (test_reverse_sync_e2e.py)
- [x] 기존 테스트 30개 전체 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)