### PR TITLE
confluence-mdx: 리스트 항목의 code span 경계 변경을 감지하여 inner HTML 교체 패치를 생성합니다

### DIFF
--- a/confluence-mdx/bin/reverse_sync/xhtml_patcher.py
+++ b/confluence-mdx/bin/reverse_sync/xhtml_patcher.py
@@ -154,6 +154,7 @@ def _find_element_by_xpath(soup: BeautifulSoup, xpath: str):
 
     단일 xpath: "p[1]", "h2[3]", "macro-info[1]"
     복합 xpath: "macro-info[1]/p[1]", "macro-note[2]/ul[1]"
+    다단계 xpath: "ol[1]/li[2]/p[1]", "ul[3]/li[1]/p[1]"
     """
     parts = xpath.split('/')
     if len(parts) == 1:
@@ -165,10 +166,17 @@ def _find_element_by_xpath(soup: BeautifulSoup, xpath: str):
         return None
 
     container = _find_content_container(parent)
-    if container is None:
-        return None
+    if container is not None:
+        # macro 내부 컨테이너에서 자식 검색 (기존 동작 유지)
+        return _find_child_in_element(container, parts[1])
 
-    return _find_child_in_element(container, parts[1])
+    # macro가 아닌 일반 요소 (ol, ul 등)에서는 요소 자체를 컨테이너로 사용
+    current = parent
+    for part in parts[1:]:
+        current = _find_child_in_element(current, part)
+        if current is None:
+            return None
+    return current
 
 
 def _find_element_by_simple_xpath(soup: BeautifulSoup, xpath: str):


### PR DESCRIPTION
## Description
- 리스트 항목에서 backtick(code span) 경계가 변경된 경우, 텍스트 변경만으로는 XHTML의 `<code>` 태그 구조를 수정할 수 없는 문제를 해결합니다.
- `_has_inline_format_change()` 함수로 code span 경계 변경을 감지합니다.
- `_build_list_item_level_patches()` 함수로 개별 `<li><p>` 요소에 대한 `new_inner_xhtml` 패치를 생성합니다.
- `_find_element_by_xpath()`를 확장하여 `ol[N]/li[M]/p[K]` 형태의 다단계 xpath를 지원합니다.

### Background
- Type 12 버그: backtick이 잘못된 범위의 텍스트를 감싸고 있을 때, 개선 MDX에서 올바른 범위로 수정하면 reverse-sync가 `<code>` 태그 구조를 변경하지 못하여 roundtrip 검증에 실패합니다.
- 예: `` `Verify Deletion Key 버튼을 클릭합니다.` `` → `` `Verify Deletion Key` 버튼을 클릭합니다.``

## Related tickets & links
- #740 (reverse-sync 버그 재현 테스트케이스)
- 테스트케이스 565575990 (Type 12) 해결

## Added/updated tests?
- [x] No, and this is why: 기존 테스트케이스 565575990가 이 변경으로 PASS됩니다. 기존 16개 base 테스트 모두 통과.

## Additional notes
- `_has_inline_format_change()`는 code span만 감지합니다. bold(`**`) 경계 변경은 별도 처리가 필요합니다.
- 기존 monolithic 패치 방식을 유지하되, inline format 변경이 있는 경우에만 per-item 패치로 전환합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)