### PR TITLE
feat(confluence-mdx): 검증기에 외부 diff 엔진 및 산출물 저장 옵션 추가

### DIFF
--- a/confluence-mdx/bin/mdx_to_storage_xhtml_verify_cli.py
+++ b/confluence-mdx/bin/mdx_to_storage_xhtml_verify_cli.py
@@ -33,6 +33,17 @@ def _build_parser() -> argparse.ArgumentParser:
         default=3,
         help="Max number of failing case diffs to print",
     )
+    parser.add_argument(
+        "--write-generated",
+        action="store_true",
+        help="Write generated XHTML file for each testcase",
+    )
+    parser.add_argument(
+        "--diff-engine",
+        choices=("internal", "external"),
+        default="external",
+        help="Diff engine: internal normalizer or external xhtml_beautify_diff.py",
+    )
     return parser
 
 
@@ -58,7 +69,14 @@ def main() -> int:
         print("No testcase directories containing page.xhtml + expected.mdx found.")
         return 0
 
-    results = [verify_testcase_dir(case_dir) for case_dir in case_dirs]
+    results = [
+        verify_testcase_dir(
+            case_dir,
+            write_generated=args.write_generated,
+            diff_engine=args.diff_engine,
+        )
+        for case_dir in case_dirs
+    ]
     passed = [r for r in results if r.passed]
     failed = [r for r in results if not r.passed]
 
@@ -78,4 +96,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
-

--- a/confluence-mdx/tests/README.md
+++ b/confluence-mdx/tests/README.md
@@ -60,7 +60,7 @@ make test-one TEST_ID=568918170
 
 ```bash
 cd confluence-mdx
-./bin/mdx_to_storage_xhtml_verify_cli.py --testcases-dir tests/testcases --show-diff-limit 3
+./bin/mdx_to_storage_xhtml_verify_cli.py --testcases-dir tests/testcases --diff-engine external --write-generated --show-diff-limit 3
 ```
 
 ### 출력 파일 정리

--- a/confluence-mdx/tests/test_mdx_to_storage_xhtml_verify.py
+++ b/confluence-mdx/tests/test_mdx_to_storage_xhtml_verify.py
@@ -4,6 +4,7 @@ from reverse_sync.mdx_to_storage_xhtml_verify import (
     iter_testcase_dirs,
     mdx_to_storage_xhtml_fragment,
     verify_expected_mdx_against_page_xhtml,
+    verify_testcase_dir,
 )
 
 
@@ -39,3 +40,13 @@ def test_iter_testcase_dirs_filters_required_files(tmp_path: Path):
     dirs = list(iter_testcase_dirs(tmp_path))
     assert dirs == [good]
 
+
+def test_verify_testcase_dir_writes_generated_file(tmp_path: Path):
+    case = tmp_path / "300"
+    case.mkdir()
+    (case / "expected.mdx").write_text("# Title\n\nParagraph\n", encoding="utf-8")
+    (case / "page.xhtml").write_text("<h1>Title</h1><p>Paragraph</p>", encoding="utf-8")
+
+    result = verify_testcase_dir(case, write_generated=True, diff_engine="external")
+    assert result.passed is True
+    assert (case / "generated.from.expected.xhtml").exists()


### PR DESCRIPTION
## 개요
이 PR은 검증기의 diff 생성 정확도와 운영 편의성을 높이기 위해 외부 canonical diff 도구 실행 모드와 산출물 저장 옵션을 추가합니다.

## 구현 내용
- `mdx_to_storage_xhtml_verify_cli.py`에 `--diff-engine {internal,external}` 옵션을 추가했습니다.
- 기본 diff 엔진을 `external`로 설정해 `xhtml_beautify_diff.py` 기준과 일치시켰습니다.
- 검증 모듈에서 `xhtml_beautify_diff.py`를 외부 프로세스로 직접 실행하는 경로를 추가했습니다.
- 기존 내부 비교 경로(`internal`)도 유지해 디버깅/호환성을 보장했습니다.
- `--write-generated` 옵션을 추가해 testcase별 generated XHTML 파일 저장을 지원했습니다.
- generated 파일명은 `generated.from.expected.xhtml`로 표준화했습니다.
- `verify_testcase_dir`가 diff 엔진/파일 저장 옵션을 모두 처리하도록 확장했습니다.
- CLI/모듈 구조를 분리해 테스트와 재사용성(다른 스크립트 호출)도 유지했습니다.
- 외부 엔진 + 파일 저장 동작을 검증하는 단위 테스트를 보강했습니다.
- README 실행 예제를 외부 엔진 중심으로 업데이트했습니다.
- 어떤 diff 경로를 사용했는지 옵션으로 명시 가능해 운영 가시성이 좋아졌습니다.
- 후속 변환기 개선 PR에서 실패 케이스 분석에 바로 활용 가능한 기반을 마련했습니다.

## 검증 방법
- `pytest -q confluence-mdx/tests/test_mdx_to_storage_xhtml_verify.py`
- `cd confluence-mdx && ./bin/mdx_to_storage_xhtml_verify_cli.py --testcases-dir tests/testcases --case-id 793608206 --diff-engine external --show-diff-limit 1`

## 범위 메모
이 PR은 검증 품질/운영 기능 확장에 초점을 둡니다.
테이블/매크로/콜아웃의 의미 보존율 개선은 후속 변환 로직 PR에서 진행합니다.
