### PR TITLE
fix: korean-titles-translations.txt 오탈자 수정

### DIFF
--- a/confluence-mdx/etc/korean-titles-translations.txt
+++ b/confluence-mdx/etc/korean-titles-translations.txt
@@ -55,7 +55,7 @@ Multi Agent OS별 3rd Party Tool 지원 목록 | Multi Agent 3rd Party Tool Supp
 Multi Agent 제약사항 | Multi Agent Limitations
 
 # User Management
-Email을 통한 사용자 비밀 번호 초기화 | User Password Reset via Email
+Email을 통한 사용자 비밀번호 초기화 | User Password Reset via Email
 사용자 프로필 | User Profile
 qp-admin 기본 계정에 대한 패스워드 변경 강제화 및 계정 삭제 기능 | Password Change Enforcement and Account Deletion Feature for qp-admin Default Account
 LDAP 연동하기 | Integrating with LDAP


### PR DESCRIPTION
## Summary
- `korean-titles-translations.txt`에서 "비밀 번호" → "비밀번호" 띄어쓰기 오류 수정
- #702 교정 작업에서 MDX 문서 제목이 변경되었으나, 번역 매핑 파일의 한국어 제목이 미반영된 부분을 수정

## Test plan
- [ ] `reverse-sync` 파이프라인에서 해당 페이지 제목 매핑이 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)