### PR TITLE
fix(reverse-sync): sidecar_lookup.py 코드 리뷰 반영

### DIFF
--- a/confluence-mdx/tests/test_reverse_sync_sidecar_lookup.py
+++ b/confluence-mdx/tests/test_reverse_sync_sidecar_lookup.py
@@ -11,7 +11,6 @@ sidecar_lookup.py의 핵심 기능을 검증한다:
 import pytest
 import yaml
 from pathlib import Path
-from unittest.mock import patch
 
 from reverse_sync.sidecar_lookup import (
     SidecarEntry,
@@ -73,6 +72,12 @@ class TestLoadSidecarMapping:
     def test_empty_mappings(self, tmp_path):
         mapping_file = tmp_path / 'mapping.yaml'
         mapping_file.write_text(yaml.dump({'version': 1, 'mappings': []}))
+        entries = load_sidecar_mapping(str(mapping_file))
+        assert entries == []
+
+    def test_empty_yaml_file(self, tmp_path):
+        mapping_file = tmp_path / 'mapping.yaml'
+        mapping_file.write_text('')
         entries = load_sidecar_mapping(str(mapping_file))
         assert entries == []
 


### PR DESCRIPTION
## Summary
- `sidecar_lookup.py` 코드 리뷰에서 발견된 이슈 수정
- 미사용 코드 제거, 방어 코드 추가, 테스트 파일명 규칙 준수

## Changes
| 항목 | 변경 |
|---|---|
| `load_sidecar_mapping()` | 빈 YAML 파일 방어 (`yaml.safe_load() or {}`) |
| `generate_sidecar_mapping()` | 미사용 `SKIP_TYPES`, `NO_MDX_XPATHS` 제거 |
| `_count_child_mdx_blocks()` | 미사용 파라미터 4개 제거 |
| 테스트 파일 | `test_sidecar_lookup.py` → `test_reverse_sync_sidecar_lookup.py` |
| 테스트 import | 미사용 `unittest.mock.patch` 제거 |
| 테스트 추가 | 빈 YAML 파일 edge case |

## Test plan
- [x] 241/241 pytest 통과
- [x] 기존 동작 변경 없음

## Related tickets & links
- #685 (원본 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)