### PR TITLE
perf(Dockerfile): fetch_cli.py를 --recent 모드로 변경하여 빌드 시간 단축

### DIFF
--- a/confluence-mdx/Dockerfile
+++ b/confluence-mdx/Dockerfile
@@ -23,11 +23,11 @@ RUN chmod +x bin/*.py bin/*.sh
 COPY etc/ ./etc/
 COPY tests/ ./tests/
 
-# Copy cache/ data (included in image)
-COPY cache/ ./cache/
+# Restore var/ from previous image cache (baseline for --recent mode)
+COPY cache/ ./var/
 
-# Populate var/ directory by running fetch_cli.py --remote --attachments
-RUN python3 bin/fetch_cli.py --remote --attachments
+# Update var/ with recently modified pages only
+RUN python3 bin/fetch_cli.py --recent --attachments
 
 # Create target/ directory
 RUN mkdir -p target/ko target/en target/ja target/public


### PR DESCRIPTION
## Summary
- `fetch_cli.py --remote` → `--recent` 모드로 변경하여 Docker 이미지 빌드 시간을 **~9분 → ~2분 이내**로 단축합니다.
- `setup-cache.sh`가 추출한 이전 이미지 데이터를 `var/`에 직접 복원하여 `--recent` 모드의 baseline으로 활용합니다.

### 변경 전 (현재)
| 단계 | 소요 시간 |
|------|-----------|
| `COPY cache/ ./cache/` | 3초 |
| `RUN fetch_cli.py --remote --attachments` | **7분 6초** |
| **전체** | **8분 54초** |

### 변경 후 (예상)
| 단계 | 소요 시간 |
|------|-----------|
| `COPY cache/ ./var/` | 3초 |
| `RUN fetch_cli.py --recent --attachments` | **수십 초** |
| **전체** | **~1-2분** |

### 참고
- 분석 대상 빌드: https://github.com/querypie/querypie-docs/actions/runs/21945525797/job/63381967354

## Test plan
- [ ] CI 빌드 워크플로우가 정상 실행되는지 확인
- [ ] `--recent` 모드로 빌드한 이미지에 최신 페이지 데이터가 포함되는지 확인
- [ ] 로컬에서 `docker compose build` 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)