### PR TITLE
refactor(tests): test-xhtml → test-convert 이름 변경 및 누락 타겟 추가

### DIFF
--- a/.github/workflows/test-confluence-mdx.yml
+++ b/.github/workflows/test-confluence-mdx.yml
@@ -43,15 +43,27 @@ jobs:
 
       - name: Run Python unit tests
         working-directory: ./confluence-mdx/tests
-        run: ../venv/bin/python -m pytest test_mdx_to_skeleton.py -v
+        run: ../venv/bin/python -m pytest test_mdx_to_skeleton.py test_xhtml_beautify_diff.py -v
 
-      - name: Run XHTML to MDX tests
+      - name: Run XHTML to MDX convert tests
         working-directory: ./confluence-mdx/tests
-        run: make test-xhtml
+        run: make test-convert
 
       - name: Run Skeleton MDX tests
         working-directory: ./confluence-mdx/tests
         run: make test-skeleton
+
+      - name: Run Reverse-Sync tests
+        working-directory: ./confluence-mdx/tests
+        run: make test-reverse-sync
+
+      - name: Run Image-Copy tests
+        working-directory: ./confluence-mdx/tests
+        run: make test-image-copy
+
+      - name: Run XHTML-Diff tests
+        working-directory: ./confluence-mdx/tests
+        run: make test-xhtml-diff
 
       - name: Run MDX Render tests
         working-directory: ./confluence-mdx/tests

--- a/confluence-mdx/tests/Makefile
+++ b/confluence-mdx/tests/Makefile
@@ -7,37 +7,37 @@ PROJECT_ROOT = $(shell cd ../.. && pwd)
 
 # Default target
 .PHONY: all
-all: test-xhtml test-skeleton test-render
+all: test-convert test-skeleton test-render
 	@echo ""
 	@echo "All tests completed."
 
-# Run XHTML tests only
-.PHONY: test-xhtml
-test-xhtml:
-	@$(TEST_SCRIPT) --type xhtml --log-level warning $(VERBOSE_FLAG)
+# Run convert tests (XHTML → MDX)
+.PHONY: test-convert
+test-convert:
+	@$(TEST_SCRIPT) --type convert --log-level warning $(VERBOSE_FLAG)
 
-# Run a specific XHTML test
-.PHONY: test-xhtml-one
-test-xhtml-one:
+# Run a specific convert test
+.PHONY: test-convert-one
+test-convert-one:
 	@if [ -z "$(TEST_ID)" ]; then \
-		echo "Usage: make test-xhtml-one TEST_ID=<test_id>"; \
+		echo "Usage: make test-convert-one TEST_ID=<test_id>"; \
 		exit 1; \
 	fi
-	@$(TEST_SCRIPT) --type xhtml --log-level warning --test-id $(TEST_ID) $(VERBOSE_FLAG)
+	@$(TEST_SCRIPT) --type convert --log-level warning --test-id $(TEST_ID) $(VERBOSE_FLAG)
 
-# Run XHTML tests with debug log level
-.PHONY: debug-xhtml
-debug-xhtml:
-	@$(TEST_SCRIPT) --type xhtml --log-level debug $(VERBOSE_FLAG)
+# Run convert tests with debug log level
+.PHONY: debug-convert
+debug-convert:
+	@$(TEST_SCRIPT) --type convert --log-level debug $(VERBOSE_FLAG)
 
-# Run a specific XHTML test with debug log level
-.PHONY: debug-xhtml-one
-debug-xhtml-one:
+# Run a specific convert test with debug log level
+.PHONY: debug-convert-one
+debug-convert-one:
 	@if [ -z "$(TEST_ID)" ]; then \
-		echo "Usage: make debug-xhtml-one TEST_ID=<test_id>"; \
+		echo "Usage: make debug-convert-one TEST_ID=<test_id>"; \
 		exit 1; \
 	fi
-	@$(TEST_SCRIPT) --type xhtml --log-level debug --test-id $(TEST_ID) $(VERBOSE_FLAG)
+	@$(TEST_SCRIPT) --type convert --log-level debug --test-id $(TEST_ID) $(VERBOSE_FLAG)
 
 # Run skeleton tests
 .PHONY: test-skeleton
@@ -67,6 +67,34 @@ test-reverse-sync-one:
 	fi
 	@$(TEST_SCRIPT) --type reverse-sync --test-id $(TEST_ID) $(VERBOSE_FLAG)
 
+# Run image-copy tests
+.PHONY: test-image-copy
+test-image-copy:
+	@$(TEST_SCRIPT) --type image-copy $(VERBOSE_FLAG)
+
+# Run a specific image-copy test
+.PHONY: test-image-copy-one
+test-image-copy-one:
+	@if [ -z "$(TEST_ID)" ]; then \
+		echo "Usage: make test-image-copy-one TEST_ID=<test_id>"; \
+		exit 1; \
+	fi
+	@$(TEST_SCRIPT) --type image-copy --test-id $(TEST_ID) $(VERBOSE_FLAG)
+
+# Run xhtml-diff tests
+.PHONY: test-xhtml-diff
+test-xhtml-diff:
+	@$(TEST_SCRIPT) --type xhtml-diff $(VERBOSE_FLAG)
+
+# Run a specific xhtml-diff test
+.PHONY: test-xhtml-diff-one
+test-xhtml-diff-one:
+	@if [ -z "$(TEST_ID)" ]; then \
+		echo "Usage: make test-xhtml-diff-one TEST_ID=<test_id>"; \
+		exit 1; \
+	fi
+	@$(TEST_SCRIPT) --type xhtml-diff --test-id $(TEST_ID) $(VERBOSE_FLAG)
+
 # Run render tests (MDX to HTML)
 .PHONY: test-render
 test-render:
@@ -91,32 +119,49 @@ clean:
 	@find testcases -name "_meta.ts" -path "*/output/*" -type f -delete
 	@find testcases -name "output.reverse-sync.*" -type f -delete
 	@find testcases -name "output.mdx.diff" -type f -delete
+	@find testcases -name "output.beautify-diff" -type f -delete
 
 # Help
 .PHONY: help
 help:
 	@echo "Available targets:"
-	@echo "  all                - Run all tests: XHTML + Skeleton + Render (default)"
-	@echo "  test-xhtml         - Run XHTML tests"
-	@echo "  test-xhtml-one     - Run a specific XHTML test"
-	@echo "  test-skeleton      - Run Skeleton tests"
-	@echo "  test-skeleton-one  - Run a specific Skeleton test"
-	@echo "  test-reverse-sync      - Run Reverse-Sync tests"
-	@echo "  test-reverse-sync-one  - Run a specific Reverse-Sync test"
-	@echo "  test-render        - Run Render tests (MDX to HTML)"
-	@echo "  test-render-one    - Run a specific Render test"
-	@echo "  debug-xhtml        - Run XHTML tests with debug log level"
-	@echo "  debug-xhtml-one    - Run a specific XHTML test with debug log level"
-	@echo "  clean              - Remove all output files"
-	@echo "  help               - Show this help message"
+	@echo ""
+	@echo "  all (default)"
+	@echo "    test-convert + test-skeleton + test-render 를 순서대로 실행"
+	@echo ""
+	@echo "  test-convert / test-convert-one"
+	@echo "    XHTML → MDX 정방향 변환. expected.mdx 와 비교"
+	@echo ""
+	@echo "  test-skeleton / test-skeleton-one"
+	@echo "    MDX → skeleton MDX 변환. expected.skel.mdx 와 비교"
+	@echo ""
+	@echo "  test-reverse-sync / test-reverse-sync-one"
+	@echo "    MDX 편집분을 XHTML 에 역패치."
+	@echo "    patched.xhtml, diff.yaml 등 5개 산출물 비교"
+	@echo ""
+	@echo "  test-image-copy / test-image-copy-one"
+	@echo "    이미지 파일 복사 및 파일명 sanitize 검증"
+	@echo ""
+	@echo "  test-xhtml-diff / test-xhtml-diff-one"
+	@echo "    page.xhtml ↔ patched.xhtml beautify-diff."
+	@echo "    serializer 부산물 무시, 실제 변경만 검증"
+	@echo ""
+	@echo "  test-render / test-render-one"
+	@echo "    MDX → HTML 렌더링(vitest). expected.html 과 비교"
+	@echo ""
+	@echo "  debug-convert / debug-convert-one"
+	@echo "    test-convert 와 동일하나 debug 로그 출력"
+	@echo ""
+	@echo "  clean    output.* 생성 파일 삭제"
+	@echo "  help     이 도움말"
 	@echo ""
 	@echo "Options:"
-	@echo "  TEST_ID=<id>       - Specify test case ID for *-one targets"
-	@echo "  VERBOSE=1          - Show executed commands and converter output"
+	@echo "  TEST_ID=<id>   *-one 타겟에서 실행할 testcase ID"
+	@echo "  VERBOSE=1      실행 명령과 변환기 출력 표시"
 	@echo ""
 	@echo "Examples:"
-	@echo "  make                                           # Run all tests"
-	@echo "  make test-xhtml VERBOSE=1                      # Run XHTML tests with verbose"
-	@echo "  make test-xhtml-one TEST_ID=568918170          # Run specific XHTML test"
-	@echo "  make test-reverse-sync-one TEST_ID=1911652402   # Run specific Reverse-Sync test"
-	@echo "  make test-render-one TEST_ID=544382364         # Run specific Render test"
+	@echo "  make"
+	@echo "  make test-convert VERBOSE=1"
+	@echo "  make test-convert-one TEST_ID=568918170"
+	@echo "  make test-reverse-sync-one TEST_ID=1911652402"
+	@echo "  make test-render-one TEST_ID=544382364"

--- a/confluence-mdx/tests/run-tests.sh
+++ b/confluence-mdx/tests/run-tests.sh
@@ -6,7 +6,7 @@
 #   ./run-tests.sh [options]
 #
 # Options:
-#   --type TYPE       Test type: xhtml (default), skeleton, reverse-sync, image-copy, xhtml-diff
+#   --type TYPE       Test type: convert (default), skeleton, reverse-sync, image-copy, xhtml-diff
 #   --log-level LEVEL Log level: warning (default), debug, info
 #   --test-id ID      Run specific test case only
 #   --verbose, -v     Show converter output (stdout/stderr)
@@ -30,7 +30,7 @@ SKELETON_SCRIPT="${BIN_DIR}/skeleton/cli.py"
 export PYTHONPATH="${BIN_DIR}:${PYTHONPATH:-}"
 
 # Default options
-TEST_TYPE="xhtml"
+TEST_TYPE="convert"
 LOG_LEVEL="warning"
 TEST_ID=""
 VERBOSE=false
@@ -121,8 +121,8 @@ sys.exit(1)
 " "${page_id}"
 }
 
-# Run XHTML test for a single test case
-run_xhtml_test() {
+# Run convert test for a single test case (XHTML → MDX)
+run_convert_test() {
     local test_id="$1"
     local test_path="${TEST_DIR}/${test_id}"
 
@@ -168,7 +168,7 @@ run_skeleton_test() {
 }
 
 # Check if test case has required input files
-has_xhtml_input() {
+has_convert_input() {
     local test_id="$1"
     [[ -f "${TEST_DIR}/${test_id}/page.xhtml" ]]
 }
@@ -184,6 +184,7 @@ run_reverse_sync_test() {
     local test_path="${TEST_DIR}/${test_id}"
 
     # verify 실행 (cwd를 confluence-mdx root로 이동 — run_verify()가 var/<page_id>/에 중간 파일을 쓰므로)
+    mkdir -p "../var/${test_id}"
     pushd .. > /dev/null
     run_cmd env PYTHONPATH=bin python3 bin/reverse_sync_test_verify.py \
         "${test_id}" \
@@ -373,11 +374,11 @@ main() {
     activate_venv
 
     case "${TEST_TYPE}" in
-        xhtml)
+        convert)
             if [[ -n "${TEST_ID}" ]]; then
-                run_single_test run_xhtml_test "XHTML" "${TEST_ID}"
+                run_single_test run_convert_test "Convert" "${TEST_ID}"
             else
-                run_all_tests run_xhtml_test "XHTML" has_xhtml_input
+                run_all_tests run_convert_test "Convert" has_convert_input
             fi
             ;;
         skeleton)

--- a/confluence-mdx/tests/test_xhtml_beautify_diff.py
+++ b/confluence-mdx/tests/test_xhtml_beautify_diff.py
@@ -193,7 +193,7 @@ class TestCli:
         result = subprocess.run(
             [sys.executable, "bin/xhtml_beautify_diff.py", str(file_a), str(file_b)],
             capture_output=True, text=True,
-            cwd="/Users/jk/workspace/querypie-docs/confluence-mdx",
+            cwd=str(Path(__file__).resolve().parent.parent),
         )
         assert result.returncode == 0
         assert result.stdout.strip() == ""
@@ -208,7 +208,7 @@ class TestCli:
         result = subprocess.run(
             [sys.executable, "bin/xhtml_beautify_diff.py", str(file_a), str(file_b)],
             capture_output=True, text=True,
-            cwd="/Users/jk/workspace/querypie-docs/confluence-mdx",
+            cwd=str(Path(__file__).resolve().parent.parent),
         )
         assert result.returncode == 1
         assert "Old" in result.stdout
@@ -223,7 +223,7 @@ class TestCli:
             [sys.executable, "bin/xhtml_beautify_diff.py",
              str(file_a), str(tmp_path / "nonexistent.xhtml")],
             capture_output=True, text=True,
-            cwd="/Users/jk/workspace/querypie-docs/confluence-mdx",
+            cwd=str(Path(__file__).resolve().parent.parent),
         )
         assert result.returncode == 2
         assert "not found" in result.stderr
@@ -238,6 +238,6 @@ class TestCli:
         result = subprocess.run(
             [sys.executable, "bin/xhtml_beautify_diff.py", str(file_a), str(file_b)],
             capture_output=True, text=True,
-            cwd="/Users/jk/workspace/querypie-docs/confluence-mdx",
+            cwd=str(Path(__file__).resolve().parent.parent),
         )
         assert result.returncode == 0


### PR DESCRIPTION
## Summary
- `test-xhtml` → `test-convert`로 이름 변경 (실제 동작인 XHTML→MDX 변환을 반영)
- `run-tests.sh --type xhtml` → `--type convert`로 동기화
- 누락된 Makefile 타겟 추가: `test-image-copy`, `test-xhtml-diff`
- `make help` 도움말에 각 테스트가 무엇을 수행하는지 설명 추가

## Test plan
- [x] `make test-convert` → 21/21 passed
- [x] `make test-xhtml-diff` → 14/14 passed
- [x] `make help` 출력 80컬럼 이내 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)