### PR TITLE
feat(reverse_sync): verify 커맨드에 git ref 지원 추가

### DIFF
--- a/confluence-mdx/tests/test_reverse_sync_cli.py
+++ b/confluence-mdx/tests/test_reverse_sync_cli.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
-from reverse_sync_cli import run_verify, main
+from reverse_sync_cli import run_verify, main, MdxSource, _resolve_mdx_source
 
 
 @pytest.fixture
@@ -22,15 +22,11 @@ def test_verify_no_changes(setup_var, tmp_path):
     """변경 없으면 no_changes, rsync/result.yaml 생성."""
     page_id, var_dir = setup_var
     mdx_content = "## Title\n\nParagraph.\n"
-    original = tmp_path / "original.mdx"
-    improved = tmp_path / "improved.mdx"
-    original.write_text(mdx_content)
-    improved.write_text(mdx_content)
 
     result = run_verify(
         page_id=page_id,
-        original_mdx_path=str(original),
-        improved_mdx_path=str(improved),
+        original_src=MdxSource(content=mdx_content, descriptor="original.mdx"),
+        improved_src=MdxSource(content=mdx_content, descriptor="improved.mdx"),
     )
     assert result['status'] == 'no_changes'
     assert (var_dir / "reverse-sync.result.yaml").exists()
@@ -39,10 +35,6 @@ def test_verify_no_changes(setup_var, tmp_path):
 def test_verify_detects_changes(setup_var, tmp_path):
     """텍스트 변경 감지 + forward 변환 mock으로 roundtrip 검증."""
     page_id, var_dir = setup_var
-    original = tmp_path / "original.mdx"
-    improved = tmp_path / "improved.mdx"
-    original.write_text("## Title\n\nParagraph.\n")
-    improved.write_text("## Title\n\nModified.\n")
 
     # forward converter를 mock: verify.mdx에 improved_mdx 내용을 그대로 써서 pass 유도
     def mock_forward_convert(patched_xhtml_path, output_mdx_path, page_id):
@@ -52,8 +44,8 @@ def test_verify_detects_changes(setup_var, tmp_path):
     with patch('reverse_sync_cli._forward_convert', side_effect=mock_forward_convert):
         result = run_verify(
             page_id=page_id,
-            original_mdx_path=str(original),
-            improved_mdx_path=str(improved),
+            original_src=MdxSource(content="## Title\n\nParagraph.\n", descriptor="original.mdx"),
+            improved_src=MdxSource(content="## Title\n\nModified.\n", descriptor="improved.mdx"),
         )
     assert result['changes_count'] == 1
     assert result['status'] == 'pass'
@@ -66,13 +58,9 @@ def test_verify_detects_changes(setup_var, tmp_path):
     assert (var_dir / "reverse-sync.result.yaml").exists()
 
 
-def test_verify_roundtrip_fail(setup_var, tmp_path):
+def test_verify_roundtrip_fail(setup_var):
     """forward 변환 결과가 다르면 status=fail."""
     page_id, var_dir = setup_var
-    original = tmp_path / "original.mdx"
-    improved = tmp_path / "improved.mdx"
-    original.write_text("## Title\n\nParagraph.\n")
-    improved.write_text("## Title\n\nModified.\n")
 
     def mock_forward_convert(patched_xhtml_path, output_mdx_path, page_id):
         # 다른 내용을 반환하여 roundtrip 실패 유도
@@ -83,8 +71,8 @@ def test_verify_roundtrip_fail(setup_var, tmp_path):
     with patch('reverse_sync_cli._forward_convert', side_effect=mock_forward_convert):
         result = run_verify(
             page_id=page_id,
-            original_mdx_path=str(original),
-            improved_mdx_path=str(improved),
+            original_src=MdxSource(content="## Title\n\nParagraph.\n", descriptor="original.mdx"),
+            improved_src=MdxSource(content="## Title\n\nModified.\n", descriptor="improved.mdx"),
         )
     assert result['status'] == 'fail'
     assert result['verification']['exact_match'] is False
@@ -170,3 +158,44 @@ def test_push_success(setup_push_var, monkeypatch):
     assert result['page_id'] == page_id
     assert result['version'] == 6
     assert result['title'] == 'Test Page'
+
+
+# --- _resolve_mdx_source tests ---
+
+
+def test_resolve_mdx_source_file_path(tmp_path):
+    """파일 경로로 MdxSource를 생성한다."""
+    mdx_file = tmp_path / "test.mdx"
+    mdx_file.write_text("## Hello\n")
+    src = _resolve_mdx_source(str(mdx_file), "dummy-page-id")
+    assert src.content == "## Hello\n"
+    assert src.descriptor == str(mdx_file)
+
+
+def test_resolve_mdx_source_ref_path():
+    """ref:path 형식으로 MdxSource를 생성한다."""
+    with patch('reverse_sync_cli._is_valid_git_ref', return_value=True), \
+         patch('reverse_sync_cli._get_file_from_git', return_value="## From Git\n"):
+        src = _resolve_mdx_source("main:src/content/ko/test.mdx", "dummy")
+    assert src.content == "## From Git\n"
+    assert src.descriptor == "main:src/content/ko/test.mdx"
+
+
+def test_resolve_mdx_source_bare_ref():
+    """bare ref로 pages.yaml에서 경로를 유도하여 MdxSource를 생성한다."""
+    with patch('reverse_sync_cli._is_valid_git_ref', return_value=True), \
+         patch('reverse_sync_cli._resolve_mdx_path_from_page_id',
+               return_value='src/content/ko/user-manual/user-agent.mdx'), \
+         patch('reverse_sync_cli._get_file_from_git', return_value="## Agent\n"), \
+         patch('pathlib.Path.is_file', return_value=False):
+        src = _resolve_mdx_source("main", "544112828")
+    assert src.content == "## Agent\n"
+    assert src.descriptor == "main:src/content/ko/user-manual/user-agent.mdx"
+
+
+def test_resolve_mdx_source_invalid():
+    """유효하지 않은 인자는 ValueError를 발생시킨다."""
+    with patch('reverse_sync_cli._is_valid_git_ref', return_value=False), \
+         patch('pathlib.Path.is_file', return_value=False):
+        with pytest.raises(ValueError, match="Cannot resolve MDX source"):
+            _resolve_mdx_source("nonexistent", "dummy")


### PR DESCRIPTION
## Summary
- `--original-mdx`/`--improved-mdx` 인자가 파일 경로 외에 `ref:path`(예: `main:src/content/ko/user-manual/user-agent.mdx`), bare ref(예: `main`)도 지원
- `MdxSource` dataclass 도입으로 `run_verify()` 시그니처 개선
- 3-tier 해석: ref:path → 파일 경로 → bare ref (pages.yaml로 경로 자동 유도)

## Test plan
- [x] pytest 15/15 passed (unit + e2e)
- [x] shell e2e 14/14 passed (`make test-reverse-sync`)
- [x] 기존 파일 경로 방식 하위 호환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)