### PR TITLE
mdx: en/ja 번역 파일에 confluenceUrl frontmatter 동기화

### DIFF
--- a/src/content/en/administrator-manual.mdx
+++ b/src/content/en/administrator-manual.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Administrator Manual'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544178405'
 ---
 
 # Administrator Manual

--- a/src/content/en/administrator-manual/audit.mdx
+++ b/src/content/en/administrator-manual/audit.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Audit'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379062/Audit'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/audit/database-logs.mdx
+++ b/src/content/en/administrator-manual/audit/database-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Database Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544080248/Database+Logs'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/audit/database-logs/access-control-logs.mdx
+++ b/src/content/en/administrator-manual/audit/database-logs/access-control-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Access Control Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544080264/Access+Control+Logs'
 ---
 
 # Access Control Logs

--- a/src/content/en/administrator-manual/audit/database-logs/account-lock-history.mdx
+++ b/src/content/en/administrator-manual/audit/database-logs/account-lock-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Account Lock History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544014894/Account+Lock+History'
 ---
 
 # Account Lock History

--- a/src/content/en/administrator-manual/audit/database-logs/db-access-history.mdx
+++ b/src/content/en/administrator-manual/audit/database-logs/db-access-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'DB Access History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544113141/DB+Access+History'
 ---
 
 # DB Access History

--- a/src/content/en/administrator-manual/audit/database-logs/dml-snapshots.mdx
+++ b/src/content/en/administrator-manual/audit/database-logs/dml-snapshots.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'DML Snapshots'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544244163/DML+Snapshots'
 ---
 
 # DML Snapshots

--- a/src/content/en/administrator-manual/audit/database-logs/policy-audit-logs.mdx
+++ b/src/content/en/administrator-manual/audit/database-logs/policy-audit-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Policy Audit Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070694532/Policy+Audit+Logs'
 ---
 
 # Policy Audit Logs

--- a/src/content/en/administrator-manual/audit/database-logs/policy-exception-logs.mdx
+++ b/src/content/en/administrator-manual/audit/database-logs/policy-exception-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Policy Exception logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1164705793/Policy+Exception+logs'
 ---
 
 # Policy Exception logs

--- a/src/content/en/administrator-manual/audit/database-logs/query-audit.mdx
+++ b/src/content/en/administrator-manual/audit/database-logs/query-audit.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Query Audit'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544244149/Query+Audit'
 ---
 
 # Query Audit

--- a/src/content/en/administrator-manual/audit/database-logs/running-queries.mdx
+++ b/src/content/en/administrator-manual/audit/database-logs/running-queries.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Running Queries'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544145819/Running+Queries'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/audit/general-logs.mdx
+++ b/src/content/en/administrator-manual/audit/general-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'General Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544211450/General+Logs'
 ---
 
 # General Logs

--- a/src/content/en/administrator-manual/audit/general-logs/activity-logs.mdx
+++ b/src/content/en/administrator-manual/audit/general-logs/activity-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Activity Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544113108/Activity+Logs'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/audit/general-logs/admin-role-history.mdx
+++ b/src/content/en/administrator-manual/audit/general-logs/admin-role-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Admin Role History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544047557/Admin+Role+History'
 ---
 
 # Admin Role History

--- a/src/content/en/administrator-manual/audit/general-logs/reverse-tunnels.mdx
+++ b/src/content/en/administrator-manual/audit/general-logs/reverse-tunnels.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Reverse Tunnels'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/775455036/Reverse+Tunnels'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-clusters-through-reverse-tunnel.mdx
+++ b/src/content/en/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-clusters-through-reverse-tunnel.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Communicating with Clusters through Reverse Tunnel'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/811466988/Reverse+Tunnel'
 ---
 
 # Communicating with Clusters through Reverse Tunnel

--- a/src/content/en/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-db-through-reverse-tunnel.mdx
+++ b/src/content/en/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-db-through-reverse-tunnel.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Communicating with DB through Reverse Tunnel'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/955318273/Reverse+Tunnel+DB'
 ---
 
 # Communicating with DB through Reverse Tunnel

--- a/src/content/en/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-servers-through-reverse-tunnel.mdx
+++ b/src/content/en/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-servers-through-reverse-tunnel.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Communicating with Servers through Reverse Tunnel'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/811434216/Reverse+Tunnel'
 ---
 
 # Communicating with Servers through Reverse Tunnel

--- a/src/content/en/administrator-manual/audit/general-logs/user-access-history.mdx
+++ b/src/content/en/administrator-manual/audit/general-logs/user-access-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'User Access History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544080230/User+Access+History'
 ---
 
 # User Access History

--- a/src/content/en/administrator-manual/audit/general-logs/workflow-logs.mdx
+++ b/src/content/en/administrator-manual/audit/general-logs/workflow-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Workflow Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/705724442/Workflow+Logs'
 ---
 
 # Workflow Logs

--- a/src/content/en/administrator-manual/audit/kubernetes-logs.mdx
+++ b/src/content/en/administrator-manual/audit/kubernetes-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Kubernetes Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544383513/Kubernetes+Logs'
 ---
 
 # Kubernetes Logs

--- a/src/content/en/administrator-manual/audit/kubernetes-logs/kubernetes-role-history.mdx
+++ b/src/content/en/administrator-manual/audit/kubernetes-logs/kubernetes-role-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Kubernetes Role History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544383799/Kubernetes+Role+History'
 ---
 
 # Kubernetes Role History

--- a/src/content/en/administrator-manual/audit/kubernetes-logs/pod-session-recordings.mdx
+++ b/src/content/en/administrator-manual/audit/kubernetes-logs/pod-session-recordings.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Pod Session Recordings'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544383693/Pod+Session+Recordings'
 ---
 
 # Pod Session Recordings

--- a/src/content/en/administrator-manual/audit/kubernetes-logs/request-audit.mdx
+++ b/src/content/en/administrator-manual/audit/kubernetes-logs/request-audit.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Request Audit'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544383587/Request+Audit'
 ---
 
 # Request Audit

--- a/src/content/en/administrator-manual/audit/reports.mdx
+++ b/src/content/en/administrator-manual/audit/reports.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Reports'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/693043522/Reports'
 ---
 
 # Reports

--- a/src/content/en/administrator-manual/audit/reports/audit-log-export.mdx
+++ b/src/content/en/administrator-manual/audit/reports/audit-log-export.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Audit Log Export'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379140/Audit+Log+Export'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/audit/reports/reports.mdx
+++ b/src/content/en/administrator-manual/audit/reports/reports.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Reports'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544384417/Reports'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/audit/server-logs.mdx
+++ b/src/content/en/administrator-manual/audit/server-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544014907/Server+Logs'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/audit/server-logs/access-control-logs.mdx
+++ b/src/content/en/administrator-manual/audit/server-logs/access-control-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Access Control Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544244234/Access+Control+Logs'
 ---
 
 # Access Control Logs

--- a/src/content/en/administrator-manual/audit/server-logs/account-lock-history.mdx
+++ b/src/content/en/administrator-manual/audit/server-logs/account-lock-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Account Lock History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/543949311/Account+Lock+History'
 ---
 
 # Account Lock History

--- a/src/content/en/administrator-manual/audit/server-logs/command-audit.mdx
+++ b/src/content/en/administrator-manual/audit/server-logs/command-audit.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Command Audit'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544244208/Command+Audit'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/audit/server-logs/server-access-history.mdx
+++ b/src/content/en/administrator-manual/audit/server-logs/server-access-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Access History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544244182/Server+Access+History'
 ---
 
 # Server Access History

--- a/src/content/en/administrator-manual/audit/server-logs/server-role-history.mdx
+++ b/src/content/en/administrator-manual/audit/server-logs/server-role-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Role History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544244244/Server+Role+History'
 ---
 
 # Server Role History

--- a/src/content/en/administrator-manual/audit/server-logs/session-logs.mdx
+++ b/src/content/en/administrator-manual/audit/server-logs/session-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Session Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544014927/Session+Logs'
 ---
 
 # Session Logs

--- a/src/content/en/administrator-manual/audit/server-logs/session-monitoring-moved.mdx
+++ b/src/content/en/administrator-manual/audit/server-logs/session-monitoring-moved.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Session Monitoring (Moved)'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544014940/Session+Monitoring+Moved'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/audit/web-app-logs.mdx
+++ b/src/content/en/administrator-manual/audit/web-app-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web App Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064829366/Web+App+Logs'
 ---
 
 # Web App Logs

--- a/src/content/en/administrator-manual/audit/web-app-logs/jit-access-control-logs.mdx
+++ b/src/content/en/administrator-manual/audit/web-app-logs/jit-access-control-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'JIT Access Control Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070694552/JIT+Access+Control+Logs'
 ---
 
 # JIT Access Control Logs

--- a/src/content/en/administrator-manual/audit/web-app-logs/user-activity-recordings.mdx
+++ b/src/content/en/administrator-manual/audit/web-app-logs/user-activity-recordings.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'User Activity Recordings'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070694561/User+Activity+Recordings'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/audit/web-app-logs/web-access-history.mdx
+++ b/src/content/en/administrator-manual/audit/web-app-logs/web-access-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web Access History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064829380/Web+Access+History'
 ---
 
 # Web Access History

--- a/src/content/en/administrator-manual/audit/web-app-logs/web-app-role-history.mdx
+++ b/src/content/en/administrator-manual/audit/web-app-logs/web-app-role-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web App Role History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070563469/Web+App+Role+History'
 ---
 
 # Web App Role History

--- a/src/content/en/administrator-manual/audit/web-app-logs/web-event-audit.mdx
+++ b/src/content/en/administrator-manual/audit/web-app-logs/web-event-audit.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web Event Audit'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070563457/Web+Event+Audit'
 ---
 
 # Web Event Audit

--- a/src/content/en/administrator-manual/databases.mdx
+++ b/src/content/en/administrator-manual/databases.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Databases'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379638/Databases'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/databases/connection-management.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Connection Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379705/Connection+Management'
 ---
 
 # Connection Management

--- a/src/content/en/administrator-manual/databases/connection-management/cloud-providers.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/cloud-providers.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Cloud Providers'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544145672/Cloud+Providers'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-aws.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-aws.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Synchronizing DB Resources from AWS'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379719/AWS+DB'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-google-cloud.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-google-cloud.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Synchronizing DB Resources from Google Cloud'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/562167809/Google+Cloud+DB'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-ms-azure.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-ms-azure.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Synchronizing DB Resources from MS Azure'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/562167871/MS+Azure+DB'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/databases/connection-management/cloud-providers/verifying-cloud-synchronization-settings-with-dry-run-feature.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/cloud-providers/verifying-cloud-synchronization-settings-with-dry-run-feature.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Verifying Cloud Synchronization Settings with Dry Run Feature'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/712507393/Dry+Run'
 ---
 
 # Verifying Cloud Synchronization Settings with Dry Run Feature

--- a/src/content/en/administrator-manual/databases/connection-management/db-connections.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/db-connections.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'DB Connections'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544014712/DB+Connections'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/databases/connection-management/db-connections/aws-athena-specific-guide.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/db-connections/aws-athena-specific-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'AWS Athena Specific Guide'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/820806182/AWS+Athena'
 ---
 
 # AWS Athena Specific Guide

--- a/src/content/en/administrator-manual/databases/connection-management/db-connections/custom-data-source-configuration-and-log-verification.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/db-connections/custom-data-source-configuration-and-log-verification.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Custom Data Source Configuration and Log Verification'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/880082945/Custom+Data+Source'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/databases/connection-management/db-connections/documentdb-specific-guide.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/db-connections/documentdb-specific-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'DocumentDB Specific Guide'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/568852692/DocumentDB'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/databases/connection-management/db-connections/google-bigquery-oauth-authentication-configuration.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/db-connections/google-bigquery-oauth-authentication-configuration.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Google BigQuery OAuth Authentication Configuration'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/811434142/Google+BigQuery+OAuth'
 ---
 
 # Google BigQuery OAuth Authentication Configuration

--- a/src/content/en/administrator-manual/databases/connection-management/db-connections/mongodb-specific-guide.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/db-connections/mongodb-specific-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'MongoDB Specific Guide'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380381/MongoDB'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/databases/connection-management/kerberos-configurations.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/kerberos-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Kerberos Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544112932/Kerberos+Configurations'
 ---
 
 # Kerberos Configurations

--- a/src/content/en/administrator-manual/databases/connection-management/ssh-configurations.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/ssh-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'SSH Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544047436/SSH+Configurations'
 ---
 
 # SSH Configurations

--- a/src/content/en/administrator-manual/databases/connection-management/ssl-configurations.mdx
+++ b/src/content/en/administrator-manual/databases/connection-management/ssl-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'SSL Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544145691/SSL+Configurations'
 ---
 
 # SSL Configurations

--- a/src/content/en/administrator-manual/databases/dac-general-configurations.mdx
+++ b/src/content/en/administrator-manual/databases/dac-general-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'DAC General Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/956071939/DAC+General+Configurations'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/databases/dac-general-configurations/masking-pattern-menu-relocated.mdx
+++ b/src/content/en/administrator-manual/databases/dac-general-configurations/masking-pattern-menu-relocated.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Masking Pattern (Menu Relocated)'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1275396097/Masking+Pattern'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/databases/dac-general-configurations/unmasking-zones.mdx
+++ b/src/content/en/administrator-manual/databases/dac-general-configurations/unmasking-zones.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Unmasking Zones'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/921436219/Unmasking+Zones'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/databases/db-access-control.mdx
+++ b/src/content/en/administrator-manual/databases/db-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'DB Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380126/DB+Access+Control'
 ---
 
 # DB Access Control

--- a/src/content/en/administrator-manual/databases/db-access-control/access-control.mdx
+++ b/src/content/en/administrator-manual/databases/db-access-control/access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380173/Access+Control'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/databases/db-access-control/privilege-type.mdx
+++ b/src/content/en/administrator-manual/databases/db-access-control/privilege-type.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Privilege Type'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380140/Privilege+Type'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/databases/ledger-management.mdx
+++ b/src/content/en/administrator-manual/databases/ledger-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Ledger Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/571277577/Ledger+Management'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/databases/ledger-management/ledger-approval-rules.mdx
+++ b/src/content/en/administrator-manual/databases/ledger-management/ledger-approval-rules.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Ledger Approval Rules'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/571277650/Ledger+Approval+Rules'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/databases/ledger-management/ledger-table-policy.mdx
+++ b/src/content/en/administrator-manual/databases/ledger-management/ledger-table-policy.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Ledger Table Policy'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380061/Ledger+Table+Policy'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/databases/monitoring.mdx
+++ b/src/content/en/administrator-manual/databases/monitoring.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Monitoring'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/954139156/Monitoring'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/databases/monitoring/proxy-management.mdx
+++ b/src/content/en/administrator-manual/databases/monitoring/proxy-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Proxy Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/954204974/Proxy+Management'
 ---
 
 # Proxy Management

--- a/src/content/en/administrator-manual/databases/monitoring/running-queries.mdx
+++ b/src/content/en/administrator-manual/databases/monitoring/running-queries.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Running Queries'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/954172219/Running+Queries'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/databases/new-policy-management.mdx
+++ b/src/content/en/administrator-manual/databases/new-policy-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: '(New) Policy Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/873136365/New+Policy+Management'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/databases/new-policy-management/data-paths.mdx
+++ b/src/content/en/administrator-manual/databases/new-policy-management/data-paths.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Data Paths'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/878805502/Data+Paths'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/databases/new-policy-management/data-policies.mdx
+++ b/src/content/en/administrator-manual/databases/new-policy-management/data-policies.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Data Policies'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/879198569/Data+Policies'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/databases/new-policy-management/exception-management.mdx
+++ b/src/content/en/administrator-manual/databases/new-policy-management/exception-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Exception Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064796485/Exception+Management'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/databases/policies.mdx
+++ b/src/content/en/administrator-manual/databases/policies.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Policies'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379868/Policies'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/databases/policies/data-access.mdx
+++ b/src/content/en/administrator-manual/databases/policies/data-access.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Data Access'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379937/Data+Access'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/databases/policies/data-masking.mdx
+++ b/src/content/en/administrator-manual/databases/policies/data-masking.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Data Masking'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379882/Data+Masking'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/databases/policies/masking-pattern.mdx
+++ b/src/content/en/administrator-manual/databases/policies/masking-pattern.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Masking Pattern'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/569376769/Masking+Pattern'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/databases/policies/policy-exception.mdx
+++ b/src/content/en/administrator-manual/databases/policies/policy-exception.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Policy Exception'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/713129986/Policy+Exception'
 ---
 
 # Policy Exception

--- a/src/content/en/administrator-manual/databases/policies/sensitive-data.mdx
+++ b/src/content/en/administrator-manual/databases/policies/sensitive-data.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Sensitive Data'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379993/Sensitive+Data'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general.mdx
+++ b/src/content/en/administrator-manual/general.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'General'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544080057/General'
 ---
 
 # General

--- a/src/content/en/administrator-manual/general/company-management.mdx
+++ b/src/content/en/administrator-manual/general/company-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Company Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/543948978/Company+Management'
 ---
 
 # Company Management

--- a/src/content/en/administrator-manual/general/company-management/alerts.mdx
+++ b/src/content/en/administrator-manual/general/company-management/alerts.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Alerts'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/543981760/Alerts'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/company-management/alerts/new-request-template-variables-by-request-type.mdx
+++ b/src/content/en/administrator-manual/general/company-management/alerts/new-request-template-variables-by-request-type.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'New Request > Template Variables by Request Type'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/793608206/New+Request'
 ---
 
 # New Request > Template Variables by Request Type

--- a/src/content/en/administrator-manual/general/company-management/allowed-zones.mdx
+++ b/src/content/en/administrator-manual/general/company-management/allowed-zones.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Allowed Zones'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544112846/Allowed+Zones'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/company-management/channels.mdx
+++ b/src/content/en/administrator-manual/general/company-management/channels.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Channels'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544243925/Channels'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/company-management/general.mdx
+++ b/src/content/en/administrator-manual/general/company-management/general.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'General'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544145591/General'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/company-management/licenses.mdx
+++ b/src/content/en/administrator-manual/general/company-management/licenses.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Licenses'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544178443/Licenses'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/company-management/security.mdx
+++ b/src/content/en/administrator-manual/general/company-management/security.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Security'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544178422/Security'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/system.mdx
+++ b/src/content/en/administrator-manual/general/system.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'System'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544112865/System'
 ---
 
 # System

--- a/src/content/en/administrator-manual/general/system/api-token.mdx
+++ b/src/content/en/administrator-manual/general/system/api-token.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'API Token'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544377652/API+Token'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/system/integrations.mdx
+++ b/src/content/en/administrator-manual/general/system/integrations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Integrations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544080097/Integrations'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/system/integrations/identity-providers.mdx
+++ b/src/content/en/administrator-manual/general/system/integrations/identity-providers.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Identity Providers'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1454342158/Identity+Providers'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/system/integrations/identity-providers/integrating-with-aws-sso-saml-20.mdx
+++ b/src/content/en/administrator-manual/general/system/integrations/identity-providers/integrating-with-aws-sso-saml-20.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Integrate AWS SSO (SAML 2.0)'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1495433217/AWS+SSO+SAML+2.0'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/system/integrations/integrating-google-cloud-api-for-oauth-20.mdx
+++ b/src/content/en/administrator-manual/general/system/integrations/integrating-google-cloud-api-for-oauth-20.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Integrating Google Cloud API for OAuth 2.0'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/811401365/OAuth+2.0+Google+Cloud+API'
 ---
 
 # Integrating Google Cloud API for OAuth 2.0

--- a/src/content/en/administrator-manual/general/system/integrations/integrating-with-email.mdx
+++ b/src/content/en/administrator-manual/general/system/integrations/integrating-with-email.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Email Integration'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/798064641/Email'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/system/integrations/integrating-with-event-callback.mdx
+++ b/src/content/en/administrator-manual/general/system/integrations/integrating-with-event-callback.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Integrating with Event Callback'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1267007528/Event+Callback'
 ---
 
 # Integrating with Event Callback

--- a/src/content/en/administrator-manual/general/system/integrations/integrating-with-secret-store.mdx
+++ b/src/content/en/administrator-manual/general/system/integrations/integrating-with-secret-store.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Secret Store Integration'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379587/Secret+Store'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/system/integrations/integrating-with-slack-dm.mdx
+++ b/src/content/en/administrator-manual/general/system/integrations/integrating-with-slack-dm.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Slack DM Integration'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/883654669/Slack+DM'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/system/integrations/integrating-with-slack-dm/slack-dm-workflow-notification-types.mdx
+++ b/src/content/en/administrator-manual/general/system/integrations/integrating-with-slack-dm/slack-dm-workflow-notification-types.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Slack DM - Workflow Notification Types'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544378759/Slack+DM+-+Workflow'
 ---
 
 # Slack DM - Workflow Notification Types

--- a/src/content/en/administrator-manual/general/system/integrations/integrating-with-splunk.mdx
+++ b/src/content/en/administrator-manual/general/system/integrations/integrating-with-splunk.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Splunk Integration'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/557940795/Splunk'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/system/integrations/integrating-with-syslog.mdx
+++ b/src/content/en/administrator-manual/general/system/integrations/integrating-with-syslog.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Syslog Integration'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379393/Syslog'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/system/integrations/oauth-client-application.mdx
+++ b/src/content/en/administrator-manual/general/system/integrations/oauth-client-application.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'OAuth Client Application'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1453588486/OAuth+Client+Application'
 ---
 
 # OAuth Client Application

--- a/src/content/en/administrator-manual/general/system/jobs.mdx
+++ b/src/content/en/administrator-manual/general/system/jobs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Jobs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544211220/Jobs'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/system/maintenance.mdx
+++ b/src/content/en/administrator-manual/general/system/maintenance.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Maintenance'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1456144391/Maintenance'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/user-management.mdx
+++ b/src/content/en/administrator-manual/general/user-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'User Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375969/User+Management'
 ---
 
 # User Management

--- a/src/content/en/administrator-manual/general/user-management/authentication.mdx
+++ b/src/content/en/administrator-manual/general/user-management/authentication.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Authentication'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375984/Authentication'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/user-management/authentication/integrating-with-aws-sso.mdx
+++ b/src/content/en/administrator-manual/general/user-management/authentication/integrating-with-aws-sso.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Integrating with AWS SSO'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544376183/AWS+SSO'
 ---
 
 # Integrating with AWS SSO

--- a/src/content/en/administrator-manual/general/user-management/authentication/integrating-with-google-saml.mdx
+++ b/src/content/en/administrator-manual/general/user-management/authentication/integrating-with-google-saml.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Integrating with Google SAML'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/619381289/Google+SAML'
 ---
 
 # Integrating with Google SAML

--- a/src/content/en/administrator-manual/general/user-management/authentication/integrating-with-ldap.mdx
+++ b/src/content/en/administrator-manual/general/user-management/authentication/integrating-with-ldap.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Integrating with LDAP'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544376004/LDAP'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/user-management/authentication/integrating-with-okta.mdx
+++ b/src/content/en/administrator-manual/general/user-management/authentication/integrating-with-okta.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Integrating with Okta'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544376100/Okta'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/user-management/authentication/setting-up-multi-factor-authentication.mdx
+++ b/src/content/en/administrator-manual/general/user-management/authentication/setting-up-multi-factor-authentication.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Setting up Multi-Factor Authentication'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/793575425/Multi-Factor+Authentication'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/user-management/groups.mdx
+++ b/src/content/en/administrator-manual/general/user-management/groups.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Groups'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544047341/Groups'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/user-management/profile-editor.mdx
+++ b/src/content/en/administrator-manual/general/user-management/profile-editor.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Profile Editor'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544376982/Profile+Editor'
 ---
 
 # Profile Editor

--- a/src/content/en/administrator-manual/general/user-management/profile-editor/custom-attribute.mdx
+++ b/src/content/en/administrator-manual/general/user-management/profile-editor/custom-attribute.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Custom Attribute'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/953221256/Custom+Attribute'
 ---
 
 # Custom Attribute

--- a/src/content/en/administrator-manual/general/user-management/provisioning.mdx
+++ b/src/content/en/administrator-manual/general/user-management/provisioning.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Provisioning'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544376236/Provisioning'
 ---
 
 # Provisioning

--- a/src/content/en/administrator-manual/general/user-management/provisioning/activating-provisioning.mdx
+++ b/src/content/en/administrator-manual/general/user-management/provisioning/activating-provisioning.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Activating Provisioning'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544376265/Provisioning'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/user-management/provisioning/okta-provisioning-integration-guide.mdx
+++ b/src/content/en/administrator-manual/general/user-management/provisioning/okta-provisioning-integration-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: '[Okta] Provisioning Integration Guide'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544376394/Okta'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/user-management/roles.mdx
+++ b/src/content/en/administrator-manual/general/user-management/roles.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Roles'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/543948996/Roles'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/user-management/users.mdx
+++ b/src/content/en/administrator-manual/general/user-management/users.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Users'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544047331/Users'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/user-management/users/password-change-enforcement-and-account-deletion-feature-for-qp-admin-default-account.mdx
+++ b/src/content/en/administrator-manual/general/user-management/users/password-change-enforcement-and-account-deletion-feature-for-qp-admin-default-account.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Password Change Enforcement and Account Deletion Feature for qp-admin Default Account'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/920944732/qp-admin'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/user-management/users/user-profile.mdx
+++ b/src/content/en/administrator-manual/general/user-management/users/user-profile.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'User Profile'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544376787'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/workflow-management.mdx
+++ b/src/content/en/administrator-manual/general/workflow-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Workflow Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544178462/Workflow+Management'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/workflow-management/all-requests.mdx
+++ b/src/content/en/administrator-manual/general/workflow-management/all-requests.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'All Requests'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544047359/All+Requests'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/workflow-management/approval-rules.mdx
+++ b/src/content/en/administrator-manual/general/workflow-management/approval-rules.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Approval Rules'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544378513/Approval+Rules'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/general/workflow-management/workflow-configurations.mdx
+++ b/src/content/en/administrator-manual/general/workflow-management/workflow-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Workflow Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/561414376/Workflow+Configurations'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/kubernetes.mdx
+++ b/src/content/en/administrator-manual/kubernetes.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Kubernetes'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381596/Kubernetes'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/kubernetes/connection-management.mdx
+++ b/src/content/en/administrator-manual/kubernetes/connection-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Connection Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381637/Connection+Management'
 ---
 
 # Connection Management

--- a/src/content/en/administrator-manual/kubernetes/connection-management/cloud-providers.mdx
+++ b/src/content/en/administrator-manual/kubernetes/connection-management/cloud-providers.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Cloud Providers'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381651/Cloud+Providers'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/kubernetes/connection-management/cloud-providers/synchronizing-kubernetes-resources-from-aws.mdx
+++ b/src/content/en/administrator-manual/kubernetes/connection-management/cloud-providers/synchronizing-kubernetes-resources-from-aws.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Synchronizing Kubernetes Resources from AWS'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381739/AWS'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/kubernetes/connection-management/clusters.mdx
+++ b/src/content/en/administrator-manual/kubernetes/connection-management/clusters.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Clusters'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381839/Clusters'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/kubernetes/connection-management/clusters/manually-registering-kubernetes-clusters.mdx
+++ b/src/content/en/administrator-manual/kubernetes/connection-management/clusters/manually-registering-kubernetes-clusters.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Manually Registering Kubernetes Clusters'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381877'
 ---
 
 # Manually Registering Kubernetes Clusters

--- a/src/content/en/administrator-manual/kubernetes/k8s-access-control.mdx
+++ b/src/content/en/administrator-manual/kubernetes/k8s-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'K8s Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544383110/K8s+Access+Control'
 ---
 
 # K8s Access Control

--- a/src/content/en/administrator-manual/kubernetes/k8s-access-control/access-control.mdx
+++ b/src/content/en/administrator-manual/kubernetes/k8s-access-control/access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544383124/Access+Control'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/kubernetes/k8s-access-control/access-control/granting-and-revoking-kubernetes-roles.mdx
+++ b/src/content/en/administrator-manual/kubernetes/k8s-access-control/access-control/granting-and-revoking-kubernetes-roles.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Granting and Revoking Kubernetes Roles'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544383381'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/kubernetes/k8s-access-control/policies.mdx
+++ b/src/content/en/administrator-manual/kubernetes/k8s-access-control/policies.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Policies'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544382060/Policies'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-action-configuration-reference-guide.mdx
+++ b/src/content/en/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-action-configuration-reference-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Kubernetes Policy Action Configuration Reference Guide'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544382659/Action'
 ---
 
 # Kubernetes Policy Action Configuration Reference Guide

--- a/src/content/en/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-tips-guide.mdx
+++ b/src/content/en/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-tips-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Kubernetes Policy Tips Guide'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544382445/Tips'
 ---
 
 # Kubernetes Policy Tips Guide

--- a/src/content/en/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-ui-code-helper-guide.mdx
+++ b/src/content/en/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-ui-code-helper-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Kubernetes Policy UI Code Helper Guide'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544382522/UI'
 ---
 
 # Kubernetes Policy UI Code Helper Guide

--- a/src/content/en/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-yaml-code-syntax-guide.mdx
+++ b/src/content/en/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-yaml-code-syntax-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Kubernetes Policy YAML Code Syntax Guide'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544382364/YAML+Code'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/kubernetes/k8s-access-control/policies/setting-kubernetes-policies.mdx
+++ b/src/content/en/administrator-manual/kubernetes/k8s-access-control/policies/setting-kubernetes-policies.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Setting Kubernetes Policies'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544382274'
 ---
 
 # Setting Kubernetes Policies

--- a/src/content/en/administrator-manual/kubernetes/k8s-access-control/roles.mdx
+++ b/src/content/en/administrator-manual/kubernetes/k8s-access-control/roles.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Roles'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544382741/Roles'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles.mdx
+++ b/src/content/en/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Setting Kubernetes Roles'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544382963'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/kubernetes/kac-general-configurations.mdx
+++ b/src/content/en/administrator-manual/kubernetes/kac-general-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'KAC General Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/954172232/KAC+General+Configurations'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/multi-agent-limitations.mdx
+++ b/src/content/en/administrator-manual/multi-agent-limitations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Multi Agent Limitations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/851280543/Multi+Agent'
 ---
 
 # Multi Agent Limitations

--- a/src/content/en/administrator-manual/servers.mdx
+++ b/src/content/en/administrator-manual/servers.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Servers'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380588/Servers'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/servers/connection-management.mdx
+++ b/src/content/en/administrator-manual/servers/connection-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Connection Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380635/Connection+Management'
 ---
 
 # Connection Management

--- a/src/content/en/administrator-manual/servers/connection-management/cloud-providers.mdx
+++ b/src/content/en/administrator-manual/servers/connection-management/cloud-providers.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Cloud Providers'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544178567/Cloud+Providers'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-aws.mdx
+++ b/src/content/en/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-aws.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Synchronizing Server Resources from AWS'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380650/AWS'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-azure.mdx
+++ b/src/content/en/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-azure.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Synchronizing Server Resources from Azure'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380741/Azure'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-gcp.mdx
+++ b/src/content/en/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-gcp.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Synchronizing Server Resources from GCP'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380708/GCP'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/servers/connection-management/proxyjump-configurations.mdx
+++ b/src/content/en/administrator-manual/servers/connection-management/proxyjump-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'ProxyJump Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/615710737/ProxyJump+Configurations'
 ---
 
 # ProxyJump Configurations

--- a/src/content/en/administrator-manual/servers/connection-management/proxyjump-configurations/creating-proxyjump.mdx
+++ b/src/content/en/administrator-manual/servers/connection-management/proxyjump-configurations/creating-proxyjump.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Creating ProxyJump'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/615743551/ProxyJump'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/servers/connection-management/server-agents-for-rdp.mdx
+++ b/src/content/en/administrator-manual/servers/connection-management/server-agents-for-rdp.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Agents for RDP'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544211376/Server+Agents+for+RDP'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/servers/connection-management/server-agents-for-rdp/installing-and-removing-server-agent.mdx
+++ b/src/content/en/administrator-manual/servers/connection-management/server-agents-for-rdp/installing-and-removing-server-agent.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Installing and Removing Server Agent'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/565575990/Server+Agent'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/servers/connection-management/server-groups.mdx
+++ b/src/content/en/administrator-manual/servers/connection-management/server-groups.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Groups'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544080186/Server+Groups'
 ---
 
 # Server Groups

--- a/src/content/en/administrator-manual/servers/connection-management/server-groups/managing-servers-as-groups.mdx
+++ b/src/content/en/administrator-manual/servers/connection-management/server-groups/managing-servers-as-groups.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Managing Servers as Groups'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380846'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/servers/connection-management/servers.mdx
+++ b/src/content/en/administrator-manual/servers/connection-management/servers.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Servers'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544211361/Servers'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/servers/connection-management/servers/manually-registering-individual-servers.mdx
+++ b/src/content/en/administrator-manual/servers/connection-management/servers/manually-registering-individual-servers.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Manually Registering Individual Servers'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380774'
 ---
 
 # Manually Registering Individual Servers

--- a/src/content/en/administrator-manual/servers/sac-general-configurations.mdx
+++ b/src/content/en/administrator-manual/servers/sac-general-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'SAC General Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/954336174/SAC+General+Configurations'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/servers/server-access-control.mdx
+++ b/src/content/en/administrator-manual/servers/server-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/543949216/Server+Access+Control'
 ---
 
 # Server Access Control

--- a/src/content/en/administrator-manual/servers/server-access-control/access-control.mdx
+++ b/src/content/en/administrator-manual/servers/server-access-control/access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381186/Access+Control'
 ---
 
 # Access Control

--- a/src/content/en/administrator-manual/servers/server-access-control/access-control/granting-and-revoking-permissions.mdx
+++ b/src/content/en/administrator-manual/servers/server-access-control/access-control/granting-and-revoking-permissions.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Granting and Revoking Permissions'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381282/Permissions'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/servers/server-access-control/access-control/granting-and-revoking-roles.mdx
+++ b/src/content/en/administrator-manual/servers/server-access-control/access-control/granting-and-revoking-roles.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Granting and Revoking Roles'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381200/Role'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/servers/server-access-control/access-control/granting-server-privilege.mdx
+++ b/src/content/en/administrator-manual/servers/server-access-control/access-control/granting-server-privilege.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Granting Server Privilege'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/878838349/Server+Privilege'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/servers/server-access-control/blocked-accounts.mdx
+++ b/src/content/en/administrator-manual/servers/server-access-control/blocked-accounts.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Blocked Accounts'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544244109/Blocked+Accounts'
 ---
 
 # Blocked Accounts

--- a/src/content/en/administrator-manual/servers/server-access-control/command-templates.mdx
+++ b/src/content/en/administrator-manual/servers/server-access-control/command-templates.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Command Templates'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381118/Command+Templates'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/servers/server-access-control/policies.mdx
+++ b/src/content/en/administrator-manual/servers/server-access-control/policies.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Policies'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381025/Policies'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/servers/server-access-control/policies/enabling-server-proxy.mdx
+++ b/src/content/en/administrator-manual/servers/server-access-control/policies/enabling-server-proxy.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Enable Server Proxy'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544377895/Server+Proxy'
 ---
 
 # Enable Server Proxy

--- a/src/content/en/administrator-manual/servers/server-access-control/policies/setting-server-access-policy.mdx
+++ b/src/content/en/administrator-manual/servers/server-access-control/policies/setting-server-access-policy.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Setting Server Access Policies'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381039'
 ---
 
 # Setting Server Access Policies

--- a/src/content/en/administrator-manual/servers/server-access-control/roles.mdx
+++ b/src/content/en/administrator-manual/servers/server-access-control/roles.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Roles'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381150/Roles'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/servers/server-account-management.mdx
+++ b/src/content/en/administrator-manual/servers/server-account-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Account Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/613777446/Server+Account+Management'
 ---
 
 # Server Account Management

--- a/src/content/en/administrator-manual/servers/server-account-management/account-management.mdx
+++ b/src/content/en/administrator-manual/servers/server-account-management/account-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Account Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/615743501/Account+Management'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/servers/server-account-management/password-provisioning.mdx
+++ b/src/content/en/administrator-manual/servers/server-account-management/password-provisioning.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Password Provisioning'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/615677962/Password+Provisioning'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/servers/server-account-management/password-provisioning/creating-password-change-job.mdx
+++ b/src/content/en/administrator-manual/servers/server-account-management/password-provisioning/creating-password-change-job.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Creating Password Change Jobs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/619380898/Job'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/servers/server-account-management/server-account-templates.mdx
+++ b/src/content/en/administrator-manual/servers/server-account-management/server-account-templates.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Account Templates'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380991/Server+Account+Templates'
 ---
 
 # Server Account Templates

--- a/src/content/en/administrator-manual/servers/server-account-management/ssh-key-configurations.mdx
+++ b/src/content/en/administrator-manual/servers/server-account-management/ssh-key-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'SSH Key Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380960/SSH+Key+Configurations'
 ---
 
 # SSH Key Configurations

--- a/src/content/en/administrator-manual/servers/session-monitoring.mdx
+++ b/src/content/en/administrator-manual/servers/session-monitoring.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Session Monitoring'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1760657435/Session+Monitoring'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/web-apps.mdx
+++ b/src/content/en/administrator-manual/web-apps.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web Apps'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/783515900/Web+Apps'
 ---
 
 # Web Apps

--- a/src/content/en/administrator-manual/web-apps/connection-management.mdx
+++ b/src/content/en/administrator-manual/web-apps/connection-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Connection Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064829276/Connection+Management'
 ---
 
 # Connection Management

--- a/src/content/en/administrator-manual/web-apps/connection-management/web-app-configurations.mdx
+++ b/src/content/en/administrator-manual/web-apps/connection-management/web-app-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web App Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064829246/Web+App+Configurations'
 ---
 
 # Web App Configurations

--- a/src/content/en/administrator-manual/web-apps/connection-management/web-apps.mdx
+++ b/src/content/en/administrator-manual/web-apps/connection-management/web-apps.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web Apps'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070694423/Web+Apps'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/web-apps/wac-quickstart.mdx
+++ b/src/content/en/administrator-manual/web-apps/wac-quickstart.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'WAC Quickstart'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/783417593/WAC+Quickstart'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/web-apps/wac-quickstart/1027-wac-role-policy-guide.mdx
+++ b/src/content/en/administrator-manual/web-apps/wac-quickstart/1027-wac-role-policy-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: '[~10.2.7] WAC Role & Policy Guide'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/783745324/~10.2.7+WAC+Role+Policy+Guide'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/web-apps/wac-quickstart/1028-wac-rbac-guide.mdx
+++ b/src/content/en/administrator-manual/web-apps/wac-quickstart/1028-wac-rbac-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: '[10.2.8~] WAC RBAC Guide'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/924287097/10.2.8~+WAC+RBAC+Guide'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/web-apps/wac-quickstart/1030-wac-jit-permission-acquisition-guide.mdx
+++ b/src/content/en/administrator-manual/web-apps/wac-quickstart/1030-wac-jit-permission-acquisition-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: '[10.3.0 ~] WAC JIT Permission Acquisition Guide'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/956235931/10.3.0+~+WAC+JIT+Guide'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/web-apps/wac-quickstart/initial-wac-setup-in-web-app-configurations.mdx
+++ b/src/content/en/administrator-manual/web-apps/wac-quickstart/initial-wac-setup-in-web-app-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Initial WAC Setup in Web App Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/883654785/Web+App+Configurations+WAC'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/web-apps/wac-quickstart/root-ca-certificate-installation-guide.mdx
+++ b/src/content/en/administrator-manual/web-apps/wac-quickstart/root-ca-certificate-installation-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Root CA Certificate Installation Guide'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/805962425/Root+CA'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/web-apps/wac-quickstart/wac-faq.mdx
+++ b/src/content/en/administrator-manual/web-apps/wac-quickstart/wac-faq.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'WAC FAQ'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/927629410/WAC+FAQ'
 ---
 
 # WAC FAQ

--- a/src/content/en/administrator-manual/web-apps/wac-quickstart/wac-troubleshooting-guide.mdx
+++ b/src/content/en/administrator-manual/web-apps/wac-quickstart/wac-troubleshooting-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'WAC Troubleshooting Guide'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/924319936/WAC'
 ---
 
 # WAC Troubleshooting Guide

--- a/src/content/en/administrator-manual/web-apps/web-app-access-control.mdx
+++ b/src/content/en/administrator-manual/web-apps/web-app-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web App Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070596135/Web+App+Access+Control'
 ---
 
 # Web App Access Control

--- a/src/content/en/administrator-manual/web-apps/web-app-access-control/access-control.mdx
+++ b/src/content/en/administrator-manual/web-apps/web-app-access-control/access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070628904/Access+Control'
 ---
 
 # Access Control

--- a/src/content/en/administrator-manual/web-apps/web-app-access-control/access-control/granting-and-revoking-roles.mdx
+++ b/src/content/en/administrator-manual/web-apps/web-app-access-control/access-control/granting-and-revoking-roles.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Granting and Revoking Roles'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064599910/Role'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/web-apps/web-app-access-control/policies.mdx
+++ b/src/content/en/administrator-manual/web-apps/web-app-access-control/policies.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Policies'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064829343/Policies'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/administrator-manual/web-apps/web-app-access-control/roles.mdx
+++ b/src/content/en/administrator-manual/web-apps/web-app-access-control/roles.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Roles'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070628923/Roles'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/installation.mdx
+++ b/src/content/en/installation.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Product Installation'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375808'
 ---
 
 # Product Installation

--- a/src/content/en/installation/container-environment-variables.mdx
+++ b/src/content/en/installation/container-environment-variables.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Container Environment Variables'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/954761289'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/installation/container-environment-variables/optimizing-dbmaxconnectionsize.mdx
+++ b/src/content/en/installation/container-environment-variables/optimizing-dbmaxconnectionsize.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'DB_MAX_CONNECTION_SIZE Optimization'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/938016931/DB_MAX_CONNECTION_SIZE'
 ---
 
 # DB_MAX_CONNECTION_SIZE Optimization

--- a/src/content/en/installation/container-environment-variables/querypieweburl.mdx
+++ b/src/content/en/installation/container-environment-variables/querypieweburl.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'QUERYPIE_WEB_URL'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/876937310/QUERYPIE_WEB_URL'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/installation/installation.mdx
+++ b/src/content/en/installation/installation.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Installation'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1689387010'
 ---
 
 # Installation

--- a/src/content/en/installation/installation/comparison-of-setupsh-and-setupv2sh.mdx
+++ b/src/content/en/installation/installation/comparison-of-setupsh-and-setupv2sh.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Comparison of setup.sh and setup.v2.sh'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1261895760/setup.sh+setup.v2.sh'
 ---
 
 # Comparison of setup.sh and setup.v2.sh

--- a/src/content/en/installation/installation/installation-guide-setupv2sh.mdx
+++ b/src/content/en/installation/installation/installation-guide-setupv2sh.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Installation Guide - setup.v2.sh'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1177321474/-+setup.v2.sh'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/installation/installation/installation-guide-simple-configuration.mdx
+++ b/src/content/en/installation/installation/installation-guide-simple-configuration.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Installation Guide - Simple Configuration'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/964952065/-'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/installation/installation/installing-on-aws-eks.mdx
+++ b/src/content/en/installation/installation/installing-on-aws-eks.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Installing on AWS EKS Environment'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/815235967/AWS+EKS'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/installation/license-installation.mdx
+++ b/src/content/en/installation/license-installation.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'License Installation'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/912326893'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/installation/post-installation-setup.mdx
+++ b/src/content/en/installation/post-installation-setup.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Post Installation Setup'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1907294209'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/installation/prerequisites.mdx
+++ b/src/content/en/installation/prerequisites.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Prerequisites'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/862126081'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/installation/prerequisites/configuring-rootless-mode-with-podman.mdx
+++ b/src/content/en/installation/prerequisites/configuring-rootless-mode-with-podman.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Configuring Rootless Mode with Podman'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1297383451/Podman+Rootless+Mode'
 ---
 
 # Configuring Rootless Mode with Podman

--- a/src/content/en/installation/prerequisites/linux-distribution-and-docker-podman-support-status.mdx
+++ b/src/content/en/installation/prerequisites/linux-distribution-and-docker-podman-support-status.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Linux Distribution and Docker, Podman Support Status'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1298530305/Docker+Podman'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/installation/product-versions.mdx
+++ b/src/content/en/installation/product-versions.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Product Versions'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1881243653'
 ---
 
 # Product Versions

--- a/src/content/en/installation/querypie-acp-community-edition.mdx
+++ b/src/content/en/installation/querypie-acp-community-edition.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'QueryPie ACP Community Edition'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1239416833/QueryPie+ACP+Community+Edition'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/installation/querypie-acp-community-edition/mcp-configuration-guide.mdx
+++ b/src/content/en/installation/querypie-acp-community-edition/mcp-configuration-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'MCP Configuration Guide'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1735589937/MCP'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/installation/server-configuration-requirements.mdx
+++ b/src/content/en/installation/server-configuration-requirements.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Configuration Requirements'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1690402874'
 ---
 
 # Server Configuration Requirements

--- a/src/content/en/installation/server-configuration-requirements/on-premise-vm-requirements.mdx
+++ b/src/content/en/installation/server-configuration-requirements/on-premise-vm-requirements.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'On-Premise VM Requirements'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1688371232/On-Premise+VM'
 ---
 
 # On-Premise VM Requirements

--- a/src/content/en/installation/server-configuration-requirements/public-cloud-production-server-requirements.mdx
+++ b/src/content/en/installation/server-configuration-requirements/public-cloud-production-server-requirements.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Public Cloud Production Server Requirements'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/903086124/Public+Cloud'
 ---
 
 # Public Cloud Production Server Requirements

--- a/src/content/en/installation/server-configuration-requirements/server-configuration-requirements-summary.mdx
+++ b/src/content/en/installation/server-configuration-requirements/server-configuration-requirements-summary.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Configuration Requirements Summary Table'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1692303361'
 ---
 
 # Server Configuration Requirements Summary Table

--- a/src/content/en/installation/system-architecture-and-network-access-control.mdx
+++ b/src/content/en/installation/system-architecture-and-network-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'System Architecture and Network Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/862093313'
 ---
 
 # System Architecture and Network Access Control

--- a/src/content/en/overview.mdx
+++ b/src/content/en/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Overview'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375784/Overview'
 ---
 
 # Overview

--- a/src/content/en/overview/proxy-management.mdx
+++ b/src/content/en/overview/proxy-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Proxy Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544112942/Proxy+Management'
 ---
 
 # Proxy Management

--- a/src/content/en/overview/proxy-management/enable-database-proxy.mdx
+++ b/src/content/en/overview/proxy-management/enable-database-proxy.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Enable Database Proxy Usage'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544377869/Database+Proxy'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/overview/system-architecture-overview.mdx
+++ b/src/content/en/overview/system-architecture-overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'System Architecture Overview'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375859'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/release-notes.mdx
+++ b/src/content/en/release-notes.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Release Notes'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375335/Release+Notes'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/release-notes/10.0.0-10.0.2.mdx
+++ b/src/content/en/release-notes/10.0.0-10.0.2.mdx
@@ -1,5 +1,6 @@
 ---
 title: '10.0.0 ~ 10.0.2'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375355/10.0.0+~+10.0.2'
 ---
 
 # 10.0.0 ~ 10.0.2

--- a/src/content/en/release-notes/10.1.0-10.1.11.mdx
+++ b/src/content/en/release-notes/10.1.0-10.1.11.mdx
@@ -1,5 +1,6 @@
 ---
 title: '10.1.0 ~ 10.1.11'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/604995641/10.1.0+~+10.1.11'
 ---
 
 # 10.1.0 ~ 10.1.11

--- a/src/content/en/release-notes/10.2.0-10.2.12.mdx
+++ b/src/content/en/release-notes/10.2.0-10.2.12.mdx
@@ -1,5 +1,6 @@
 ---
 title: '10.2.0 ~ 10.2.12'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/703463517/10.2.0+~+10.2.12'
 ---
 
 # 10.2.0 ~ 10.2.12

--- a/src/content/en/release-notes/10.3.0-10.3.4.mdx
+++ b/src/content/en/release-notes/10.3.0-10.3.4.mdx
@@ -1,5 +1,6 @@
 ---
 title: '10.3.0 ~ 10.3.4'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/954335909/10.3.0+~+10.3.4'
 ---
 
 # 10.3.0 ~ 10.3.4

--- a/src/content/en/release-notes/11.0.0.mdx
+++ b/src/content/en/release-notes/11.0.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: '11.0.0'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064830173/11.0.0'
 ---
 
 # 11.0.0

--- a/src/content/en/release-notes/11.1.0-11.1.2.mdx
+++ b/src/content/en/release-notes/11.1.0-11.1.2.mdx
@@ -1,5 +1,6 @@
 ---
 title: '11.1.0 ~ 11.1.2'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1171488777/11.1.0+~+11.1.2'
 ---
 
 # 11.1.0 ~ 11.1.2

--- a/src/content/en/release-notes/11.2.0.mdx
+++ b/src/content/en/release-notes/11.2.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: '11.2.0'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1291878563/11.2.0'
 ---
 
 # 11.2.0

--- a/src/content/en/release-notes/11.3.0.mdx
+++ b/src/content/en/release-notes/11.3.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: '11.3.0'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1421475841/11.3.0'
 ---
 
 # 11.3.0

--- a/src/content/en/release-notes/11.4.0.mdx
+++ b/src/content/en/release-notes/11.4.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: '11.4.0'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1568735233/11.4.0'
 ---
 
 # 11.4.0

--- a/src/content/en/release-notes/11.5.0.mdx
+++ b/src/content/en/release-notes/11.5.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: '11.5.0'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1751810049/11.5.0'
 ---
 
 # 11.5.0

--- a/src/content/en/release-notes/9.10.0-9.10.4.mdx
+++ b/src/content/en/release-notes/9.10.0-9.10.4.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.10.0 ~ 9.10.4'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375607/9.10.0+~+9.10.4'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/release-notes/9.10.0-9.10.4/external-api-changes-9100-version.mdx
+++ b/src/content/en/release-notes/9.10.0-9.10.4/external-api-changes-9100-version.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'External API Changes (Version 9.10.0)'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375624/External+API+9.10.0'
 ---
 
 # External API Changes (Version 9.10.0)

--- a/src/content/en/release-notes/9.11.0-9.11.5.mdx
+++ b/src/content/en/release-notes/9.11.0-9.11.5.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.11.0 ~ 9.11.5'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375587/9.11.0+~+9.11.5'
 ---
 
 # 9.11.0 ~ 9.11.5

--- a/src/content/en/release-notes/9.12.0-9.12.14.mdx
+++ b/src/content/en/release-notes/9.12.0-9.12.14.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.12.0 ~ 9.12.14'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375485/9.12.0+~+9.12.14'
 ---
 
 # 9.12.0 ~ 9.12.14

--- a/src/content/en/release-notes/9.12.0-9.12.14/menu-improvement-guide-9120.mdx
+++ b/src/content/en/release-notes/9.12.0-9.12.14/menu-improvement-guide-9120.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Menu Improvement Guide (9.12.0)'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375505/9.12.0'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/release-notes/9.13.0-9.13.5.mdx
+++ b/src/content/en/release-notes/9.13.0-9.13.5.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.13.0 ~ 9.13.5'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375471/9.13.0+~+9.13.5'
 ---
 
 # 9.13.0 ~ 9.13.5

--- a/src/content/en/release-notes/9.14.0-9.14.3.mdx
+++ b/src/content/en/release-notes/9.14.0-9.14.3.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.14.0 ~ 9.14.3'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375457/9.14.0+~+9.14.3'
 ---
 
 # 9.14.0 ~ 9.14.3

--- a/src/content/en/release-notes/9.15.0-9.15.4.mdx
+++ b/src/content/en/release-notes/9.15.0-9.15.4.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.15.0 ~ 9.15.4'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375443/9.15.0+~+9.15.4'
 ---
 
 # 9.15.0 ~ 9.15.4

--- a/src/content/en/release-notes/9.16.0-9.16.4.mdx
+++ b/src/content/en/release-notes/9.16.0-9.16.4.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.16.0 ~ 9.16.4'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375429/9.16.0+~+9.16.4'
 ---
 
 # 9.16.0 ~ 9.16.4

--- a/src/content/en/release-notes/9.17.0-9.17.1.mdx
+++ b/src/content/en/release-notes/9.17.0-9.17.1.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.17.0 ~ 9.17.1'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375414/9.17.0+~+9.17.1'
 ---
 
 # 9.17.0 ~ 9.17.1

--- a/src/content/en/release-notes/9.18.0-9.18.3.mdx
+++ b/src/content/en/release-notes/9.18.0-9.18.3.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.18.0 ~ 9.18.3'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375399/9.18.0+~+9.18.3'
 ---
 
 # 9.18.0 ~ 9.18.3

--- a/src/content/en/release-notes/9.19.0.mdx
+++ b/src/content/en/release-notes/9.19.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.19.0'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375385/9.19.0'
 ---
 
 # 9.19.0

--- a/src/content/en/release-notes/9.20.0-9.20.2.mdx
+++ b/src/content/en/release-notes/9.20.0-9.20.2.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.20.0 ~ 9.20.2'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375370/9.20.0+~+9.20.2'
 ---
 
 # 9.20.0 ~ 9.20.2

--- a/src/content/en/release-notes/9.8.0-9.8.12.mdx
+++ b/src/content/en/release-notes/9.8.0-9.8.12.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.8.0 ~ 9.8.12'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375768/9.8.0+~+9.8.12'
 ---
 
 # 9.8.0 ~ 9.8.12

--- a/src/content/en/release-notes/9.9.0-9.9.8.mdx
+++ b/src/content/en/release-notes/9.9.0-9.9.8.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.9.0 ~ 9.9.8'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375659/9.9.0+~+9.9.8'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/release-notes/9.9.0-9.9.8/external-api-changes-9810-version-994-version.mdx
+++ b/src/content/en/release-notes/9.9.0-9.9.8/external-api-changes-9810-version-994-version.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'External API Changes (9.8.10 Version > 9.9.4 Version)'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375685/External+API+9.8.10+9.9.4'
 ---
 
 # External API Changes (9.8.10 Version > 9.9.4 Version)

--- a/src/content/en/release-notes/9.9.0-9.9.8/external-api-changes-994-version-995-version.mdx
+++ b/src/content/en/release-notes/9.9.0-9.9.8/external-api-changes-994-version-995-version.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'External API Changes (9.9.4 Version > 9.9.5 Version)'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375741/External+API+9.9.4+9.9.5'
 ---
 
 # External API Changes (9.9.4 Version > 9.9.5 Version)

--- a/src/content/en/support.mdx
+++ b/src/content/en/support.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Support'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1844969501'
 ---
 
 # Support

--- a/src/content/en/support/premium-support.mdx
+++ b/src/content/en/support/premium-support.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Premium Support'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1853358081'
 ---
 
 # Premium Support

--- a/src/content/en/unreleased.mdx
+++ b/src/content/en/unreleased.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Unreleased'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1911423023/Unreleased'
 ---
 
 # Unreleased

--- a/src/content/en/unreleased/reverse-sync-test-page.mdx
+++ b/src/content/en/unreleased/reverse-sync-test-page.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Reverse Sync Test Page'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1911652402/Reverse+Sync+Test+Page'
 ---
 
 # Reverse Sync Test Page

--- a/src/content/en/user-manual.mdx
+++ b/src/content/en/user-manual.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'User Manual'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544211126'
 ---
 
 # User Manual

--- a/src/content/en/user-manual/database-access-control.mdx
+++ b/src/content/en/user-manual/database-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Database Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380204/Database+Access+Control'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/database-access-control/connecting-to-custom-data-source.mdx
+++ b/src/content/en/user-manual/database-access-control/connecting-to-custom-data-source.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Connecting to Custom Data Source'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/880181257/Custom+Data+Source'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/database-access-control/connecting-to-proxy-without-agent.mdx
+++ b/src/content/en/user-manual/database-access-control/connecting-to-proxy-without-agent.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Connecting to Proxy without Agent'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/559906893'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/database-access-control/connecting-via-google-bigquery-oauth-authentication.mdx
+++ b/src/content/en/user-manual/database-access-control/connecting-via-google-bigquery-oauth-authentication.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Connect via Google BigQuery OAuth Authentication'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/820609510/Google+BigQuery+OAuth'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/database-access-control/connecting-with-web-sql-editor.mdx
+++ b/src/content/en/user-manual/database-access-control/connecting-with-web-sql-editor.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Connecting with Web SQL Editor'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380222/SQL'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/database-access-control/setting-default-privilege.mdx
+++ b/src/content/en/user-manual/database-access-control/setting-default-privilege.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Setting Default Privilege'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380354/Default+Privilege'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/kubernetes-access-control.mdx
+++ b/src/content/en/user-manual/kubernetes-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Kubernetes Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544384011/Kubernetes+Access+Control'
 ---
 
 # Kubernetes Access Control

--- a/src/content/en/user-manual/kubernetes-access-control/checking-access-permission-list.mdx
+++ b/src/content/en/user-manual/kubernetes-access-control/checking-access-permission-list.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Checking Access Permission List'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544384025'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/multi-agent.mdx
+++ b/src/content/en/user-manual/multi-agent.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Multi Agent'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/852066413/Multi+Agent'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/multi-agent/multi-agent-3rd-party-tool-support-list-by-os.mdx
+++ b/src/content/en/user-manual/multi-agent/multi-agent-3rd-party-tool-support-list-by-os.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Multi Agent 3rd-Party Tool Support List by OS'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/919240916/Multi+Agent+OS+3rd+Party+Tool'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/multi-agent/multi-agent-linux-installation-and-usage-guide.mdx
+++ b/src/content/en/user-manual/multi-agent/multi-agent-linux-installation-and-usage-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Multi Agent Linux Installation and Usage Guide'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/912425276/Multi+Agent+Linux'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/multi-agent/multi-agent-seamless-ssh-usage-guide.mdx
+++ b/src/content/en/user-manual/multi-agent/multi-agent-seamless-ssh-usage-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Multi Agent Seamless SSH Usage Guide'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/912425288/Multi+Agent+Seamless+SSH'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/my-dashboard.mdx
+++ b/src/content/en/user-manual/my-dashboard.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'My Dashboard'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/578945174/My+Dashboard'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/my-dashboard/user-password-reset-via-email.mdx
+++ b/src/content/en/user-manual/my-dashboard/user-password-reset-via-email.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'User Password Reset via Email'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/793542657/Email'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/preferences.mdx
+++ b/src/content/en/user-manual/preferences.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Preferences'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/568950885/Preferences'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/server-access-control.mdx
+++ b/src/content/en/user-manual/server-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381369/Server+Access+Control'
 ---
 
 # Server Access Control

--- a/src/content/en/user-manual/server-access-control/connecting-to-authorized-servers.mdx
+++ b/src/content/en/user-manual/server-access-control/connecting-to-authorized-servers.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Connecting to Authorized Servers'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381383'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/server-access-control/using-web-sftp.mdx
+++ b/src/content/en/user-manual/server-access-control/using-web-sftp.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Using Web SFTP'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381477/SFTP'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/server-access-control/using-web-terminal.mdx
+++ b/src/content/en/user-manual/server-access-control/using-web-terminal.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Using Web Terminal'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381410'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/user-agent.mdx
+++ b/src/content/en/user-manual/user-agent.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'User Agent'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544112828/User+Agent'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/web-access-control.mdx
+++ b/src/content/en/user-manual/web-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064829218/Web+Access+Control'
 ---
 
 # Web Access Control

--- a/src/content/en/user-manual/web-access-control/accessing-web-applications-websites.mdx
+++ b/src/content/en/user-manual/web-access-control/accessing-web-applications-websites.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Accessing Web Applications (Websites)'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064796396'
 ---
 
 # Accessing Web Applications (Websites)

--- a/src/content/en/user-manual/web-access-control/installing-root-ca-certificate-and-extension.mdx
+++ b/src/content/en/user-manual/web-access-control/installing-root-ca-certificate-and-extension.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Installing Root CA Certificate and Extension'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1073709107/Root+CA+Extension'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/workflow.mdx
+++ b/src/content/en/user-manual/workflow.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Workflow'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544377922/Workflow'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/workflow/approval-additional-features-proxy-approval-resubmission-etc.mdx
+++ b/src/content/en/user-manual/workflow/approval-additional-features-proxy-approval-resubmission-etc.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Approval Additional Features (Proxy Approval, Resubmission, etc.)'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/568918170'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/workflow/requesting-access-role.mdx
+++ b/src/content/en/user-manual/workflow/requesting-access-role.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Requesting Access Role Request'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544378348/Access+Role+Request'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/workflow/requesting-db-access.mdx
+++ b/src/content/en/user-manual/workflow/requesting-db-access.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Requesting DB Access Request'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544377968/DB+Access+Request'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/workflow/requesting-db-policy-exception.mdx
+++ b/src/content/en/user-manual/workflow/requesting-db-policy-exception.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Requesting DB Policy Exception Request'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070006273/DB+DB+Policy+Exception+Request'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/workflow/requesting-ip-registration.mdx
+++ b/src/content/en/user-manual/workflow/requesting-ip-registration.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Requesting IP Registration Request'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1055358996/IP+Registration+Request'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/workflow/requesting-restricted-data-access.mdx
+++ b/src/content/en/user-manual/workflow/requesting-restricted-data-access.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Requesting Restricted Data Access'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1060306945/Restricted+Data+Access'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/workflow/requesting-server-access.mdx
+++ b/src/content/en/user-manual/workflow/requesting-server-access.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Requesting Server Access Request'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544378254/Server+Access+Request'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/workflow/requesting-server-privilege.mdx
+++ b/src/content/en/user-manual/workflow/requesting-server-privilege.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Requesting Server Privilege Request'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/878936417/Server+Privilege+Request'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/workflow/requesting-sql-export.mdx
+++ b/src/content/en/user-manual/workflow/requesting-sql-export.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Requesting SQL Export Request'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544378182/SQL+Export+Request'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/workflow/requesting-sql.mdx
+++ b/src/content/en/user-manual/workflow/requesting-sql.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Requesting SQL Request'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544378069/SQL+Request'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/workflow/requesting-sql/using-execution-plan-explain-feature.mdx
+++ b/src/content/en/user-manual/workflow/requesting-sql/using-execution-plan-explain-feature.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Using Execution Plan (Explain) Feature'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/692355151/Explain'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/en/user-manual/workflow/requesting-unmasking-mask-removal-request.mdx
+++ b/src/content/en/user-manual/workflow/requesting-unmasking-mask-removal-request.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Requesting Unmasking (Mask Removal Request)'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/712769539/Unmasking+Request'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual.mdx
+++ b/src/content/ja/administrator-manual.mdx
@@ -1,5 +1,6 @@
 ---
 title: '管理者マニュアル'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544178405'
 ---
 
 # 管理者マニュアル

--- a/src/content/ja/administrator-manual/audit.mdx
+++ b/src/content/ja/administrator-manual/audit.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Audit'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379062/Audit'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/audit/database-logs.mdx
+++ b/src/content/ja/administrator-manual/audit/database-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Database Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544080248/Database+Logs'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/audit/database-logs/access-control-logs.mdx
+++ b/src/content/ja/administrator-manual/audit/database-logs/access-control-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Access Control Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544080264/Access+Control+Logs'
 ---
 
 # Access Control Logs

--- a/src/content/ja/administrator-manual/audit/database-logs/account-lock-history.mdx
+++ b/src/content/ja/administrator-manual/audit/database-logs/account-lock-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Account Lock History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544014894/Account+Lock+History'
 ---
 
 # Account Lock History

--- a/src/content/ja/administrator-manual/audit/database-logs/db-access-history.mdx
+++ b/src/content/ja/administrator-manual/audit/database-logs/db-access-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'DB Access History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544113141/DB+Access+History'
 ---
 
 # DB Access History

--- a/src/content/ja/administrator-manual/audit/database-logs/dml-snapshots.mdx
+++ b/src/content/ja/administrator-manual/audit/database-logs/dml-snapshots.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'DML Snapshots'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544244163/DML+Snapshots'
 ---
 
 # DML Snapshots

--- a/src/content/ja/administrator-manual/audit/database-logs/policy-audit-logs.mdx
+++ b/src/content/ja/administrator-manual/audit/database-logs/policy-audit-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Policy Audit Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070694532/Policy+Audit+Logs'
 ---
 
 # Policy Audit Logs

--- a/src/content/ja/administrator-manual/audit/database-logs/policy-exception-logs.mdx
+++ b/src/content/ja/administrator-manual/audit/database-logs/policy-exception-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Policy Exception logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1164705793/Policy+Exception+logs'
 ---
 
 # Policy Exception logs

--- a/src/content/ja/administrator-manual/audit/database-logs/query-audit.mdx
+++ b/src/content/ja/administrator-manual/audit/database-logs/query-audit.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Query Audit'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544244149/Query+Audit'
 ---
 
 # Query Audit

--- a/src/content/ja/administrator-manual/audit/database-logs/running-queries.mdx
+++ b/src/content/ja/administrator-manual/audit/database-logs/running-queries.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Running Queries'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544145819/Running+Queries'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/audit/general-logs.mdx
+++ b/src/content/ja/administrator-manual/audit/general-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'General Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544211450/General+Logs'
 ---
 
 # General Logs

--- a/src/content/ja/administrator-manual/audit/general-logs/activity-logs.mdx
+++ b/src/content/ja/administrator-manual/audit/general-logs/activity-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Activity Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544113108/Activity+Logs'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/audit/general-logs/admin-role-history.mdx
+++ b/src/content/ja/administrator-manual/audit/general-logs/admin-role-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Admin Role History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544047557/Admin+Role+History'
 ---
 
 # Admin Role History

--- a/src/content/ja/administrator-manual/audit/general-logs/reverse-tunnels.mdx
+++ b/src/content/ja/administrator-manual/audit/general-logs/reverse-tunnels.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Reverse Tunnels'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/775455036/Reverse+Tunnels'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-clusters-through-reverse-tunnel.mdx
+++ b/src/content/ja/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-clusters-through-reverse-tunnel.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Reverse Tunnelを介してクラスターに通信する'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/811466988/Reverse+Tunnel'
 ---
 
 # Reverse Tunnelを介してクラスターに通信する

--- a/src/content/ja/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-db-through-reverse-tunnel.mdx
+++ b/src/content/ja/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-db-through-reverse-tunnel.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Reverse Tunnelを通じてDBに通信する'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/955318273/Reverse+Tunnel+DB'
 ---
 
 # Reverse Tunnelを通じてDBに通信する

--- a/src/content/ja/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-servers-through-reverse-tunnel.mdx
+++ b/src/content/ja/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-servers-through-reverse-tunnel.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Reverse Tunnelを通じてサーバーに通信する'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/811434216/Reverse+Tunnel'
 ---
 
 # Reverse Tunnelを通じてサーバーに通信する

--- a/src/content/ja/administrator-manual/audit/general-logs/user-access-history.mdx
+++ b/src/content/ja/administrator-manual/audit/general-logs/user-access-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'User Access History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544080230/User+Access+History'
 ---
 
 # User Access History

--- a/src/content/ja/administrator-manual/audit/general-logs/workflow-logs.mdx
+++ b/src/content/ja/administrator-manual/audit/general-logs/workflow-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Workflow Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/705724442/Workflow+Logs'
 ---
 
 # Workflow Logs

--- a/src/content/ja/administrator-manual/audit/kubernetes-logs.mdx
+++ b/src/content/ja/administrator-manual/audit/kubernetes-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Kubernetes Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544383513/Kubernetes+Logs'
 ---
 
 # Kubernetes Logs

--- a/src/content/ja/administrator-manual/audit/kubernetes-logs/kubernetes-role-history.mdx
+++ b/src/content/ja/administrator-manual/audit/kubernetes-logs/kubernetes-role-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Kubernetes Role History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544383799/Kubernetes+Role+History'
 ---
 
 # Kubernetes Role History

--- a/src/content/ja/administrator-manual/audit/kubernetes-logs/pod-session-recordings.mdx
+++ b/src/content/ja/administrator-manual/audit/kubernetes-logs/pod-session-recordings.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Pod Session Recordings'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544383693/Pod+Session+Recordings'
 ---
 
 # Pod Session Recordings

--- a/src/content/ja/administrator-manual/audit/kubernetes-logs/request-audit.mdx
+++ b/src/content/ja/administrator-manual/audit/kubernetes-logs/request-audit.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Request Audit'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544383587/Request+Audit'
 ---
 
 # Request Audit

--- a/src/content/ja/administrator-manual/audit/reports.mdx
+++ b/src/content/ja/administrator-manual/audit/reports.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Reports'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/693043522/Reports'
 ---
 
 # Reports

--- a/src/content/ja/administrator-manual/audit/reports/audit-log-export.mdx
+++ b/src/content/ja/administrator-manual/audit/reports/audit-log-export.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Audit Log Export'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379140/Audit+Log+Export'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/audit/reports/reports.mdx
+++ b/src/content/ja/administrator-manual/audit/reports/reports.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Reports'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544384417/Reports'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/audit/server-logs.mdx
+++ b/src/content/ja/administrator-manual/audit/server-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544014907/Server+Logs'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/audit/server-logs/access-control-logs.mdx
+++ b/src/content/ja/administrator-manual/audit/server-logs/access-control-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Access Control Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544244234/Access+Control+Logs'
 ---
 
 # Access Control Logs

--- a/src/content/ja/administrator-manual/audit/server-logs/account-lock-history.mdx
+++ b/src/content/ja/administrator-manual/audit/server-logs/account-lock-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Account Lock History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/543949311/Account+Lock+History'
 ---
 
 # Account Lock History

--- a/src/content/ja/administrator-manual/audit/server-logs/command-audit.mdx
+++ b/src/content/ja/administrator-manual/audit/server-logs/command-audit.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Command Audit'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544244208/Command+Audit'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/audit/server-logs/server-access-history.mdx
+++ b/src/content/ja/administrator-manual/audit/server-logs/server-access-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Access History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544244182/Server+Access+History'
 ---
 
 # Server Access History

--- a/src/content/ja/administrator-manual/audit/server-logs/server-role-history.mdx
+++ b/src/content/ja/administrator-manual/audit/server-logs/server-role-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Role History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544244244/Server+Role+History'
 ---
 
 # Server Role History

--- a/src/content/ja/administrator-manual/audit/server-logs/session-logs.mdx
+++ b/src/content/ja/administrator-manual/audit/server-logs/session-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Session Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544014927/Session+Logs'
 ---
 
 # Session Logs

--- a/src/content/ja/administrator-manual/audit/server-logs/session-monitoring-moved.mdx
+++ b/src/content/ja/administrator-manual/audit/server-logs/session-monitoring-moved.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Session Monitoring (Moved)'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544014940/Session+Monitoring+Moved'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/audit/web-app-logs.mdx
+++ b/src/content/ja/administrator-manual/audit/web-app-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web App Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064829366/Web+App+Logs'
 ---
 
 # Web App Logs

--- a/src/content/ja/administrator-manual/audit/web-app-logs/jit-access-control-logs.mdx
+++ b/src/content/ja/administrator-manual/audit/web-app-logs/jit-access-control-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'JIT Access Control Logs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070694552/JIT+Access+Control+Logs'
 ---
 
 # JIT Access Control Logs

--- a/src/content/ja/administrator-manual/audit/web-app-logs/user-activity-recordings.mdx
+++ b/src/content/ja/administrator-manual/audit/web-app-logs/user-activity-recordings.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'User Activity Recordings'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070694561/User+Activity+Recordings'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/audit/web-app-logs/web-access-history.mdx
+++ b/src/content/ja/administrator-manual/audit/web-app-logs/web-access-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web Access History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064829380/Web+Access+History'
 ---
 
 # Web Access History

--- a/src/content/ja/administrator-manual/audit/web-app-logs/web-app-role-history.mdx
+++ b/src/content/ja/administrator-manual/audit/web-app-logs/web-app-role-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web App Role History'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070563469/Web+App+Role+History'
 ---
 
 # Web App Role History

--- a/src/content/ja/administrator-manual/audit/web-app-logs/web-event-audit.mdx
+++ b/src/content/ja/administrator-manual/audit/web-app-logs/web-event-audit.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web Event Audit'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070563457/Web+Event+Audit'
 ---
 
 # Web Event Audit

--- a/src/content/ja/administrator-manual/databases.mdx
+++ b/src/content/ja/administrator-manual/databases.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Databases'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379638/Databases'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/databases/connection-management.mdx
+++ b/src/content/ja/administrator-manual/databases/connection-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Connection Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379705/Connection+Management'
 ---
 
 # Connection Management

--- a/src/content/ja/administrator-manual/databases/connection-management/cloud-providers.mdx
+++ b/src/content/ja/administrator-manual/databases/connection-management/cloud-providers.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Cloud Providers'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544145672/Cloud+Providers'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-aws.mdx
+++ b/src/content/ja/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-aws.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'AWSからDBリソース同期'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379719/AWS+DB'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-google-cloud.mdx
+++ b/src/content/ja/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-google-cloud.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Google CloudからDBリソース同期'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/562167809/Google+Cloud+DB'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-ms-azure.mdx
+++ b/src/content/ja/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-ms-azure.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'MS AzureからDBリソース同期'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/562167871/MS+Azure+DB'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/databases/connection-management/cloud-providers/verifying-cloud-synchronization-settings-with-dry-run-feature.mdx
+++ b/src/content/ja/administrator-manual/databases/connection-management/cloud-providers/verifying-cloud-synchronization-settings-with-dry-run-feature.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Dry Run機能でクラウド同期設定確認'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/712507393/Dry+Run'
 ---
 
 # Dry Run機能でクラウド同期設定確認

--- a/src/content/ja/administrator-manual/databases/connection-management/db-connections.mdx
+++ b/src/content/ja/administrator-manual/databases/connection-management/db-connections.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'DB Connections'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544014712/DB+Connections'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/databases/connection-management/db-connections/aws-athena-specific-guide.mdx
+++ b/src/content/ja/administrator-manual/databases/connection-management/db-connections/aws-athena-specific-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'AWS Athena専用ガイド'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/820806182/AWS+Athena'
 ---
 
 # AWS Athena専用ガイド

--- a/src/content/ja/administrator-manual/databases/connection-management/db-connections/custom-data-source-configuration-and-log-verification.mdx
+++ b/src/content/ja/administrator-manual/databases/connection-management/db-connections/custom-data-source-configuration-and-log-verification.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Custom Data Source設定およびログ確認'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/880082945/Custom+Data+Source'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/databases/connection-management/db-connections/documentdb-specific-guide.mdx
+++ b/src/content/ja/administrator-manual/databases/connection-management/db-connections/documentdb-specific-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'DocumentDB専用ガイド'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/568852692/DocumentDB'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/databases/connection-management/db-connections/google-bigquery-oauth-authentication-configuration.mdx
+++ b/src/content/ja/administrator-manual/databases/connection-management/db-connections/google-bigquery-oauth-authentication-configuration.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Google BigQuery OAuth認証設定'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/811434142/Google+BigQuery+OAuth'
 ---
 
 # Google BigQuery OAuth認証設定

--- a/src/content/ja/administrator-manual/databases/connection-management/db-connections/mongodb-specific-guide.mdx
+++ b/src/content/ja/administrator-manual/databases/connection-management/db-connections/mongodb-specific-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'MongoDB専用ガイド'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380381/MongoDB'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/databases/connection-management/kerberos-configurations.mdx
+++ b/src/content/ja/administrator-manual/databases/connection-management/kerberos-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Kerberos Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544112932/Kerberos+Configurations'
 ---
 
 # Kerberos Configurations

--- a/src/content/ja/administrator-manual/databases/connection-management/ssh-configurations.mdx
+++ b/src/content/ja/administrator-manual/databases/connection-management/ssh-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'SSH Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544047436/SSH+Configurations'
 ---
 
 # SSH Configurations

--- a/src/content/ja/administrator-manual/databases/connection-management/ssl-configurations.mdx
+++ b/src/content/ja/administrator-manual/databases/connection-management/ssl-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'SSL Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544145691/SSL+Configurations'
 ---
 
 # SSL Configurations

--- a/src/content/ja/administrator-manual/databases/dac-general-configurations.mdx
+++ b/src/content/ja/administrator-manual/databases/dac-general-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'DAC General Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/956071939/DAC+General+Configurations'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/databases/dac-general-configurations/masking-pattern-menu-relocated.mdx
+++ b/src/content/ja/administrator-manual/databases/dac-general-configurations/masking-pattern-menu-relocated.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Masking Pattern (メニュー位置移動)'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1275396097/Masking+Pattern'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/databases/dac-general-configurations/unmasking-zones.mdx
+++ b/src/content/ja/administrator-manual/databases/dac-general-configurations/unmasking-zones.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Unmasking Zones'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/921436219/Unmasking+Zones'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/databases/db-access-control.mdx
+++ b/src/content/ja/administrator-manual/databases/db-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'DB Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380126/DB+Access+Control'
 ---
 
 # DB Access Control

--- a/src/content/ja/administrator-manual/databases/db-access-control/access-control.mdx
+++ b/src/content/ja/administrator-manual/databases/db-access-control/access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380173/Access+Control'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/databases/db-access-control/privilege-type.mdx
+++ b/src/content/ja/administrator-manual/databases/db-access-control/privilege-type.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Privilege Type'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380140/Privilege+Type'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/databases/ledger-management.mdx
+++ b/src/content/ja/administrator-manual/databases/ledger-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Ledger Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/571277577/Ledger+Management'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/databases/ledger-management/ledger-approval-rules.mdx
+++ b/src/content/ja/administrator-manual/databases/ledger-management/ledger-approval-rules.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Ledger Approval Rules'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/571277650/Ledger+Approval+Rules'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/databases/ledger-management/ledger-table-policy.mdx
+++ b/src/content/ja/administrator-manual/databases/ledger-management/ledger-table-policy.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Ledger Table Policy'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380061/Ledger+Table+Policy'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/databases/monitoring.mdx
+++ b/src/content/ja/administrator-manual/databases/monitoring.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Monitoring'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/954139156/Monitoring'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/databases/monitoring/proxy-management.mdx
+++ b/src/content/ja/administrator-manual/databases/monitoring/proxy-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Proxy Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/954204974/Proxy+Management'
 ---
 
 # Proxy Management

--- a/src/content/ja/administrator-manual/databases/monitoring/running-queries.mdx
+++ b/src/content/ja/administrator-manual/databases/monitoring/running-queries.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Running Queries'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/954172219/Running+Queries'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/databases/new-policy-management.mdx
+++ b/src/content/ja/administrator-manual/databases/new-policy-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: '(New) Policy Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/873136365/New+Policy+Management'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/databases/new-policy-management/data-paths.mdx
+++ b/src/content/ja/administrator-manual/databases/new-policy-management/data-paths.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Data Paths'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/878805502/Data+Paths'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/databases/new-policy-management/data-policies.mdx
+++ b/src/content/ja/administrator-manual/databases/new-policy-management/data-policies.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Data Policies'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/879198569/Data+Policies'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/databases/new-policy-management/exception-management.mdx
+++ b/src/content/ja/administrator-manual/databases/new-policy-management/exception-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Exception Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064796485/Exception+Management'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/databases/policies.mdx
+++ b/src/content/ja/administrator-manual/databases/policies.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Policies'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379868/Policies'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/databases/policies/data-access.mdx
+++ b/src/content/ja/administrator-manual/databases/policies/data-access.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Data Access'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379937/Data+Access'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/databases/policies/data-masking.mdx
+++ b/src/content/ja/administrator-manual/databases/policies/data-masking.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Data Masking'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379882/Data+Masking'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/databases/policies/masking-pattern.mdx
+++ b/src/content/ja/administrator-manual/databases/policies/masking-pattern.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Masking Pattern'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/569376769/Masking+Pattern'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/databases/policies/policy-exception.mdx
+++ b/src/content/ja/administrator-manual/databases/policies/policy-exception.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Policy Exception'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/713129986/Policy+Exception'
 ---
 
 # Policy Exception

--- a/src/content/ja/administrator-manual/databases/policies/sensitive-data.mdx
+++ b/src/content/ja/administrator-manual/databases/policies/sensitive-data.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Sensitive Data'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379993/Sensitive+Data'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general.mdx
+++ b/src/content/ja/administrator-manual/general.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'General'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544080057/General'
 ---
 
 # General

--- a/src/content/ja/administrator-manual/general/company-management.mdx
+++ b/src/content/ja/administrator-manual/general/company-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Company Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/543948978/Company+Management'
 ---
 
 # Company Management

--- a/src/content/ja/administrator-manual/general/company-management/alerts.mdx
+++ b/src/content/ja/administrator-manual/general/company-management/alerts.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Alerts'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/543981760/Alerts'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/company-management/alerts/new-request-template-variables-by-request-type.mdx
+++ b/src/content/ja/administrator-manual/general/company-management/alerts/new-request-template-variables-by-request-type.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'New Request > リクエストタイプ別テンプレート変数'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/793608206/New+Request'
 ---
 
 # New Request > リクエストタイプ別テンプレート変数

--- a/src/content/ja/administrator-manual/general/company-management/allowed-zones.mdx
+++ b/src/content/ja/administrator-manual/general/company-management/allowed-zones.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Allowed Zones'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544112846/Allowed+Zones'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/company-management/channels.mdx
+++ b/src/content/ja/administrator-manual/general/company-management/channels.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Channels'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544243925/Channels'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/company-management/general.mdx
+++ b/src/content/ja/administrator-manual/general/company-management/general.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'General'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544145591/General'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/company-management/licenses.mdx
+++ b/src/content/ja/administrator-manual/general/company-management/licenses.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Licenses'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544178443/Licenses'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/company-management/security.mdx
+++ b/src/content/ja/administrator-manual/general/company-management/security.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Security'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544178422/Security'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/system.mdx
+++ b/src/content/ja/administrator-manual/general/system.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'System'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544112865/System'
 ---
 
 # System

--- a/src/content/ja/administrator-manual/general/system/api-token.mdx
+++ b/src/content/ja/administrator-manual/general/system/api-token.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'API Token'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544377652/API+Token'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/system/integrations.mdx
+++ b/src/content/ja/administrator-manual/general/system/integrations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Integrations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544080097/Integrations'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/system/integrations/identity-providers.mdx
+++ b/src/content/ja/administrator-manual/general/system/integrations/identity-providers.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Identity Providers'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1454342158/Identity+Providers'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/system/integrations/identity-providers/integrating-with-aws-sso-saml-20.mdx
+++ b/src/content/ja/administrator-manual/general/system/integrations/identity-providers/integrating-with-aws-sso-saml-20.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'AWS SSO連携（SAML 2.0）'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1495433217/AWS+SSO+SAML+2.0'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/system/integrations/integrating-google-cloud-api-for-oauth-20.mdx
+++ b/src/content/ja/administrator-manual/general/system/integrations/integrating-google-cloud-api-for-oauth-20.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'OAuth 2.0を使用するためのGoogle Cloud API連携'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/811401365/OAuth+2.0+Google+Cloud+API'
 ---
 
 # OAuth 2.0を使用するためのGoogle Cloud API連携

--- a/src/content/ja/administrator-manual/general/system/integrations/integrating-with-email.mdx
+++ b/src/content/ja/administrator-manual/general/system/integrations/integrating-with-email.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Email連携'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/798064641/Email'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/system/integrations/integrating-with-event-callback.mdx
+++ b/src/content/ja/administrator-manual/general/system/integrations/integrating-with-event-callback.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Event Callback連携'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1267007528/Event+Callback'
 ---
 
 # Event Callback連携

--- a/src/content/ja/administrator-manual/general/system/integrations/integrating-with-secret-store.mdx
+++ b/src/content/ja/administrator-manual/general/system/integrations/integrating-with-secret-store.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Secret Store連携'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379587/Secret+Store'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/system/integrations/integrating-with-slack-dm.mdx
+++ b/src/content/ja/administrator-manual/general/system/integrations/integrating-with-slack-dm.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Slack DM連携'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/883654669/Slack+DM'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/system/integrations/integrating-with-slack-dm/slack-dm-workflow-notification-types.mdx
+++ b/src/content/ja/administrator-manual/general/system/integrations/integrating-with-slack-dm/slack-dm-workflow-notification-types.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Slack DM - Workflow通知タイプ'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544378759/Slack+DM+-+Workflow'
 ---
 
 # Slack DM - Workflow通知タイプ

--- a/src/content/ja/administrator-manual/general/system/integrations/integrating-with-splunk.mdx
+++ b/src/content/ja/administrator-manual/general/system/integrations/integrating-with-splunk.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Splunk連携'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/557940795/Splunk'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/system/integrations/integrating-with-syslog.mdx
+++ b/src/content/ja/administrator-manual/general/system/integrations/integrating-with-syslog.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Syslog連携'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544379393/Syslog'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/system/integrations/oauth-client-application.mdx
+++ b/src/content/ja/administrator-manual/general/system/integrations/oauth-client-application.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'OAuth Client Application'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1453588486/OAuth+Client+Application'
 ---
 
 # OAuth Client Application

--- a/src/content/ja/administrator-manual/general/system/jobs.mdx
+++ b/src/content/ja/administrator-manual/general/system/jobs.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Jobs'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544211220/Jobs'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/system/maintenance.mdx
+++ b/src/content/ja/administrator-manual/general/system/maintenance.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Maintenance'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1456144391/Maintenance'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/user-management.mdx
+++ b/src/content/ja/administrator-manual/general/user-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'User Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375969/User+Management'
 ---
 
 # User Management

--- a/src/content/ja/administrator-manual/general/user-management/authentication.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/authentication.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Authentication'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375984/Authentication'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/user-management/authentication/integrating-with-aws-sso.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/authentication/integrating-with-aws-sso.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'AWS SSO連携'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544376183/AWS+SSO'
 ---
 
 # AWS SSO連携

--- a/src/content/ja/administrator-manual/general/user-management/authentication/integrating-with-google-saml.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/authentication/integrating-with-google-saml.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Google SAML連携'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/619381289/Google+SAML'
 ---
 
 # Google SAML連携

--- a/src/content/ja/administrator-manual/general/user-management/authentication/integrating-with-ldap.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/authentication/integrating-with-ldap.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'LDAP連携'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544376004/LDAP'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/user-management/authentication/integrating-with-okta.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/authentication/integrating-with-okta.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Okta連携'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544376100/Okta'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/user-management/authentication/setting-up-multi-factor-authentication.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/authentication/setting-up-multi-factor-authentication.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Multi-Factor Authentication設定'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/793575425/Multi-Factor+Authentication'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/user-management/groups.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/groups.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Groups'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544047341/Groups'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/user-management/profile-editor.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/profile-editor.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Profile Editor'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544376982/Profile+Editor'
 ---
 
 # Profile Editor

--- a/src/content/ja/administrator-manual/general/user-management/profile-editor/custom-attribute.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/profile-editor/custom-attribute.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Custom Attribute'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/953221256/Custom+Attribute'
 ---
 
 # Custom Attribute

--- a/src/content/ja/administrator-manual/general/user-management/provisioning.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/provisioning.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Provisioning'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544376236/Provisioning'
 ---
 
 # Provisioning

--- a/src/content/ja/administrator-manual/general/user-management/provisioning/activating-provisioning.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/provisioning/activating-provisioning.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Provisioning有効化'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544376265/Provisioning'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/user-management/provisioning/okta-provisioning-integration-guide.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/provisioning/okta-provisioning-integration-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: '[Okta]プロビジョニング連動ガイド'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544376394/Okta'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/user-management/roles.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/roles.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Roles'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/543948996/Roles'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/user-management/users.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/users.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Users'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544047331/Users'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/user-management/users/password-change-enforcement-and-account-deletion-feature-for-qp-admin-default-account.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/users/password-change-enforcement-and-account-deletion-feature-for-qp-admin-default-account.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'qp-admin基本アカウントに対するパスワード変更強制化およびアカウント削除機能'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/920944732/qp-admin'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/user-management/users/user-profile.mdx
+++ b/src/content/ja/administrator-manual/general/user-management/users/user-profile.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'ユーザープロファイル'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544376787'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/workflow-management.mdx
+++ b/src/content/ja/administrator-manual/general/workflow-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Workflow Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544178462/Workflow+Management'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/workflow-management/all-requests.mdx
+++ b/src/content/ja/administrator-manual/general/workflow-management/all-requests.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'All Requests'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544047359/All+Requests'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/workflow-management/approval-rules.mdx
+++ b/src/content/ja/administrator-manual/general/workflow-management/approval-rules.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Approval Rules'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544378513/Approval+Rules'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/general/workflow-management/workflow-configurations.mdx
+++ b/src/content/ja/administrator-manual/general/workflow-management/workflow-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Workflow Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/561414376/Workflow+Configurations'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/kubernetes.mdx
+++ b/src/content/ja/administrator-manual/kubernetes.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Kubernetes'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381596/Kubernetes'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/kubernetes/connection-management.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/connection-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Connection Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381637/Connection+Management'
 ---
 
 # Connection Management

--- a/src/content/ja/administrator-manual/kubernetes/connection-management/cloud-providers.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/connection-management/cloud-providers.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Cloud Providers'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381651/Cloud+Providers'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/kubernetes/connection-management/cloud-providers/synchronizing-kubernetes-resources-from-aws.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/connection-management/cloud-providers/synchronizing-kubernetes-resources-from-aws.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'AWSからKubernetesリソース同期'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381739/AWS'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/kubernetes/connection-management/clusters.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/connection-management/clusters.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Clusters'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381839/Clusters'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/kubernetes/connection-management/clusters/manually-registering-kubernetes-clusters.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/connection-management/clusters/manually-registering-kubernetes-clusters.mdx
@@ -1,5 +1,6 @@
 ---
 title: '手動でKubernetesクラスター登録'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381877'
 ---
 
 # 手動でKubernetesクラスター登録

--- a/src/content/ja/administrator-manual/kubernetes/k8s-access-control.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/k8s-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'K8s Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544383110/K8s+Access+Control'
 ---
 
 # K8s Access Control

--- a/src/content/ja/administrator-manual/kubernetes/k8s-access-control/access-control.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/k8s-access-control/access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544383124/Access+Control'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/kubernetes/k8s-access-control/access-control/granting-and-revoking-kubernetes-roles.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/k8s-access-control/access-control/granting-and-revoking-kubernetes-roles.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Kubernetes役割付与および回収'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544383381'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/kubernetes/k8s-access-control/policies.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/k8s-access-control/policies.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Policies'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544382060/Policies'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-action-configuration-reference-guide.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-action-configuration-reference-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'KubernetesポリシーAction設定参考ガイド'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544382659/Action'
 ---
 
 # KubernetesポリシーAction設定参考ガイド

--- a/src/content/ja/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-tips-guide.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-tips-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'KubernetesポリシーTips案内'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544382445/Tips'
 ---
 
 # KubernetesポリシーTips案内

--- a/src/content/ja/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-ui-code-helper-guide.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-ui-code-helper-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'KubernetesポリシーUIコードヘルパー案内'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544382522/UI'
 ---
 
 # KubernetesポリシーUIコードヘルパー案内

--- a/src/content/ja/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-yaml-code-syntax-guide.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-yaml-code-syntax-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'KubernetesポリシーYAML Code文法案内'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544382364/YAML+Code'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/kubernetes/k8s-access-control/policies/setting-kubernetes-policies.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/k8s-access-control/policies/setting-kubernetes-policies.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Kubernetesポリシー設定'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544382274'
 ---
 
 # Kubernetesポリシー設定

--- a/src/content/ja/administrator-manual/kubernetes/k8s-access-control/roles.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/k8s-access-control/roles.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Roles'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544382741/Roles'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Kubernetes役割設定方法'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544382963'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/kubernetes/kac-general-configurations.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/kac-general-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'KAC General Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/954172232/KAC+General+Configurations'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/multi-agent-limitations.mdx
+++ b/src/content/ja/administrator-manual/multi-agent-limitations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Multi Agent 制約事項'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/851280543/Multi+Agent'
 ---
 
 # Multi Agent 制約事項

--- a/src/content/ja/administrator-manual/servers.mdx
+++ b/src/content/ja/administrator-manual/servers.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Servers'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380588/Servers'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/servers/connection-management.mdx
+++ b/src/content/ja/administrator-manual/servers/connection-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Connection Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380635/Connection+Management'
 ---
 
 # Connection Management

--- a/src/content/ja/administrator-manual/servers/connection-management/cloud-providers.mdx
+++ b/src/content/ja/administrator-manual/servers/connection-management/cloud-providers.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Cloud Providers'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544178567/Cloud+Providers'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-aws.mdx
+++ b/src/content/ja/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-aws.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'AWSからサーバーリソース同期'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380650/AWS'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-azure.mdx
+++ b/src/content/ja/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-azure.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Azureからサーバーリソース同期'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380741/Azure'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-gcp.mdx
+++ b/src/content/ja/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-gcp.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'GCPからサーバーリソース同期'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380708/GCP'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/servers/connection-management/proxyjump-configurations.mdx
+++ b/src/content/ja/administrator-manual/servers/connection-management/proxyjump-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'ProxyJump Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/615710737/ProxyJump+Configurations'
 ---
 
 # ProxyJump Configurations

--- a/src/content/ja/administrator-manual/servers/connection-management/proxyjump-configurations/creating-proxyjump.mdx
+++ b/src/content/ja/administrator-manual/servers/connection-management/proxyjump-configurations/creating-proxyjump.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'ProxyJump作成'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/615743551/ProxyJump'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/servers/connection-management/server-agents-for-rdp.mdx
+++ b/src/content/ja/administrator-manual/servers/connection-management/server-agents-for-rdp.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Agents for RDP'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544211376/Server+Agents+for+RDP'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/servers/connection-management/server-agents-for-rdp/installing-and-removing-server-agent.mdx
+++ b/src/content/ja/administrator-manual/servers/connection-management/server-agents-for-rdp/installing-and-removing-server-agent.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Agentインストールおよび削除'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/565575990/Server+Agent'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/servers/connection-management/server-groups.mdx
+++ b/src/content/ja/administrator-manual/servers/connection-management/server-groups.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Groups'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544080186/Server+Groups'
 ---
 
 # Server Groups

--- a/src/content/ja/administrator-manual/servers/connection-management/server-groups/managing-servers-as-groups.mdx
+++ b/src/content/ja/administrator-manual/servers/connection-management/server-groups/managing-servers-as-groups.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'サーバーをグループで管理'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380846'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/servers/connection-management/servers.mdx
+++ b/src/content/ja/administrator-manual/servers/connection-management/servers.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Servers'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544211361/Servers'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/servers/connection-management/servers/manually-registering-individual-servers.mdx
+++ b/src/content/ja/administrator-manual/servers/connection-management/servers/manually-registering-individual-servers.mdx
@@ -1,5 +1,6 @@
 ---
 title: '手動で個別サーバー登録'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380774'
 ---
 
 # 手動で個別サーバー登録

--- a/src/content/ja/administrator-manual/servers/sac-general-configurations.mdx
+++ b/src/content/ja/administrator-manual/servers/sac-general-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'SAC General Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/954336174/SAC+General+Configurations'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/servers/server-access-control.mdx
+++ b/src/content/ja/administrator-manual/servers/server-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/543949216/Server+Access+Control'
 ---
 
 # Server Access Control

--- a/src/content/ja/administrator-manual/servers/server-access-control/access-control.mdx
+++ b/src/content/ja/administrator-manual/servers/server-access-control/access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381186/Access+Control'
 ---
 
 # Access Control

--- a/src/content/ja/administrator-manual/servers/server-access-control/access-control/granting-and-revoking-permissions.mdx
+++ b/src/content/ja/administrator-manual/servers/server-access-control/access-control/granting-and-revoking-permissions.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Permissions付与および回収'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381282/Permissions'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/servers/server-access-control/access-control/granting-and-revoking-roles.mdx
+++ b/src/content/ja/administrator-manual/servers/server-access-control/access-control/granting-and-revoking-roles.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Role付与および回収'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381200/Role'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/servers/server-access-control/access-control/granting-server-privilege.mdx
+++ b/src/content/ja/administrator-manual/servers/server-access-control/access-control/granting-server-privilege.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Privilege付与'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/878838349/Server+Privilege'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/servers/server-access-control/blocked-accounts.mdx
+++ b/src/content/ja/administrator-manual/servers/server-access-control/blocked-accounts.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Blocked Accounts'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544244109/Blocked+Accounts'
 ---
 
 # Blocked Accounts

--- a/src/content/ja/administrator-manual/servers/server-access-control/command-templates.mdx
+++ b/src/content/ja/administrator-manual/servers/server-access-control/command-templates.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Command Templates'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381118/Command+Templates'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/servers/server-access-control/policies.mdx
+++ b/src/content/ja/administrator-manual/servers/server-access-control/policies.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Policies'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381025/Policies'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/servers/server-access-control/policies/enabling-server-proxy.mdx
+++ b/src/content/ja/administrator-manual/servers/server-access-control/policies/enabling-server-proxy.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Proxy使用有効化'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544377895/Server+Proxy'
 ---
 
 # Server Proxy使用有効化

--- a/src/content/ja/administrator-manual/servers/server-access-control/policies/setting-server-access-policy.mdx
+++ b/src/content/ja/administrator-manual/servers/server-access-control/policies/setting-server-access-policy.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'サーバーアクセスポリシー設定'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381039'
 ---
 
 # サーバーアクセスポリシー設定

--- a/src/content/ja/administrator-manual/servers/server-access-control/roles.mdx
+++ b/src/content/ja/administrator-manual/servers/server-access-control/roles.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Roles'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381150/Roles'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/servers/server-account-management.mdx
+++ b/src/content/ja/administrator-manual/servers/server-account-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Account Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/613777446/Server+Account+Management'
 ---
 
 # Server Account Management

--- a/src/content/ja/administrator-manual/servers/server-account-management/account-management.mdx
+++ b/src/content/ja/administrator-manual/servers/server-account-management/account-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Account Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/615743501/Account+Management'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/servers/server-account-management/password-provisioning.mdx
+++ b/src/content/ja/administrator-manual/servers/server-account-management/password-provisioning.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Password Provisioning'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/615677962/Password+Provisioning'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/servers/server-account-management/password-provisioning/creating-password-change-job.mdx
+++ b/src/content/ja/administrator-manual/servers/server-account-management/password-provisioning/creating-password-change-job.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'パスワード変更Job生成'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/619380898/Job'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/servers/server-account-management/server-account-templates.mdx
+++ b/src/content/ja/administrator-manual/servers/server-account-management/server-account-templates.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Account Templates'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380991/Server+Account+Templates'
 ---
 
 # Server Account Templates

--- a/src/content/ja/administrator-manual/servers/server-account-management/ssh-key-configurations.mdx
+++ b/src/content/ja/administrator-manual/servers/server-account-management/ssh-key-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'SSH Key Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380960/SSH+Key+Configurations'
 ---
 
 # SSH Key Configurations

--- a/src/content/ja/administrator-manual/servers/session-monitoring.mdx
+++ b/src/content/ja/administrator-manual/servers/session-monitoring.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Session Monitoring'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1760657435/Session+Monitoring'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/web-apps.mdx
+++ b/src/content/ja/administrator-manual/web-apps.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web Apps'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/783515900/Web+Apps'
 ---
 
 # Web Apps

--- a/src/content/ja/administrator-manual/web-apps/connection-management.mdx
+++ b/src/content/ja/administrator-manual/web-apps/connection-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Connection Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064829276/Connection+Management'
 ---
 
 # Connection Management

--- a/src/content/ja/administrator-manual/web-apps/connection-management/web-app-configurations.mdx
+++ b/src/content/ja/administrator-manual/web-apps/connection-management/web-app-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web App Configurations'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064829246/Web+App+Configurations'
 ---
 
 # Web App Configurations

--- a/src/content/ja/administrator-manual/web-apps/connection-management/web-apps.mdx
+++ b/src/content/ja/administrator-manual/web-apps/connection-management/web-apps.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web Apps'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070694423/Web+Apps'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/web-apps/wac-quickstart.mdx
+++ b/src/content/ja/administrator-manual/web-apps/wac-quickstart.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'WAC Quickstart'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/783417593/WAC+Quickstart'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/web-apps/wac-quickstart/1027-wac-role-policy-guide.mdx
+++ b/src/content/ja/administrator-manual/web-apps/wac-quickstart/1027-wac-role-policy-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: '[~10.2.7] WAC Role & Policy Guide'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/783745324/~10.2.7+WAC+Role+Policy+Guide'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/web-apps/wac-quickstart/1028-wac-rbac-guide.mdx
+++ b/src/content/ja/administrator-manual/web-apps/wac-quickstart/1028-wac-rbac-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: '[10.2.8~] WAC RBAC Guide'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/924287097/10.2.8~+WAC+RBAC+Guide'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/web-apps/wac-quickstart/1030-wac-jit-permission-acquisition-guide.mdx
+++ b/src/content/ja/administrator-manual/web-apps/wac-quickstart/1030-wac-jit-permission-acquisition-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: '[10.3.0 ~] WAC JIT権限取得Guide'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/956235931/10.3.0+~+WAC+JIT+Guide'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/web-apps/wac-quickstart/initial-wac-setup-in-web-app-configurations.mdx
+++ b/src/content/ja/administrator-manual/web-apps/wac-quickstart/initial-wac-setup-in-web-app-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web App ConfigurationsでWAC初期設定'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/883654785/Web+App+Configurations+WAC'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/web-apps/wac-quickstart/root-ca-certificate-installation-guide.mdx
+++ b/src/content/ja/administrator-manual/web-apps/wac-quickstart/root-ca-certificate-installation-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Root CA証明書インストールガイド'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/805962425/Root+CA'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/web-apps/wac-quickstart/wac-faq.mdx
+++ b/src/content/ja/administrator-manual/web-apps/wac-quickstart/wac-faq.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'WAC FAQ'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/927629410/WAC+FAQ'
 ---
 
 # WAC FAQ

--- a/src/content/ja/administrator-manual/web-apps/wac-quickstart/wac-troubleshooting-guide.mdx
+++ b/src/content/ja/administrator-manual/web-apps/wac-quickstart/wac-troubleshooting-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'WACトラブルシューティングガイド'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/924319936/WAC'
 ---
 
 # WACトラブルシューティングガイド

--- a/src/content/ja/administrator-manual/web-apps/web-app-access-control.mdx
+++ b/src/content/ja/administrator-manual/web-apps/web-app-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web App Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070596135/Web+App+Access+Control'
 ---
 
 # Web App Access Control

--- a/src/content/ja/administrator-manual/web-apps/web-app-access-control/access-control.mdx
+++ b/src/content/ja/administrator-manual/web-apps/web-app-access-control/access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070628904/Access+Control'
 ---
 
 # Access Control

--- a/src/content/ja/administrator-manual/web-apps/web-app-access-control/access-control/granting-and-revoking-roles.mdx
+++ b/src/content/ja/administrator-manual/web-apps/web-app-access-control/access-control/granting-and-revoking-roles.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Role付与および回収'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064599910/Role'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/web-apps/web-app-access-control/policies.mdx
+++ b/src/content/ja/administrator-manual/web-apps/web-app-access-control/policies.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Policies'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064829343/Policies'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/administrator-manual/web-apps/web-app-access-control/roles.mdx
+++ b/src/content/ja/administrator-manual/web-apps/web-app-access-control/roles.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Roles'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070628923/Roles'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/installation.mdx
+++ b/src/content/ja/installation.mdx
@@ -1,5 +1,6 @@
 ---
 title: '製品インストール'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375808'
 ---
 
 # 製品インストール

--- a/src/content/ja/installation/container-environment-variables.mdx
+++ b/src/content/ja/installation/container-environment-variables.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'コンテナ環境変数'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/954761289'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/installation/container-environment-variables/optimizing-dbmaxconnectionsize.mdx
+++ b/src/content/ja/installation/container-environment-variables/optimizing-dbmaxconnectionsize.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'DB_MAX_CONNECTION_SIZE最適化'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/938016931/DB_MAX_CONNECTION_SIZE'
 ---
 
 # DB_MAX_CONNECTION_SIZE最適化

--- a/src/content/ja/installation/container-environment-variables/querypieweburl.mdx
+++ b/src/content/ja/installation/container-environment-variables/querypieweburl.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'QUERYPIE_WEB_URL'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/876937310/QUERYPIE_WEB_URL'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/installation/installation.mdx
+++ b/src/content/ja/installation/installation.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'インストール'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1689387010'
 ---
 
 # インストール

--- a/src/content/ja/installation/installation/comparison-of-setupsh-and-setupv2sh.mdx
+++ b/src/content/ja/installation/installation/comparison-of-setupsh-and-setupv2sh.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'setup.sh、setup.v2.sh比較'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1261895760/setup.sh+setup.v2.sh'
 ---
 
 # setup.sh、setup.v2.sh比較

--- a/src/content/ja/installation/installation/installation-guide-setupv2sh.mdx
+++ b/src/content/ja/installation/installation/installation-guide-setupv2sh.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'インストールガイド - setup.v2.sh'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1177321474/-+setup.v2.sh'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/installation/installation/installation-guide-simple-configuration.mdx
+++ b/src/content/ja/installation/installation/installation-guide-simple-configuration.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'インストールガイド - 簡単な構成'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/964952065/-'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/installation/installation/installing-on-aws-eks.mdx
+++ b/src/content/ja/installation/installation/installing-on-aws-eks.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'AWS EKS環境でインストール'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/815235967/AWS+EKS'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/installation/license-installation.mdx
+++ b/src/content/ja/installation/license-installation.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'ライセンスインストール'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/912326893'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/installation/post-installation-setup.mdx
+++ b/src/content/ja/installation/post-installation-setup.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'インストール後の初期設定'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1907294209'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/installation/prerequisites.mdx
+++ b/src/content/ja/installation/prerequisites.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'インストール前の準備事項'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/862126081'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/installation/prerequisites/configuring-rootless-mode-with-podman.mdx
+++ b/src/content/ja/installation/prerequisites/configuring-rootless-mode-with-podman.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'PodmanでRootless Mode構成'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1297383451/Podman+Rootless+Mode'
 ---
 
 # PodmanでRootless Mode構成

--- a/src/content/ja/installation/prerequisites/linux-distribution-and-docker-podman-support-status.mdx
+++ b/src/content/ja/installation/prerequisites/linux-distribution-and-docker-podman-support-status.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'LinuxディストリビューションとDocker、Podmanサポート現況'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1298530305/Docker+Podman'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/installation/product-versions.mdx
+++ b/src/content/ja/installation/product-versions.mdx
@@ -1,5 +1,6 @@
 ---
 title: '製品バージョン'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1881243653'
 ---
 
 # 製品バージョン

--- a/src/content/ja/installation/querypie-acp-community-edition.mdx
+++ b/src/content/ja/installation/querypie-acp-community-edition.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'QueryPie ACP Community Edition'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1239416833/QueryPie+ACP+Community+Edition'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/installation/querypie-acp-community-edition/mcp-configuration-guide.mdx
+++ b/src/content/ja/installation/querypie-acp-community-edition/mcp-configuration-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'MCP設定ガイド'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1735589937/MCP'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/installation/server-configuration-requirements.mdx
+++ b/src/content/ja/installation/server-configuration-requirements.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'サーバ構成要件'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1690402874'
 ---
 
 # サーバ構成要件

--- a/src/content/ja/installation/server-configuration-requirements/on-premise-vm-requirements.mdx
+++ b/src/content/ja/installation/server-configuration-requirements/on-premise-vm-requirements.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'On-Premise VM要件'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1688371232/On-Premise+VM'
 ---
 
 # On-Premise VM要件

--- a/src/content/ja/installation/server-configuration-requirements/public-cloud-production-server-requirements.mdx
+++ b/src/content/ja/installation/server-configuration-requirements/public-cloud-production-server-requirements.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Public Cloud運用サーバ要件'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/903086124/Public+Cloud'
 ---
 
 # Public Cloud運用サーバ要件

--- a/src/content/ja/installation/server-configuration-requirements/server-configuration-requirements-summary.mdx
+++ b/src/content/ja/installation/server-configuration-requirements/server-configuration-requirements-summary.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'サーバ構成要件要約表'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1692303361'
 ---
 
 # サーバ構成要件要約表

--- a/src/content/ja/installation/system-architecture-and-network-access-control.mdx
+++ b/src/content/ja/installation/system-architecture-and-network-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'システムアーキテクチャとネットワークアクセス制御'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/862093313'
 ---
 
 # システムアーキテクチャとネットワークアクセス制御

--- a/src/content/ja/overview.mdx
+++ b/src/content/ja/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Overview'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375784/Overview'
 ---
 
 # Overview

--- a/src/content/ja/overview/proxy-management.mdx
+++ b/src/content/ja/overview/proxy-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Proxy Management'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544112942/Proxy+Management'
 ---
 
 # Proxy Management

--- a/src/content/ja/overview/proxy-management/enable-database-proxy.mdx
+++ b/src/content/ja/overview/proxy-management/enable-database-proxy.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Database Proxy 使用活性化'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544377869/Database+Proxy'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/overview/system-architecture-overview.mdx
+++ b/src/content/ja/overview/system-architecture-overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'システム構成図概要'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375859'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/release-notes.mdx
+++ b/src/content/ja/release-notes.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Release Notes'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375335/Release+Notes'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/release-notes/10.0.0-10.0.2.mdx
+++ b/src/content/ja/release-notes/10.0.0-10.0.2.mdx
@@ -1,5 +1,6 @@
 ---
 title: '10.0.0 ~ 10.0.2'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375355/10.0.0+~+10.0.2'
 ---
 
 # 10.0.0 ~ 10.0.2

--- a/src/content/ja/release-notes/10.1.0-10.1.11.mdx
+++ b/src/content/ja/release-notes/10.1.0-10.1.11.mdx
@@ -1,5 +1,6 @@
 ---
 title: '10.1.0 ~ 10.1.11'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/604995641/10.1.0+~+10.1.11'
 ---
 
 # 10.1.0 ~ 10.1.11

--- a/src/content/ja/release-notes/10.2.0-10.2.12.mdx
+++ b/src/content/ja/release-notes/10.2.0-10.2.12.mdx
@@ -1,5 +1,6 @@
 ---
 title: '10.2.0 ~ 10.2.12'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/703463517/10.2.0+~+10.2.12'
 ---
 
 # 10.2.0 ~ 10.2.12

--- a/src/content/ja/release-notes/10.3.0-10.3.4.mdx
+++ b/src/content/ja/release-notes/10.3.0-10.3.4.mdx
@@ -1,5 +1,6 @@
 ---
 title: '10.3.0 ~ 10.3.4'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/954335909/10.3.0+~+10.3.4'
 ---
 
 # 10.3.0 ~ 10.3.4

--- a/src/content/ja/release-notes/11.0.0.mdx
+++ b/src/content/ja/release-notes/11.0.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: '11.0.0'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064830173/11.0.0'
 ---
 
 # 11.0.0

--- a/src/content/ja/release-notes/11.1.0-11.1.2.mdx
+++ b/src/content/ja/release-notes/11.1.0-11.1.2.mdx
@@ -1,5 +1,6 @@
 ---
 title: '11.1.0 ~ 11.1.2'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1171488777/11.1.0+~+11.1.2'
 ---
 
 # 11.1.0 ~ 11.1.2

--- a/src/content/ja/release-notes/11.2.0.mdx
+++ b/src/content/ja/release-notes/11.2.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: '11.2.0'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1291878563/11.2.0'
 ---
 
 # 11.2.0

--- a/src/content/ja/release-notes/11.3.0.mdx
+++ b/src/content/ja/release-notes/11.3.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: '11.3.0'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1421475841/11.3.0'
 ---
 
 # 11.3.0

--- a/src/content/ja/release-notes/11.4.0.mdx
+++ b/src/content/ja/release-notes/11.4.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: '11.4.0'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1568735233/11.4.0'
 ---
 
 # 11.4.0

--- a/src/content/ja/release-notes/11.5.0.mdx
+++ b/src/content/ja/release-notes/11.5.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: '11.5.0'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1751810049/11.5.0'
 ---
 
 # 11.5.0

--- a/src/content/ja/release-notes/9.10.0-9.10.4.mdx
+++ b/src/content/ja/release-notes/9.10.0-9.10.4.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.10.0 ~ 9.10.4'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375607/9.10.0+~+9.10.4'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/release-notes/9.10.0-9.10.4/external-api-changes-9100-version.mdx
+++ b/src/content/ja/release-notes/9.10.0-9.10.4/external-api-changes-9100-version.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'External API変更事項（9.10.0バージョン）'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375624/External+API+9.10.0'
 ---
 
 # External API変更事項（9.10.0バージョン）

--- a/src/content/ja/release-notes/9.11.0-9.11.5.mdx
+++ b/src/content/ja/release-notes/9.11.0-9.11.5.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.11.0 ~ 9.11.5'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375587/9.11.0+~+9.11.5'
 ---
 
 # 9.11.0 ~ 9.11.5

--- a/src/content/ja/release-notes/9.12.0-9.12.14.mdx
+++ b/src/content/ja/release-notes/9.12.0-9.12.14.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.12.0 ~ 9.12.14'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375485/9.12.0+~+9.12.14'
 ---
 
 # 9.12.0 ~ 9.12.14

--- a/src/content/ja/release-notes/9.12.0-9.12.14/menu-improvement-guide-9120.mdx
+++ b/src/content/ja/release-notes/9.12.0-9.12.14/menu-improvement-guide-9120.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'メニュー改善ガイド（9.12.0）'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375505/9.12.0'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/release-notes/9.13.0-9.13.5.mdx
+++ b/src/content/ja/release-notes/9.13.0-9.13.5.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.13.0 ~ 9.13.5'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375471/9.13.0+~+9.13.5'
 ---
 
 # 9.13.0 ~ 9.13.5

--- a/src/content/ja/release-notes/9.14.0-9.14.3.mdx
+++ b/src/content/ja/release-notes/9.14.0-9.14.3.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.14.0 ~ 9.14.3'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375457/9.14.0+~+9.14.3'
 ---
 
 # 9.14.0 ~ 9.14.3

--- a/src/content/ja/release-notes/9.15.0-9.15.4.mdx
+++ b/src/content/ja/release-notes/9.15.0-9.15.4.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.15.0 ~ 9.15.4'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375443/9.15.0+~+9.15.4'
 ---
 
 # 9.15.0 ~ 9.15.4

--- a/src/content/ja/release-notes/9.16.0-9.16.4.mdx
+++ b/src/content/ja/release-notes/9.16.0-9.16.4.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.16.0 ~ 9.16.4'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375429/9.16.0+~+9.16.4'
 ---
 
 # 9.16.0 ~ 9.16.4

--- a/src/content/ja/release-notes/9.17.0-9.17.1.mdx
+++ b/src/content/ja/release-notes/9.17.0-9.17.1.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.17.0 ~ 9.17.1'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375414/9.17.0+~+9.17.1'
 ---
 
 # 9.17.0 ~ 9.17.1

--- a/src/content/ja/release-notes/9.18.0-9.18.3.mdx
+++ b/src/content/ja/release-notes/9.18.0-9.18.3.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.18.0 ~ 9.18.3'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375399/9.18.0+~+9.18.3'
 ---
 
 # 9.18.0 ~ 9.18.3

--- a/src/content/ja/release-notes/9.19.0.mdx
+++ b/src/content/ja/release-notes/9.19.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.19.0'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375385/9.19.0'
 ---
 
 # 9.19.0

--- a/src/content/ja/release-notes/9.20.0-9.20.2.mdx
+++ b/src/content/ja/release-notes/9.20.0-9.20.2.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.20.0 ~ 9.20.2'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375370/9.20.0+~+9.20.2'
 ---
 
 # 9.20.0 ~ 9.20.2

--- a/src/content/ja/release-notes/9.8.0-9.8.12.mdx
+++ b/src/content/ja/release-notes/9.8.0-9.8.12.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.8.0 ~ 9.8.12'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375768/9.8.0+~+9.8.12'
 ---
 
 # 9.8.0 ~ 9.8.12

--- a/src/content/ja/release-notes/9.9.0-9.9.8.mdx
+++ b/src/content/ja/release-notes/9.9.0-9.9.8.mdx
@@ -1,5 +1,6 @@
 ---
 title: '9.9.0 ~ 9.9.8'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375659/9.9.0+~+9.9.8'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/release-notes/9.9.0-9.9.8/external-api-changes-9810-version-994-version.mdx
+++ b/src/content/ja/release-notes/9.9.0-9.9.8/external-api-changes-9810-version-994-version.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'External API変更事項（9.8.10バージョン > 9.9.4バージョン）'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375685/External+API+9.8.10+9.9.4'
 ---
 
 # External API変更事項（9.8.10バージョン > 9.9.4バージョン）

--- a/src/content/ja/release-notes/9.9.0-9.9.8/external-api-changes-994-version-995-version.mdx
+++ b/src/content/ja/release-notes/9.9.0-9.9.8/external-api-changes-994-version-995-version.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'External API変更事項（9.9.4バージョン > 9.9.5バージョン）'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544375741/External+API+9.9.4+9.9.5'
 ---
 
 # External API変更事項（9.9.4バージョン > 9.9.5バージョン）

--- a/src/content/ja/support.mdx
+++ b/src/content/ja/support.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'サポート'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1844969501'
 ---
 
 # サポート

--- a/src/content/ja/support/premium-support.mdx
+++ b/src/content/ja/support/premium-support.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'プレミアムサポート'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1853358081'
 ---
 
 # プレミアムサポート

--- a/src/content/ja/unreleased.mdx
+++ b/src/content/ja/unreleased.mdx
@@ -1,5 +1,6 @@
 ---
 title: '未リリース'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1911423023/Unreleased'
 ---
 
 # 未リリース

--- a/src/content/ja/unreleased/reverse-sync-test-page.mdx
+++ b/src/content/ja/unreleased/reverse-sync-test-page.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Reverse Sync Test Page'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1911652402/Reverse+Sync+Test+Page'
 ---
 
 # Reverse Sync Test Page

--- a/src/content/ja/user-manual.mdx
+++ b/src/content/ja/user-manual.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'ユーザーガイド'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544211126'
 ---
 
 # ユーザーガイド

--- a/src/content/ja/user-manual/database-access-control.mdx
+++ b/src/content/ja/user-manual/database-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Database Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380204/Database+Access+Control'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/database-access-control/connecting-to-custom-data-source.mdx
+++ b/src/content/ja/user-manual/database-access-control/connecting-to-custom-data-source.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Custom Data Source接続'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/880181257/Custom+Data+Source'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/database-access-control/connecting-to-proxy-without-agent.mdx
+++ b/src/content/ja/user-manual/database-access-control/connecting-to-proxy-without-agent.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'エージェントなしでプロキシ接続'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/559906893'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/database-access-control/connecting-via-google-bigquery-oauth-authentication.mdx
+++ b/src/content/ja/user-manual/database-access-control/connecting-via-google-bigquery-oauth-authentication.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Google BigQuery OAuth認証を通じて接続する'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/820609510/Google+BigQuery+OAuth'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/database-access-control/connecting-with-web-sql-editor.mdx
+++ b/src/content/ja/user-manual/database-access-control/connecting-with-web-sql-editor.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'ウェブSQLエディターで接続する'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380222/SQL'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/database-access-control/setting-default-privilege.mdx
+++ b/src/content/ja/user-manual/database-access-control/setting-default-privilege.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Default Privilege設定'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544380354/Default+Privilege'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/kubernetes-access-control.mdx
+++ b/src/content/ja/user-manual/kubernetes-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Kubernetes Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544384011/Kubernetes+Access+Control'
 ---
 
 # Kubernetes Access Control

--- a/src/content/ja/user-manual/kubernetes-access-control/checking-access-permission-list.mdx
+++ b/src/content/ja/user-manual/kubernetes-access-control/checking-access-permission-list.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'アクセス権限リストの確認'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544384025'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/multi-agent.mdx
+++ b/src/content/ja/user-manual/multi-agent.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Multi Agent'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/852066413/Multi+Agent'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/multi-agent/multi-agent-3rd-party-tool-support-list-by-os.mdx
+++ b/src/content/ja/user-manual/multi-agent/multi-agent-3rd-party-tool-support-list-by-os.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Multi Agent OS別3rd Party Toolサポートリスト'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/919240916/Multi+Agent+OS+3rd+Party+Tool'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/multi-agent/multi-agent-linux-installation-and-usage-guide.mdx
+++ b/src/content/ja/user-manual/multi-agent/multi-agent-linux-installation-and-usage-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Multi Agent Linux インストールおよび使用ガイド'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/912425276/Multi+Agent+Linux'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/multi-agent/multi-agent-seamless-ssh-usage-guide.mdx
+++ b/src/content/ja/user-manual/multi-agent/multi-agent-seamless-ssh-usage-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Multi Agent Seamless SSH 使用ガイド'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/912425288/Multi+Agent+Seamless+SSH'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/my-dashboard.mdx
+++ b/src/content/ja/user-manual/my-dashboard.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'My Dashboard'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/578945174/My+Dashboard'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/my-dashboard/user-password-reset-via-email.mdx
+++ b/src/content/ja/user-manual/my-dashboard/user-password-reset-via-email.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Emailを通じたユーザーパスワードリセット'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/793542657/Email'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/preferences.mdx
+++ b/src/content/ja/user-manual/preferences.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Preferences'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/568950885/Preferences'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/server-access-control.mdx
+++ b/src/content/ja/user-manual/server-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381369/Server+Access+Control'
 ---
 
 # Server Access Control

--- a/src/content/ja/user-manual/server-access-control/connecting-to-authorized-servers.mdx
+++ b/src/content/ja/user-manual/server-access-control/connecting-to-authorized-servers.mdx
@@ -1,5 +1,6 @@
 ---
 title: '権限のあるサーバーに接続する'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381383'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/server-access-control/using-web-sftp.mdx
+++ b/src/content/ja/user-manual/server-access-control/using-web-sftp.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web SFTP使用'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381477/SFTP'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/server-access-control/using-web-terminal.mdx
+++ b/src/content/ja/user-manual/server-access-control/using-web-terminal.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'ウェブターミナルの使用'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544381410'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/user-agent.mdx
+++ b/src/content/ja/user-manual/user-agent.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'User Agent'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544112828/User+Agent'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/web-access-control.mdx
+++ b/src/content/ja/user-manual/web-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Web Access Control'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064829218/Web+Access+Control'
 ---
 
 # Web Access Control

--- a/src/content/ja/user-manual/web-access-control/accessing-web-applications-websites.mdx
+++ b/src/content/ja/user-manual/web-access-control/accessing-web-applications-websites.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Webアプリケーション（Webサイト）への接続'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1064796396'
 ---
 
 # Webアプリケーション（Webサイト）への接続

--- a/src/content/ja/user-manual/web-access-control/installing-root-ca-certificate-and-extension.mdx
+++ b/src/content/ja/user-manual/web-access-control/installing-root-ca-certificate-and-extension.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Root CA証明書およびExtensionのインストール'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1073709107/Root+CA+Extension'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/workflow.mdx
+++ b/src/content/ja/user-manual/workflow.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Workflow'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544377922/Workflow'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/workflow/approval-additional-features-proxy-approval-resubmission-etc.mdx
+++ b/src/content/ja/user-manual/workflow/approval-additional-features-proxy-approval-resubmission-etc.mdx
@@ -1,5 +1,6 @@
 ---
 title: '決裁付加機能（代理決裁、再上申など）'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/568918170'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/workflow/requesting-access-role.mdx
+++ b/src/content/ja/user-manual/workflow/requesting-access-role.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Access Role Request の申請'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544378348/Access+Role+Request'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/workflow/requesting-db-access.mdx
+++ b/src/content/ja/user-manual/workflow/requesting-db-access.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'DB Access Request要求'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544377968/DB+Access+Request'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/workflow/requesting-db-policy-exception.mdx
+++ b/src/content/ja/user-manual/workflow/requesting-db-policy-exception.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'DB政策例外要求（DB Policy Exception Request）'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1070006273/DB+DB+Policy+Exception+Request'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/workflow/requesting-ip-registration.mdx
+++ b/src/content/ja/user-manual/workflow/requesting-ip-registration.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'IP Registration Request の申請'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1055358996/IP+Registration+Request'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/workflow/requesting-restricted-data-access.mdx
+++ b/src/content/ja/user-manual/workflow/requesting-restricted-data-access.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Restricted Data Access の申請（制限されたデータアクセス要求）'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/1060306945/Restricted+Data+Access'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/workflow/requesting-server-access.mdx
+++ b/src/content/ja/user-manual/workflow/requesting-server-access.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Access Request の申請'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544378254/Server+Access+Request'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/workflow/requesting-server-privilege.mdx
+++ b/src/content/ja/user-manual/workflow/requesting-server-privilege.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Server Privilege Request の申請'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/878936417/Server+Privilege+Request'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/workflow/requesting-sql-export.mdx
+++ b/src/content/ja/user-manual/workflow/requesting-sql-export.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'SQL Export Request の申請'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544378182/SQL+Export+Request'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/workflow/requesting-sql.mdx
+++ b/src/content/ja/user-manual/workflow/requesting-sql.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'SQL Request要求'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/544378069/SQL+Request'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/workflow/requesting-sql/using-execution-plan-explain-feature.mdx
+++ b/src/content/ja/user-manual/workflow/requesting-sql/using-execution-plan-explain-feature.mdx
@@ -1,5 +1,6 @@
 ---
 title: '実行計画（Explain）機能の使用'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/692355151/Explain'
 ---
 
 import { Callout } from 'nextra/components'

--- a/src/content/ja/user-manual/workflow/requesting-unmasking-mask-removal-request.mdx
+++ b/src/content/ja/user-manual/workflow/requesting-unmasking-mask-removal-request.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Unmasking Request の申請（マスキング解除要求）'
+confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/712769539/Unmasking+Request'
 ---
 
 import { Callout } from 'nextra/components'


### PR DESCRIPTION
## Summary
- `sync_confluence_url.py`를 사용하여 ko MDX의 `confluenceUrl`을 en/ja 578개 파일에 일괄 삽입
- Skeleton 비교 시 frontmatter 구조 불일치(ko에만 `confluenceUrl` 존재) 해소

## Test plan
- [x] 578개 파일 업데이트 확인 (289 en + 289 ja)
- [x] 2회 실행 시 모두 `unchanged` (idempotent 검증)
- [x] `python3 confluence-mdx/bin/skeleton/cli.py -r`로 skeleton 구조 일치 확인 — confluenceUrl 추가로 인한 새로운 불일치 없음 (ja 273 matched / en 268 matched, unmatched 39건은 기존 번역 차이)

🤖 Generated with [Claude Code](https://claude.com/claude-code)