### PR TITLE
confluence-mdx: 중첩 리스트의 텍스트 전송 시 하위 항목 텍스트 소실 방지 (Type 5)

### DIFF
--- a/confluence-mdx/bin/reverse_sync/xhtml_patcher.py
+++ b/confluence-mdx/bin/reverse_sync/xhtml_patcher.py
@@ -154,6 +154,7 @@ def _find_element_by_xpath(soup: BeautifulSoup, xpath: str):
 
     단일 xpath: "p[1]", "h2[3]", "macro-info[1]"
     복합 xpath: "macro-info[1]/p[1]", "macro-note[2]/ul[1]"
+    다단계 xpath: "ol[2]/li[3]/p[1]"
     """
     parts = xpath.split('/')
     if len(parts) == 1:
@@ -165,10 +166,17 @@ def _find_element_by_xpath(soup: BeautifulSoup, xpath: str):
         return None
 
     container = _find_content_container(parent)
-    if container is None:
-        return None
+    if container is not None:
+        # macro 내부 컨테이너에서 자식 검색 (기존 동작 유지)
+        return _find_child_in_element(container, parts[1])
 
-    return _find_child_in_element(container, parts[1])
+    # macro가 아닌 일반 요소 (ol, ul 등)에서는 요소 자체를 컨테이너로 사용
+    current = parent
+    for part in parts[1:]:
+        current = _find_child_in_element(current, part)
+        if current is None:
+            return None
+    return current
 
 
 def _find_element_by_simple_xpath(soup: BeautifulSoup, xpath: str):


### PR DESCRIPTION
## Summary
- 3단계 이상 중첩된 리스트 블록에서 `_apply_text_changes`가 하위 항목의 텍스트를 상위 항목으로 병합시키는 문제를 수정합니다 (Type 5: 중첩 리스트 내용 소실)
- 중첩 항목의 첫 줄이 변경된 경우, 항목별 패치(`ol[N]/li[M]/p[1]`)를 생성하여 하위 구조를 보존합니다
- 다단계 xpath 지원 추가 (`ol[2]/li[3]/p[1]` 등)

## Test plan
- [x] Base tests: 16 passed, 0 failed (no regressions)
- [x] Bug test 544383693 (Type 5 중첩 리스트): PASS (기존 FAIL)
- [x] Bug test 544145591 (얕은 중첩 리스트): regression 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)