### PR TITLE
confluence-mdx: --recent CQL 검색을 분 단위 슬라이딩 윈도우로 개선합니다

### DIFF
--- a/confluence-mdx/bin/fetch/processor.py
+++ b/confluence-mdx/bin/fetch/processor.py
@@ -216,6 +216,19 @@ class ConfluencePageProcessor:
                 if original_count != len(modified_pages):
                     self.logger.info(f"Excluded page ID {excluded_page_id} from collection ({original_count} -> {len(modified_pages)} pages)")
 
+                # Log result set metadata at INFO level
+                if modified_pages:
+                    pages_with_date = [p for p in modified_pages if p.get("last_modified")]
+                    if pages_with_date:
+                        sorted_by_date = sorted(pages_with_date, key=lambda p: p["last_modified"])
+                        oldest = sorted_by_date[0]
+                        newest = sorted_by_date[-1]
+                        self.logger.info(
+                            f"Recent fetch result: {len(modified_pages)} pages, "
+                            f"oldest: {oldest['last_modified']} \"{oldest.get('title', 'N/A')}\", "
+                            f"newest: {newest['last_modified']} \"{newest.get('title', 'N/A')}\""
+                        )
+
                 # Download each page through all 4 stages and output to stdout
                 # Store downloaded pages for list.txt
                 self.logger.warning(f"Downloading {len(modified_pages)} recently modified pages")

--- a/confluence-mdx/bin/fetch_cli.py
+++ b/confluence-mdx/bin/fetch_cli.py
@@ -70,13 +70,17 @@ def main():
 
     parser.add_argument("--output-dir", default=Config().default_output_dir,
                         help="Directory to store output files (default: %(default)s)")
+    parser.add_argument("--verbose", "-v", action="store_true",
+                        help="Enable verbose output (sets log level to INFO)")
     parser.add_argument("--log-level", default="WARNING", choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
                         help="Set the logging level (default: %(default)s)")
     args = parser.parse_args()
 
     # Set up logging configuration
+    # --verbose flag overrides --log-level to INFO
+    effective_level = "INFO" if args.verbose else args.log_level
     logging.basicConfig(
-        level=getattr(logging, args.log_level),
+        level=getattr(logging, effective_level),
         format='%(levelname)s - %(filename)s:%(lineno)d - %(message)s',
         stream=sys.stderr
     )


### PR DESCRIPTION
## Summary
- CQL `lastModified` 조건을 날짜(`yyyy-MM-dd`)에서 일시(`yyyy-MM-dd HH:mm`)로 변경하여 검색 범위를 정밀하게 제어합니다
- 안전 마진을 1일 → 1시간으로 축소하고, `order by lastModified asc` 정렬을 적용합니다
- 미인증 API의 100건 제한을 **슬라이딩 윈도우** 방식으로 극복하여, 변경 페이지가 많아도 누락 없이 전체를 수집합니다
- `--verbose` / `-v` 옵션을 추가하여 CQL 쿼리, 라운드별 수집 현황, 결과셋의 최신/최고령 문서 메타정보를 INFO 레벨로 확인할 수 있습니다

## 변경 파일
| 파일 | 변경 내용 |
|---|---|
| `confluence-mdx/bin/fetch/api_client.py` | CQL datetime 정밀도, 슬라이딩 윈도우, 결과에 title/last_modified 추가 |
| `confluence-mdx/bin/fetch/processor.py` | 결과셋 메타정보 INFO 로깅 |
| `confluence-mdx/bin/fetch_cli.py` | `--verbose` 옵션 추가 |

## 슬라이딩 윈도우 동작 원리
```
Round 1: lastModified >= "2026-02-13 09:37" → 100건 반환
         → 배치 내 최신 lastModified = "2026-02-13 14:22"
Round 2: lastModified >= "2026-02-13 14:22" → 45건 반환
         → 100건 미만이므로 종료
결과: 중복 제거 후 총 140건 수집 완료
```

## Test plan
- [ ] `bin/fetch_cli.py --recent --verbose` 실행하여 CQL 쿼리와 라운드별 로그 확인
- [ ] `bin/fetch_cli.py --recent --days 30 --verbose` 로 넓은 범위 조회 시 슬라이딩 윈도우 동작 확인
- [ ] `bin/fetch_cli.py --verbose` 에서 결과셋 oldest/newest 메타정보 출력 확인
- [ ] `bin/fetch_cli.py --local` 등 기존 모드가 영향받지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)