### PR TITLE
feat(reverse_sync): push 커맨드 구현

### DIFF
--- a/confluence-mdx/bin/reverse_sync/confluence_client.py
+++ b/confluence-mdx/bin/reverse_sync/confluence_client.py
@@ -1,0 +1,52 @@
+"""Confluence API 클라이언트 — reverse sync push용."""
+import os
+
+import requests
+from dataclasses import dataclass, field
+from typing import Dict, Any
+
+
+def _env(key: str) -> str:
+    return os.environ.get(key, '')
+
+
+@dataclass
+class ConfluenceConfig:
+    base_url: str = "https://querypie.atlassian.net/wiki"
+    email: str = field(default_factory=lambda: _env('ATLASSIAN_USERNAME'))
+    api_token: str = field(default_factory=lambda: _env('ATLASSIAN_API_TOKEN'))
+
+
+def get_page_version(config: ConfluenceConfig, page_id: str) -> Dict[str, Any]:
+    """페이지의 현재 version number와 title을 조회한다."""
+    url = f"{config.base_url}/rest/api/content/{page_id}?expand=version"
+    resp = requests.get(url, auth=(config.email, config.api_token),
+                        headers={"Accept": "application/json"})
+    resp.raise_for_status()
+    data = resp.json()
+    return {
+        'version': data['version']['number'],
+        'title': data['title'],
+    }
+
+
+def update_page_body(config: ConfluenceConfig, page_id: str,
+                     title: str, version: int, xhtml_body: str) -> Dict[str, Any]:
+    """페이지의 body를 업데이트한다."""
+    url = f"{config.base_url}/rest/api/content/{page_id}"
+    payload = {
+        "type": "page",
+        "title": title,
+        "version": {"number": version},
+        "body": {
+            "storage": {
+                "value": xhtml_body,
+                "representation": "storage",
+            }
+        },
+    }
+    resp = requests.put(url, json=payload, auth=(config.email, config.api_token),
+                        headers={"Content-Type": "application/json",
+                                 "Accept": "application/json"})
+    resp.raise_for_status()
+    return resp.json()


### PR DESCRIPTION
## Summary
- Confluence API 클라이언트 모듈 신규 생성 (`bin/reverse_sync/confluence_client.py`) — GET version 조회 + PUT body 업데이트
- `reverse_sync_cli.py`의 push stub을 실제 구현으로 교체 — verify pass 검증 → 최신 version API 조회 → XHTML 업로드
- push 커맨드 테스트 3건 추가 (verify 미실행 에러, non-pass 에러, mock API 정상 push)

## Test plan
- [x] `test_push_requires_verify_first` — result.yaml 없으면 exit 1
- [x] `test_push_rejects_non_pass` — status != pass이면 exit 1
- [x] `test_push_success` — mock API로 version 조회 → +1 increment → 업데이트 확인
- [x] 기존 88개 테스트 전체 통과 (회귀 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)