### PR TITLE
docs: 변환 파이프라인 단순화 구현 계획

### DIFF
--- a/confluence-mdx/docs/plan-simplify-convert-pipeline.md
+++ b/confluence-mdx/docs/plan-simplify-convert-pipeline.md
@@ -33,7 +33,13 @@ convert_all.py           # 2. 전체 변환 (pages.yaml 기반)
 - `translate_titles.py`, `generate_commands_for_xhtml2markdown.py`, `xhtml2markdown.ko.sh`를 대체합니다.
 - 진행 상황을 stderr로 출력합니다 (예: `[42/290] 544375859 → target/ko/overview/system-architecture.mdx`).
 
-### R2. 번역 검증 (`--verify-translations`)
+### R2. 디버깅용 목록 파일 생성 (`--generate-list`)
+
+- `convert_all.py --generate-list` 옵션으로 기존 `list.txt` / `list.en.txt`를 선택적으로 생성합니다.
+- 기본 실행 시에는 생성하지 않습니다 (변환만 수행).
+- 디버깅, 수동 검증 등 필요한 경우에만 사용합니다.
+
+### R3. 번역 검증 (`--verify-translations`)
 
 - `convert_all.py --verify-translations` 또는 별도 서브커맨드로, 변환 전에 번역 누락을 검출합니다.
 - `pages.yaml`의 모든 한국어 제목을 `etc/korean-titles-translations.txt`와 대조합니다.
@@ -41,17 +47,17 @@ convert_all.py           # 2. 전체 변환 (pages.yaml 기반)
 - 모두 커버되면 통과 메시지를 출력합니다.
 - `convert_all.py` 실행 시에도 변환 전 자동으로 검증을 수행합니다.
 
-### R3. 기존 도구 보존
+### R4. 기존 도구 보존
 
 - `converter/cli.py`는 단일 파일 변환 도구로 유지합니다 (인터페이스 변경 없음).
 - `translate_titles.py`, `generate_commands_for_xhtml2markdown.py`는 삭제하지 않고 유지합니다.
   - 단, `entrypoint.sh`의 `full` 워크플로우는 `convert_all.py`를 사용하도록 변경합니다.
 
-### R4. `entrypoint.sh` / `Dockerfile` 업데이트
+### R5. `entrypoint.sh` / `Dockerfile` 업데이트
 
 - `full` 워크플로우: `fetch_cli.py` → `convert_all.py` 2단계로 변경합니다.
 - `convert_all.py`를 컨테이너 명령으로 추가합니다.
 
-### R5. 문서 업데이트
+### R6. 문서 업데이트
 
 - `README.md`: 단순화된 사용법 반영.


### PR DESCRIPTION
## Summary
- 4단계 변환 파이프라인을 2단계로 단순화하는 구현 계획을 추가합니다.
- 리뷰 후 구현을 진행합니다.

## Description
현재 MDX 변환에 4개 명령이 필요합니다:
1. `fetch_cli.py` → 데이터 수집
2. `translate_titles.py` → 제목 번역 (list.txt → list.en.txt)
3. `generate_commands_for_xhtml2markdown.py` → 셸 스크립트 생성
4. `bash xhtml2markdown.ko.sh` → 변환 실행

`pages.yaml`에 이미 영어 breadcrumbs와 slugified path가 포함되어 있어, 2~4단계는 중복입니다.

### 계획 요약
- `convert_all.py` 신규 작성: `pages.yaml` 기반 일괄 변환
- `--verify-translations`: 번역 누락 검증 기능
- `entrypoint.sh full` 워크플로우 단순화

계획 문서: `docs/plan-simplify-convert-pipeline.md`

## Added/updated tests?
- [x] No, and this is why: 구현 계획 문서만 추가합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)