### PR TITLE
fix(reverse-sync): innerHTML 교체 → 텍스트 레벨 패칭으로 verify 실패 수정

### DIFF
--- a/confluence-mdx/bin/reverse_sync/mdx_to_xhtml_inline.py
+++ b/confluence-mdx/bin/reverse_sync/mdx_to_xhtml_inline.py
@@ -50,7 +50,7 @@ def _convert_paragraph(text: str) -> str:
         if not line:
             continue
         converted.append(_convert_inline(line))
-    return ''.join(converted)
+    return ' '.join(converted)
 
 
 def _convert_code_block(text: str) -> str:

--- a/confluence-mdx/bin/reverse_sync_cli.py
+++ b/confluence-mdx/bin/reverse_sync_cli.py
@@ -25,7 +25,7 @@ from reverse_sync.block_diff import diff_blocks, BlockChange
 from reverse_sync.mapping_recorder import record_mapping, BlockMapping
 from reverse_sync.xhtml_patcher import patch_xhtml
 from reverse_sync.roundtrip_verifier import verify_roundtrip
-from reverse_sync.mdx_to_xhtml_inline import mdx_block_to_inner_xhtml
+
 
 
 @dataclass
@@ -279,7 +279,7 @@ def _normalize_mdx_to_plain(content: str, block_type: str) -> str:
         s = s.strip()
         if s:
             parts.append(s)
-    return ''.join(parts)
+    return ' '.join(parts)
 
 
 def _collapse_ws(text: str) -> str:
@@ -337,11 +337,11 @@ def _build_patches(
             continue
 
         new_block = change.new_block
+        new_plain = _normalize_mdx_to_plain(new_block.content, new_block.type)
         patches.append({
             'xhtml_xpath': mapping.xhtml_xpath,
             'old_plain_text': mapping.xhtml_plain_text,
-            'new_inner_xhtml': mdx_block_to_inner_xhtml(
-                new_block.content, new_block.type),
+            'new_plain_text': new_plain,
         })
 
     return patches

--- a/confluence-mdx/tests/test_reverse_sync_cli.py
+++ b/confluence-mdx/tests/test_reverse_sync_cli.py
@@ -480,8 +480,8 @@ def test_normalize_mdx_list():
     )
     result = _normalize_mdx_to_plain(content, 'paragraph')
     expected = (
-        "Administrator > Audit > ... 메뉴로 이동합니다."
-        "당월 기준으로..."
+        "Administrator > Audit > ... 메뉴로 이동합니다. "
+        "당월 기준으로... "
         "Access Control Updated  : 커넥션 접근 권한 수정이력"
     )
     assert result == expected
@@ -495,7 +495,7 @@ def test_normalize_mdx_list_with_figure():
         "2. 두 번째 항목"
     )
     result = _normalize_mdx_to_plain(content, 'paragraph')
-    assert result == '첫 번째 항목두 번째 항목'
+    assert result == '첫 번째 항목 두 번째 항목'
 
 
 # --- _build_patches index-based mapping tests ---
@@ -540,7 +540,7 @@ def test_build_patches_index_mapping():
     assert len(patches) == 1
     assert patches[0]['xhtml_xpath'] == 'p[1]'
     assert patches[0]['old_plain_text'] == 'Old text.'
-    assert patches[0]['new_inner_xhtml'] == 'New text.'
+    assert patches[0]['new_plain_text'] == 'New text.'
 
 
 def test_build_patches_skips_non_content():


### PR DESCRIPTION
## Summary
- `reverse-sync verify`가 paragraph/heading 블록에서 항상 FAIL하던 문제를 수정합니다.
- innerHTML 전체 교체(`new_inner_xhtml`) 대신 텍스트 레벨 패칭(`new_plain_text`)을 사용하여 XHTML 인라인 구조를 보존합니다.
- CLI 경로 독립성 개선 및 컬러 diff 출력, `--limit` 옵션을 추가합니다.

## 근본 원인
1. `_convert_paragraph()`가 다중 행을 공백 없이 합쳐 XHTML과 불일치 발생
2. `_replace_inner_html()`가 `<code>`, `<ac:link>` 등 인라인 구조를 파괴하여 forward 변환 시 원본 MDX 재현 불가
3. `_normalize_mdx_to_plain()`의 동일한 join 문제로 텍스트 매칭 부정확

## 변경 내용
- `_normalize_mdx_to_plain()`: `''.join()` → `' '.join()` (공백 구분자)
- `_build_patches()`: `new_inner_xhtml` → `new_plain_text` (텍스트 노드만 수정)
- `_convert_paragraph()`: `''.join()` → `' '.join()` (공백 구분자)
- CLI: 경로 독립성 확보(`_PROJECT_DIR` 기반), 컬러 diff 출력, `--limit`/`--json` 옵션

## Test plan
- [x] `python3 -m pytest tests/ -v` — 관련 5개 테스트 모두 PASS 확인
- [ ] `python3 bin/reverse_sync_cli.py verify --branch jk/fix-typo-and-grammar --limit 5` 실행하여 실제 verify 결과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)