### PR TITLE
fix(docker): Docker Hub untagged image 자동 삭제 API 수정

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -58,45 +58,9 @@ jobs:
       - name: Clean up untagged images from Docker Hub
         if: github.event_name != 'pull_request'
         continue-on-error: true
+        working-directory: ./confluence-mdx
         env:
           DOCKERHUB_USERNAME: ${{ vars.CONTAINER_REGISTRY_USERNAME }}
           DOCKERHUB_PASSWORD: ${{ secrets.CONTAINER_REGISTRY_CREDENTIAL }}
-        run: |
-          set -o errexit -o nounset -o pipefail
-          REPO="querypie/confluence-mdx"
-
-          # Get Docker Hub API token
-          RESPONSE=$(curl -s "https://hub.docker.com/v2/users/login" \
-            -H "Content-Type: application/json" \
-            -d "{\"username\":\"${DOCKERHUB_USERNAME}\",\"password\":\"${DOCKERHUB_PASSWORD}\"}")
-
-          TOKEN=$(echo "${RESPONSE}" | jq -r '.token // empty')
-          if [ -z "${TOKEN}" ]; then
-            echo "::warning::Failed to get Docker Hub API token"
-            echo "${RESPONSE}" | jq . 2>/dev/null || echo "${RESPONSE}"
-            exit 1
-          fi
-
-          # List inactive (untagged) image digests
-          RESPONSE=$(curl -s "https://hub.docker.com/v2/repositories/${REPO}/images?status=inactive&page_size=100" \
-            -H "Authorization: Bearer ${TOKEN}")
-
-          DIGESTS=$(echo "${RESPONSE}" | jq '[.results[]? | {repository: "confluence-mdx", digest: .digest}]' 2>/dev/null || echo "[]")
-          COUNT=$(echo "${DIGESTS}" | jq 'length')
-
-          if [ "${COUNT}" -gt 0 ]; then
-            echo "Deleting ${COUNT} inactive (untagged) image(s)..."
-            curl -s -X POST "https://hub.docker.com/v2/repositories/${REPO}/images/delete" \
-              -H "Authorization: Bearer ${TOKEN}" \
-              -H "Content-Type: application/json" \
-              -d "{\"dry_run\":false,\"manifests\":${DIGESTS}}"
-            echo ""
-            echo "Cleanup complete."
-          else
-            echo "No inactive images to clean up."
-            if ! echo "${RESPONSE}" | jq -e '.results' > /dev/null 2>&1; then
-              echo "::warning::Unexpected API response"
-              echo "${RESPONSE}" | jq . 2>/dev/null || echo "${RESPONSE}"
-            fi
-          fi
+        run: python3 bin/dockerhub-cleanup.py
 

--- a/confluence-mdx/bin/dockerhub-cleanup.py
+++ b/confluence-mdx/bin/dockerhub-cleanup.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Delete untagged manifests from a Docker Hub repository.
+
+Usage:
+    # Using Docker credential store (local):
+    ./dockerhub-cleanup.py
+
+    # Using environment variables (CI/CD):
+    DOCKERHUB_USERNAME=user DOCKERHUB_PASSWORD=token ./dockerhub-cleanup.py
+
+    # Dry-run (list only, no delete):
+    ./dockerhub-cleanup.py --dry-run
+
+Environment variables:
+    DOCKERHUB_USERNAME  Docker Hub username
+    DOCKERHUB_PASSWORD  Docker Hub password or Personal Access Token
+    DOCKERHUB_REPO      Repository (default: querypie/confluence-mdx)
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.request
+import urllib.error
+
+
+REPO_DEFAULT = "querypie/confluence-mdx"
+
+
+def get_credentials():
+    """Get Docker Hub credentials from env vars or Docker credential store."""
+    username = os.environ.get("DOCKERHUB_USERNAME", "")
+    password = os.environ.get("DOCKERHUB_PASSWORD", "")
+    if username and password:
+        return username, password
+
+    # Try Docker credential store (works on macOS/Linux with Docker Desktop)
+    for helper in ["docker-credential-desktop", "docker-credential-osxkeychain"]:
+        try:
+            result = subprocess.run(
+                [helper, "get"],
+                input="https://index.docker.io/v1/",
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                creds = json.loads(result.stdout)
+                if creds.get("Username") and creds.get("Secret"):
+                    return creds["Username"], creds["Secret"]
+        except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError):
+            continue
+
+    print("ERROR: No credentials found.", file=sys.stderr)
+    print("  Set DOCKERHUB_USERNAME and DOCKERHUB_PASSWORD env vars,", file=sys.stderr)
+    print("  or log in via Docker Desktop.", file=sys.stderr)
+    sys.exit(1)
+
+
+def api_request(url, headers=None, method="GET", data=None):
+    """Make an HTTP request and return (status_code, parsed_json)."""
+    hdrs = headers or {}
+    body = json.dumps(data).encode() if data else None
+    req = urllib.request.Request(url, data=body, headers=hdrs, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read().decode()
+            return resp.status, json.loads(raw) if raw.strip() else {}
+    except urllib.error.HTTPError as e:
+        try:
+            err_body = json.loads(e.read().decode())
+        except Exception:
+            err_body = {"error": str(e)}
+        return e.code, err_body
+
+
+def authenticate(username, password):
+    """Authenticate with Docker Hub and return a Bearer token."""
+    status, body = api_request(
+        "https://hub.docker.com/v2/users/login",
+        headers={"Content-Type": "application/json"},
+        data={"username": username, "password": password},
+    )
+    token = body.get("token", "")
+    if status != 200 or not token:
+        detail = body.get("detail", body.get("message", str(body)))
+        print(f"ERROR: Docker Hub login failed (HTTP {status}): {detail}", file=sys.stderr)
+        sys.exit(1)
+    return token
+
+
+def list_manifests(token, namespace, repo):
+    """List all manifests in a repository, handling pagination."""
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    base_url = f"https://hub.docker.com/v2/namespaces/{namespace}/repositories/{repo}/manifests"
+    all_manifests = []
+    url = f"{base_url}?page_size=100"
+
+    while url:
+        status, body = api_request(url, headers=headers)
+        if status != 200:
+            msg = body.get("message", body.get("error", str(body)))
+            print(f"ERROR: Failed to list manifests (HTTP {status}): {msg}", file=sys.stderr)
+            sys.exit(1)
+
+        manifests = body.get("manifests", [])
+        all_manifests.extend(manifests)
+
+        # Pagination: use last_evaluated_key if present
+        last_key = body.get("last_evaluated_key")
+        if last_key and manifests:
+            url = f"{base_url}?page_size=100&last_evaluated_key={last_key}"
+        else:
+            url = None
+
+    return all_manifests
+
+
+def delete_manifests(token, namespace, repo, digests):
+    """Delete manifests by digest."""
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    url = f"https://hub.docker.com/v2/namespaces/{namespace}/repositories/{repo}/manifests"
+
+    status, body = api_request(
+        url,
+        headers=headers,
+        method="DELETE",
+        data={"digests": digests, "delete_references": True},
+    )
+
+    if status != 200:
+        msg = body.get("message", body.get("error", str(body)))
+        print(f"ERROR: Failed to delete manifests (HTTP {status}): {msg}", file=sys.stderr)
+        return False
+
+    # Check individual results
+    results = body.get("status", {})
+    success = 0
+    failed = 0
+    for digest, info in results.items():
+        s = info.get("status", {}).get("status", "unknown")
+        if s == "success":
+            success += 1
+        else:
+            failed += 1
+            print(f"  WARN: {digest[:30]}... status={s}", file=sys.stderr)
+
+    print(f"  Deleted: {success}, Failed: {failed}")
+    return failed == 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Delete untagged manifests from Docker Hub")
+    parser.add_argument("--dry-run", action="store_true", help="List untagged manifests without deleting")
+    parser.add_argument("--repo", default=os.environ.get("DOCKERHUB_REPO", REPO_DEFAULT),
+                        help=f"Repository (default: {REPO_DEFAULT})")
+    args = parser.parse_args()
+
+    parts = args.repo.split("/", 1)
+    if len(parts) != 2:
+        print(f"ERROR: Invalid repo format '{args.repo}', expected 'namespace/repo'", file=sys.stderr)
+        sys.exit(1)
+    namespace, repo = parts
+
+    # Authenticate
+    username, password = get_credentials()
+    token = authenticate(username, password)
+
+    # List all manifests
+    manifests = list_manifests(token, namespace, repo)
+    tagged = [m for m in manifests if m.get("tags")]
+    untagged = [m for m in manifests if not m.get("tags")]
+
+    print(f"Repository: {namespace}/{repo}")
+    print(f"Total manifests: {len(manifests)}")
+    print(f"  Tagged: {len(tagged)}")
+    for m in tagged:
+        d = m["manifest_digest"][:30]
+        print(f"    {d}... tags={m['tags']}")
+    print(f"  Untagged: {len(untagged)}")
+    for m in untagged:
+        d = m["manifest_digest"][:30]
+        pushed = m.get("last_pushed", "?")
+        print(f"    {d}... pushed={pushed}")
+
+    if not untagged:
+        print("\nNo untagged manifests to clean up.")
+        return
+
+    if args.dry_run:
+        print(f"\n[DRY RUN] Would delete {len(untagged)} untagged manifest(s).")
+        return
+
+    # Delete untagged manifests
+    digests = [m["manifest_digest"] for m in untagged]
+    print(f"\nDeleting {len(digests)} untagged manifest(s)...")
+    ok = delete_manifests(token, namespace, repo, digests)
+
+    # Verify
+    manifests_after = list_manifests(token, namespace, repo)
+    untagged_after = [m for m in manifests_after if not m.get("tags")]
+    print(f"\nVerification: {len(untagged)} -> {len(untagged_after)} untagged manifests")
+
+    if untagged_after:
+        print(f"WARNING: {len(untagged_after)} untagged manifest(s) remain", file=sys.stderr)
+        sys.exit(1)
+    else:
+        print("All untagged manifests deleted successfully.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Docker Hub의 Advanced Image Management API(`/v2/repositories/.../images?status=inactive`)가 폐지(retired)되어 매 빌드마다 cleanup step이 404로 조용히 실패하고 있었음
- 새로운 manifests API 엔드포인트로 교체하여 untagged image 자동 삭제 복구
- 38줄 인라인 bash 코드를 독립 Python 스크립트(`bin/dockerhub-cleanup.py`)로 분리

## Details

**Root Cause:** Docker Hub가 `/v2/repositories/{ns}/{repo}/images` 엔드포인트를 폐지. `continue-on-error: true` 설정 때문에 실패가 숨겨져 있었음.

**New API:**

| 용도 | 기존 (404) | 신규 (작동 확인) |
|------|-----------|-----------------|
| 목록 | `GET /v2/repositories/.../images?status=inactive` | `GET /v2/namespaces/{ns}/repositories/{repo}/manifests` |
| 삭제 | `POST /v2/repositories/.../images/delete` | `DELETE /v2/namespaces/{ns}/repositories/{repo}/manifests` |

**검증 결과:** 로컬에서 실행하여 12개 untagged manifest 삭제 성공, 삭제 후 0개 확인.

## Test plan

- [ ] `python3 bin/dockerhub-cleanup.py --dry-run` 로컬 실행 확인
- [ ] main 머지 후 GHA workflow 트리거하여 cleanup step 정상 동작 확인
- [ ] Docker Hub에서 untagged image가 남아있지 않은지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)