### PR TITLE
refactor(reverse_sync): conf 파일 기반 인증으로 변경

### DIFF
--- a/confluence-mdx/bin/reverse_sync_cli.py
+++ b/confluence-mdx/bin/reverse_sync_cli.py
@@ -233,7 +233,7 @@ def main():
         from reverse_sync.confluence_client import ConfluenceConfig, get_page_version, update_page_body
         config = ConfluenceConfig()
         if not config.email or not config.api_token:
-            print('Error: ATLASSIAN_USERNAME, ATLASSIAN_API_TOKEN 환경변수를 설정하세요.')
+            print('Error: ~/.config/atlassian/confluence.conf 파일을 설정하세요. (형식: email:api_token)')
             sys.exit(1)
 
         # 최신 버전 조회

--- a/confluence-mdx/tests/test_reverse_sync_cli.py
+++ b/confluence-mdx/tests/test_reverse_sync_cli.py
@@ -135,8 +135,6 @@ def test_push_success(setup_push_var, monkeypatch):
         yaml.dump({'status': 'pass', 'page_id': page_id}))
     (var_dir / 'reverse-sync.patched.xhtml').write_text('<p>Updated content</p>')
 
-    monkeypatch.setenv('ATLASSIAN_USERNAME', 'test@example.com')
-    monkeypatch.setenv('ATLASSIAN_API_TOKEN', 'test-token')
     monkeypatch.setattr('sys.argv', ['reverse_sync_cli.py', 'push', '--page-id', page_id])
 
     mock_get_version = MagicMock(return_value={'version': 5, 'title': 'Test Page'})
@@ -145,8 +143,10 @@ def test_push_success(setup_push_var, monkeypatch):
         'version': {'number': 6},
         '_links': {'webui': '/spaces/QP/pages/test-page-001'},
     })
+    mock_load = MagicMock(return_value=('test@example.com', 'test-token'))
 
-    with patch('reverse_sync.confluence_client.get_page_version', mock_get_version), \
+    with patch('reverse_sync.confluence_client._load_credentials', mock_load), \
+         patch('reverse_sync.confluence_client.get_page_version', mock_get_version), \
          patch('reverse_sync.confluence_client.update_page_body', mock_update), \
          patch('builtins.print') as mock_print:
         main()


### PR DESCRIPTION
## Summary
- `confluence_client.py`에서 환경변수(`ATLASSIAN_USERNAME`, `ATLASSIAN_API_TOKEN`) 의존 제거
- `~/.config/atlassian/confluence.conf` (email:token 형식)에서 인증 정보를 로드하도록 변경
- `bin/confluence` bash CLI와 동일한 인증 방식 사용

## Test plan
- [x] `_load_credentials()`가 conf 파일에서 email:token을 파싱
- [x] conf 파일 없을 때 빈 문자열 반환 → CLI에서 에러 메시지 출력
- [x] 88개 전체 테스트 통과 (회귀 없음)
- [x] 실제 push 동작 확인 (page 1911652402, version 1→2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)