### PR TITLE
fix(skeleton): PYTHONPATH 없이 skeleton 스크립트 실행 가능하도록 개선

### DIFF
--- a/.claude/skills/mdx-skeleton-comparison.md
+++ b/.claude/skills/mdx-skeleton-comparison.md
@@ -26,16 +26,16 @@ cd confluence-mdx/
 source venv/bin/activate
 
 # 전체 비교 실행 (기본: target/ko, target/ja, target/en)
-PYTHONPATH=bin bin/skeleton/cli.py -r
+bin/skeleton/cli.py -r
 
 # 최대 20개 차이까지 출력
-PYTHONPATH=bin bin/skeleton/cli.py -r --max-diff=20
+bin/skeleton/cli.py -r --max-diff=20
 
 # 특정 파일 변환 + 한국어 스켈레톤과 비교
-PYTHONPATH=bin bin/skeleton/cli.py target/en/path/to/file.mdx
+bin/skeleton/cli.py target/en/path/to/file.mdx
 
 # ignore 규칙을 적용하여 비교
-PYTHONPATH=bin bin/skeleton/cli.py --use-ignore target/ja/path/to/file.mdx
+bin/skeleton/cli.py --use-ignore target/ja/path/to/file.mdx
 ```
 
 ## CLI 옵션 레퍼런스
@@ -94,23 +94,23 @@ PYTHONPATH=bin bin/skeleton/cli.py --use-ignore target/ja/path/to/file.mdx
 
 ```bash
 # 기본 실행 (max-diff=5)
-PYTHONPATH=bin bin/skeleton/cli.py -r
+bin/skeleton/cli.py -r
 
 # 충분한 diff 출력으로 전체 현황 파악
-PYTHONPATH=bin bin/skeleton/cli.py -r --max-diff=50
+bin/skeleton/cli.py -r --max-diff=50
 
 # unmatched 파일 목록을 파일로 저장
-PYTHONPATH=bin bin/skeleton/cli.py -r --max-diff=100 --output /tmp/unmatched.txt
+bin/skeleton/cli.py -r --max-diff=100 --output /tmp/unmatched.txt
 ```
 
 ### 파일 존재 여부 비교 (구조 비교 없이)
 
 ```bash
 # 3개 언어 중 누락된 파일만 표시
-PYTHONPATH=bin bin/skeleton/cli.py --compare
+bin/skeleton/cli.py --compare
 
 # 모든 파일 표시 (3개 언어 모두 존재하는 파일 포함)
-PYTHONPATH=bin bin/skeleton/cli.py --compare --verbose
+bin/skeleton/cli.py --compare --verbose
 ```
 
 출력 형식: `/path/to/file.mdx ko en ja` (누락 시 `-` 표시)
@@ -119,20 +119,20 @@ PYTHONPATH=bin bin/skeleton/cli.py --compare --verbose
 
 ```bash
 # 변환 + 한국어 스켈레톤과 비교
-PYTHONPATH=bin bin/skeleton/cli.py target/ja/administrator-manual/databases/db-connections.mdx
+bin/skeleton/cli.py target/ja/administrator-manual/databases/db-connections.mdx
 
 # ignore 규칙 적용하여 비교
-PYTHONPATH=bin bin/skeleton/cli.py --use-ignore target/ja/administrator-manual/databases/db-connections.mdx
+bin/skeleton/cli.py --use-ignore target/ja/administrator-manual/databases/db-connections.mdx
 ```
 
 ### 스켈레톤 파일 정리
 
 ```bash
 # 모든 .skel.mdx 파일 삭제 (기본 디렉토리)
-PYTHONPATH=bin bin/skeleton/cli.py --reset
+bin/skeleton/cli.py --reset
 
 # 특정 디렉토리만 정리
-PYTHONPATH=bin bin/skeleton/cli.py --reset target/ja
+bin/skeleton/cli.py --reset target/ja
 ```
 
 ### 순차 리뷰 (review-skeleton-diff.sh)
@@ -141,7 +141,7 @@ unmatched 파일 목록을 입력받아 파일별로 순차 리뷰합니다.
 
 ```bash
 # 먼저 unmatched 목록 생성
-PYTHONPATH=bin bin/skeleton/cli.py -r --max-diff=100 --output /tmp/unmatched.txt
+bin/skeleton/cli.py -r --max-diff=100 --output /tmp/unmatched.txt
 
 # 대화형 리뷰 (파일별 확인 후 계속)
 bin/review-skeleton-diff.sh /tmp/unmatched.txt
@@ -221,10 +221,10 @@ ignores:
 
 ```bash
 # 기본 제외: /index.skel.mdx
-PYTHONPATH=bin bin/skeleton/cli.py -r
+bin/skeleton/cli.py -r
 
 # 추가 경로 제외
-PYTHONPATH=bin bin/skeleton/cli.py -r --exclude /index.skel.mdx /release-notes/overview.skel.mdx
+bin/skeleton/cli.py -r --exclude /index.skel.mdx /release-notes/overview.skel.mdx
 ```
 
 ## 번역 수정 시 주의사항
@@ -239,7 +239,7 @@ PYTHONPATH=bin bin/skeleton/cli.py -r --exclude /index.skel.mdx /release-notes/o
 ```bash
 cd confluence-mdx/
 source venv/bin/activate
-PYTHONPATH=bin python -m pytest tests/test_mdx_to_skeleton.py -v
+python -m pytest tests/test_mdx_to_skeleton.py -v
 ```
 
 ## 상세 문서

--- a/confluence-mdx/bin/review-skeleton-diff.sh
+++ b/confluence-mdx/bin/review-skeleton-diff.sh
@@ -83,11 +83,11 @@ function process_file() {
 
   # Step 1: Run without --use-ignore
   echo "# --- Step 1: skeleton/cli.py (without --use-ignore) ---"
-  PYTHONPATH=bin bin/skeleton/cli.py "$file" 2>&1
+  bin/skeleton/cli.py "$file" 2>&1
 
   # Step 2: Run with --use-ignore
   echo "# --- Step 2: skeleton/cli.py (with --use-ignore) ---"
-  PYTHONPATH=bin bin/skeleton/cli.py --use-ignore "$file" 2>&1
+  bin/skeleton/cli.py --use-ignore "$file" 2>&1
 
   # Ask for user confirmation (skip if --yes option is provided)
   if [[ "$YES_MODE" == false ]]; then

--- a/confluence-mdx/bin/skeleton/cli.py
+++ b/confluence-mdx/bin/skeleton/cli.py
@@ -95,6 +95,10 @@ from typing import List, Tuple, Optional
 _SCRIPT_DIR = Path(__file__).resolve().parent.parent  # confluence-mdx/bin/
 _PROJECT_DIR = _SCRIPT_DIR.parent                     # confluence-mdx/
 
+# Ensure bin/ is on sys.path so skeleton package imports resolve without PYTHONPATH
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
 # Import modules for recursive processing and comparison
 from skeleton.compare import compare_files
 from skeleton.diff import (

--- a/confluence-mdx/bin/skeleton/diff.py
+++ b/confluence-mdx/bin/skeleton/diff.py
@@ -17,6 +17,10 @@ from typing import List, Tuple, Optional, Dict, Set
 _SCRIPT_DIR = Path(__file__).resolve().parent.parent  # confluence-mdx/bin/
 _PROJECT_DIR = _SCRIPT_DIR.parent                     # confluence-mdx/
 
+# Ensure bin/ is on sys.path so skeleton package imports resolve without PYTHONPATH
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
 try:
     import yaml
 except ImportError:

--- a/confluence-mdx/tests/run-tests.sh
+++ b/confluence-mdx/tests/run-tests.sh
@@ -26,8 +26,7 @@ VENV_DIR="../venv"
 CONVERTER_SCRIPT="${BIN_DIR}/converter/cli.py"
 SKELETON_SCRIPT="${BIN_DIR}/skeleton/cli.py"
 
-# Ensure bin/ is on PYTHONPATH so skeleton package imports resolve
-export PYTHONPATH="${BIN_DIR}:${PYTHONPATH:-}"
+# Note: PYTHONPATH is no longer needed — skeleton scripts resolve their own sys.path
 
 # Default options
 TEST_TYPE="convert"

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -42,7 +42,7 @@
     - 이 Skeleton MDX 파일을 비교하여, 원문과 번역문의 MDX 파일이 동일한 구성을 갖고 있는지, 문장의 수가 동일한지, Image link 가 동일한
       파일을 가리키는지, 검증할 수 있습니다.
 - `skeleton/cli.py`는 venv 환경에서 실행할 수 있습니다.
-    - `cd confluence-mdx; source venv/bin/activate; python bin/skeleton/cli.py filename.mdx` 와 같이 실행할 수 있습니다.
+    - `cd confluence-mdx; source venv/bin/activate; bin/skeleton/cli.py filename.mdx` 와 같이 실행할 수 있습니다.
     - Skeleton MDX 파일은 원문 MDX 파일과 동일한 디렉토리에 생성됩니다.
 - `bin/skeleton/cli.py --recursive`를 실행하면, target 디렉토리 아래의 모든 MDX 파일에 대해 Skeleton MDX 를 생성하고,
   한국어 원문 MDX 와 번역문 MDX 의 Skeleton MDX 를 비교하여 줍니다. 이때, diff 결과와 유사한 형식의 결과가 출력되는데, Skeleton MDX 의 비교와 함께


### PR DESCRIPTION
## Summary
- `PYTHONPATH=bin` 접두사 없이 `bin/skeleton/cli.py`를 직접 실행할 수 있도록 개선합니다
- Python 스크립트가 자체적으로 `sys.path`를 설정하여 `skeleton` 패키지를 찾습니다

## 변경 내용
- `bin/skeleton/cli.py`, `bin/skeleton/diff.py`: import 전에 `bin/` 디렉토리를 `sys.path`에 자동 추가
- `bin/review-skeleton-diff.sh`: `PYTHONPATH=bin` 접두사 제거
- `tests/run-tests.sh`: `PYTHONPATH` export 제거
- `.claude/skills/mdx-skeleton-comparison.md`: 실행 예시에서 `PYTHONPATH=bin` 제거
- `docs/translation.md`: 실행 예시 업데이트

## Before / After
```bash
# Before
PYTHONPATH=bin bin/skeleton/cli.py -r

# After
bin/skeleton/cli.py -r
```

## Test plan
- [x] `bin/skeleton/cli.py --help` — PYTHONPATH 없이 정상 실행 확인
- [x] `python -m pytest tests/test_mdx_to_skeleton.py -v` — 58 passed
- [x] `tests/run-tests.sh --type skeleton` — 18 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)