### PR TITLE
fix(reverse-sync): heading 정규화에 backtick/bold/HTML 제거 추가

### DIFF
--- a/confluence-mdx/bin/reverse_sync_cli.py
+++ b/confluence-mdx/bin/reverse_sync_cli.py
@@ -313,7 +313,12 @@ def _normalize_mdx_to_plain(content: str, block_type: str) -> str:
     text = content.strip()
 
     if block_type == 'heading':
-        return text.lstrip('#').strip()
+        s = text.lstrip('#').strip()
+        s = re.sub(r'\*\*(.+?)\*\*', r'\1', s)
+        s = re.sub(r'`([^`]+)`', r'\1', s)
+        s = re.sub(r'<[^>]+/?>', '', s)
+        s = html_module.unescape(s)
+        return s.strip()
 
     lines = text.split('\n')
     parts = []


### PR DESCRIPTION
## Summary
- `_normalize_mdx_to_plain`에서 heading 타입이 `#` 제거만 수행하고 backtick, bold, HTML 태그를 제거하지 않던 문제 수정
- backtick 코드가 포함된 heading 텍스트의 XHTML 매핑 매칭이 실패하던 문제 해결
- wac-troubleshooting-guide.mdx의 heading 텍스트 변경("접속이 안되고" → "접속이 안 되고", "메세지" → "메시지")이 올바르게 반영

## Test plan
- [x] `reverse_sync_cli.py verify`에서 wac-troubleshooting-guide.mdx가 pass 확인
- [x] `pytest confluence-mdx/tests/` 202 tests 통과 확인
- [ ] CI (Test, Lint, Build) 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)