### PR TITLE
fix(docker): setup-cache.sh local/docker 모드 지원

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -32,7 +32,7 @@ jobs:
         working-directory: ./confluence-mdx
         run: |
           set -o errexit -o nounset -o pipefail -o xtrace
-          ./bin/setup-cache.sh
+          ./bin/setup-cache.sh docker
 
       - name: Log in to Docker Hub
         if: github.event_name != 'pull_request'

--- a/confluence-mdx/bin/setup-cache.sh
+++ b/confluence-mdx/bin/setup-cache.sh
@@ -1,113 +1,149 @@
 #!/usr/bin/env bash
 
-# This script sets up the cache directory by pulling the Docker image
-# docker.io/querypie/confluence-mdx:latest and copying numeric directories
-# from /workdir/var in the image to the local cache/ directory.
-# It creates or cleans the cache directory before copying.
+# Setup cache/ directory from either local var/ or a Docker image.
+#
+# Usage:
+#   setup-cache.sh local   — copy numeric directories from local var/ to cache/
+#   setup-cache.sh docker  — extract numeric directories from confluence-mdx:latest image
 
-set -o nounset -o errtrace -o pipefail
+set -o nounset -o errexit -o errtrace -o pipefail
 
-# Global variables
-CONFLUENCE_MDX_DIR=""
+SCRIPT_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
+CONFLUENCE_MDX_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
 
-# Function to setup environment: navigate to confluence-mdx directory
-function setup_environment() {
-  local script_dir
+readonly BOLD_CYAN="\e[1;36m"
+readonly BOLD_RED="\e[1;91m"
+readonly RESET="\e[0m"
 
-  # Get script directory and navigate to confluence-mdx directory
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  CONFLUENCE_MDX_DIR="$(cd "$script_dir/.." && pwd)"
-
-  # Change to confluence-mdx directory
-  cd "$CONFLUENCE_MDX_DIR"
+function log::error() {
+  printf "%bERROR: %s%b\n" "$BOLD_RED" "$*" "$RESET" 1>&2
 }
 
-# Function to setup cache directory: create or clean existing cache directory
-function setup_cache() {
+function log::do() {
+  local line_no
+  line_no=$(caller | awk '{print $1}')
+  # shellcheck disable=SC2064
+  trap "log::error 'Failed to run at line $line_no: $*'" ERR
+  printf "%b+ %s%b\n" "$BOLD_CYAN" "$*" "$RESET" 1>&2
+  "$@"
+}
+
+# Create or clean cache directory (preserving dot-files)
+function cache::clean() {
   local cache_dir="$CONFLUENCE_MDX_DIR/cache"
 
-  # Create cache directory if it doesn't exist
   if [[ ! -d "$cache_dir" ]]; then
-    mkdir -p "$cache_dir"
-    echo >&2 "# Created cache directory: $cache_dir"
+    log::do mkdir -p "$cache_dir"
   else
-    echo >&2 "# Cache directory already exists: $cache_dir"
-    echo >&2 "# Cleaning cache directory contents..."
-
-    # Remove all subdirectories and files, but ignore files starting with .
-    if [[ -n "$(find "$cache_dir" -mindepth 1 -maxdepth 1 ! -name '.*' 2>/dev/null)" ]]; then
-      find "$cache_dir" -mindepth 1 -maxdepth 1 ! -name '.*' -exec rm -rf {} +
-      echo >&2 "# Removed all contents from cache directory"
-    else
-      echo >&2 "# Cache directory is already empty"
-    fi
+    echo >&2 "# Cleaning cache directory..."
+    log::do find "$cache_dir" -mindepth 1 -maxdepth 1 ! -name '.*' -exec rm -rf {} +
   fi
 }
 
-# Function to copy numeric directories from Docker image to cache/
-function copy_numeric_dirs_from_image() {
-  local image_name="docker.io/querypie/confluence-mdx:latest"
-  local image_var_dir="/workdir/var"
+# Copy numeric directories from $1 (source dir) into cache/
+function cache::copy_numeric_dirs() {
+  local src_dir="$1"
   local cache_dir="$CONFLUENCE_MDX_DIR/cache"
-  local container_id
-  local temp_dir
-  local dir
+  local count=0
 
-  echo >&2 "# Pulling Docker image: $image_name"
-  if ! docker pull --platform linux/amd64 "$image_name"; then
-    echo >&2 "# Error: Failed to pull Docker image $image_name"
-    return 1
-  fi
-
-  echo >&2 "# Creating temporary container from image..."
-  container_id="$(docker create --platform linux/amd64 "$image_name")"
-  if [[ -z "$container_id" ]]; then
-    echo >&2 "# Error: Failed to create container from image"
-    return 1
-  fi
-
-  # Create temporary directory to extract files from container
-  temp_dir="$(mktemp -d)"
-  trap "rm -rf '$temp_dir'; docker rm '$container_id' >/dev/null 2>&1 || true" EXIT
-
-  echo >&2 "# Copying /workdir/var from container..."
-  if ! docker cp "$container_id:$image_var_dir" "$temp_dir/" 2>/dev/null; then
-    echo >&2 "# Warning: /workdir/var directory not found in container or copy failed"
-    docker rm "$container_id" >/dev/null 2>&1 || true
-    return 0
-  fi
-
-  # Remove container as we no longer need it
-  docker rm "$container_id" >/dev/null 2>&1 || true
-
-  local extracted_var_dir="$temp_dir/var"
-  if [[ ! -d "$extracted_var_dir" ]]; then
-    echo >&2 "# Warning: Extracted var directory not found"
-    return 0
-  fi
-
-  echo >&2 "# Moving numeric directories to cache/..."
-
-  # Find all directories in extracted var/ that contain only digits and move them to cache
   while IFS= read -r -d '' dir; do
     local dirname
     dirname="$(basename "$dir")"
-    # Check if directory name contains only digits
     if [[ "$dirname" =~ ^[0-9]+$ ]]; then
-      echo >&2 "# Moving: $dirname"
-      mv "$dir" "$cache_dir/"
+      log::do cp -a "$dir" "$cache_dir/"
+      (( ++count ))
     fi
-  done < <(find "$extracted_var_dir" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null)
+  done < <(find "$src_dir" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null)
 
-  echo >&2 "# Finished moving numeric directories"
+  echo >&2 "# Copied $count directories to cache/"
 }
 
-# Main function
+# Move numeric directories from $1 (temp dir) into cache/
+function cache::move_numeric_dirs() {
+  local src_dir="$1"
+  local cache_dir="$CONFLUENCE_MDX_DIR/cache"
+  local count=0
+
+  while IFS= read -r -d '' dir; do
+    local dirname
+    dirname="$(basename "$dir")"
+    if [[ "$dirname" =~ ^[0-9]+$ ]]; then
+      log::do mv "$dir" "$cache_dir/"
+      (( ++count ))
+    fi
+  done < <(find "$src_dir" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null)
+
+  echo >&2 "# Moved $count directories to cache/"
+}
+
+# ── local mode ──────────────────────────────────────
+function cmd::local() {
+  local var_dir="$CONFLUENCE_MDX_DIR/var"
+
+  if [[ ! -d "$var_dir" ]]; then
+    log::error "var/ directory not found"
+    return 1
+  fi
+
+  echo >&2 "# Source: local var/"
+  cache::clean
+  cache::copy_numeric_dirs "$var_dir"
+}
+
+# ── docker mode ─────────────────────────────────────
+function cmd::docker() {
+  local image_name="docker.io/querypie/confluence-mdx:latest"
+  local container_id
+  local temp_dir
+
+  echo >&2 "# Source: Docker image"
+  cache::clean
+
+  log::do docker pull --platform linux/amd64 "$image_name"
+
+  container_id="$(docker create --platform linux/amd64 "$image_name")"
+  if [[ -z "$container_id" ]]; then
+    log::error "Failed to create container"
+    return 1
+  fi
+
+  temp_dir="$(mktemp -d)"
+  # shellcheck disable=SC2064
+  trap "rm -rf '$temp_dir'; docker rm '$container_id' >/dev/null 2>&1 || true" EXIT
+
+  log::do docker cp "$container_id:/workdir/var" "$temp_dir/"
+
+  docker rm "$container_id" >/dev/null 2>&1 || true
+
+  if [[ ! -d "$temp_dir/var" ]]; then
+    log::error "Extracted var directory not found"
+    return 1
+  fi
+
+  cache::move_numeric_dirs "$temp_dir/var"
+}
+
+# ── main ────────────────────────────────────────────
+function print_usage_and_exit() {
+  local code=${1:-0} out=2
+  [[ code -eq 0 ]] && out=1
+  cat >&"${out}" <<END_OF_USAGE
+Usage: $(basename "$0") {local|docker}
+
+  local   Copy from local var/ directory
+  docker  Extract from confluence-mdx:latest image
+
+END_OF_USAGE
+  exit "$code"
+}
+
 function main() {
-  setup_environment
-  setup_cache
-  copy_numeric_dirs_from_image
+  case "${1:-}" in
+    local)  cmd::local ;;
+    docker) cmd::docker ;;
+    -h|--help) print_usage_and_exit 0 ;;
+    *) print_usage_and_exit 1 ;;
+  esac
 }
 
 main "$@"
-


### PR DESCRIPTION
## Summary
- `setup-cache.sh`를 `local`/`docker` 두 가지 모드로 재작성
  - `local`: 로컬 `var/`에서 `cache/`로 복제 (`cp -a`) — `fetch_state.yaml` 포함
  - `docker`: Docker Hub 이미지에서 추출 후 이동 (`mv`) — 기존 동작
- GHA 워크플로우에서 `./bin/setup-cache.sh docker` 명시적 호출로 수정
- Bash 코딩 스타일 가이드 적용 (`log::do`, `namespace::function`, `set -o errtrace`)

## Background
`cache/`에 `fetch_state.yaml`이 누락되어 Docker 빌드 시 `--recent` 모드가 fetch state를 찾지 못하고, 기본 21일치 100개 페이지 + 첨부파일을 불필요하게 재다운로드하는 문제 발생. `setup-cache.sh local` 모드로 로컬 `var/`에서 cache를 구성하면 `fetch_state.yaml`이 포함되어 문제 해결.

## Test results
- [x] `bin/setup-cache.sh` (인자 없이) → usage 출력, exit code 1
- [x] `bin/setup-cache.sh local` → 302개 숫자 디렉토리 + `fetch_state.yaml` 복제 확인
- [x] Docker 빌드: `Auto-detected since_date` 출력 ("No fetch state" 경고 미출력)
- [x] Docker 빌드: `Skipped 100 pages (already up-to-date)`, 첨부파일 다운로드 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)