### PR TITLE
refactor(reverse_sync): --page-id 제거 및 CLI 간소화

### DIFF
--- a/confluence-mdx/bin/reverse_sync_test_verify.py
+++ b/confluence-mdx/bin/reverse_sync_test_verify.py
@@ -1,0 +1,39 @@
+"""run-tests.sh용 thin wrapper — run_verify()를 page_id와 함께 직접 호출한다.
+
+Usage:
+    python reverse_sync_test_verify.py <page_id> <original_mdx_path> <improved_mdx_path> <xhtml_path>
+"""
+import json
+import sys
+
+from reverse_sync_cli import run_verify, MdxSource
+
+
+def main():
+    if len(sys.argv) != 5:
+        print(f'Usage: {sys.argv[0]} <page_id> <original_mdx> <improved_mdx> <xhtml>',
+              file=sys.stderr)
+        sys.exit(1)
+
+    page_id, original_path, improved_path, xhtml_path = sys.argv[1:5]
+
+    original_src = MdxSource(
+        content=open(original_path).read(),
+        descriptor=original_path,
+    )
+    improved_src = MdxSource(
+        content=open(improved_path).read(),
+        descriptor=improved_path,
+    )
+
+    result = run_verify(
+        page_id=page_id,
+        original_src=original_src,
+        improved_src=improved_src,
+        xhtml_path=xhtml_path,
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/confluence-mdx/tests/run-tests.sh
+++ b/confluence-mdx/tests/run-tests.sh
@@ -161,13 +161,13 @@ run_reverse_sync_test() {
     local test_id="$1"
     local test_path="${TEST_DIR}/${test_id}"
 
-    # verify 실행 (cwd를 confluence-mdx root로 이동 — CLI가 var/<page_id>/에 중간 파일을 쓰므로)
+    # verify 실행 (cwd를 confluence-mdx root로 이동 — run_verify()가 var/<page_id>/에 중간 파일을 쓰므로)
     pushd .. > /dev/null
-    run_cmd env PYTHONPATH=bin python bin/reverse_sync_cli.py verify \
-        --page-id "${test_id}" \
-        --original-mdx "tests/${test_path}/original.mdx" \
-        --improved-mdx "tests/${test_path}/improved.mdx" \
-        --xhtml "tests/${test_path}/page.xhtml"
+    run_cmd env PYTHONPATH=bin python3 bin/reverse_sync_test_verify.py \
+        "${test_id}" \
+        "tests/${test_path}/original.mdx" \
+        "tests/${test_path}/improved.mdx" \
+        "tests/${test_path}/page.xhtml"
     popd > /dev/null
 
     # var/에 생성된 중간 파일을 output.*으로 복사


### PR DESCRIPTION
## Summary

- verify/push 커맨드에서 `--page-id` 필수 인자 제거
- MDX 경로에서 `pages.yaml`을 통해 `page_id`를 자동 유도
- `--original-mdx`를 optional로 변경 (기본값: `main:<improved 경로>`)
- push 커맨드: `--page-id` → `--mdx-path`로 변경

### Before
```bash
reverse_sync_cli.py verify \
  --page-id 544112828 \
  --original-mdx "main:src/content/ko/user-manual/user-agent.mdx" \
  --improved-mdx "proofread/fix-typo:src/content/ko/user-manual/user-agent.mdx"

reverse_sync_cli.py push --page-id 544112828
```

### After
```bash
reverse_sync_cli.py verify \
  --improved-mdx "proofread/fix-typo:src/content/ko/user-manual/user-agent.mdx"

reverse_sync_cli.py push \
  --mdx-path src/content/ko/user-manual/user-agent.mdx
```

## Changes

| 파일 | 변경 |
|------|------|
| `bin/reverse_sync_cli.py` | `_resolve_mdx_source()` 2-tier 단순화, `_extract_ko_mdx_path()` + `_resolve_page_id()` 추가, bare ref 및 `_resolve_mdx_path_from_page_id()` 제거 |
| `bin/reverse_sync_test_verify.py` | 신규 — run_verify() 직접 호출 thin wrapper (run-tests.sh용) |
| `tests/test_reverse_sync_cli.py` | push 테스트 `--mdx-path` 적용, bare ref 테스트 제거, `_extract_ko_mdx_path`/`_resolve_page_id` 테스트 추가 |
| `tests/run-tests.sh` | `reverse_sync_test_verify.py` 호출로 변경 |

## Test plan

- [x] `PYTHONPATH=bin python3 -m pytest tests/test_reverse_sync_cli.py tests/test_reverse_sync_e2e.py -v` → **19/19 passed**
- [x] `cd tests && make test-reverse-sync` → **14/14 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)