### PR TITLE
fix(workflow): cleanup step 에러 가시성 개선

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -57,6 +57,7 @@ jobs:
 
       - name: Clean up untagged images from Docker Hub
         if: github.event_name != 'pull_request'
+        continue-on-error: true
         env:
           DOCKERHUB_USERNAME: ${{ vars.CONTAINER_REGISTRY_USERNAME }}
           DOCKERHUB_PASSWORD: ${{ secrets.CONTAINER_REGISTRY_CREDENTIAL }}
@@ -65,26 +66,37 @@ jobs:
           REPO="querypie/confluence-mdx"
 
           # Get Docker Hub API token
-          TOKEN=$(curl -sf "https://hub.docker.com/v2/users/login" \
+          RESPONSE=$(curl -s "https://hub.docker.com/v2/users/login" \
             -H "Content-Type: application/json" \
-            -d "{\"username\":\"${DOCKERHUB_USERNAME}\",\"password\":\"${DOCKERHUB_PASSWORD}\"}" \
-            | jq -r '.token')
+            -d "{\"username\":\"${DOCKERHUB_USERNAME}\",\"password\":\"${DOCKERHUB_PASSWORD}\"}")
+
+          TOKEN=$(echo "${RESPONSE}" | jq -r '.token // empty')
+          if [ -z "${TOKEN}" ]; then
+            echo "::warning::Failed to get Docker Hub API token"
+            echo "${RESPONSE}" | jq . 2>/dev/null || echo "${RESPONSE}"
+            exit 1
+          fi
 
           # List inactive (untagged) image digests
-          DIGESTS=$(curl -sf "https://hub.docker.com/v2/repositories/${REPO}/images?status=inactive&page_size=100" \
-            -H "Authorization: Bearer ${TOKEN}" \
-            | jq '[.results[] | {repository: "confluence-mdx", digest: .digest}]')
+          RESPONSE=$(curl -s "https://hub.docker.com/v2/repositories/${REPO}/images?status=inactive&page_size=100" \
+            -H "Authorization: Bearer ${TOKEN}")
 
+          DIGESTS=$(echo "${RESPONSE}" | jq '[.results[]? | {repository: "confluence-mdx", digest: .digest}]' 2>/dev/null || echo "[]")
           COUNT=$(echo "${DIGESTS}" | jq 'length')
 
           if [ "${COUNT}" -gt 0 ]; then
             echo "Deleting ${COUNT} inactive (untagged) image(s)..."
-            curl -sf -X POST "https://hub.docker.com/v2/repositories/${REPO}/images/delete" \
+            curl -s -X POST "https://hub.docker.com/v2/repositories/${REPO}/images/delete" \
               -H "Authorization: Bearer ${TOKEN}" \
               -H "Content-Type: application/json" \
               -d "{\"dry_run\":false,\"manifests\":${DIGESTS}}"
+            echo ""
             echo "Cleanup complete."
           else
             echo "No inactive images to clean up."
+            if ! echo "${RESPONSE}" | jq -e '.results' > /dev/null 2>&1; then
+              echo "::warning::Unexpected API response"
+              echo "${RESPONSE}" | jq . 2>/dev/null || echo "${RESPONSE}"
+            fi
           fi
 


### PR DESCRIPTION
## Summary

- #692 merge 후 GHA에서 cleanup step이 exit code 22로 실패한 문제 수정
- `curl -sf` → `curl -s` + 수동 에러 핸들링으로 HTTP 에러 응답 내용을 확인할 수 있도록 개선
- `continue-on-error: true` 추가하여 cleanup 실패가 전체 빌드를 실패시키지 않도록 변경

## Context

cleanup step의 `curl -sf`에서 `-f` 플래그가 HTTP 에러를 exit code 22로만 반환하고 응답 내용을 숨김. 실패 원인(인증 문제, API 미지원 등)을 파악하기 위해 에러 응답을 GHA warning annotation으로 노출.

## Test plan

- [ ] GHA 빌드에서 cleanup step의 에러 메시지가 정상 출력되는지 확인
- [ ] cleanup 실패 시 전체 빌드가 성공으로 완료되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)