### PR TITLE
refactor(bin): Phase 4 - 유틸리티 정리 및 타입 힌트 개선

### DIFF
--- a/confluence-mdx/bin/converter/core.py
+++ b/confluence-mdx/bin/converter/core.py
@@ -96,7 +96,7 @@ class Attachment:
             # Change file permission to 0644
             os.chmod(destination_file, 0o644)
 
-    def as_markdown(self, caption: Optional[str] = None, width: Optional[str] = None, align: str = None) -> str:
+    def as_markdown(self, caption: Optional[str] = None, width: Optional[str] = None, align: Optional[str] = None) -> str:
         if not caption:
             caption = self.filename
 

--- a/confluence-mdx/bin/pages_of_confluence.py
+++ b/confluence-mdx/bin/pages_of_confluence.py
@@ -59,8 +59,8 @@ class Config:
     default_output_dir: str = "var"
     cache_dir: str = "cache"
     translations_file: str = "etc/korean-titles-translations.txt"
-    email: str = None
-    api_token: str = None
+    email: Optional[str] = None
+    api_token: Optional[str] = None
     download_attachments: bool = False
     mode: str = "recent"  # Mode: "local", "remote", or "recent"
 
@@ -154,9 +154,9 @@ class Page:
     page_id: str
     title: str
     title_orig: str
-    breadcrumbs: List[str] = None
-    breadcrumbs_en: List[str] = None
-    path: List[str] = None
+    breadcrumbs: Optional[List[str]] = None
+    breadcrumbs_en: Optional[List[str]] = None
+    path: Optional[List[str]] = None
 
     def __post_init__(self):
         if self.breadcrumbs is None:

--- a/confluence-mdx/bin/translate_titles.py
+++ b/confluence-mdx/bin/translate_titles.py
@@ -7,16 +7,14 @@ Structure of list.txt in Korean
 - <page_id> \t <first-breadcrumb> ' />> ' <second-breadcrumb> ' />> ' ...
 """
 
-# Paths
-TRANSLATIONS_FILE = "etc/korean-titles-translations.txt"
-INPUT_FILE = "var/list.txt"
-OUTPUT_FILE = "var/list.en.txt"
+import argparse
+import sys
 
 
-def load_translations():
+def load_translations(translations_file: str) -> dict:
     """Load translations from the translations file"""
     translations = {}
-    with open(TRANSLATIONS_FILE, 'r', encoding='utf-8') as f:
+    with open(translations_file, 'r', encoding='utf-8') as f:
         for line in f:
             line = line.strip()
             if not line or line.startswith('#') or '|' not in line:
@@ -32,9 +30,9 @@ def load_translations():
     return translations
 
 
-def translate_file(translations):
-    """Translate Korean titles in list.en.txt to English"""
-    with open(INPUT_FILE, 'r', encoding='utf-8') as f:
+def translate_file(translations: dict, input_file: str, output_file: str) -> None:
+    """Translate Korean titles in input file to English and write to output file"""
+    with open(input_file, 'r', encoding='utf-8') as f:
         content = f.read()
 
     # Sort translations by length (longest first) to avoid partial matches
@@ -47,18 +45,28 @@ def translate_file(translations):
         content = content.replace(f"\t{korean}", f"\t{english}")
 
     # Write the translated content to the output file
-    with open(OUTPUT_FILE, 'w', encoding='utf-8') as f:
+    with open(output_file, 'w', encoding='utf-8') as f:
         f.write(content)
 
 
 def main():
     """Main function"""
-    translations = load_translations()
+    parser = argparse.ArgumentParser(
+        description='Translate Korean titles in list.txt to English')
+    parser.add_argument('--translations', default='etc/korean-titles-translations.txt',
+                        help='Path to translations file (default: etc/korean-titles-translations.txt)')
+    parser.add_argument('--input', default='var/list.txt',
+                        help='Path to input file (default: var/list.txt)')
+    parser.add_argument('--output', default='var/list.en.txt',
+                        help='Path to output file (default: var/list.en.txt)')
+    args = parser.parse_args()
+
+    translations = load_translations(args.translations)
     print(f"Loaded {len(translations)} translations")
 
-    translate_file(translations)
-    print(f"Translated file saved to {OUTPUT_FILE}")
+    translate_file(translations, args.input, args.output)
+    print(f"Translated file saved to {args.output}")
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- `translate_titles.py`: argparse 추가, 하드코딩된 파일 경로를 CLI 인자로 변경
- `pages_of_confluence.py`: Config, Page dataclass 타입 힌트 `Optional` 적용
- `converter/core.py`: `Attachment.as_markdown(align)` 파라미터 `Optional` 적용

## Test plan

- [x] XHTML 변환 테스트 21/21 통과
- [x] pytest 109/109 통과

> 4-Phase 리팩토링 시리즈 (4/4) — base: refactor/bin-phase-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)