### PR TITLE
chore(scripts/deploy): Dependabot 보안 취약점 패키지 업데이트

### DIFF
--- a/scripts/deploy/package-lock.json
+++ b/scripts/deploy/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "querypie-docs-deploy",
       "devDependencies": {
-        "@vercel/sdk": "^1.18.7",
+        "@vercel/sdk": "^1.19.1",
         "dotenv": "^17.2.3"
       }
     },
@@ -24,9 +24,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.25.3",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.3.tgz",
-      "integrity": "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
+      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -38,14 +38,15 @@
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
-        "jose": "^6.1.1",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
         "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
         "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.0"
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
@@ -64,12 +65,12 @@
       }
     },
     "node_modules/@vercel/sdk": {
-      "version": "1.18.7",
-      "resolved": "https://registry.npmjs.org/@vercel/sdk/-/sdk-1.18.7.tgz",
-      "integrity": "sha512-2PwPnlkOEj0H7ieSZW1CPYdqgWBhahlaDpwPLk5RtnAwjB3TqqzQIASBrl9Hj+uZrUeXJR2Lt8A+ONaaYMNAfA==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@vercel/sdk/-/sdk-1.19.1.tgz",
+      "integrity": "sha512-K4rmtUT6t1vX06tiY44ot8A7W1FKN7g/tMkE7yZghCgNQ8b30SzljBd4ni8RNp2pJzM/HrZmphRDeIArO7oZuw==",
       "dev": true,
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.24.0",
+        "@modelcontextprotocol/sdk": "^1.26.0",
         "zod": "^3.25.0 || ^4.0.0"
       },
       "bin": {
@@ -459,11 +460,14 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -629,12 +633,11 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.5.tgz",
-      "integrity": "sha512-WemPi9/WfyMwZs+ZUXdiwcCh9Y+m7L+8vki9MzDw3jJ+W9Lc+12HGsd368Qc1vZi1xwW8BWMMsnK5efYKPdt4g==",
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.8.tgz",
+      "integrity": "sha512-eVkB/CYCCei7K2WElZW9yYQFWssG0DhaDhVvr7wy5jJ22K+ck8fWW0EsLpB0sITUTvPnc97+rrbQqIr5iqiy9Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -683,6 +686,16 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/scripts/deploy/package.json
+++ b/scripts/deploy/package.json
@@ -6,7 +6,7 @@
     "delete-deploy": "node delete-deploy.js"
   },
   "devDependencies": {
-    "@vercel/sdk": "^1.18.7",
+    "@vercel/sdk": "^1.19.1",
     "dotenv": "^17.2.3"
   }
 }


### PR DESCRIPTION
## Description
- `scripts/deploy/` 디렉토리의 Dependabot 보안 경고를 해결합니다.
- `@vercel/sdk`를 1.19.1로 업데이트하여 전이적 의존성의 취약점을 수정합니다.

### 수정된 보안 취약점
| 패키지 | 이전 버전 | 수정 버전 | 심각도 | 취약점 |
|--------|----------|----------|--------|--------|
| `@modelcontextprotocol/sdk` | 1.25.3 | 1.26.0 | high | Cross-client data leak via shared server/transport instance reuse |
| `hono` | 4.11.5 | 4.11.8 | medium | XSS through ErrorBoundary component |
| `hono` | 4.11.5 | 4.11.8 | medium | Arbitrary Key Read in Serve static Middleware |
| `hono` | 4.11.5 | 4.11.8 | medium | Cache middleware ignores "Cache-Control: private" (Web Cache Deception) |

### 근본 원인
- `@vercel/sdk@1.18.7` → `@modelcontextprotocol/sdk@^1.24.0` → `@hono/node-server` → `hono@^4`
- `@vercel/sdk`를 `1.19.1`로 업데이트하면 `@modelcontextprotocol/sdk@^1.26.0`을 요구하여 모든 전이적 의존성이 함께 수정됩니다.

## Related tickets & links
- https://github.com/querypie/querypie-docs/security/dependabot

## Added/updated tests?
- [ ] Yes
- [x] No, and this is why: `deploy 스크립트의 패키지 버전 업데이트이므로 별도 테스트 불필요`

## Additional notes
- `npm audit` 결과 0 vulnerabilities 확인
- 이전 PR #607에서 루트 패키지의 보안 경고 5건은 이미 수정 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)