### PR TITLE
refactor(bin): Python 스크립트 코드 품질 개선

### DIFF
--- a/confluence-mdx/bin/fetch_cli.py
+++ b/confluence-mdx/bin/fetch_cli.py
@@ -30,10 +30,13 @@ import logging
 import sys
 from pathlib import Path
 
-# Ensure bin/ is on sys.path when run as a script (e.g. bin/fetch_cli.py)
-_bin_dir = str(Path(__file__).resolve().parent)
-if _bin_dir not in sys.path:
-    sys.path.insert(0, _bin_dir)
+# 스크립트 위치 기반 경로 상수
+_SCRIPT_DIR = Path(__file__).resolve().parent   # confluence-mdx/bin/
+_PROJECT_DIR = _SCRIPT_DIR.parent               # confluence-mdx/
+
+# Ensure bin/ is on sys.path so local package imports resolve without PYTHONPATH
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
 
 from fetch.config import Config
 from fetch.processor import ConfluencePageProcessor

--- a/confluence-mdx/bin/image_status.py
+++ b/confluence-mdx/bin/image_status.py
@@ -13,6 +13,7 @@ Usage:
 """
 
 import argparse
+import logging
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -58,6 +59,7 @@ def scan_pages(var_dir: Path) -> list[dict]:
                 "created_at": version_info.get("createdAt", ""),
             })
         except Exception:
+            logging.warning("Failed to parse %s, skipping", v2_file)
             continue
     return pages
 

--- a/confluence-mdx/bin/restore_alt_from_diff.py
+++ b/confluence-mdx/bin/restore_alt_from_diff.py
@@ -24,7 +24,7 @@ def get_diff_for_lang(lang: str) -> str:
     """특정 언어의 git diff 가져오기"""
     result = subprocess.run(
         ['git', 'diff', f'src/content/{lang}/'],
-        capture_output=True, text=True,
+        capture_output=True, text=True, check=True,
         cwd=str(_REPO_ROOT),
     )
     return result.stdout

--- a/confluence-mdx/bin/reverse_sync/test_verify.py
+++ b/confluence-mdx/bin/reverse_sync/test_verify.py
@@ -8,10 +8,12 @@ import json
 import sys
 from pathlib import Path
 
-# Ensure bin/ is on sys.path when run as a script (e.g. bin/reverse_sync/test_verify.py)
-_bin_dir = str(Path(__file__).resolve().parent.parent)
-if _bin_dir not in sys.path:
-    sys.path.insert(0, _bin_dir)
+# 스크립트 위치 기반 경로 상수
+_SCRIPT_DIR = Path(__file__).resolve().parent.parent  # confluence-mdx/bin/
+
+# Ensure bin/ is on sys.path so local package imports resolve without PYTHONPATH
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
 
 from reverse_sync_cli import run_verify, MdxSource
 

--- a/confluence-mdx/bin/reverse_sync_cli.py
+++ b/confluence-mdx/bin/reverse_sync_cli.py
@@ -20,6 +20,10 @@ _SCRIPT_DIR = Path(__file__).resolve().parent   # confluence-mdx/bin/
 _PROJECT_DIR = _SCRIPT_DIR.parent               # confluence-mdx/
 _REPO_ROOT = _PROJECT_DIR.parent                # 레포 루트
 
+# Ensure bin/ is on sys.path so local package imports resolve without PYTHONPATH
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
 from reverse_sync.mdx_block_parser import parse_mdx_blocks
 from reverse_sync.block_diff import diff_blocks
 from reverse_sync.mapping_recorder import record_mapping


### PR DESCRIPTION
## Summary
- `reverse_sync_cli.py`에 `sys.path` 자동 설정 추가 (PYTHONPATH 없이 실행 가능)
- `fetch_cli.py`, `reverse_sync/test_verify.py`의 `sys.path` 패턴을 `_SCRIPT_DIR` 방식으로 통일
- `image_status.py`의 bare exception handler에 `logging.warning` 추가
- `restore_alt_from_diff.py`의 `subprocess.run`에 `check=True` 추가

## Test plan
- [x] pytest: 390 passed
- [x] Convert tests: 21 passed
- [x] Skeleton tests: 18 passed
- [x] Reverse-Sync tests: 16 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)