### PR TITLE
feat(confluence-mdx): JSON 리포트 및 비오염 검증 실행 흐름 추가

### DIFF
--- a/confluence-mdx/tests/README.md
+++ b/confluence-mdx/tests/README.md
@@ -60,7 +60,21 @@ make test-one TEST_ID=568918170
 
 ```bash
 cd confluence-mdx
-./bin/mdx_to_storage_xhtml_verify_cli.py --testcases-dir tests/testcases --diff-engine external --write-generated --show-diff-limit 3
+./bin/mdx_to_storage_xhtml_verify_cli.py \
+  --testcases-dir tests/testcases \
+  --diff-engine external \
+  --show-diff-limit 3 \
+  --report-json var/mdx_to_xhtml_verify_report.json
+```
+
+생성 XHTML 파일을 보관하려면:
+
+```bash
+./bin/mdx_to_storage_xhtml_verify_cli.py \
+  --testcases-dir tests/testcases \
+  --diff-engine external \
+  --write-generated \
+  --generated-out-dir var/mdx_to_xhtml_generated
 ```
 
 ### 출력 파일 정리

--- a/confluence-mdx/tests/test_mdx_to_storage_xhtml_verify.py
+++ b/confluence-mdx/tests/test_mdx_to_storage_xhtml_verify.py
@@ -50,3 +50,14 @@ def test_verify_testcase_dir_writes_generated_file(tmp_path: Path):
     result = verify_testcase_dir(case, write_generated=True, diff_engine="external")
     assert result.passed is True
     assert (case / "generated.from.expected.xhtml").exists()
+
+
+def test_verify_testcase_dir_external_does_not_pollute_case_by_default(tmp_path: Path):
+    case = tmp_path / "301"
+    case.mkdir()
+    (case / "expected.mdx").write_text("# Title\n\nParagraph\n", encoding="utf-8")
+    (case / "page.xhtml").write_text("<h1>Title</h1><p>Paragraph</p>", encoding="utf-8")
+
+    result = verify_testcase_dir(case, write_generated=False, diff_engine="external")
+    assert result.passed is True
+    assert not (case / "generated.from.expected.xhtml").exists()


### PR DESCRIPTION
## 개요
이 PR은 검증 실행 시 작업 트리를 오염시키지 않도록 기본 동작을 개선하고, CI/자동화 연계를 위한 JSON 리포트를 추가합니다.

## 구현 내용
- `--report-json <path>` 옵션을 추가해 검증 요약을 JSON으로 출력할 수 있게 했습니다.
- JSON에는 total/passed/failed/failed_cases/diff_engine/write_generated 정보를 포함합니다.
- `--generated-out-dir <dir>` 옵션을 추가해 generated XHTML 저장 위치를 분리할 수 있게 했습니다.
- 외부 diff 엔진 사용 시 기본적으로 임시 파일을 사용하도록 변경했습니다.
- 따라서 `--write-generated`를 지정하지 않으면 `tests/testcases/*`가 오염되지 않습니다.
- 디버깅이 필요한 경우에는 `--write-generated` + `--generated-out-dir` 조합으로 산출물 보관이 가능합니다.
- `verify_testcase_dir`에 출력 디렉토리 라우팅 인자를 추가해 경로 제어를 명시화했습니다.
- “기본은 깨끗한 실행, 필요 시 명시적 산출물 저장” 원칙을 코드로 반영했습니다.
- 외부 엔진 기본 실행의 비오염 동작을 테스트 케이스로 추가/검증했습니다.
- README에 JSON 리포트 예제와 산출물 분리 저장 예제를 추가했습니다.
- 운영 관점에서 반복 실행 시 불필요한 untracked 파일이 쌓이는 문제를 줄였습니다.
- 자동화 파이프라인에서 후처리 가능한 표준 리포트 포맷을 확보했습니다.

## 검증 방법
- `pytest -q confluence-mdx/tests/test_mdx_to_storage_xhtml_verify.py`
- `cd confluence-mdx && ./bin/mdx_to_storage_xhtml_verify_cli.py --testcases-dir tests/testcases --case-id 793608206 --diff-engine external --show-diff-limit 0 --report-json var/mdx_to_xhtml_verify_report.json`

## 범위 메모
이 PR은 실행 안정성/리포팅 가독성 개선 PR입니다.
변환 정확도 자체(의미 보존율)는 별도 기능 개선 PR에서 계속 진행합니다.
