### PR TITLE
fix(reverse_sync): verify 시 이미지 경로 불일치 수정

### DIFF
--- a/confluence-mdx/bin/confluence_xhtml_to_markdown.py
+++ b/confluence-mdx/bin/confluence_xhtml_to_markdown.py
@@ -2039,7 +2039,8 @@ class ConfluenceToMarkdown:
         else:
             self._imports[module_name] = False
 
-    def load_attachments(self, input_dir: str, output_dir: str, public_dir: str) -> None:
+    def load_attachments(self, input_dir: str, output_dir: str, public_dir: str,
+                         skip_image_copy: bool = False) -> None:
         # Find all ac:image nodes first
         ac_image_nodes = self.soup.find_all('ac:image')
         attachments: List[Attachment] = []
@@ -2049,7 +2050,8 @@ class ConfluenceToMarkdown:
             for node in attachment_nodes:
                 logging.debug(f"add attachment of <ac:image>{node}")
                 attachment = Attachment(node, input_dir, output_dir, public_dir)
-                attachment.copy_to_destination()
+                if not skip_image_copy:
+                    attachment.copy_to_destination()
                 attachments.append(attachment)
 
         logging.debug(f"attachments: {attachments}")
@@ -2154,6 +2156,8 @@ def main():
                         help='/public directory path')
     parser.add_argument('--attachment-dir',
                         help='Directory to save attachments (default: output file directory)')
+    parser.add_argument('--skip-image-copy', action='store_true',
+                        help='이미지 파일 복사를 생략 (경로만 지정대로 생성)')
     parser.add_argument('--log-level',
                         choices=['debug', 'info', 'warning', 'error', 'critical'],
                         default='info',
@@ -2218,7 +2222,8 @@ def main():
         GLOBAL_LINK_MAPPING = build_link_mapping(page_v1)
 
         converter = ConfluenceToMarkdown(html_content)
-        converter.load_attachments(input_dir, output_dir, args.public_dir)
+        converter.load_attachments(input_dir, output_dir, args.public_dir,
+                                   skip_image_copy=args.skip_image_copy)
         markdown_content = converter.as_markdown()
 
         with open(args.output_file, 'w', encoding='utf-8') as f:


### PR DESCRIPTION
## Summary
- `_forward_convert()`가 `--attachment-dir /{page_id}/verify`를 사용하여 roundtrip MDX의 이미지 경로가 원본과 달라지는 문제 수정
- `pages.yaml`에서 page path를 조회하는 `_resolve_attachment_dir()` 추가하여 올바른 attachment-dir 전달
- `confluence_xhtml_to_markdown.py`에 `--skip-image-copy` 옵션 추가하여 검증 시 불필요한 이미지 파일 복사 생략

## Test plan
- [x] pytest 20개 전체 통과 (`test_reverse_sync_cli.py`, `test_reverse_sync_e2e.py`)
- [x] shell e2e 14개 전체 통과 (`make test-reverse-sync`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)