### PR TITLE
fix(skeleton): Badge 태그 속성 잘림 현상 수정

### DIFF
--- a/confluence-mdx/tests/testcases/544384417/expected.skel.mdx
+++ b/confluence-mdx/tests/testcases/544384417/expected.skel.mdx
@@ -106,7 +106,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_ <Badge
+_TEXT_ <Badge color="green">_TEXT_</Badge><br/>
 </td>
 <td>
 _TEXT_
@@ -120,7 +120,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_ <Badge
+_TEXT_ <Badge color="green">_TEXT_</Badge><br/>
 </td>
 <td>
 _TEXT_
@@ -227,7 +227,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_ <Badge
+_TEXT_ <Badge color="blue">_TEXT_</Badge><br/>
 </td>
 <td>
 _TEXT_
@@ -244,7 +244,7 @@ _TEXT_
 _TEXT_
 </td>
 <td rowspan="2">
-_TEXT_ <Badge
+_TEXT_ <Badge color="green">_TEXT_</Badge>
 </td>
 <td>
 _TEXT_ <br/>
@@ -337,7 +337,7 @@ _TEXT_
 </tr>
 <tr>
 <td rowspan="2">
-_TEXT_ <Badge
+_TEXT_ <Badge color="green">_TEXT_</Badge>
 </td>
 <td>
 _TEXT_ <br/>
@@ -354,7 +354,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_ <Badge
+_TEXT_ <Badge color="green">_TEXT_</Badge>
 _TEXT_
 </td>
 <td>
@@ -372,7 +372,7 @@ _TEXT_
 _TEXT_
 </td>
 <td rowspan="2">
-_TEXT_ <br/> <Badge
+_TEXT_ <br/> <Badge color="green">_TEXT_</Badge>
 </td>
 <td>
 _TEXT_ <br/>
@@ -403,7 +403,7 @@ _TEXT_
 </tr>
 <tr>
 <td rowspan="2">
-_TEXT_ <Badge
+_TEXT_ <Badge color="green">_TEXT_</Badge>
 </td>
 <td>
 _TEXT_ <br/>
@@ -434,7 +434,7 @@ _TEXT_
 </tr>
 <tr>
 <td rowspan="2">
-_TEXT_ <Badge
+_TEXT_ <Badge color="green">_TEXT_</Badge>
 </td>
 <td>
 _TEXT_ <br/>
@@ -468,7 +468,7 @@ _TEXT_
 _TEXT_
 </td>
 <td>
-_TEXT_ <Badge
+_TEXT_ <Badge color="blue">_TEXT_</Badge><br/>
 </td>
 <td>
 _TEXT_
@@ -510,7 +510,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_ <Badge
+_TEXT_ <Badge color="green">_TEXT_</Badge><br/>
 </td>
 <td>
 _TEXT_
@@ -524,7 +524,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_ <Badge
+_TEXT_ <Badge color="green">_TEXT_</Badge><br/>
 </td>
 <td>
 _TEXT_
@@ -538,7 +538,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_ <Badge
+_TEXT_ <Badge color="green">_TEXT_</Badge><br/>
 </td>
 <td>
 _TEXT_
@@ -658,7 +658,7 @@ _TEXT_
 </tr>
 <tr>
 <td>
-_TEXT_ <br/> <Badge
+_TEXT_ <br/> <Badge color="green">_TEXT_</Badge>
 </td>
 <td>
 _TEXT_ <br/>


### PR DESCRIPTION
## 문제 (Issue #567)

skeleton 변환 시 속성이 있는 HTML 태그가 잘리는 버그입니다.

```markdown
# 입력
Group Status <Badge color="green">added-10.2.2</Badge>

# 기대 결과
_TEXT_ <Badge color="green">_TEXT_</Badge>

# 실제 결과 (버그)
_TEXT_ <Badge
```

testcase 544384417에서 16개 Badge 태그 중 14개가 불완전하게 변환되었습니다.

## 원인

`_normalize_pattern_order()`에서 `content.split()`이 **태그 속성 내부의 공백에서도 분리**합니다:

```python
"<Badge color=\"green\">_TEXT_</Badge>".split()
→ ['<Badge', 'color="green">_TEXT_</Badge>']
```

이후 중복 제거 로직이 `color="green">_TEXT_</Badge>` 토큰에서 `_TEXT_` 패턴을 감지하고 필터링하면서, 불완전한 `<Badge`만 남게 됩니다.

## 해결

`<...>` 꺾쇠 안의 공백에서는 분리하지 않는 `_split_preserving_html_tags()` 메서드를 추가했습니다:

```python
def _split_preserving_html_tags(self, text: str) -> list[str]:
    """Split by whitespace, but preserve spaces inside <...> tag brackets."""
    ...
    for i, char in enumerate(text):
        if in_tag:
            current.append(char)
            ...
            elif char == '>':
                in_tag = False
        elif char == '<' and i + 1 < len(text) and (text[i + 1].isalpha() or text[i + 1] == '/'):
            # <Badge, </div> 등 실제 HTML 태그만 인식
            # <=, <`, <$ 같은 비-HTML 문맥은 무시
            current.append(char)
            in_tag = True
        elif char.isspace():
            if current:
                tokens.append(''.join(current))
                current = []
        else:
            current.append(char)
    ...
```

핵심: `content.split()` → `self._split_preserving_html_tags(content)` 한 줄 교체.

## 변경 파일

| 파일 | 변경 |
|---|---|
| `confluence-mdx/bin/skeleton/cli.py` | `_split_preserving_html_tags()` 추가, `split()` 호출 1줄 교체 |
| `confluence-mdx/tests/test_mdx_to_skeleton.py` | 단위 테스트 3개 추가 |
| `confluence-mdx/tests/testcases/544384417/expected.skel.mdx` | Badge 태그 수정 반영 (14줄) |

## 테스트

- 단위 테스트 57개 전체 통과
- skeleton 통합 테스트 18개 전체 통과
- testcase 544384417: Badge 태그 **16개 모두 완전 생성** 확인

```diff
- _TEXT_ <Badge
+ _TEXT_ <Badge color="green">_TEXT_</Badge>
```