### PR TITLE
fix(ci): Generate MDX 워크플로우 .env 생성 시점 수정

### DIFF
--- a/.github/workflows/generate-mdx-from-confluence.yml
+++ b/.github/workflows/generate-mdx-from-confluence.yml
@@ -42,6 +42,7 @@ jobs:
           set -o xtrace
           docker --version
           docker compose version
+          touch .env # Create an empty .env to prevent missing .env error.
           # 플랫폼을 명시적으로 지정하여 아키텍처 불일치 오류 방지
           DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose --progress=quiet pull confluence-mdx
 
@@ -58,7 +59,6 @@ jobs:
         working-directory: ./confluence-mdx
         run: |
           set -o xtrace
-          touch .env # Create an empty .env to prevent missing .env error.
           docker compose run --rm confluence-mdx full ${{ inputs.arguments }}
 
       - name: Check for changes


### PR DESCRIPTION
## Summary
- `touch .env`를 "Pull latest Docker image" 단계로 이동하여 모든 `docker compose` 명령 전에 실행되도록 수정합니다.
- #717에서 추가된 "Docker image status" 단계가 `.env` 없이 `docker compose run`을 실행하여 워크플로우가 실패하던 문제를 수정합니다.

## Root cause
PR #717 (`21dbecd8`)에서 "Docker image status" 단계를 추가하면서, `docker compose run`이 기존 `touch .env`보다 먼저 실행되는 순서 문제가 발생했습니다.

- 실패 로그: https://github.com/querypie/querypie-docs/actions/runs/22014495466/job/63614028418

## Test plan
- [ ] `Generate MDX from Confluence` 워크플로우를 수동 실행하여 "Docker image status" 단계가 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)