### PR TITLE
confluence-mdx: 인접 bold span 병합 정규화를 roundtrip verifier에 추가합니다

### DIFF
--- a/confluence-mdx/bin/reverse_sync/roundtrip_verifier.py
+++ b/confluence-mdx/bin/reverse_sync/roundtrip_verifier.py
@@ -118,6 +118,17 @@ def _normalize_table_cell_lines(text: str) -> str:
     return '\n'.join(result)
 
 
+def _normalize_adjacent_bold_spans(text: str) -> str:
+    """인접한 bold span을 하나로 병합한다.
+
+    Confluence XHTML에서 <strong>A</strong> <strong>B</strong> 구조를
+    forward converter가 **A**   **B** 로 변환하지만,
+    MDX 교정에서 **A B** 로 병합하는 경우가 있다.
+    두 형태를 동일하게 취급하기 위해 **A** <spaces> **B** → **A B** 로 정규화한다.
+    """
+    return re.sub(r'\*\*\s+\*\*', ' ', text)
+
+
 def _normalize_html_entities_in_code(text: str) -> str:
     """코드 블록 내의 HTML 엔티티를 일반 문자로 변환한다.
 
@@ -154,6 +165,8 @@ def verify_roundtrip(expected_mdx: str, actual_mdx: str) -> VerifyResult:
     actual_mdx = _normalize_table_cell_lines(actual_mdx)
     expected_mdx = _normalize_html_entities_in_code(expected_mdx)
     actual_mdx = _normalize_html_entities_in_code(actual_mdx)
+    expected_mdx = _normalize_adjacent_bold_spans(expected_mdx)
+    actual_mdx = _normalize_adjacent_bold_spans(actual_mdx)
 
     if expected_mdx == actual_mdx:
         return VerifyResult(passed=True, diff_report="")


### PR DESCRIPTION
## Description
- Roundtrip verifier에 인접한 bold span 병합 정규화 함수 `_normalize_adjacent_bold_spans()`를 추가합니다.
- Forward converter가 `<strong>A</strong> <strong>B</strong>`를 `**A** **B**`로 변환하지만, MDX 교정에서 `**A B**`로 병합하는 경우, 두 형태를 동일하게 취급합니다.
- 패턴: `**text1**<spaces>**text2**` → `**text1 text2**`로 정규화

### Background
- Confluence XHTML에서 별도의 `<strong>` 태그로 분리된 텍스트가 forward converter를 거치면 `**A** **B**` 형태가 됩니다.
- MDX 교정 시 이를 `**A B**`로 병합하는 것이 자연스러우며, 이 두 형태는 의미적으로 동일합니다.
- roundtrip 검증 시 이 차이를 무시하여 불필요한 FAIL을 방지합니다.

## Related tickets & links
- #740 (reverse-sync 버그 재현 테스트케이스)
- 테스트케이스 954172219 (Type 11) 해결

## Added/updated tests?
- [x] No, and this is why: 기존 테스트케이스 954172219가 이 변경으로 PASS됩니다.

## Additional notes
- `roundtrip_verifier.py`의 `verify_roundtrip()` 함수에서 기존 정규화 체인에 추가되는 방식입니다.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>