### PR TITLE
fix(converter): emoji 패키지 미설치 시 converter 실행을 중단합니다

### DIFF
--- a/confluence-mdx/bin/converter/context.py
+++ b/confluence-mdx/bin/converter/context.py
@@ -21,9 +21,11 @@ from text_utils import clean_text
 
 try:
     import emoji
-    EMOJI_AVAILABLE = True
 except ImportError:
-    EMOJI_AVAILABLE = False
+    raise SystemExit(
+        "Required package 'emoji' is not installed.\n"
+        "Run: pip install 'emoji>=2.8.0'"
+    )
 
 
 # Type definitions for page_v1 structure

--- a/confluence-mdx/bin/converter/core.py
+++ b/confluence-mdx/bin/converter/core.py
@@ -27,7 +27,7 @@ from bs4.element import CData
 import converter.context as ctx
 from converter.context import (
     PAGES_BY_TITLE,
-    CONFLUENCE_COLOR_TO_BADGE_COLOR, EMOJI_AVAILABLE,
+    CONFLUENCE_COLOR_TO_BADGE_COLOR,
     confluence_url, parse_confluence_url, convert_confluence_url,
     get_page_v1, get_attachments, set_page_v1, set_attachments,
     relative_path_to_titled_page, resolve_external_link,
@@ -333,24 +333,13 @@ class SingleLineParser:
                 self.markdown_lines.append(fallback)
             elif shortname:
                 # Convert shortname to actual emoji
-                if EMOJI_AVAILABLE:
-                    # Use emoji library to convert shortname to actual emoji
-                    emoji_char = emoji.emojize(shortname, language='alias')
-                    if emoji_char != shortname:
-                        # Conversion successful (converted to actual emoji)
-                        self.markdown_lines.append(emoji_char)
-                    else:
-                        # Conversion failed (use fallback or shortname as-is)
-                        if fallback:
-                            self.markdown_lines.append(fallback)
-                        else:
-                            self.markdown_lines.append(shortname)
+                emoji_char = emoji.emojize(shortname, language='alias')
+                if emoji_char != shortname:
+                    self.markdown_lines.append(emoji_char)
+                elif fallback:
+                    self.markdown_lines.append(fallback)
                 else:
-                    # emoji library not available, use fallback or shortname
-                    if fallback:
-                        self.markdown_lines.append(fallback)
-                    else:
-                        self.markdown_lines.append(shortname)
+                    self.markdown_lines.append(shortname)
             elif fallback:
                 # No shortname but fallback is available
                 self.markdown_lines.append(fallback)


### PR DESCRIPTION
## Summary
- `emoji` 패키지가 설치되지 않은 경우, converter가 조용히 fallback 경로를 타며 shortname(`:check_mark:`)을 그대로 출력하는 문제를 수정합니다.
- `EMOJI_AVAILABLE` 플래그를 제거하고, import 실패 시 `SystemExit`으로 즉시 중단합니다.
- `core.py`의 불필요한 `EMOJI_AVAILABLE` 분기를 제거하여 코드를 단순화합니다.

## Related
- Closes #644

## Test plan
- [x] venv에 emoji 설치 후 convert 테스트 21/21 통과
- [ ] emoji 미설치 환경에서 converter 실행 시 명확한 에러 메시지 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)