### PR TITLE
fix(reverse-sync): Confluence 링크 Title|Anchor 정규화

### DIFF
--- a/confluence-mdx/bin/reverse_sync_cli.py
+++ b/confluence-mdx/bin/reverse_sync_cli.py
@@ -327,7 +327,13 @@ def _normalize_mdx_to_plain(content: str, block_type: str) -> str:
         s = re.sub(r'^[-*+]\s+', '', s)
         s = re.sub(r'\*\*(.+?)\*\*', r'\1', s)
         s = re.sub(r'`([^`]+)`', r'\1', s)
-        s = re.sub(r'\[([^\]]+)\]\([^)]+\)', r'\1', s)
+        # Confluence 링크 패턴: "[Title | Anchor](url)" → Title만 추출
+        # (XHTML ac:link-body에는 Title만 포함됨)
+        s = re.sub(
+            r'\[([^\]]+)\]\([^)]+\)',
+            lambda m: m.group(1).split(' | ')[0] if ' | ' in m.group(1) else m.group(1),
+            s,
+        )
         s = re.sub(r'<[^>]+/?>', '', s)
         s = html_module.unescape(s)
         s = s.strip()


### PR DESCRIPTION
## Summary
- `_normalize_mdx_to_plain`에서 Confluence 링크 패턴 `[Title | Anchor](url)`의 링크 텍스트를 Title만 추출하도록 수정
- XHTML `ac:link-body`에는 Title만 포함되므로, 이 정규화 없이는 테이블 등 복합 블록의 매핑 매칭이 실패함
- databases.mdx 테이블 내 "민감데이터" → "민감 데이터" 띄어쓰기 변경이 roundtrip verify를 통과

## Test plan
- [x] `reverse_sync_cli.py verify`에서 databases.mdx가 pass 확인
- [x] `pytest confluence-mdx/tests/` 202 tests 통과 확인
- [ ] CI (Test, Lint, Build) 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)