### PR TITLE
fix(docker): 빌드 시 첨부파일 중복 다운로드 방지

### DIFF
--- a/confluence-mdx/Dockerfile
+++ b/confluence-mdx/Dockerfile
@@ -20,11 +20,13 @@ COPY bin/ ./bin/
 RUN chmod +x bin/*.py bin/*.sh
 COPY etc/ ./etc/
 
-# Restore var/ from previous image cache (baseline for --recent mode)
-COPY cache/ ./var/
+# Restore cache at its expected path (for Stage 3 attachment fallback)
+COPY cache/ ./cache/
 
-# Update var/ with recently modified pages only
-RUN python3 bin/fetch_cli.py --recent --attachments
+# Populate var/ baseline from cache and fetch recent updates in one step.
+# cp -a creates var/ with all cached YAML/content/attachment files,
+# then fetch_cli.py downloads only recently modified pages.
+RUN cp -a cache/. var/ && python3 bin/fetch_cli.py --recent --attachments
 
 # ── Stage 2: Final image ────────────────────────────
 FROM python:3.12-slim

--- a/confluence-mdx/bin/fetch/stages.py
+++ b/confluence-mdx/bin/fetch/stages.py
@@ -188,6 +188,16 @@ class Stage3Processor(StageBase):
             if "fileSize" in extensions:
                 expected_size = extensions["fileSize"]
 
+            # Check if file already exists at target path with matching size.
+            # Avoids redundant cache-to-var copy or API download on re-runs.
+            if os.path.exists(filepath):
+                existing_size = os.path.getsize(filepath)
+                if existing_size > 0:
+                    if expected_size is None or existing_size == expected_size:
+                        self.logger.info(f"Skipped attachment (already exists): {filename} (size: {existing_size} bytes)")
+                        return
+                    self.logger.warning(f"Existing file size mismatch for {filename}: actual={existing_size}, expected={expected_size}. Will re-download.")
+
             # Check cache directory for the file before downloading from API
             cache_page_dir = self.get_cache_page_directory(page_id)
             cache_filepath = os.path.join(cache_page_dir, filename)


### PR DESCRIPTION
## 요약

- **근본 원인**: `COPY cache/ ./var/`가 컨테이너 내부의 `cache/`를 비워둠 → Stage 3의 캐시 체크가 항상 실패 → 모든 첨부파일을 API에서 재다운로드 (~898초/15분 소요)
- **Dockerfile 수정**: `COPY cache/ ./cache/` + `cp -a cache/. var/`로 캐시를 코드가 기대하는 경로에 배치
- **코드 수정**: 대상 경로(`var/`)에 파일이 이미 존재하면 캐시 복사·API 다운로드 없이 즉시 skip

## 테스트 계획

- [x] 호스트에서 `fetch_cli.py --recent --attachments` 실행: Skipped 1,262건 / Downloaded 0건 확인
- [ ] Docker 이미지 빌드하여 step 소요시간 비교 (기존 ~898초 → 예상 ~30-60초)
- [ ] 빌드된 이미지의 `var/` 내용이 기존과 동일한지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)