### PR TITLE
fix(ci): Generate MDX 워크플로우 기본값을 --recent --attachments 로 변경

### DIFF
--- a/.github/workflows/generate-mdx-from-confluence.yml
+++ b/.github/workflows/generate-mdx-from-confluence.yml
@@ -14,7 +14,7 @@ on:
           - '--remote'
           - '--remote --attachments'
           - '--local'
-        default: '--recent'
+        default: '--recent --attachments'
 
 jobs:
   generate-mdx:


### PR DESCRIPTION
## Summary
- Generate MDX from Confluence 워크플로우의 기본 arguments를 `--recent`에서 `--recent --attachments`로 변경
- 첨부파일 다운로드가 기본으로 포함되어 빌드 시 첨부파일 누락 방지

🤖 Generated with [Claude Code](https://claude.com/claude-code)