### PR TITLE
feat(converter): Sidecar mapping 파일 생성 기능 추가

### DIFF
--- a/confluence-mdx/bin/converter/sidecar_mapping.py
+++ b/confluence-mdx/bin/converter/sidecar_mapping.py
@@ -1,0 +1,159 @@
+"""Sidecar Mapping — forward converter가 생성한 XHTML→MDX 대응 정보를 기록한다.
+
+변환 완료 후, XHTML 블록과 MDX 블록을 순서대로 매칭하여
+mapping.yaml sidecar 파일을 생성한다.
+"""
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Set
+
+import yaml
+
+from reverse_sync.mapping_recorder import BlockMapping, record_mapping
+from reverse_sync.mdx_block_parser import MdxBlock, parse_mdx_blocks
+
+logger = logging.getLogger(__name__)
+
+# MDX 파서가 content 블록으로 분류하지 않는 타입들
+_NON_CONTENT_TYPES = frozenset({'frontmatter', 'import_statement', 'empty'})
+
+
+def generate_sidecar_mapping(
+    xhtml_content: str,
+    mdx_content: str,
+    page_id: Optional[str],
+    input_dir: str,
+    output_file_path: str,
+) -> Optional[str]:
+    """XHTML→MDX 매핑 sidecar 파일을 생성한다.
+
+    Args:
+        xhtml_content: namespace prefix 제거 전 원본 XHTML
+        mdx_content: 변환된 MDX 문자열
+        page_id: Confluence page ID
+        input_dir: var/<page_id>/ 디렉토리
+        output_file_path: MDX 출력 파일 경로
+
+    Returns:
+        생성된 mapping.yaml 파일 경로, 실패 시 None
+    """
+    xhtml_mappings = record_mapping(xhtml_content)
+    mdx_blocks = parse_mdx_blocks(mdx_content)
+
+    entries = _build_mapping_entries(xhtml_mappings, mdx_blocks)
+
+    mapping_path = os.path.join(input_dir, 'mapping.yaml')
+    data = {
+        'version': 1,
+        'source_page_id': page_id or '',
+        'generated_at': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
+        'mdx_file': os.path.basename(output_file_path),
+        'mappings': entries,
+    }
+
+    with open(mapping_path, 'w', encoding='utf-8') as f:
+        yaml.dump(data, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+
+    logger.info(f"Sidecar mapping 생성 완료: {mapping_path} ({len(entries)} entries)")
+    return mapping_path
+
+
+def _build_mapping_entries(
+    xhtml_mappings: List[BlockMapping],
+    mdx_blocks: List[MdxBlock],
+) -> List[Dict]:
+    """XHTML 매핑과 MDX 블록을 순서대로 매칭하여 매핑 엔트리를 생성한다."""
+    # content 블록만 필터 (frontmatter, import, empty 제외)
+    content_blocks: List[tuple] = []  # (original_index, block)
+    for idx, block in enumerate(mdx_blocks):
+        if block.type not in _NON_CONTENT_TYPES:
+            content_blocks.append((idx, block))
+
+    # 자식 block_id 집합 구성 — 자식은 부모가 처리하므로 건너뜀
+    child_ids: Set[str] = set()
+    for m in xhtml_mappings:
+        child_ids.update(m.children)
+
+    entries: List[Dict] = []
+    mdx_idx = 0  # content_blocks 내 현재 위치
+
+    for mapping in xhtml_mappings:
+        if mapping.block_id in child_ids:
+            continue
+
+        if mdx_idx >= len(content_blocks):
+            logger.debug(f"MDX 블록 소진: {mapping.xhtml_xpath} 이후 매핑 불가")
+            break
+
+        if mapping.children:
+            # Callout: MDX에서 <Callout ~ </Callout> 범위를 찾아 할당
+            callout_indices = _find_callout_range(content_blocks, mdx_idx)
+            if callout_indices:
+                entries.append({
+                    'xhtml_xpath': mapping.xhtml_xpath,
+                    'xhtml_type': mapping.type,
+                    'mdx_blocks': callout_indices,
+                })
+                mdx_idx = _next_index_after(content_blocks, callout_indices[-1], mdx_idx)
+            else:
+                # Callout 범위를 찾지 못하면 1:1로 할당
+                orig_idx = content_blocks[mdx_idx][0]
+                entries.append({
+                    'xhtml_xpath': mapping.xhtml_xpath,
+                    'xhtml_type': mapping.type,
+                    'mdx_blocks': [orig_idx],
+                })
+                mdx_idx += 1
+        else:
+            # 일반 블록: 1:1 매칭
+            orig_idx = content_blocks[mdx_idx][0]
+            entries.append({
+                'xhtml_xpath': mapping.xhtml_xpath,
+                'xhtml_type': mapping.type,
+                'mdx_blocks': [orig_idx],
+            })
+            mdx_idx += 1
+
+    return entries
+
+
+def _find_callout_range(
+    content_blocks: List[tuple],
+    start_idx: int,
+) -> Optional[List[int]]:
+    """content_blocks[start_idx]부터 Callout 범위를 찾아 원본 인덱스 리스트를 반환한다."""
+    if start_idx >= len(content_blocks):
+        return None
+
+    orig_idx, block = content_blocks[start_idx]
+    if '<Callout' not in block.content:
+        return None
+
+    indices = [orig_idx]
+    depth = block.content.count('<Callout') - block.content.count('</Callout>')
+
+    i = start_idx + 1
+    while i < len(content_blocks) and depth > 0:
+        o_idx, blk = content_blocks[i]
+        indices.append(o_idx)
+        depth += blk.content.count('<Callout') - blk.content.count('</Callout>')
+        i += 1
+
+    if depth != 0:
+        # 닫힘 태그를 찾지 못한 경우 — 현재 블록만 반환
+        return [orig_idx]
+
+    return indices
+
+
+def _next_index_after(
+    content_blocks: List[tuple],
+    last_orig_idx: int,
+    current_mdx_idx: int,
+) -> int:
+    """last_orig_idx 이후의 content_blocks 인덱스를 반환한다."""
+    for i in range(current_mdx_idx, len(content_blocks)):
+        if content_blocks[i][0] > last_orig_idx:
+            return i
+    return len(content_blocks)


### PR DESCRIPTION
## Summary
- Forward converter가 XHTML→MDX 변환 완료 후 `mapping.yaml` sidecar 파일을 생성합니다.
- 기존 `record_mapping()`, `parse_mdx_blocks()` 모듈을 재사용하여 post-hoc sequential matching 방식으로 양쪽 블록을 순서대로 매칭합니다.
- Reverse-sync Phase 2에서 fuzzy matching 대신 이 매핑 파일을 활용하여 정확한 XHTML↔MDX 대응이 가능해집니다.

## Description
- `bin/converter/sidecar_mapping.py` **(신규)**: 매핑 생성 로직 (~140줄)
  - `generate_sidecar_mapping()`: XHTML 블록과 MDX 블록을 순서 기반 매칭
  - Callout 매크로(`<Callout` ~ `</Callout>`)는 depth 추적으로 다수 MDX 블록에 매핑
  - frontmatter/import/empty 블록은 필터링, 자식 블록은 부모가 처리
- `bin/converter/cli.py` **(수정, +13줄)**:
  - namespace prefix 제거 전 원본 XHTML 보존 (`xhtml_original`)
  - 변환 완료 후 `generate_sidecar_mapping()` 호출 (try/except로 감싸서 실패해도 변환 차단하지 않음)

### Background
Reverse-sync Phase 1 회고에서 fuzzy matching 매핑의 근본적 문제가 확인되었습니다. Forward converter가 변환 시 대응 정보를 기록하지 않아, reverse-sync가 매번 텍스트 유사도로 매핑을 추론해야 했습니다. Converter 내부(1600줄)를 계측하지 않고, 변환 완료 후 기존 모듈 2개를 조합하는 방식으로 관심사를 분리했습니다.

## Related tickets & links
- reverse-sync 매핑 재설계 프로젝트

## Added/updated tests?
- [ ] Yes
- [x] No, and this is why: 기존 pytest 202개 전체 통과 확인 (회귀 없음). 21개 테스트 케이스 전체에서 `mapping.yaml` 정상 생성 수동 확인.
- [ ] I need help with writing tests

## Additional notes
- 생성되는 `mapping.yaml` 형식:
  ```yaml
  version: 1
  source_page_id: "544381877"
  generated_at: "2026-02-12T10:30:00Z"
  mdx_file: page.mdx
  mappings:
    - xhtml_xpath: "h2[1]"
      xhtml_type: heading
      mdx_blocks: [3]
    - xhtml_xpath: "macro-info[1]"
      xhtml_type: html_block
      mdx_blocks: [7, 8, 9]
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)