### PR TITLE
fix(reverse-sync): Markdown table 행별 분리 매칭 및 패딩 정규화

### DIFF
--- a/confluence-mdx/bin/reverse_sync/roundtrip_verifier.py
+++ b/confluence-mdx/bin/reverse_sync/roundtrip_verifier.py
@@ -36,6 +36,22 @@ def _normalize_dates(text: str) -> str:
     return _KO_DATE_RE.sub(_replace, text)
 
 
+def _normalize_table_cell_padding(text: str) -> str:
+    """Markdown table 행의 셀 패딩 공백을 정규화한다.
+
+    XHTML→MDX forward 변환 시 테이블 셀의 컬럼 폭 계산이 원본 MDX와
+    1~2자 차이날 수 있으므로, 연속 공백을 단일 공백으로 축약한다.
+    """
+    lines = text.split('\n')
+    result = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith('|') and stripped.endswith('|'):
+            line = re.sub(r'  +', ' ', line)
+        result.append(line)
+    return '\n'.join(result)
+
+
 def verify_roundtrip(expected_mdx: str, actual_mdx: str) -> VerifyResult:
     """두 MDX 문자열의 일치를 검증한다.
 
@@ -53,6 +69,8 @@ def verify_roundtrip(expected_mdx: str, actual_mdx: str) -> VerifyResult:
     actual_mdx = _normalize_trailing_ws(actual_mdx)
     expected_mdx = _normalize_dates(expected_mdx)
     actual_mdx = _normalize_dates(actual_mdx)
+    expected_mdx = _normalize_table_cell_padding(expected_mdx)
+    actual_mdx = _normalize_table_cell_padding(actual_mdx)
 
     if expected_mdx == actual_mdx:
         return VerifyResult(passed=True, diff_report="")

--- a/confluence-mdx/bin/reverse_sync_cli.py
+++ b/confluence-mdx/bin/reverse_sync_cli.py
@@ -323,6 +323,13 @@ def _normalize_mdx_to_plain(content: str, block_type: str) -> str:
             continue
         if s.startswith('<figure') or s.startswith('<img') or s.startswith('</figure'):
             continue
+        # Markdown table separator 행 건너뛰기 (| --- | --- | ...)
+        if re.match(r'^\|[\s\-:|]+\|$', s):
+            continue
+        # Markdown table row: | 구분자 제거하여 셀 내용만 추출
+        if s.startswith('|') and s.endswith('|'):
+            cells = [c.strip() for c in s.split('|')[1:-1]]
+            s = ' '.join(c for c in cells if c)
         s = re.sub(r'^\d+\.\s+', '', s)
         s = re.sub(r'^[-*+]\s+', '', s)
         s = re.sub(r'\*\*(.+?)\*\*', r'\1', s)
@@ -562,6 +569,12 @@ def _build_patches(
                     _build_list_item_patches(change, mappings, used_ids))
                 continue
 
+            # Markdown table이 paragraph로 파싱된 경우: 행별 분리 매칭
+            if _is_markdown_table(change.old_block.content):
+                patches.extend(
+                    _build_table_row_patches(change, mappings, used_ids))
+                continue
+
             # html_block 등: substring 매칭으로 상위 블록 탐색
             new_plain = _normalize_mdx_to_plain(
                 change.new_block.content, change.new_block.type)
@@ -604,6 +617,92 @@ def _build_patches(
             'new_plain_text': xhtml_text,
         })
         used_ids.add(bid)
+
+    return patches
+
+
+def _is_markdown_table(content: str) -> bool:
+    """Content가 Markdown table 형식인지 판별한다."""
+    lines = [l.strip() for l in content.strip().split('\n') if l.strip()]
+    if len(lines) < 2:
+        return False
+    pipe_lines = sum(1 for l in lines if l.startswith('|') and l.endswith('|'))
+    return pipe_lines >= 2
+
+
+def _split_table_rows(content: str) -> List[str]:
+    """Markdown table content를 데이터 행(non-separator) 목록으로 분리한다."""
+    rows = []
+    for line in content.strip().split('\n'):
+        s = line.strip()
+        if not s:
+            continue
+        # separator 행 건너뛰기 (| --- | --- | ...)
+        if re.match(r'^\|[\s\-:|]+\|$', s):
+            continue
+        if s.startswith('|') and s.endswith('|'):
+            rows.append(s)
+    return rows
+
+
+def _normalize_table_row(row: str) -> str:
+    """Markdown table row를 XHTML plain text 대응 형태로 변환한다."""
+    cells = [c.strip() for c in row.split('|')[1:-1]]
+    parts = []
+    for cell in cells:
+        s = cell
+        s = re.sub(r'\*\*(.+?)\*\*', r'\1', s)
+        s = re.sub(r'`([^`]+)`', r'\1', s)
+        s = re.sub(r'(?<!\*)\*([^*]+)\*(?!\*)', r'\1', s)
+        s = re.sub(r'\[([^\]]+)\]\([^)]+\)', r'\1', s)
+        s = re.sub(r'<[^>]+/?>', '', s)
+        s = html_module.unescape(s)
+        s = s.strip()
+        if s:
+            parts.append(s)
+    return ' '.join(parts)
+
+
+def _build_table_row_patches(
+    change: 'BlockChange',
+    mappings: List[BlockMapping],
+    used_ids: 'set | None' = None,
+) -> List[Dict[str, str]]:
+    """Markdown table 블록의 변경된 행을 XHTML table에 substring 매칭으로 패치한다."""
+    old_rows = _split_table_rows(change.old_block.content)
+    new_rows = _split_table_rows(change.new_block.content)
+    if len(old_rows) != len(new_rows):
+        return []
+
+    patches = []
+    containing_changes: dict = {}  # block_id → (mapping, [(old_plain, new_plain)])
+    for old_row, new_row in zip(old_rows, new_rows):
+        if old_row == new_row:
+            continue
+        old_plain = _normalize_table_row(old_row)
+        new_plain = _normalize_table_row(new_row)
+        if not old_plain or old_plain == new_plain:
+            continue
+        container = _find_containing_mapping(
+            old_plain, mappings, exclude=used_ids)
+        if container is not None:
+            bid = container.block_id
+            if bid not in containing_changes:
+                containing_changes[bid] = (container, [])
+            containing_changes[bid][1].append((old_plain, new_plain))
+
+    for bid, (mapping, item_changes) in containing_changes.items():
+        xhtml_text = mapping.xhtml_plain_text
+        for old_plain, new_plain in item_changes:
+            xhtml_text = _transfer_text_changes(
+                old_plain, new_plain, xhtml_text)
+        patches.append({
+            'xhtml_xpath': mapping.xhtml_xpath,
+            'old_plain_text': mapping.xhtml_plain_text,
+            'new_plain_text': xhtml_text,
+        })
+        if used_ids is not None:
+            used_ids.add(bid)
 
     return patches
 


### PR DESCRIPTION
## Summary
- MDX 파서가 Markdown table을 `paragraph` 블록으로 분류할 때, XHTML `table` 매핑과 전체 텍스트 매칭이 실패하여 테이블 셀 변경이 반영되지 않던 문제 수정
- `_normalize_mdx_to_plain`에 Markdown table `|` 구분자 및 separator 행 처리 추가
- `_build_table_row_patches` 함수로 변경된 행을 개별 정규화 후 substring 매칭
- `roundtrip_verifier`에 table cell padding 공백 정규화 추가 (XHTML→MDX 변환 시 컬럼 폭 차이 허용)

## Test plan
- [x] 202개 기존 테스트 통과
- [x] `container-environment-variables.mdx` (page 954761289) verify PASS 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)