### PR TITLE
fix(compose): 불필요한 list.txt bind mount 제거

### DIFF
--- a/confluence-mdx/compose.yml
+++ b/confluence-mdx/compose.yml
@@ -51,7 +51,6 @@ services:
       - ./etc/korean-titles-translations.txt:/workdir/etc/korean-titles-translations.txt
       # Mount files in var to host
       - ./var/pages.yaml:/workdir/var/pages.yaml
-      - ./var/list.txt:/workdir/var/list.txt
       # Mount output directories to host (matching symlink structure in target/)
       # target/ko -> ../../src/content/ko
       - ../src/content/ko:/workdir/target/ko


### PR DESCRIPTION
## Summary
- #683에서 `var/list.txt`를 git 추적에서 제거했으나, `compose.yml`의 bind mount가 남아있어 GHA 워크플로우 실패
- 호스트에 `list.txt`가 없으면 Docker가 디렉토리로 자동 생성하여 파일/디렉토리 타입 불일치 오류 발생
- 불필요한 `list.txt` volume mount를 제거합니다.

## Related
- https://github.com/querypie/querypie-docs/actions/runs/21951812994/job/63404414505

## Test plan
- [x] 로컬 `docker compose run --rm confluence-mdx help` 정상 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)