### PR TITLE
mdx(ko): MDX frontmatter에 confluenceUrl 추가

### DIFF
--- a/src/content/ko/administrator-manual.mdx
+++ b/src/content/ko/administrator-manual.mdx
@@ -1,5 +1,6 @@
 ---
 title: '관리자 매뉴얼'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544178405'
 ---
 
 # 관리자 매뉴얼

--- a/src/content/ko/administrator-manual/audit.mdx
+++ b/src/content/ko/administrator-manual/audit.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Audit'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379062/Audit'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/audit/database-logs.mdx
+++ b/src/content/ko/administrator-manual/audit/database-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Database Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544080248/Database+Logs'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/audit/database-logs/access-control-logs.mdx
+++ b/src/content/ko/administrator-manual/audit/database-logs/access-control-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Access Control Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544080264/Access+Control+Logs'
 ---
 
 # Access Control Logs

--- a/src/content/ko/administrator-manual/audit/database-logs/account-lock-history.mdx
+++ b/src/content/ko/administrator-manual/audit/database-logs/account-lock-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Account Lock History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544014894/Account+Lock+History'
 ---
 
 # Account Lock History

--- a/src/content/ko/administrator-manual/audit/database-logs/db-access-history.mdx
+++ b/src/content/ko/administrator-manual/audit/database-logs/db-access-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'DB Access History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544113141/DB+Access+History'
 ---
 
 # DB Access History

--- a/src/content/ko/administrator-manual/audit/database-logs/dml-snapshots.mdx
+++ b/src/content/ko/administrator-manual/audit/database-logs/dml-snapshots.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'DML Snapshots'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544244163/DML+Snapshots'
 ---
 
 # DML Snapshots

--- a/src/content/ko/administrator-manual/audit/database-logs/policy-audit-logs.mdx
+++ b/src/content/ko/administrator-manual/audit/database-logs/policy-audit-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Policy Audit Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070694532/Policy+Audit+Logs'
 ---
 
 # Policy Audit Logs

--- a/src/content/ko/administrator-manual/audit/database-logs/policy-exception-logs.mdx
+++ b/src/content/ko/administrator-manual/audit/database-logs/policy-exception-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Policy Exception logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1164705793/Policy+Exception+logs'
 ---
 
 # Policy Exception logs

--- a/src/content/ko/administrator-manual/audit/database-logs/query-audit.mdx
+++ b/src/content/ko/administrator-manual/audit/database-logs/query-audit.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Query Audit'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544244149/Query+Audit'
 ---
 
 # Query Audit

--- a/src/content/ko/administrator-manual/audit/database-logs/running-queries.mdx
+++ b/src/content/ko/administrator-manual/audit/database-logs/running-queries.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Running Queries'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544145819/Running+Queries'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/audit/general-logs.mdx
+++ b/src/content/ko/administrator-manual/audit/general-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'General Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544211450/General+Logs'
 ---
 
 # General Logs

--- a/src/content/ko/administrator-manual/audit/general-logs/activity-logs.mdx
+++ b/src/content/ko/administrator-manual/audit/general-logs/activity-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Activity Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544113108/Activity+Logs'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/audit/general-logs/admin-role-history.mdx
+++ b/src/content/ko/administrator-manual/audit/general-logs/admin-role-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Admin Role History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544047557/Admin+Role+History'
 ---
 
 # Admin Role History

--- a/src/content/ko/administrator-manual/audit/general-logs/reverse-tunnels.mdx
+++ b/src/content/ko/administrator-manual/audit/general-logs/reverse-tunnels.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Reverse Tunnels'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/775455036/Reverse+Tunnels'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-clusters-through-reverse-tunnel.mdx
+++ b/src/content/ko/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-clusters-through-reverse-tunnel.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Reverse Tunnel을 통해 클러스터에 통신하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/811466988/Reverse+Tunnel'
 ---
 
 # Reverse Tunnel을 통해 클러스터에 통신하기

--- a/src/content/ko/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-db-through-reverse-tunnel.mdx
+++ b/src/content/ko/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-db-through-reverse-tunnel.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Reverse Tunnel을 통해 DB에 통신하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/955318273/Reverse+Tunnel+DB'
 ---
 
 # Reverse Tunnel을 통해 DB에 통신하기

--- a/src/content/ko/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-servers-through-reverse-tunnel.mdx
+++ b/src/content/ko/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-servers-through-reverse-tunnel.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Reverse Tunnel을 통해 서버에 통신하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/811434216/Reverse+Tunnel'
 ---
 
 # Reverse Tunnel을 통해 서버에 통신하기

--- a/src/content/ko/administrator-manual/audit/general-logs/user-access-history.mdx
+++ b/src/content/ko/administrator-manual/audit/general-logs/user-access-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'User Access History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544080230/User+Access+History'
 ---
 
 # User Access History

--- a/src/content/ko/administrator-manual/audit/general-logs/workflow-logs.mdx
+++ b/src/content/ko/administrator-manual/audit/general-logs/workflow-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Workflow Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/705724442/Workflow+Logs'
 ---
 
 # Workflow Logs

--- a/src/content/ko/administrator-manual/audit/kubernetes-logs.mdx
+++ b/src/content/ko/administrator-manual/audit/kubernetes-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Kubernetes Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544383513/Kubernetes+Logs'
 ---
 
 # Kubernetes Logs

--- a/src/content/ko/administrator-manual/audit/kubernetes-logs/kubernetes-role-history.mdx
+++ b/src/content/ko/administrator-manual/audit/kubernetes-logs/kubernetes-role-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Kubernetes Role History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544383799/Kubernetes+Role+History'
 ---
 
 # Kubernetes Role History

--- a/src/content/ko/administrator-manual/audit/kubernetes-logs/pod-session-recordings.mdx
+++ b/src/content/ko/administrator-manual/audit/kubernetes-logs/pod-session-recordings.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Pod Session Recordings'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544383693/Pod+Session+Recordings'
 ---
 
 # Pod Session Recordings

--- a/src/content/ko/administrator-manual/audit/kubernetes-logs/request-audit.mdx
+++ b/src/content/ko/administrator-manual/audit/kubernetes-logs/request-audit.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Request Audit'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544383587/Request+Audit'
 ---
 
 # Request Audit

--- a/src/content/ko/administrator-manual/audit/reports.mdx
+++ b/src/content/ko/administrator-manual/audit/reports.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Reports'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/693043522/Reports'
 ---
 
 # Reports

--- a/src/content/ko/administrator-manual/audit/reports/audit-log-export.mdx
+++ b/src/content/ko/administrator-manual/audit/reports/audit-log-export.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Audit Log Export'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379140/Audit+Log+Export'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/audit/reports/reports.mdx
+++ b/src/content/ko/administrator-manual/audit/reports/reports.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Reports'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544384417/Reports'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/audit/server-logs.mdx
+++ b/src/content/ko/administrator-manual/audit/server-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544014907/Server+Logs'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/audit/server-logs/access-control-logs.mdx
+++ b/src/content/ko/administrator-manual/audit/server-logs/access-control-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Access Control Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544244234/Access+Control+Logs'
 ---
 
 # Access Control Logs

--- a/src/content/ko/administrator-manual/audit/server-logs/account-lock-history.mdx
+++ b/src/content/ko/administrator-manual/audit/server-logs/account-lock-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Account Lock History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/543949311/Account+Lock+History'
 ---
 
 # Account Lock History

--- a/src/content/ko/administrator-manual/audit/server-logs/command-audit.mdx
+++ b/src/content/ko/administrator-manual/audit/server-logs/command-audit.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Command Audit'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544244208/Command+Audit'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/audit/server-logs/server-access-history.mdx
+++ b/src/content/ko/administrator-manual/audit/server-logs/server-access-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Access History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544244182/Server+Access+History'
 ---
 
 # Server Access History

--- a/src/content/ko/administrator-manual/audit/server-logs/server-role-history.mdx
+++ b/src/content/ko/administrator-manual/audit/server-logs/server-role-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Role History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544244244/Server+Role+History'
 ---
 
 # Server Role History

--- a/src/content/ko/administrator-manual/audit/server-logs/session-logs.mdx
+++ b/src/content/ko/administrator-manual/audit/server-logs/session-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Session Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544014927/Session+Logs'
 ---
 
 # Session Logs

--- a/src/content/ko/administrator-manual/audit/server-logs/session-monitoring-moved.mdx
+++ b/src/content/ko/administrator-manual/audit/server-logs/session-monitoring-moved.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Session Monitoring (Moved)'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544014940/Session+Monitoring+Moved'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/audit/web-app-logs.mdx
+++ b/src/content/ko/administrator-manual/audit/web-app-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web App Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064829366/Web+App+Logs'
 ---
 
 # Web App Logs

--- a/src/content/ko/administrator-manual/audit/web-app-logs/jit-access-control-logs.mdx
+++ b/src/content/ko/administrator-manual/audit/web-app-logs/jit-access-control-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'JIT Access Control Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070694552/JIT+Access+Control+Logs'
 ---
 
 # JIT Access Control Logs

--- a/src/content/ko/administrator-manual/audit/web-app-logs/user-activity-recordings.mdx
+++ b/src/content/ko/administrator-manual/audit/web-app-logs/user-activity-recordings.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'User Activity Recordings'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070694561/User+Activity+Recordings'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/audit/web-app-logs/web-access-history.mdx
+++ b/src/content/ko/administrator-manual/audit/web-app-logs/web-access-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web Access History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064829380/Web+Access+History'
 ---
 
 # Web Access History

--- a/src/content/ko/administrator-manual/audit/web-app-logs/web-app-role-history.mdx
+++ b/src/content/ko/administrator-manual/audit/web-app-logs/web-app-role-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web App Role History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070563469/Web+App+Role+History'
 ---
 
 # Web App Role History

--- a/src/content/ko/administrator-manual/audit/web-app-logs/web-event-audit.mdx
+++ b/src/content/ko/administrator-manual/audit/web-app-logs/web-event-audit.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web Event Audit'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070563457/Web+Event+Audit'
 ---
 
 # Web Event Audit

--- a/src/content/ko/administrator-manual/databases.mdx
+++ b/src/content/ko/administrator-manual/databases.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Databases'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379638/Databases'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/databases/connection-management.mdx
+++ b/src/content/ko/administrator-manual/databases/connection-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Connection Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379705/Connection+Management'
 ---
 
 # Connection Management

--- a/src/content/ko/administrator-manual/databases/connection-management/cloud-providers.mdx
+++ b/src/content/ko/administrator-manual/databases/connection-management/cloud-providers.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Cloud Providers'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544145672/Cloud+Providers'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-aws.mdx
+++ b/src/content/ko/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-aws.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'AWS에서 DB 리소스 동기화'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379719/AWS+DB'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-google-cloud.mdx
+++ b/src/content/ko/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-google-cloud.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Google Cloud에서 DB 리소스 동기화'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/562167809/Google+Cloud+DB'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-ms-azure.mdx
+++ b/src/content/ko/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-ms-azure.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'MS Azure에서 DB 리소스 동기화'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/562167871/MS+Azure+DB'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/databases/connection-management/cloud-providers/verifying-cloud-synchronization-settings-with-dry-run-feature.mdx
+++ b/src/content/ko/administrator-manual/databases/connection-management/cloud-providers/verifying-cloud-synchronization-settings-with-dry-run-feature.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Dry Run 기능으로 클라우드 동기화 설정 확인하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/712507393/Dry+Run'
 ---
 
 # Dry Run 기능으로 클라우드 동기화 설정 확인하기

--- a/src/content/ko/administrator-manual/databases/connection-management/db-connections.mdx
+++ b/src/content/ko/administrator-manual/databases/connection-management/db-connections.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'DB Connections'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544014712/DB+Connections'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/databases/connection-management/db-connections/aws-athena-specific-guide.mdx
+++ b/src/content/ko/administrator-manual/databases/connection-management/db-connections/aws-athena-specific-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'AWS Athena 전용 가이드'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/820806182/AWS+Athena'
 ---
 
 # AWS Athena 전용 가이드

--- a/src/content/ko/administrator-manual/databases/connection-management/db-connections/custom-data-source-configuration-and-log-verification.mdx
+++ b/src/content/ko/administrator-manual/databases/connection-management/db-connections/custom-data-source-configuration-and-log-verification.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Custom Data Source 설정 및 로그 확인'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/880082945/Custom+Data+Source'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/databases/connection-management/db-connections/documentdb-specific-guide.mdx
+++ b/src/content/ko/administrator-manual/databases/connection-management/db-connections/documentdb-specific-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'DocumentDB 전용 가이드'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/568852692/DocumentDB'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/databases/connection-management/db-connections/google-bigquery-oauth-authentication-configuration.mdx
+++ b/src/content/ko/administrator-manual/databases/connection-management/db-connections/google-bigquery-oauth-authentication-configuration.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Google BigQuery OAuth 인증 설정'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/811434142/Google+BigQuery+OAuth'
 ---
 
 # Google BigQuery OAuth 인증 설정

--- a/src/content/ko/administrator-manual/databases/connection-management/db-connections/mongodb-specific-guide.mdx
+++ b/src/content/ko/administrator-manual/databases/connection-management/db-connections/mongodb-specific-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'MongoDB 전용 가이드'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380381/MongoDB'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/databases/connection-management/kerberos-configurations.mdx
+++ b/src/content/ko/administrator-manual/databases/connection-management/kerberos-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Kerberos Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544112932/Kerberos+Configurations'
 ---
 
 # Kerberos Configurations

--- a/src/content/ko/administrator-manual/databases/connection-management/ssh-configurations.mdx
+++ b/src/content/ko/administrator-manual/databases/connection-management/ssh-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'SSH Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544047436/SSH+Configurations'
 ---
 
 # SSH Configurations

--- a/src/content/ko/administrator-manual/databases/connection-management/ssl-configurations.mdx
+++ b/src/content/ko/administrator-manual/databases/connection-management/ssl-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'SSL Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544145691/SSL+Configurations'
 ---
 
 # SSL Configurations

--- a/src/content/ko/administrator-manual/databases/dac-general-configurations.mdx
+++ b/src/content/ko/administrator-manual/databases/dac-general-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'DAC General Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/956071939/DAC+General+Configurations'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/databases/dac-general-configurations/masking-pattern-menu-relocated.mdx
+++ b/src/content/ko/administrator-manual/databases/dac-general-configurations/masking-pattern-menu-relocated.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Masking Pattern (메뉴 위치 이동)'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1275396097/Masking+Pattern'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/databases/dac-general-configurations/unmasking-zones.mdx
+++ b/src/content/ko/administrator-manual/databases/dac-general-configurations/unmasking-zones.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Unmasking Zones'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/921436219/Unmasking+Zones'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/databases/db-access-control.mdx
+++ b/src/content/ko/administrator-manual/databases/db-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'DB Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380126/DB+Access+Control'
 ---
 
 # DB Access Control

--- a/src/content/ko/administrator-manual/databases/db-access-control/access-control.mdx
+++ b/src/content/ko/administrator-manual/databases/db-access-control/access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380173/Access+Control'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/databases/db-access-control/privilege-type.mdx
+++ b/src/content/ko/administrator-manual/databases/db-access-control/privilege-type.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Privilege Type'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380140/Privilege+Type'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/databases/ledger-management.mdx
+++ b/src/content/ko/administrator-manual/databases/ledger-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Ledger Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/571277577/Ledger+Management'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/databases/ledger-management/ledger-approval-rules.mdx
+++ b/src/content/ko/administrator-manual/databases/ledger-management/ledger-approval-rules.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Ledger Approval Rules'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/571277650/Ledger+Approval+Rules'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/databases/ledger-management/ledger-table-policy.mdx
+++ b/src/content/ko/administrator-manual/databases/ledger-management/ledger-table-policy.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Ledger Table Policy'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380061/Ledger+Table+Policy'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/databases/monitoring.mdx
+++ b/src/content/ko/administrator-manual/databases/monitoring.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Monitoring'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/954139156/Monitoring'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/databases/monitoring/proxy-management.mdx
+++ b/src/content/ko/administrator-manual/databases/monitoring/proxy-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Proxy Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/954204974/Proxy+Management'
 ---
 
 # Proxy Management

--- a/src/content/ko/administrator-manual/databases/monitoring/running-queries.mdx
+++ b/src/content/ko/administrator-manual/databases/monitoring/running-queries.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Running Queries'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/954172219/Running+Queries'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/databases/new-policy-management.mdx
+++ b/src/content/ko/administrator-manual/databases/new-policy-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: '(New) Policy Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/873136365/New+Policy+Management'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/databases/new-policy-management/data-paths.mdx
+++ b/src/content/ko/administrator-manual/databases/new-policy-management/data-paths.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Data Paths'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/878805502/Data+Paths'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/databases/new-policy-management/data-policies.mdx
+++ b/src/content/ko/administrator-manual/databases/new-policy-management/data-policies.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Data Policies'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/879198569/Data+Policies'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/databases/new-policy-management/exception-management.mdx
+++ b/src/content/ko/administrator-manual/databases/new-policy-management/exception-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Exception Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064796485/Exception+Management'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/databases/policies.mdx
+++ b/src/content/ko/administrator-manual/databases/policies.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Policies'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379868/Policies'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/databases/policies/data-access.mdx
+++ b/src/content/ko/administrator-manual/databases/policies/data-access.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Data Access'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379937/Data+Access'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/databases/policies/data-masking.mdx
+++ b/src/content/ko/administrator-manual/databases/policies/data-masking.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Data Masking'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379882/Data+Masking'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/databases/policies/masking-pattern.mdx
+++ b/src/content/ko/administrator-manual/databases/policies/masking-pattern.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Masking Pattern'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/569376769/Masking+Pattern'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/databases/policies/policy-exception.mdx
+++ b/src/content/ko/administrator-manual/databases/policies/policy-exception.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Policy Exception'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/713129986/Policy+Exception'
 ---
 
 # Policy Exception

--- a/src/content/ko/administrator-manual/databases/policies/sensitive-data.mdx
+++ b/src/content/ko/administrator-manual/databases/policies/sensitive-data.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Sensitive Data'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379993/Sensitive+Data'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general.mdx
+++ b/src/content/ko/administrator-manual/general.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'General'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544080057/General'
 ---
 
 # General

--- a/src/content/ko/administrator-manual/general/company-management.mdx
+++ b/src/content/ko/administrator-manual/general/company-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Company Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/543948978/Company+Management'
 ---
 
 # Company Management

--- a/src/content/ko/administrator-manual/general/company-management/alerts.mdx
+++ b/src/content/ko/administrator-manual/general/company-management/alerts.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Alerts'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/543981760/Alerts'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/company-management/alerts/new-request-template-variables-by-request-type.mdx
+++ b/src/content/ko/administrator-manual/general/company-management/alerts/new-request-template-variables-by-request-type.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'New Request > 요청 타입별 템플릿 변수'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/793608206/New+Request'
 ---
 
 # New Request > 요청 타입별 템플릿 변수

--- a/src/content/ko/administrator-manual/general/company-management/allowed-zones.mdx
+++ b/src/content/ko/administrator-manual/general/company-management/allowed-zones.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Allowed Zones'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544112846/Allowed+Zones'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/company-management/channels.mdx
+++ b/src/content/ko/administrator-manual/general/company-management/channels.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Channels'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544243925/Channels'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/company-management/general.mdx
+++ b/src/content/ko/administrator-manual/general/company-management/general.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'General'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544145591/General'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/company-management/licenses.mdx
+++ b/src/content/ko/administrator-manual/general/company-management/licenses.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Licenses'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544178443/Licenses'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/company-management/security.mdx
+++ b/src/content/ko/administrator-manual/general/company-management/security.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Security'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544178422/Security'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/system.mdx
+++ b/src/content/ko/administrator-manual/general/system.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'System'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544112865/System'
 ---
 
 # System

--- a/src/content/ko/administrator-manual/general/system/api-token.mdx
+++ b/src/content/ko/administrator-manual/general/system/api-token.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'API Token'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544377652/API+Token'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/system/integrations.mdx
+++ b/src/content/ko/administrator-manual/general/system/integrations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Integrations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544080097/Integrations'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/system/integrations/identity-providers.mdx
+++ b/src/content/ko/administrator-manual/general/system/integrations/identity-providers.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Identity Providers'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1454342158/Identity+Providers'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/system/integrations/identity-providers/integrating-with-aws-sso-saml-20.mdx
+++ b/src/content/ko/administrator-manual/general/system/integrations/identity-providers/integrating-with-aws-sso-saml-20.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'AWS SSO 연동하기 (SAML 2.0)'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1495433217/AWS+SSO+SAML+2.0'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/system/integrations/integrating-google-cloud-api-for-oauth-20.mdx
+++ b/src/content/ko/administrator-manual/general/system/integrations/integrating-google-cloud-api-for-oauth-20.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'OAuth 2.0을 사용하기 위한 Google Cloud API 연동'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/811401365/OAuth+2.0+Google+Cloud+API'
 ---
 
 # OAuth 2.0을 사용하기 위한 Google Cloud API 연동

--- a/src/content/ko/administrator-manual/general/system/integrations/integrating-with-email.mdx
+++ b/src/content/ko/administrator-manual/general/system/integrations/integrating-with-email.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Email 연동'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/798064641/Email'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/system/integrations/integrating-with-event-callback.mdx
+++ b/src/content/ko/administrator-manual/general/system/integrations/integrating-with-event-callback.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Event Callback 연동'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1267007528/Event+Callback'
 ---
 
 # Event Callback 연동

--- a/src/content/ko/administrator-manual/general/system/integrations/integrating-with-secret-store.mdx
+++ b/src/content/ko/administrator-manual/general/system/integrations/integrating-with-secret-store.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Secret Store 연동'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379587/Secret+Store'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/system/integrations/integrating-with-slack-dm.mdx
+++ b/src/content/ko/administrator-manual/general/system/integrations/integrating-with-slack-dm.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Slack DM 연동'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/883654669/Slack+DM'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/system/integrations/integrating-with-slack-dm/slack-dm-workflow-notification-types.mdx
+++ b/src/content/ko/administrator-manual/general/system/integrations/integrating-with-slack-dm/slack-dm-workflow-notification-types.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Slack DM - Workflow 알림 유형'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544378759/Slack+DM+-+Workflow'
 ---
 
 # Slack DM - Workflow 알림 유형

--- a/src/content/ko/administrator-manual/general/system/integrations/integrating-with-splunk.mdx
+++ b/src/content/ko/administrator-manual/general/system/integrations/integrating-with-splunk.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Splunk 연동'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/557940795/Splunk'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/system/integrations/integrating-with-syslog.mdx
+++ b/src/content/ko/administrator-manual/general/system/integrations/integrating-with-syslog.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Syslog 연동'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379393/Syslog'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/system/integrations/oauth-client-application.mdx
+++ b/src/content/ko/administrator-manual/general/system/integrations/oauth-client-application.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'OAuth Client Application'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1453588486/OAuth+Client+Application'
 ---
 
 # OAuth Client Application

--- a/src/content/ko/administrator-manual/general/system/jobs.mdx
+++ b/src/content/ko/administrator-manual/general/system/jobs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Jobs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544211220/Jobs'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/system/maintenance.mdx
+++ b/src/content/ko/administrator-manual/general/system/maintenance.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Maintenance'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1456144391/Maintenance'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/user-management.mdx
+++ b/src/content/ko/administrator-manual/general/user-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'User Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375969/User+Management'
 ---
 
 # User Management

--- a/src/content/ko/administrator-manual/general/user-management/authentication.mdx
+++ b/src/content/ko/administrator-manual/general/user-management/authentication.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Authentication'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375984/Authentication'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/user-management/authentication/integrating-with-aws-sso.mdx
+++ b/src/content/ko/administrator-manual/general/user-management/authentication/integrating-with-aws-sso.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'AWS SSO 연동하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544376183/AWS+SSO'
 ---
 
 # AWS SSO 연동하기

--- a/src/content/ko/administrator-manual/general/user-management/authentication/integrating-with-google-saml.mdx
+++ b/src/content/ko/administrator-manual/general/user-management/authentication/integrating-with-google-saml.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Google SAML 연동하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/619381289/Google+SAML'
 ---
 
 # Google SAML 연동하기

--- a/src/content/ko/administrator-manual/general/user-management/authentication/integrating-with-ldap.mdx
+++ b/src/content/ko/administrator-manual/general/user-management/authentication/integrating-with-ldap.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'LDAP 연동하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544376004/LDAP'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/user-management/authentication/integrating-with-okta.mdx
+++ b/src/content/ko/administrator-manual/general/user-management/authentication/integrating-with-okta.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Okta 연동하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544376100/Okta'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/user-management/authentication/setting-up-multi-factor-authentication.mdx
+++ b/src/content/ko/administrator-manual/general/user-management/authentication/setting-up-multi-factor-authentication.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Multi-Factor Authentication 설정하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/793575425/Multi-Factor+Authentication'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/user-management/groups.mdx
+++ b/src/content/ko/administrator-manual/general/user-management/groups.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Groups'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544047341/Groups'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/user-management/profile-editor.mdx
+++ b/src/content/ko/administrator-manual/general/user-management/profile-editor.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Profile Editor'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544376982/Profile+Editor'
 ---
 
 # Profile Editor

--- a/src/content/ko/administrator-manual/general/user-management/profile-editor/custom-attribute.mdx
+++ b/src/content/ko/administrator-manual/general/user-management/profile-editor/custom-attribute.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Custom Attribute'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/953221256/Custom+Attribute'
 ---
 
 # Custom Attribute

--- a/src/content/ko/administrator-manual/general/user-management/provisioning.mdx
+++ b/src/content/ko/administrator-manual/general/user-management/provisioning.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Provisioning'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544376236/Provisioning'
 ---
 
 # Provisioning

--- a/src/content/ko/administrator-manual/general/user-management/provisioning/activating-provisioning.mdx
+++ b/src/content/ko/administrator-manual/general/user-management/provisioning/activating-provisioning.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Provisioning 활성화 하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544376265/Provisioning'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/user-management/provisioning/okta-provisioning-integration-guide.mdx
+++ b/src/content/ko/administrator-manual/general/user-management/provisioning/okta-provisioning-integration-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: '[Okta] 프로비저닝 연동 가이드'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544376394/Okta'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/user-management/roles.mdx
+++ b/src/content/ko/administrator-manual/general/user-management/roles.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Roles'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/543948996/Roles'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/user-management/users.mdx
+++ b/src/content/ko/administrator-manual/general/user-management/users.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Users'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544047331/Users'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/user-management/users/password-change-enforcement-and-account-deletion-feature-for-qp-admin-default-account.mdx
+++ b/src/content/ko/administrator-manual/general/user-management/users/password-change-enforcement-and-account-deletion-feature-for-qp-admin-default-account.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'qp-admin 기본 계정에 대한 패스워드 변경 강제화 및 계정 삭제 기능'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/920944732/qp-admin'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/user-management/users/user-profile.mdx
+++ b/src/content/ko/administrator-manual/general/user-management/users/user-profile.mdx
@@ -1,5 +1,6 @@
 ---
 title: '사용자 프로필'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544376787'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/workflow-management.mdx
+++ b/src/content/ko/administrator-manual/general/workflow-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Workflow Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544178462/Workflow+Management'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/workflow-management/all-requests.mdx
+++ b/src/content/ko/administrator-manual/general/workflow-management/all-requests.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'All Requests'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544047359/All+Requests'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/workflow-management/approval-rules.mdx
+++ b/src/content/ko/administrator-manual/general/workflow-management/approval-rules.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Approval Rules'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544378513/Approval+Rules'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/general/workflow-management/workflow-configurations.mdx
+++ b/src/content/ko/administrator-manual/general/workflow-management/workflow-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Workflow Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/561414376/Workflow+Configurations'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/kubernetes.mdx
+++ b/src/content/ko/administrator-manual/kubernetes.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Kubernetes'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381596/Kubernetes'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/kubernetes/connection-management.mdx
+++ b/src/content/ko/administrator-manual/kubernetes/connection-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Connection Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381637/Connection+Management'
 ---
 
 # Connection Management

--- a/src/content/ko/administrator-manual/kubernetes/connection-management/cloud-providers.mdx
+++ b/src/content/ko/administrator-manual/kubernetes/connection-management/cloud-providers.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Cloud Providers'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381651/Cloud+Providers'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/kubernetes/connection-management/cloud-providers/synchronizing-kubernetes-resources-from-aws.mdx
+++ b/src/content/ko/administrator-manual/kubernetes/connection-management/cloud-providers/synchronizing-kubernetes-resources-from-aws.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'AWS에서 쿠버네티스 리소스 동기화'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381739/AWS'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/kubernetes/connection-management/clusters.mdx
+++ b/src/content/ko/administrator-manual/kubernetes/connection-management/clusters.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Clusters'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381839/Clusters'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/kubernetes/connection-management/clusters/manually-registering-kubernetes-clusters.mdx
+++ b/src/content/ko/administrator-manual/kubernetes/connection-management/clusters/manually-registering-kubernetes-clusters.mdx
@@ -1,5 +1,6 @@
 ---
 title: '수동으로 쿠버네티스 클러스터 등록하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381877'
 ---
 
 # 수동으로 쿠버네티스 클러스터 등록하기

--- a/src/content/ko/administrator-manual/kubernetes/k8s-access-control.mdx
+++ b/src/content/ko/administrator-manual/kubernetes/k8s-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'K8s Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544383110/K8s+Access+Control'
 ---
 
 # K8s Access Control

--- a/src/content/ko/administrator-manual/kubernetes/k8s-access-control/access-control.mdx
+++ b/src/content/ko/administrator-manual/kubernetes/k8s-access-control/access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544383124/Access+Control'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/kubernetes/k8s-access-control/access-control/granting-and-revoking-kubernetes-roles.mdx
+++ b/src/content/ko/administrator-manual/kubernetes/k8s-access-control/access-control/granting-and-revoking-kubernetes-roles.mdx
@@ -1,5 +1,6 @@
 ---
 title: '쿠버네티스 역할 부여 및 회수하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544383381'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/kubernetes/k8s-access-control/policies.mdx
+++ b/src/content/ko/administrator-manual/kubernetes/k8s-access-control/policies.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Policies'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544382060/Policies'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-action-configuration-reference-guide.mdx
+++ b/src/content/ko/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-action-configuration-reference-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: '쿠버네티스 정책 Action 설정 참고 가이드'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544382659/Action'
 ---
 
 # 쿠버네티스 정책 Action 설정 참고 가이드

--- a/src/content/ko/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-tips-guide.mdx
+++ b/src/content/ko/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-tips-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: '쿠버네티스 정책 Tips 안내'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544382445/Tips'
 ---
 
 # 쿠버네티스 정책 Tips 안내

--- a/src/content/ko/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-ui-code-helper-guide.mdx
+++ b/src/content/ko/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-ui-code-helper-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: '쿠버네티스 정책 UI 코드 헬퍼 안내'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544382522/UI'
 ---
 
 # 쿠버네티스 정책 UI 코드 헬퍼 안내

--- a/src/content/ko/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-yaml-code-syntax-guide.mdx
+++ b/src/content/ko/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-yaml-code-syntax-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: '쿠버네티스 정책 YAML Code 문법 안내'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544382364/YAML+Code'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/kubernetes/k8s-access-control/policies/setting-kubernetes-policies.mdx
+++ b/src/content/ko/administrator-manual/kubernetes/k8s-access-control/policies/setting-kubernetes-policies.mdx
@@ -1,5 +1,6 @@
 ---
 title: '쿠버네티스 정책 설정하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544382274'
 ---
 
 # 쿠버네티스 정책 설정하기

--- a/src/content/ko/administrator-manual/kubernetes/k8s-access-control/roles.mdx
+++ b/src/content/ko/administrator-manual/kubernetes/k8s-access-control/roles.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Roles'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544382741/Roles'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles.mdx
+++ b/src/content/ko/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles.mdx
@@ -1,5 +1,6 @@
 ---
 title: '쿠버네티스 역할 설정하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544382963'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/kubernetes/kac-general-configurations.mdx
+++ b/src/content/ko/administrator-manual/kubernetes/kac-general-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'KAC General Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/954172232/KAC+General+Configurations'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/multi-agent-limitations.mdx
+++ b/src/content/ko/administrator-manual/multi-agent-limitations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Multi Agent 제약사항'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/851280543/Multi+Agent'
 ---
 
 # Multi Agent 제약사항

--- a/src/content/ko/administrator-manual/servers.mdx
+++ b/src/content/ko/administrator-manual/servers.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Servers'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380588/Servers'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/servers/connection-management.mdx
+++ b/src/content/ko/administrator-manual/servers/connection-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Connection Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380635/Connection+Management'
 ---
 
 # Connection Management

--- a/src/content/ko/administrator-manual/servers/connection-management/cloud-providers.mdx
+++ b/src/content/ko/administrator-manual/servers/connection-management/cloud-providers.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Cloud Providers'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544178567/Cloud+Providers'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-aws.mdx
+++ b/src/content/ko/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-aws.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'AWS에서 서버 리소스 동기화'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380650/AWS'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-azure.mdx
+++ b/src/content/ko/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-azure.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Azure에서 서버 리소스 동기화'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380741/Azure'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-gcp.mdx
+++ b/src/content/ko/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-gcp.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'GCP에서 서버 리소스 동기화'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380708/GCP'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/servers/connection-management/proxyjump-configurations.mdx
+++ b/src/content/ko/administrator-manual/servers/connection-management/proxyjump-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'ProxyJump Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/615710737/ProxyJump+Configurations'
 ---
 
 # ProxyJump Configurations

--- a/src/content/ko/administrator-manual/servers/connection-management/proxyjump-configurations/creating-proxyjump.mdx
+++ b/src/content/ko/administrator-manual/servers/connection-management/proxyjump-configurations/creating-proxyjump.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'ProxyJump 생성하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/615743551/ProxyJump'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/servers/connection-management/server-agents-for-rdp.mdx
+++ b/src/content/ko/administrator-manual/servers/connection-management/server-agents-for-rdp.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Agents for RDP'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544211376/Server+Agents+for+RDP'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/servers/connection-management/server-agents-for-rdp/installing-and-removing-server-agent.mdx
+++ b/src/content/ko/administrator-manual/servers/connection-management/server-agents-for-rdp/installing-and-removing-server-agent.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Agent 설치 및 제거하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/565575990/Server+Agent'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/servers/connection-management/server-groups.mdx
+++ b/src/content/ko/administrator-manual/servers/connection-management/server-groups.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Groups'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544080186/Server+Groups'
 ---
 
 # Server Groups

--- a/src/content/ko/administrator-manual/servers/connection-management/server-groups/managing-servers-as-groups.mdx
+++ b/src/content/ko/administrator-manual/servers/connection-management/server-groups/managing-servers-as-groups.mdx
@@ -1,5 +1,6 @@
 ---
 title: '서버를 그룹으로 관리하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380846'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/servers/connection-management/servers.mdx
+++ b/src/content/ko/administrator-manual/servers/connection-management/servers.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Servers'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544211361/Servers'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/servers/connection-management/servers/manually-registering-individual-servers.mdx
+++ b/src/content/ko/administrator-manual/servers/connection-management/servers/manually-registering-individual-servers.mdx
@@ -1,5 +1,6 @@
 ---
 title: '수동으로 개별 서버 등록하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380774'
 ---
 
 # 수동으로 개별 서버 등록하기

--- a/src/content/ko/administrator-manual/servers/sac-general-configurations.mdx
+++ b/src/content/ko/administrator-manual/servers/sac-general-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'SAC General Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/954336174/SAC+General+Configurations'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/servers/server-access-control.mdx
+++ b/src/content/ko/administrator-manual/servers/server-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/543949216/Server+Access+Control'
 ---
 
 # Server Access Control

--- a/src/content/ko/administrator-manual/servers/server-access-control/access-control.mdx
+++ b/src/content/ko/administrator-manual/servers/server-access-control/access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381186/Access+Control'
 ---
 
 # Access Control

--- a/src/content/ko/administrator-manual/servers/server-access-control/access-control/granting-and-revoking-permissions.mdx
+++ b/src/content/ko/administrator-manual/servers/server-access-control/access-control/granting-and-revoking-permissions.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Permissions 부여 및 회수하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381282/Permissions'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/servers/server-access-control/access-control/granting-and-revoking-roles.mdx
+++ b/src/content/ko/administrator-manual/servers/server-access-control/access-control/granting-and-revoking-roles.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Role 부여 및 회수하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381200/Role'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/servers/server-access-control/access-control/granting-server-privilege.mdx
+++ b/src/content/ko/administrator-manual/servers/server-access-control/access-control/granting-server-privilege.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Privilege 부여하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/878838349/Server+Privilege'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/servers/server-access-control/blocked-accounts.mdx
+++ b/src/content/ko/administrator-manual/servers/server-access-control/blocked-accounts.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Blocked Accounts'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544244109/Blocked+Accounts'
 ---
 
 # Blocked Accounts

--- a/src/content/ko/administrator-manual/servers/server-access-control/command-templates.mdx
+++ b/src/content/ko/administrator-manual/servers/server-access-control/command-templates.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Command Templates'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381118/Command+Templates'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/servers/server-access-control/policies.mdx
+++ b/src/content/ko/administrator-manual/servers/server-access-control/policies.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Policies'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381025/Policies'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/servers/server-access-control/policies/enabling-server-proxy.mdx
+++ b/src/content/ko/administrator-manual/servers/server-access-control/policies/enabling-server-proxy.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Proxy 사용 활성화'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544377895/Server+Proxy'
 ---
 
 # Server Proxy 사용 활성화

--- a/src/content/ko/administrator-manual/servers/server-access-control/policies/setting-server-access-policy.mdx
+++ b/src/content/ko/administrator-manual/servers/server-access-control/policies/setting-server-access-policy.mdx
@@ -1,5 +1,6 @@
 ---
 title: '서버 접근 정책 설정하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381039'
 ---
 
 # 서버 접근 정책 설정하기

--- a/src/content/ko/administrator-manual/servers/server-access-control/roles.mdx
+++ b/src/content/ko/administrator-manual/servers/server-access-control/roles.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Roles'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381150/Roles'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/servers/server-account-management.mdx
+++ b/src/content/ko/administrator-manual/servers/server-account-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Account Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/613777446/Server+Account+Management'
 ---
 
 # Server Account Management

--- a/src/content/ko/administrator-manual/servers/server-account-management/account-management.mdx
+++ b/src/content/ko/administrator-manual/servers/server-account-management/account-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Account Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/615743501/Account+Management'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/servers/server-account-management/password-provisioning.mdx
+++ b/src/content/ko/administrator-manual/servers/server-account-management/password-provisioning.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Password Provisioning'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/615677962/Password+Provisioning'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/servers/server-account-management/password-provisioning/creating-password-change-job.mdx
+++ b/src/content/ko/administrator-manual/servers/server-account-management/password-provisioning/creating-password-change-job.mdx
@@ -1,5 +1,6 @@
 ---
 title: '패스워드 변경 Job 생성하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/619380898/Job'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/servers/server-account-management/server-account-templates.mdx
+++ b/src/content/ko/administrator-manual/servers/server-account-management/server-account-templates.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Account Templates'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380991/Server+Account+Templates'
 ---
 
 # Server Account Templates

--- a/src/content/ko/administrator-manual/servers/server-account-management/ssh-key-configurations.mdx
+++ b/src/content/ko/administrator-manual/servers/server-account-management/ssh-key-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'SSH Key Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380960/SSH+Key+Configurations'
 ---
 
 # SSH Key Configurations

--- a/src/content/ko/administrator-manual/servers/session-monitoring.mdx
+++ b/src/content/ko/administrator-manual/servers/session-monitoring.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Session Monitoring'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1760657435/Session+Monitoring'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/web-apps.mdx
+++ b/src/content/ko/administrator-manual/web-apps.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web Apps'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/783515900/Web+Apps'
 ---
 
 # Web Apps

--- a/src/content/ko/administrator-manual/web-apps/connection-management.mdx
+++ b/src/content/ko/administrator-manual/web-apps/connection-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Connection Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064829276/Connection+Management'
 ---
 
 # Connection Management

--- a/src/content/ko/administrator-manual/web-apps/connection-management/web-app-configurations.mdx
+++ b/src/content/ko/administrator-manual/web-apps/connection-management/web-app-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web App Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064829246/Web+App+Configurations'
 ---
 
 # Web App Configurations

--- a/src/content/ko/administrator-manual/web-apps/connection-management/web-apps.mdx
+++ b/src/content/ko/administrator-manual/web-apps/connection-management/web-apps.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web Apps'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070694423/Web+Apps'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/web-apps/wac-quickstart.mdx
+++ b/src/content/ko/administrator-manual/web-apps/wac-quickstart.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'WAC Quickstart'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/783417593/WAC+Quickstart'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/web-apps/wac-quickstart/1027-wac-role-policy-guide.mdx
+++ b/src/content/ko/administrator-manual/web-apps/wac-quickstart/1027-wac-role-policy-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: '[~10.2.7] WAC Role & Policy Guide'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/783745324/~10.2.7+WAC+Role+Policy+Guide'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/web-apps/wac-quickstart/1028-wac-rbac-guide.mdx
+++ b/src/content/ko/administrator-manual/web-apps/wac-quickstart/1028-wac-rbac-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: '[10.2.8~] WAC RBAC Guide'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/924287097/10.2.8~+WAC+RBAC+Guide'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/web-apps/wac-quickstart/1030-wac-jit-permission-acquisition-guide.mdx
+++ b/src/content/ko/administrator-manual/web-apps/wac-quickstart/1030-wac-jit-permission-acquisition-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: '[10.3.0 ~] WAC JIT 권한 획득 Guide'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/956235931/10.3.0+~+WAC+JIT+Guide'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/web-apps/wac-quickstart/initial-wac-setup-in-web-app-configurations.mdx
+++ b/src/content/ko/administrator-manual/web-apps/wac-quickstart/initial-wac-setup-in-web-app-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web App Configurations에서 WAC 초기 설정하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/883654785/Web+App+Configurations+WAC'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/web-apps/wac-quickstart/root-ca-certificate-installation-guide.mdx
+++ b/src/content/ko/administrator-manual/web-apps/wac-quickstart/root-ca-certificate-installation-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Root CA 인증서 설치 가이드'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/805962425/Root+CA'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/web-apps/wac-quickstart/wac-faq.mdx
+++ b/src/content/ko/administrator-manual/web-apps/wac-quickstart/wac-faq.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'WAC FAQ'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/927629410/WAC+FAQ'
 ---
 
 # WAC FAQ

--- a/src/content/ko/administrator-manual/web-apps/wac-quickstart/wac-troubleshooting-guide.mdx
+++ b/src/content/ko/administrator-manual/web-apps/wac-quickstart/wac-troubleshooting-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'WAC 트러블슈팅 가이드'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/924319936/WAC'
 ---
 
 # WAC 트러블슈팅 가이드

--- a/src/content/ko/administrator-manual/web-apps/web-app-access-control.mdx
+++ b/src/content/ko/administrator-manual/web-apps/web-app-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web App Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070596135/Web+App+Access+Control'
 ---
 
 # Web App Access Control

--- a/src/content/ko/administrator-manual/web-apps/web-app-access-control/access-control.mdx
+++ b/src/content/ko/administrator-manual/web-apps/web-app-access-control/access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070628904/Access+Control'
 ---
 
 # Access Control

--- a/src/content/ko/administrator-manual/web-apps/web-app-access-control/access-control/granting-and-revoking-roles.mdx
+++ b/src/content/ko/administrator-manual/web-apps/web-app-access-control/access-control/granting-and-revoking-roles.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Role 부여 및 회수하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064599910/Role'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/web-apps/web-app-access-control/policies.mdx
+++ b/src/content/ko/administrator-manual/web-apps/web-app-access-control/policies.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Policies'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064829343/Policies'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/administrator-manual/web-apps/web-app-access-control/roles.mdx
+++ b/src/content/ko/administrator-manual/web-apps/web-app-access-control/roles.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Roles'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070628923/Roles'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/installation.mdx
+++ b/src/content/ko/installation.mdx
@@ -1,5 +1,6 @@
 ---
 title: '제품 설치'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375808'
 ---
 
 # 제품 설치

--- a/src/content/ko/installation/container-environment-variables.mdx
+++ b/src/content/ko/installation/container-environment-variables.mdx
@@ -1,5 +1,6 @@
 ---
 title: '컨테이너 환경변수'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/954761289'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/installation/container-environment-variables/optimizing-dbmaxconnectionsize.mdx
+++ b/src/content/ko/installation/container-environment-variables/optimizing-dbmaxconnectionsize.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'DB_MAX_CONNECTION_SIZE 최적화'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/938016931/DB_MAX_CONNECTION_SIZE'
 ---
 
 # DB_MAX_CONNECTION_SIZE 최적화

--- a/src/content/ko/installation/container-environment-variables/querypieweburl.mdx
+++ b/src/content/ko/installation/container-environment-variables/querypieweburl.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'QUERYPIE_WEB_URL'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/876937310/QUERYPIE_WEB_URL'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/installation/installation.mdx
+++ b/src/content/ko/installation/installation.mdx
@@ -1,5 +1,6 @@
 ---
 title: '설치하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1689387010'
 ---
 
 # 설치하기

--- a/src/content/ko/installation/installation/comparison-of-setupsh-and-setupv2sh.mdx
+++ b/src/content/ko/installation/installation/comparison-of-setupsh-and-setupv2sh.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'setup.sh, setup.v2.sh 비교'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1261895760/setup.sh+setup.v2.sh'
 ---
 
 # setup.sh, setup.v2.sh 비교

--- a/src/content/ko/installation/installation/installation-guide-setupv2sh.mdx
+++ b/src/content/ko/installation/installation/installation-guide-setupv2sh.mdx
@@ -1,5 +1,6 @@
 ---
 title: '설치 가이드 - setup.v2.sh'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1177321474/-+setup.v2.sh'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/installation/installation/installation-guide-simple-configuration.mdx
+++ b/src/content/ko/installation/installation/installation-guide-simple-configuration.mdx
@@ -1,5 +1,6 @@
 ---
 title: '설치 가이드 - 간단한 구성'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/964952065/-'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/installation/installation/installing-on-aws-eks.mdx
+++ b/src/content/ko/installation/installation/installing-on-aws-eks.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'AWS EKS 환경에서 설치하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/815235967/AWS+EKS'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/installation/license-installation.mdx
+++ b/src/content/ko/installation/license-installation.mdx
@@ -1,5 +1,6 @@
 ---
 title: '라이선스 설치'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/912326893'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/installation/post-installation-setup.mdx
+++ b/src/content/ko/installation/post-installation-setup.mdx
@@ -1,5 +1,6 @@
 ---
 title: '설치 후 초기 설정'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1907294209'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/installation/prerequisites.mdx
+++ b/src/content/ko/installation/prerequisites.mdx
@@ -1,5 +1,6 @@
 ---
 title: '설치 전 준비사항'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/862126081'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/installation/prerequisites/configuring-rootless-mode-with-podman.mdx
+++ b/src/content/ko/installation/prerequisites/configuring-rootless-mode-with-podman.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Podman 으로 Rootless Mode 구성하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1297383451/Podman+Rootless+Mode'
 ---
 
 # Podman 으로 Rootless Mode 구성하기

--- a/src/content/ko/installation/prerequisites/linux-distribution-and-docker-podman-support-status.mdx
+++ b/src/content/ko/installation/prerequisites/linux-distribution-and-docker-podman-support-status.mdx
@@ -1,5 +1,6 @@
 ---
 title: '리눅스 배포본과 Docker, Podman 지원 현황'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1298530305/Docker+Podman'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/installation/product-versions.mdx
+++ b/src/content/ko/installation/product-versions.mdx
@@ -1,5 +1,6 @@
 ---
 title: '제품 버전'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1881243653'
 ---
 
 # 제품 버전

--- a/src/content/ko/installation/querypie-acp-community-edition.mdx
+++ b/src/content/ko/installation/querypie-acp-community-edition.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'QueryPie ACP Community Edition'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1239416833/QueryPie+ACP+Community+Edition'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/installation/querypie-acp-community-edition/mcp-configuration-guide.mdx
+++ b/src/content/ko/installation/querypie-acp-community-edition/mcp-configuration-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'MCP 설정 가이드'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1735589937/MCP'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/installation/server-configuration-requirements.mdx
+++ b/src/content/ko/installation/server-configuration-requirements.mdx
@@ -1,5 +1,6 @@
 ---
 title: '서버구성 요구사항'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1690402874'
 ---
 
 # 서버구성 요구사항

--- a/src/content/ko/installation/server-configuration-requirements/on-premise-vm-requirements.mdx
+++ b/src/content/ko/installation/server-configuration-requirements/on-premise-vm-requirements.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'On-Premise VM 요구사항'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1688371232/On-Premise+VM'
 ---
 
 # On-Premise VM 요구사항

--- a/src/content/ko/installation/server-configuration-requirements/public-cloud-production-server-requirements.mdx
+++ b/src/content/ko/installation/server-configuration-requirements/public-cloud-production-server-requirements.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Public Cloud 운영서버 요구사항'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/903086124/Public+Cloud'
 ---
 
 # Public Cloud 운영서버 요구사항

--- a/src/content/ko/installation/server-configuration-requirements/server-configuration-requirements-summary.mdx
+++ b/src/content/ko/installation/server-configuration-requirements/server-configuration-requirements-summary.mdx
@@ -1,5 +1,6 @@
 ---
 title: '서버구성 요구사항 요약표'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1692303361'
 ---
 
 # 서버구성 요구사항 요약표

--- a/src/content/ko/installation/system-architecture-and-network-access-control.mdx
+++ b/src/content/ko/installation/system-architecture-and-network-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: '시스템 아키텍처와 네트워크 접근제어'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/862093313'
 ---
 
 # 시스템 아키텍처와 네트워크 접근제어

--- a/src/content/ko/overview.mdx
+++ b/src/content/ko/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Overview'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375784/Overview'
 ---
 
 # Overview

--- a/src/content/ko/overview/proxy-management.mdx
+++ b/src/content/ko/overview/proxy-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Proxy Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544112942/Proxy+Management'
 ---
 
 # Proxy Management

--- a/src/content/ko/overview/proxy-management/enable-database-proxy.mdx
+++ b/src/content/ko/overview/proxy-management/enable-database-proxy.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Database Proxy 사용 활성화'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544377869/Database+Proxy'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/overview/system-architecture-overview.mdx
+++ b/src/content/ko/overview/system-architecture-overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: '시스템 구성도 개요'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375859'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/release-notes.mdx
+++ b/src/content/ko/release-notes.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Release Notes'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375335/Release+Notes'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/release-notes/10.0.0-10.0.2.mdx
+++ b/src/content/ko/release-notes/10.0.0-10.0.2.mdx
@@ -1,5 +1,6 @@
 ---
 title: '10.0.0 ~ 10.0.2'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375355/10.0.0+~+10.0.2'
 ---
 
 # 10.0.0 ~ 10.0.2

--- a/src/content/ko/release-notes/10.1.0-10.1.11.mdx
+++ b/src/content/ko/release-notes/10.1.0-10.1.11.mdx
@@ -1,5 +1,6 @@
 ---
 title: '10.1.0 ~ 10.1.11'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/604995641/10.1.0+~+10.1.11'
 ---
 
 # 10.1.0 ~ 10.1.11

--- a/src/content/ko/release-notes/10.2.0-10.2.12.mdx
+++ b/src/content/ko/release-notes/10.2.0-10.2.12.mdx
@@ -1,5 +1,6 @@
 ---
 title: '10.2.0 ~ 10.2.12'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/703463517/10.2.0+~+10.2.12'
 ---
 
 # 10.2.0 ~ 10.2.12

--- a/src/content/ko/release-notes/10.3.0-10.3.4.mdx
+++ b/src/content/ko/release-notes/10.3.0-10.3.4.mdx
@@ -1,5 +1,6 @@
 ---
 title: '10.3.0 ~ 10.3.4'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/954335909/10.3.0+~+10.3.4'
 ---
 
 # 10.3.0 ~ 10.3.4

--- a/src/content/ko/release-notes/11.0.0.mdx
+++ b/src/content/ko/release-notes/11.0.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: '11.0.0'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064830173/11.0.0'
 ---
 
 # 11.0.0

--- a/src/content/ko/release-notes/11.1.0-11.1.2.mdx
+++ b/src/content/ko/release-notes/11.1.0-11.1.2.mdx
@@ -1,5 +1,6 @@
 ---
 title: '11.1.0 ~ 11.1.2'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1171488777/11.1.0+~+11.1.2'
 ---
 
 # 11.1.0 ~ 11.1.2

--- a/src/content/ko/release-notes/11.2.0.mdx
+++ b/src/content/ko/release-notes/11.2.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: '11.2.0'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1291878563/11.2.0'
 ---
 
 # 11.2.0

--- a/src/content/ko/release-notes/11.3.0.mdx
+++ b/src/content/ko/release-notes/11.3.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: '11.3.0'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1421475841/11.3.0'
 ---
 
 # 11.3.0

--- a/src/content/ko/release-notes/11.4.0.mdx
+++ b/src/content/ko/release-notes/11.4.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: '11.4.0'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1568735233/11.4.0'
 ---
 
 # 11.4.0

--- a/src/content/ko/release-notes/11.5.0.mdx
+++ b/src/content/ko/release-notes/11.5.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: '11.5.0'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1751810049/11.5.0'
 ---
 
 # 11.5.0

--- a/src/content/ko/release-notes/9.10.0-9.10.4.mdx
+++ b/src/content/ko/release-notes/9.10.0-9.10.4.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.10.0 ~ 9.10.4'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375607/9.10.0+~+9.10.4'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/release-notes/9.10.0-9.10.4/external-api-changes-9100-version.mdx
+++ b/src/content/ko/release-notes/9.10.0-9.10.4/external-api-changes-9100-version.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'External API 변경사항 (9.10.0 버전)'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375624/External+API+9.10.0'
 ---
 
 # External API 변경사항 (9.10.0 버전)

--- a/src/content/ko/release-notes/9.11.0-9.11.5.mdx
+++ b/src/content/ko/release-notes/9.11.0-9.11.5.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.11.0 ~ 9.11.5'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375587/9.11.0+~+9.11.5'
 ---
 
 # 9.11.0 ~ 9.11.5

--- a/src/content/ko/release-notes/9.12.0-9.12.14.mdx
+++ b/src/content/ko/release-notes/9.12.0-9.12.14.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.12.0 ~ 9.12.14'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375485/9.12.0+~+9.12.14'
 ---
 
 # 9.12.0 ~ 9.12.14

--- a/src/content/ko/release-notes/9.12.0-9.12.14/menu-improvement-guide-9120.mdx
+++ b/src/content/ko/release-notes/9.12.0-9.12.14/menu-improvement-guide-9120.mdx
@@ -1,5 +1,6 @@
 ---
 title: '메뉴 개선 가이드 (9.12.0)'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375505/9.12.0'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/release-notes/9.13.0-9.13.5.mdx
+++ b/src/content/ko/release-notes/9.13.0-9.13.5.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.13.0 ~ 9.13.5'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375471/9.13.0+~+9.13.5'
 ---
 
 # 9.13.0 ~ 9.13.5

--- a/src/content/ko/release-notes/9.14.0-9.14.3.mdx
+++ b/src/content/ko/release-notes/9.14.0-9.14.3.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.14.0 ~ 9.14.3'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375457/9.14.0+~+9.14.3'
 ---
 
 # 9.14.0 ~ 9.14.3

--- a/src/content/ko/release-notes/9.15.0-9.15.4.mdx
+++ b/src/content/ko/release-notes/9.15.0-9.15.4.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.15.0 ~ 9.15.4'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375443/9.15.0+~+9.15.4'
 ---
 
 # 9.15.0 ~ 9.15.4

--- a/src/content/ko/release-notes/9.16.0-9.16.4.mdx
+++ b/src/content/ko/release-notes/9.16.0-9.16.4.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.16.0 ~ 9.16.4'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375429/9.16.0+~+9.16.4'
 ---
 
 # 9.16.0 ~ 9.16.4

--- a/src/content/ko/release-notes/9.17.0-9.17.1.mdx
+++ b/src/content/ko/release-notes/9.17.0-9.17.1.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.17.0 ~ 9.17.1'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375414/9.17.0+~+9.17.1'
 ---
 
 # 9.17.0 ~ 9.17.1

--- a/src/content/ko/release-notes/9.18.0-9.18.3.mdx
+++ b/src/content/ko/release-notes/9.18.0-9.18.3.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.18.0 ~ 9.18.3'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375399/9.18.0+~+9.18.3'
 ---
 
 # 9.18.0 ~ 9.18.3

--- a/src/content/ko/release-notes/9.19.0.mdx
+++ b/src/content/ko/release-notes/9.19.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.19.0'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375385/9.19.0'
 ---
 
 # 9.19.0

--- a/src/content/ko/release-notes/9.20.0-9.20.2.mdx
+++ b/src/content/ko/release-notes/9.20.0-9.20.2.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.20.0 ~ 9.20.2'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375370/9.20.0+~+9.20.2'
 ---
 
 # 9.20.0 ~ 9.20.2

--- a/src/content/ko/release-notes/9.8.0-9.8.12.mdx
+++ b/src/content/ko/release-notes/9.8.0-9.8.12.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.8.0 ~ 9.8.12'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375768/9.8.0+~+9.8.12'
 ---
 
 # 9.8.0 ~ 9.8.12

--- a/src/content/ko/release-notes/9.9.0-9.9.8.mdx
+++ b/src/content/ko/release-notes/9.9.0-9.9.8.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.9.0 ~ 9.9.8'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375659/9.9.0+~+9.9.8'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/release-notes/9.9.0-9.9.8/external-api-changes-9810-version-994-version.mdx
+++ b/src/content/ko/release-notes/9.9.0-9.9.8/external-api-changes-9810-version-994-version.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'External API 변경사항 (9.8.10 버전 > 9.9.4 버전)'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375685/External+API+9.8.10+9.9.4'
 ---
 
 # External API 변경사항 (9.8.10 버전 > 9.9.4 버전)

--- a/src/content/ko/release-notes/9.9.0-9.9.8/external-api-changes-994-version-995-version.mdx
+++ b/src/content/ko/release-notes/9.9.0-9.9.8/external-api-changes-994-version-995-version.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'External API 변경사항 (9.9.4 버전 > 9.9.5 버전)'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375741/External+API+9.9.4+9.9.5'
 ---
 
 # External API 변경사항 (9.9.4 버전 > 9.9.5 버전)

--- a/src/content/ko/support.mdx
+++ b/src/content/ko/support.mdx
@@ -1,5 +1,6 @@
 ---
 title: '지원'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1844969501'
 ---
 
 # 지원

--- a/src/content/ko/support/premium-support.mdx
+++ b/src/content/ko/support/premium-support.mdx
@@ -1,5 +1,6 @@
 ---
 title: '프리미엄 지원'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1853358081'
 ---
 
 # 프리미엄 지원

--- a/src/content/ko/unreleased.mdx
+++ b/src/content/ko/unreleased.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Unreleased'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1911423023/Unreleased'
 ---
 
 # Unreleased

--- a/src/content/ko/unreleased/reverse-sync-test-page.mdx
+++ b/src/content/ko/unreleased/reverse-sync-test-page.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Reverse Sync Test Page'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1911652402/Reverse+Sync+Test+Page'
 ---
 
 # Reverse Sync Test Page

--- a/src/content/ko/user-manual.mdx
+++ b/src/content/ko/user-manual.mdx
@@ -1,5 +1,6 @@
 ---
 title: '사용자 매뉴얼'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544211126'
 ---
 
 # 사용자 매뉴얼

--- a/src/content/ko/user-manual/database-access-control.mdx
+++ b/src/content/ko/user-manual/database-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Database Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380204/Database+Access+Control'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/database-access-control/connecting-to-custom-data-source.mdx
+++ b/src/content/ko/user-manual/database-access-control/connecting-to-custom-data-source.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Custom Data Source 접속하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/880181257/Custom+Data+Source'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/database-access-control/connecting-to-proxy-without-agent.mdx
+++ b/src/content/ko/user-manual/database-access-control/connecting-to-proxy-without-agent.mdx
@@ -1,5 +1,6 @@
 ---
 title: '에이전트 없이 프록시 접속하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/559906893'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/database-access-control/connecting-via-google-bigquery-oauth-authentication.mdx
+++ b/src/content/ko/user-manual/database-access-control/connecting-via-google-bigquery-oauth-authentication.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Google BigQuery OAuth 인증을 통해 접속하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/820609510/Google+BigQuery+OAuth'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/database-access-control/connecting-with-web-sql-editor.mdx
+++ b/src/content/ko/user-manual/database-access-control/connecting-with-web-sql-editor.mdx
@@ -1,5 +1,6 @@
 ---
 title: '웹 SQL 에디터로 접속하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380222/SQL'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/database-access-control/setting-default-privilege.mdx
+++ b/src/content/ko/user-manual/database-access-control/setting-default-privilege.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Default Privilege 설정하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380354/Default+Privilege'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/kubernetes-access-control.mdx
+++ b/src/content/ko/user-manual/kubernetes-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Kubernetes Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544384011/Kubernetes+Access+Control'
 ---
 
 # Kubernetes Access Control

--- a/src/content/ko/user-manual/kubernetes-access-control/checking-access-permission-list.mdx
+++ b/src/content/ko/user-manual/kubernetes-access-control/checking-access-permission-list.mdx
@@ -1,5 +1,6 @@
 ---
 title: '접근 권한 목록 확인하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544384025'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/multi-agent.mdx
+++ b/src/content/ko/user-manual/multi-agent.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Multi Agent'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/852066413/Multi+Agent'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/multi-agent/multi-agent-3rd-party-tool-support-list-by-os.mdx
+++ b/src/content/ko/user-manual/multi-agent/multi-agent-3rd-party-tool-support-list-by-os.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Multi Agent OS별 3rd Party Tool 지원 목록'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/919240916/Multi+Agent+OS+3rd+Party+Tool'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/multi-agent/multi-agent-linux-installation-and-usage-guide.mdx
+++ b/src/content/ko/user-manual/multi-agent/multi-agent-linux-installation-and-usage-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Multi Agent Linux 설치 및 사용 가이드'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/912425276/Multi+Agent+Linux'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/multi-agent/multi-agent-seamless-ssh-usage-guide.mdx
+++ b/src/content/ko/user-manual/multi-agent/multi-agent-seamless-ssh-usage-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Multi Agent Seamless SSH 사용 가이드'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/912425288/Multi+Agent+Seamless+SSH'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/my-dashboard.mdx
+++ b/src/content/ko/user-manual/my-dashboard.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'My Dashboard'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/578945174/My+Dashboard'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/my-dashboard/user-password-reset-via-email.mdx
+++ b/src/content/ko/user-manual/my-dashboard/user-password-reset-via-email.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Email을 통한 사용자 비밀 번호 초기화'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/793542657/Email'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/preferences.mdx
+++ b/src/content/ko/user-manual/preferences.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Preferences'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/568950885/Preferences'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/server-access-control.mdx
+++ b/src/content/ko/user-manual/server-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381369/Server+Access+Control'
 ---
 
 # Server Access Control

--- a/src/content/ko/user-manual/server-access-control/connecting-to-authorized-servers.mdx
+++ b/src/content/ko/user-manual/server-access-control/connecting-to-authorized-servers.mdx
@@ -1,5 +1,6 @@
 ---
 title: '권한이 있는 서버에 접속하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381383'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/server-access-control/using-web-sftp.mdx
+++ b/src/content/ko/user-manual/server-access-control/using-web-sftp.mdx
@@ -1,5 +1,6 @@
 ---
 title: '웹 SFTP 사용하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381477/SFTP'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/server-access-control/using-web-terminal.mdx
+++ b/src/content/ko/user-manual/server-access-control/using-web-terminal.mdx
@@ -1,5 +1,6 @@
 ---
 title: '웹 터미널 사용하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381410'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/user-agent.mdx
+++ b/src/content/ko/user-manual/user-agent.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'User Agent'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544112828/User+Agent'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/web-access-control.mdx
+++ b/src/content/ko/user-manual/web-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064829218/Web+Access+Control'
 ---
 
 # Web Access Control

--- a/src/content/ko/user-manual/web-access-control/accessing-web-applications-websites.mdx
+++ b/src/content/ko/user-manual/web-access-control/accessing-web-applications-websites.mdx
@@ -1,5 +1,6 @@
 ---
 title: '웹 어플리케이션 (웹 사이트) 접속하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064796396'
 ---
 
 # 웹 어플리케이션 (웹 사이트) 접속하기

--- a/src/content/ko/user-manual/web-access-control/installing-root-ca-certificate-and-extension.mdx
+++ b/src/content/ko/user-manual/web-access-control/installing-root-ca-certificate-and-extension.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Root CA 인증서 및 Extension 설치하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1073709107/Root+CA+Extension'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/workflow.mdx
+++ b/src/content/ko/user-manual/workflow.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Workflow'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544377922/Workflow'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/workflow/approval-additional-features-proxy-approval-resubmission-etc.mdx
+++ b/src/content/ko/user-manual/workflow/approval-additional-features-proxy-approval-resubmission-etc.mdx
@@ -1,5 +1,6 @@
 ---
 title: '결재 부가 기능 (대리 결재, 재상신 등)'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/568918170'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/workflow/requesting-access-role.mdx
+++ b/src/content/ko/user-manual/workflow/requesting-access-role.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Access Role Request 요청하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544378348/Access+Role+Request'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/workflow/requesting-db-access.mdx
+++ b/src/content/ko/user-manual/workflow/requesting-db-access.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'DB Access Request 요청하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544377968/DB+Access+Request'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/workflow/requesting-db-policy-exception.mdx
+++ b/src/content/ko/user-manual/workflow/requesting-db-policy-exception.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'DB 정책 예외 요청하기 (DB Policy Exception Request)'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070006273/DB+DB+Policy+Exception+Request'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/workflow/requesting-ip-registration.mdx
+++ b/src/content/ko/user-manual/workflow/requesting-ip-registration.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'IP Registration Request 요청하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1055358996/IP+Registration+Request'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/workflow/requesting-restricted-data-access.mdx
+++ b/src/content/ko/user-manual/workflow/requesting-restricted-data-access.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Restricted Data Access 요청하기 (제한된 데이터 접근 요청)'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1060306945/Restricted+Data+Access'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/workflow/requesting-server-access.mdx
+++ b/src/content/ko/user-manual/workflow/requesting-server-access.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Access Request 요청하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544378254/Server+Access+Request'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/workflow/requesting-server-privilege.mdx
+++ b/src/content/ko/user-manual/workflow/requesting-server-privilege.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Privilege Request 요청하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/878936417/Server+Privilege+Request'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/workflow/requesting-sql-export.mdx
+++ b/src/content/ko/user-manual/workflow/requesting-sql-export.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'SQL Export Request 요청하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544378182/SQL+Export+Request'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/workflow/requesting-sql.mdx
+++ b/src/content/ko/user-manual/workflow/requesting-sql.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'SQL Request 요청하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544378069/SQL+Request'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/workflow/requesting-sql/using-execution-plan-explain-feature.mdx
+++ b/src/content/ko/user-manual/workflow/requesting-sql/using-execution-plan-explain-feature.mdx
@@ -1,5 +1,6 @@
 ---
 title: '실행 계획(Explain) 기능 사용하기'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/692355151/Explain'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ko/user-manual/workflow/requesting-unmasking-mask-removal-request.mdx
+++ b/src/content/ko/user-manual/workflow/requesting-unmasking-mask-removal-request.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Unmasking Request 요청하기 (마스킹 해제 요청)'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/712769539/Unmasking+Request'
 ---
 
 import { Callout } from 'nextra/components'


### PR DESCRIPTION
## Summary
- 289개 한국어 MDX 파일의 frontmatter에 `confluenceUrl` 필드를 추가합니다.
- TOC 영역의 Confluence 원문 링크 컴포넌트(#636)에서 참조하는 데이터입니다.

## Related
- #603
- #636 (코드 변경 PR)

## Test plan
- [ ] 한국어 페이지에서 TOC 영역에 Confluence 원문 링크가 표시되는지 확인
- [ ] 영어/일본어 페이지에서는 링크가 표시되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)