### PR TITLE
fix(reverse-sync): italic(*...*) 제거 정규화 추가

### DIFF
--- a/confluence-mdx/bin/reverse_sync_cli.py
+++ b/confluence-mdx/bin/reverse_sync_cli.py
@@ -327,6 +327,8 @@ def _normalize_mdx_to_plain(content: str, block_type: str) -> str:
         s = re.sub(r'^[-*+]\s+', '', s)
         s = re.sub(r'\*\*(.+?)\*\*', r'\1', s)
         s = re.sub(r'`([^`]+)`', r'\1', s)
+        # italic *...* 제거 (bold 제거 후이므로 단일 * 만 대상)
+        s = re.sub(r'(?<!\*)\*([^*]+)\*(?!\*)', r'\1', s)
         # Confluence 링크 패턴: "[Title | Anchor](url)" → Title만 추출
         # (XHTML ac:link-body에는 Title만 포함됨)
         s = re.sub(


### PR DESCRIPTION
## Summary
- `_normalize_mdx_to_plain`에서 bold(`**...**`)만 제거하고 italic(`*...*`)은 제거하지 않던 문제 수정
- `*\`{RESTRICTED}\`*` 같은 italic+code 패턴에서 asterisk가 남아 XHTML plain text와 매칭 실패하던 문제 해결
- data-access.mdx의 figure alt/figcaption 텍스트 변경이 올바르게 반영됨

## Test plan
- [x] `reverse_sync_cli.py verify`에서 data-access.mdx가 pass 확인
- [x] `pytest confluence-mdx/tests/` 202 tests 통과 확인
- [ ] CI (Test, Lint, Build) 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)