### PR TITLE
fix(tests): conftest.py 추가로 pytest PYTHONPATH 안정화 및 전체 테스트 자동 수집

### DIFF
--- a/.github/workflows/test-confluence-mdx.yml
+++ b/.github/workflows/test-confluence-mdx.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run Python unit tests
         working-directory: ./confluence-mdx/tests
-        run: ../venv/bin/python -m pytest test_mdx_to_skeleton.py test_xhtml_beautify_diff.py -v
+        run: ../venv/bin/python3 -m pytest -v
 
       - name: Run XHTML to MDX convert tests
         working-directory: ./confluence-mdx/tests

--- a/confluence-mdx/tests/conftest.py
+++ b/confluence-mdx/tests/conftest.py
@@ -1,0 +1,6 @@
+"""pytest 공통 설정: bin/ 디렉터리를 sys.path에 추가."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "bin"))

--- a/confluence-mdx/tests/test_mdx_to_skeleton.py
+++ b/confluence-mdx/tests/test_mdx_to_skeleton.py
@@ -15,12 +15,7 @@ Usage:
     python3 test_mdx_to_skeleton.py
 """
 
-import sys
-import os
 from pathlib import Path
-
-# Add the bin directory to the path so we can import skeleton package
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'bin'))
 
 from skeleton.cli import (
     ContentProtector,
@@ -1833,5 +1828,6 @@ if __name__ == "__main__":
     except ImportError:
         # Otherwise, run our simple test runner
         # Note: Integration tests require pytest for tmp_path fixture
+        import sys
         sys.exit(run_all_tests())
 


### PR DESCRIPTION
## Summary
- `tests/conftest.py` 생성하여 `bin/`을 `sys.path`에 중앙 관리
- `test_mdx_to_skeleton.py`의 개별 `sys.path.insert` 제거
- CI pytest를 파일 명시(`test_mdx_to_skeleton.py test_xhtml_beautify_diff.py`)에서 자동 수집(`-v`)으로 변경
  - 기존: 2개 파일, 97 tests
  - 변경 후: 10개 파일, 172 tests

## Test plan
- [x] `python -m pytest tests/ -v` → 172 passed
- [x] 개별 파일 실행도 정상 동작 확인 (conftest.py가 자동 로드)

🤖 Generated with [Claude Code](https://claude.com/claude-code)