### PR TITLE
feat(reverse_sync): MDX→XHTML inner HTML 변환 모듈 추가

### DIFF
--- a/confluence-mdx/bin/reverse_sync/mdx_to_xhtml_inline.py
+++ b/confluence-mdx/bin/reverse_sync/mdx_to_xhtml_inline.py
@@ -1,0 +1,202 @@
+"""MDX block content → XHTML inner HTML 변환 모듈.
+
+MDX 블록의 content를 파싱하여 대상 XHTML 요소의 innerHTML로
+직접 교체할 수 있는 HTML 문자열을 생성한다.
+"""
+import re
+from typing import List
+
+
+def mdx_block_to_inner_xhtml(content: str, block_type: str) -> str:
+    """MDX 블록 content → XHTML inner HTML.
+
+    heading:    "## Title\\n" → "Title"
+    paragraph:  "**bold** and `code`\\n" → "<strong>bold</strong> and <code>code</code>"
+    list:       "* item1\\n* item2\\n" → "<li><p>item1</p></li><li><p>item2</p></li>"
+    code_block: "```\\ncode\\n```\\n" → "code"
+    """
+    text = content.strip()
+
+    if block_type == 'heading':
+        return _convert_heading(text)
+    elif block_type == 'paragraph':
+        return _convert_paragraph(text)
+    elif block_type == 'list':
+        return _convert_list_content(text)
+    elif block_type == 'code_block':
+        return _convert_code_block(text)
+    else:
+        return _convert_inline(text)
+
+
+def _convert_heading(text: str) -> str:
+    """heading: # 마커 제거 후 인라인 변환 (bold는 마커만 제거)."""
+    stripped = re.sub(r'^#+\s+', '', text)
+    # heading 내부의 **bold**는 <strong> 변환 없이 마커만 제거
+    # (forward converter가 heading 내부 strong을 strip하므로)
+    stripped = re.sub(r'\*\*(.+?)\*\*', r'\1', stripped)
+    # code span과 link는 변환
+    stripped = _convert_code_spans(stripped)
+    stripped = _convert_links(stripped)
+    return stripped
+
+
+def _convert_paragraph(text: str) -> str:
+    """paragraph: 인라인 변환 적용. 여러 줄이면 join."""
+    lines = text.split('\n')
+    converted = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        converted.append(_convert_inline(line))
+    return ''.join(converted)
+
+
+def _convert_code_block(text: str) -> str:
+    """code_block: 펜스 마커 제거, 코드 내용만 추출."""
+    lines = text.split('\n')
+    # 첫 줄(```)과 마지막 줄(```) 제거
+    if lines and lines[0].strip().startswith('```'):
+        lines = lines[1:]
+    if lines and lines[-1].strip() == '```':
+        lines = lines[:-1]
+    return '\n'.join(lines)
+
+
+def _convert_inline(text: str) -> str:
+    """인라인 마크다운 → XHTML 변환.
+
+    처리 순서 (충돌 방지):
+    1. code span (`text` → placeholder) — 내부가 bold/link 처리되지 않도록 보호
+    2. bold (**text** → <strong>text</strong>)
+    3. link ([text](url) → <a href="url">text</a>)
+    4. code span placeholder 복원 → <code>text</code>
+    5. HTML entities (&gt;, &lt;) — 이미 XHTML 형식이므로 그대로 유지
+    6. <br/> — 그대로 유지
+    """
+    # 1. code span 추출 → placeholder
+    code_spans: List[str] = []
+    def _replace_code(m):
+        code_spans.append(m.group(1))
+        return f'\x00CODE{len(code_spans) - 1}\x00'
+    text = re.sub(r'`([^`]+)`', _replace_code, text)
+
+    # 2. bold
+    text = re.sub(r'\*\*(.+?)\*\*', r'<strong>\1</strong>', text)
+
+    # 3. link
+    text = re.sub(r'\[([^\]]+)\]\(([^)]+)\)', r'<a href="\2">\1</a>', text)
+
+    # 4. code span placeholder 복원
+    def _restore_code(m):
+        idx = int(m.group(1))
+        return f'<code>{code_spans[idx]}</code>'
+    text = re.sub(r'\x00CODE(\d+)\x00', _restore_code, text)
+
+    return text
+
+
+def _convert_code_spans(text: str) -> str:
+    """code span만 변환 (`text` → <code>text</code>)."""
+    return re.sub(r'`([^`]+)`', r'<code>\1</code>', text)
+
+
+def _convert_links(text: str) -> str:
+    """link만 변환 ([text](url) → <a href="url">text</a>)."""
+    return re.sub(r'\[([^\]]+)\]\(([^)]+)\)', r'<a href="\2">\1</a>', text)
+
+
+def _convert_list_content(text: str) -> str:
+    """리스트 블록 → <li><p>...</p></li> 구조의 inner HTML."""
+    items = _parse_list_items(text)
+    return _render_list_items(items)
+
+
+def _parse_list_items(content: str) -> List[dict]:
+    """리스트 content를 파싱하여 아이템 목록을 반환한다.
+
+    Returns:
+        list of dict: {'indent': int, 'ordered': bool, 'content': str}
+    """
+    lines = content.strip().split('\n')
+    items: List[dict] = []
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        # figure/img 줄 skip
+        if stripped.startswith('<figure') or stripped.startswith('<img') or stripped.startswith('</figure'):
+            continue
+
+        # indent level (공백 수 기준)
+        indent = len(line) - len(line.lstrip())
+
+        # ordered list: "1. ", "2. ", etc.
+        ol_match = re.match(r'^(\d+)\.\s+(.*)', stripped)
+        # unordered list: "* ", "- ", "+ "
+        ul_match = re.match(r'^[-*+]\s+(.*)', stripped)
+
+        if ol_match:
+            items.append({
+                'indent': indent,
+                'ordered': True,
+                'content': ol_match.group(2),
+            })
+        elif ul_match:
+            items.append({
+                'indent': indent,
+                'ordered': False,
+                'content': ul_match.group(1),
+            })
+        else:
+            # continuation line — append to last item
+            if items:
+                items[-1]['content'] += ' ' + stripped
+
+    return items
+
+
+def _render_list_items(items: List[dict]) -> str:
+    """파싱된 리스트 아이템을 <li><p>...</p></li> HTML로 렌더링한다.
+
+    중첩 리스트: indent 기반으로 <li> 안에 <ul>/<ol> 중첩.
+    """
+    if not items:
+        return ''
+
+    result_parts: List[str] = []
+
+    i = 0
+    while i < len(items):
+        item = items[i]
+        inner = _convert_inline(item['content'])
+
+        # 다음 아이템이 더 깊은 indent인지 확인 → 중첩 리스트
+        children_start = i + 1
+        children_end = children_start
+        while children_end < len(items) and items[children_end]['indent'] > item['indent']:
+            children_end += 1
+
+        if children_end > children_start:
+            # 중첩 리스트가 있는 경우
+            child_items = items[children_start:children_end]
+            child_html = _render_nested_list(child_items)
+            result_parts.append(f'<li><p>{inner}</p>{child_html}</li>')
+            i = children_end
+        else:
+            result_parts.append(f'<li><p>{inner}</p></li>')
+            i += 1
+
+    return ''.join(result_parts)
+
+
+def _render_nested_list(items: List[dict]) -> str:
+    """중첩 리스트 아이템을 <ul>/<ol>로 감싸서 렌더링한다."""
+    if not items:
+        return ''
+    ordered = items[0]['ordered']
+    tag = 'ol' if ordered else 'ul'
+    inner = _render_list_items(items)
+    return f'<{tag}>{inner}</{tag}>'

--- a/confluence-mdx/bin/reverse_sync_cli.py
+++ b/confluence-mdx/bin/reverse_sync_cli.py
@@ -20,6 +20,7 @@ from reverse_sync.block_diff import diff_blocks, BlockChange
 from reverse_sync.mapping_recorder import record_mapping, BlockMapping
 from reverse_sync.xhtml_patcher import patch_xhtml
 from reverse_sync.roundtrip_verifier import verify_roundtrip
+from reverse_sync.mdx_to_xhtml_inline import mdx_block_to_inner_xhtml
 
 
 @dataclass
@@ -306,7 +307,7 @@ def _build_patches(
             patches.append({
                 'xhtml_xpath': mapping.xhtml_xpath,
                 'old_plain_text': mapping.xhtml_plain_text,
-                'new_plain_text': _normalize_mdx_to_plain(
+                'new_inner_xhtml': mdx_block_to_inner_xhtml(
                     new_block.content, new_block.type),
             })
 

--- a/confluence-mdx/tests/test_reverse_sync_cli.py
+++ b/confluence-mdx/tests/test_reverse_sync_cli.py
@@ -540,7 +540,7 @@ def test_build_patches_index_mapping():
     assert len(patches) == 1
     assert patches[0]['xhtml_xpath'] == 'p[1]'
     assert patches[0]['old_plain_text'] == 'Old text.'
-    assert patches[0]['new_plain_text'] == 'New text.'
+    assert patches[0]['new_inner_xhtml'] == 'New text.'
 
 
 def test_build_patches_skips_non_content():

--- a/confluence-mdx/tests/test_reverse_sync_mdx_to_xhtml_inline.py
+++ b/confluence-mdx/tests/test_reverse_sync_mdx_to_xhtml_inline.py
@@ -1,0 +1,221 @@
+import pytest
+from reverse_sync.mdx_to_xhtml_inline import (
+    mdx_block_to_inner_xhtml,
+    _convert_inline,
+    _parse_list_items,
+)
+
+
+# --- _convert_inline 단위 테스트 ---
+
+
+class TestConvertInline:
+    def test_plain_text(self):
+        assert _convert_inline("plain text") == "plain text"
+
+    def test_bold(self):
+        assert _convert_inline("**bold**") == "<strong>bold</strong>"
+
+    def test_code(self):
+        assert _convert_inline("`code`") == "<code>code</code>"
+
+    def test_link(self):
+        assert _convert_inline("[text](url)") == '<a href="url">text</a>'
+
+    def test_entities(self):
+        """HTML entities는 그대로 유지."""
+        assert _convert_inline("A &gt; B") == "A &gt; B"
+
+    def test_mixed(self):
+        result = _convert_inline("**Company Name** : text")
+        assert result == "<strong>Company Name</strong> : text"
+
+    def test_bold_and_code(self):
+        result = _convert_inline("**bold** and `code`")
+        assert result == "<strong>bold</strong> and <code>code</code>"
+
+    def test_code_inside_not_bold(self):
+        """code span 내부의 **는 bold 처리되지 않는다."""
+        result = _convert_inline("`**not bold**`")
+        assert result == "<code>**not bold**</code>"
+
+    def test_br_preserved(self):
+        """<br/> 태그는 그대로 유지."""
+        result = _convert_inline("line1<br/>line2")
+        assert result == "line1<br/>line2"
+
+
+# --- mdx_block_to_inner_xhtml 블록 변환 테스트 ---
+
+
+class TestBlockConversion:
+    def test_heading(self):
+        """## Title → Title"""
+        result = mdx_block_to_inner_xhtml("## Title\n", "heading")
+        assert result == "Title"
+
+    def test_heading_strips_bold(self):
+        """heading 내부 **bold**는 마커만 제거."""
+        result = mdx_block_to_inner_xhtml("## **Bold Title**\n", "heading")
+        assert result == "Bold Title"
+
+    def test_heading_with_code(self):
+        """heading 내부 `code`는 변환."""
+        result = mdx_block_to_inner_xhtml("## `Config` 설정\n", "heading")
+        assert result == "<code>Config</code> 설정"
+
+    def test_paragraph_simple(self):
+        result = mdx_block_to_inner_xhtml("Simple paragraph.\n", "paragraph")
+        assert result == "Simple paragraph."
+
+    def test_paragraph_with_code(self):
+        """`User Attribute` → <code>User Attribute</code>"""
+        result = mdx_block_to_inner_xhtml("`User Attribute` 설정\n", "paragraph")
+        assert result == "<code>User Attribute</code> 설정"
+
+    def test_paragraph_with_bold(self):
+        result = mdx_block_to_inner_xhtml("**bold** text\n", "paragraph")
+        assert result == "<strong>bold</strong> text"
+
+    def test_list_bold_items(self):
+        """* **Name** : desc → <li><p><strong>Name</strong> : desc</p></li>"""
+        content = "* **Name** : desc\n"
+        result = mdx_block_to_inner_xhtml(content, "list")
+        assert result == "<li><p><strong>Name</strong> : desc</p></li>"
+
+    def test_list_multiple_items(self):
+        content = "* item1\n* item2\n"
+        result = mdx_block_to_inner_xhtml(content, "list")
+        assert result == "<li><p>item1</p></li><li><p>item2</p></li>"
+
+    def test_list_ordered(self):
+        content = "1. first\n2. second\n"
+        result = mdx_block_to_inner_xhtml(content, "list")
+        assert result == "<li><p>first</p></li><li><p>second</p></li>"
+
+    def test_list_with_figure_skip(self):
+        """figure 줄은 skip."""
+        content = "* item1\n<figure><img src=\"test.png\" /></figure>\n* item2\n"
+        result = mdx_block_to_inner_xhtml(content, "list")
+        assert result == "<li><p>item1</p></li><li><p>item2</p></li>"
+
+    def test_code_block(self):
+        content = "```sql\nSELECT * FROM users;\n```\n"
+        result = mdx_block_to_inner_xhtml(content, "code_block")
+        assert result == "SELECT * FROM users;"
+
+    def test_code_block_multiline(self):
+        content = "```\nline1\nline2\nline3\n```\n"
+        result = mdx_block_to_inner_xhtml(content, "code_block")
+        assert result == "line1\nline2\nline3"
+
+
+# --- _parse_list_items 테스트 ---
+
+
+class TestParseListItems:
+    def test_unordered_list(self):
+        content = "* item1\n* item2\n"
+        items = _parse_list_items(content)
+        assert len(items) == 2
+        assert items[0]['content'] == 'item1'
+        assert items[0]['ordered'] is False
+        assert items[1]['content'] == 'item2'
+
+    def test_ordered_list(self):
+        content = "1. first\n2. second\n"
+        items = _parse_list_items(content)
+        assert len(items) == 2
+        assert items[0]['content'] == 'first'
+        assert items[0]['ordered'] is True
+
+    def test_figure_line_skipped(self):
+        content = "* item1\n<figure><img src=\"x.png\" /></figure>\n* item2\n"
+        items = _parse_list_items(content)
+        assert len(items) == 2
+
+    def test_nested_list(self):
+        content = "* parent\n    * child\n"
+        items = _parse_list_items(content)
+        assert len(items) == 2
+        assert items[0]['indent'] == 0
+        assert items[1]['indent'] == 4
+
+    def test_dash_marker(self):
+        content = "- item1\n- item2\n"
+        items = _parse_list_items(content)
+        assert len(items) == 2
+        assert items[0]['content'] == 'item1'
+
+
+# --- xhtml_patcher _replace_inner_html 통합 테스트 ---
+
+
+class TestReplaceInnerHtml:
+    def test_patch_with_new_inner_xhtml(self):
+        from reverse_sync.xhtml_patcher import patch_xhtml
+
+        xhtml = '<p>Old text</p>'
+        patches = [{
+            'xhtml_xpath': 'p[1]',
+            'old_plain_text': 'Old text',
+            'new_inner_xhtml': '<strong>New</strong> text',
+        }]
+        result = patch_xhtml(xhtml, patches)
+        assert '<strong>New</strong> text' in result
+
+    def test_legacy_path_still_works(self):
+        from reverse_sync.xhtml_patcher import patch_xhtml
+
+        xhtml = '<p>Old text</p>'
+        patches = [{
+            'xhtml_xpath': 'p[1]',
+            'old_plain_text': 'Old text',
+            'new_plain_text': 'New text',
+        }]
+        result = patch_xhtml(xhtml, patches)
+        assert 'New text' in result
+
+    def test_heading_inner_xhtml(self):
+        from reverse_sync.xhtml_patcher import patch_xhtml
+
+        xhtml = '<h2>Old Title</h2>'
+        patches = [{
+            'xhtml_xpath': 'h2[1]',
+            'old_plain_text': 'Old Title',
+            'new_inner_xhtml': 'New Title',
+        }]
+        result = patch_xhtml(xhtml, patches)
+        assert '<h2>New Title</h2>' in result
+
+    def test_list_inner_xhtml(self):
+        from reverse_sync.xhtml_patcher import patch_xhtml
+
+        xhtml = '<ul><li><p>old item</p></li></ul>'
+        patches = [{
+            'xhtml_xpath': 'ul[1]',
+            'old_plain_text': 'old item',
+            'new_inner_xhtml': '<li><p>new item1</p></li><li><p>new item2</p></li>',
+        }]
+        result = patch_xhtml(xhtml, patches)
+        assert '<li><p>new item1</p></li>' in result
+        assert '<li><p>new item2</p></li>' in result
+
+
+# --- 중첩 리스트 테스트 ---
+
+
+class TestNestedList:
+    def test_nested_unordered(self):
+        content = "* parent\n    * child1\n    * child2\n"
+        result = mdx_block_to_inner_xhtml(content, "list")
+        assert '<li><p>parent</p><ul>' in result
+        assert '<li><p>child1</p></li>' in result
+        assert '<li><p>child2</p></li>' in result
+
+    def test_nested_ordered(self):
+        content = "1. parent\n    1. child1\n    2. child2\n"
+        result = mdx_block_to_inner_xhtml(content, "list")
+        assert '<li><p>parent</p><ol>' in result
+        assert '<li><p>child1</p></li>' in result
+        assert '<li><p>child2</p></li>' in result


### PR DESCRIPTION
## Summary

- **`mdx_to_xhtml_inline.py`** 신규 모듈 추가 — MDX 블록 content를 XHTML inner HTML로 직접 변환
  - 인라인 변환(`_convert_inline`): code span, bold, link 처리 (placeholder 전략으로 code 내부 보호)
  - 블록 타입별 처리: heading(bold 마커 strip), paragraph, list(indent 기반 중첩, figure skip), code_block
- **`xhtml_patcher.py`** — `_replace_inner_html()` 추가, `patch_xhtml()`에서 `new_inner_xhtml` 키 지원 (legacy path 유지)
- **`reverse_sync_cli.py`** — `_build_patches()`에서 `mdx_block_to_inner_xhtml()` 호출로 전환
- **32개 단위 테스트** 추가 + 기존 56개 회귀 테스트 전체 통과

기존 difflib 비율 기반 text node 분배 방식의 한계(인라인 서식 변경 불가, 멀티바이트 비율 오류)를 해소.

## Test plan

- [x] `PYTHONPATH=bin pytest tests/test_reverse_sync_mdx_to_xhtml_inline.py -v` — 32 passed
- [x] `PYTHONPATH=bin pytest tests/test_reverse_sync_xhtml_patcher.py tests/test_reverse_sync_cli.py -v` — 37 passed
- [x] `PYTHONPATH=bin pytest tests/test_reverse_sync_e2e.py tests/test_reverse_sync_mapping_recorder.py tests/test_reverse_sync_mdx_block_parser.py tests/test_reverse_sync_roundtrip_verifier.py -v` — 19 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)