### PR TITLE
feat(ci): image pull 후 image_status.py 로 이미지 상태 확인

### DIFF
--- a/.github/workflows/generate-mdx-from-confluence.yml
+++ b/.github/workflows/generate-mdx-from-confluence.yml
@@ -45,12 +45,14 @@ jobs:
           # 플랫폼을 명시적으로 지정하여 아키텍처 불일치 오류 방지
           DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose --progress=quiet pull confluence-mdx
 
-      - name: Docker image metadata
+      - name: Docker image status
+        working-directory: ./confluence-mdx
         run: |
-          echo "=== Docker Image Metadata ==="
-          docker inspect querypie/confluence-mdx:latest --format 'Image Created: {{.Created}}'
-          docker inspect querypie/confluence-mdx:latest --format 'Image ID: {{.Id}}'
-          docker inspect querypie/confluence-mdx:latest --format 'Image Size: {{.Size}} bytes'
+          STATUS=$(docker compose run --rm confluence-mdx status --top 5)
+          echo "$STATUS"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "$STATUS" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Generate MDX files
         working-directory: ./confluence-mdx


### PR DESCRIPTION
## Summary
- Generate MDX 워크플로우에서 `docker inspect` 기반 메타데이터 확인 스텝을 컨테이너 내부 `image_status.py` (`status` 커맨드) 실행으로 교체
- 이미지 빌드 날짜, 페이지 통계, 데이터 신선도 리포트를 **Step Summary**에 기록하여 Job에서 바로 확인 가능

## Test plan
- [ ] `Generate MDX from Confluence` 워크플로우를 수동 실행하여 "Docker image status" 스텝이 정상 동작하는지 확인
- [ ] Job Summary에 image_status.py 출력이 코드 블록으로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)