### PR TITLE
confluence-mdx: 모든 CLI 프로그램에 Ctrl-C 종료 처리를 통일합니다

### DIFF
--- a/confluence-mdx/bin/convert_all.py
+++ b/confluence-mdx/bin/convert_all.py
@@ -223,4 +223,7 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/confluence-mdx/bin/converter/cli.py
+++ b/confluence-mdx/bin/converter/cli.py
@@ -227,4 +227,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/confluence-mdx/bin/dockerhub-cleanup.py
+++ b/confluence-mdx/bin/dockerhub-cleanup.py
@@ -211,4 +211,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/confluence-mdx/bin/fetch_cli.py
+++ b/confluence-mdx/bin/fetch_cli.py
@@ -108,4 +108,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/confluence-mdx/bin/find_mdx_with_text.py
+++ b/confluence-mdx/bin/find_mdx_with_text.py
@@ -295,5 +295,8 @@ def main():
 
 
 if __name__ == '__main__':
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)
 

--- a/confluence-mdx/bin/image_status.py
+++ b/confluence-mdx/bin/image_status.py
@@ -169,4 +169,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/confluence-mdx/bin/restore_alt_from_diff.py
+++ b/confluence-mdx/bin/restore_alt_from_diff.py
@@ -156,4 +156,7 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/confluence-mdx/bin/reverse_sync/test_verify.py
+++ b/confluence-mdx/bin/reverse_sync/test_verify.py
@@ -60,4 +60,7 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/confluence-mdx/bin/skeleton/cli.py
+++ b/confluence-mdx/bin/skeleton/cli.py
@@ -1526,4 +1526,7 @@ def main():
 
 
 if __name__ == '__main__':
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/confluence-mdx/bin/sync_confluence_url.py
+++ b/confluence-mdx/bin/sync_confluence_url.py
@@ -263,4 +263,7 @@ def main() -> int:
 
 
 if __name__ == '__main__':
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/confluence-mdx/bin/sync_ko_commit.py
+++ b/confluence-mdx/bin/sync_ko_commit.py
@@ -323,4 +323,7 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/confluence-mdx/bin/xhtml_beautify_diff.py
+++ b/confluence-mdx/bin/xhtml_beautify_diff.py
@@ -82,4 +82,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)


### PR DESCRIPTION
## Summary
- 13개 Python CLI 스크립트 중 `reverse_sync_cli.py`만 `KeyboardInterrupt`를 처리하고 있었으며, 나머지 12개는 Ctrl-C 시 stacktrace를 출력하고 있었습니다
- 12개 스크립트에 동일한 패턴(`except KeyboardInterrupt: sys.exit(130)`)을 추가하여 Ctrl-C 시 stacktrace 없이 즉시 종료합니다
- 종료 코드 130은 SIGINT(128+2) Unix 관례를 따릅니다

## 변경 대상 (12개 파일)
`fetch_cli.py`, `convert_all.py`, `converter/cli.py`, `skeleton/cli.py`, `dockerhub-cleanup.py`, `restore_alt_from_diff.py`, `image_status.py`, `find_mdx_with_text.py`, `sync_confluence_url.py`, `xhtml_beautify_diff.py`, `sync_ko_commit.py`, `reverse_sync/test_verify.py`

## Test plan
- [ ] 각 CLI 스크립트 실행 중 Ctrl-C 입력 시 stacktrace 없이 즉시 종료되는지 확인
- [ ] 종료 코드가 130인지 확인 (`echo $?`)
- [ ] 기존 `reverse_sync_cli.py`의 동작이 변경되지 않았는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)