### PR TITLE
1단계 Task 1.3: 인라인 MDX 변환 구현

### DIFF
--- a/confluence-mdx/bin/mdx_to_storage/inline.py
+++ b/confluence-mdx/bin/mdx_to_storage/inline.py
@@ -1,17 +1,63 @@
 """Inline MDX -> XHTML conversion helpers."""
 
+import re
+
+_CODE_SPAN_RE = re.compile(r"`([^`]+)`")
+_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+_BOLD_ITALIC_RE = re.compile(r"\*\*\*(.+?)\*\*\*")
+_BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
+_ITALIC_RE = re.compile(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)")
+
 
 def convert_inline(text: str) -> str:
     """Convert inline MDX syntax to XHTML.
 
-    This is a skeleton implementation for Task 1.1.
+    Supported syntax:
+    - `code`
+    - **bold**
+    - *italic*
+    - [text](url)
     """
-    raise NotImplementedError("convert_inline is not implemented yet")
+    placeholders: list[str] = []
+
+    def _stash_code(match: re.Match[str]) -> str:
+        placeholders.append(match.group(1))
+        return f"\x00CODE{len(placeholders) - 1}\x00"
+
+    converted = _CODE_SPAN_RE.sub(_stash_code, text)
+    converted = _BOLD_ITALIC_RE.sub(r"<strong><em>\1</em></strong>", converted)
+    converted = _BOLD_RE.sub(r"<strong>\1</strong>", converted)
+    converted = _ITALIC_RE.sub(r"<em>\1</em>", converted)
+    converted = _LINK_RE.sub(r'<a href="\2">\1</a>', converted)
+
+    def _restore_code(match: re.Match[str]) -> str:
+        idx = int(match.group(1))
+        return f"<code>{placeholders[idx]}</code>"
+
+    converted = re.sub(r"\x00CODE(\d+)\x00", _restore_code, converted)
+    return converted
 
 
 def convert_heading_inline(text: str) -> str:
-    """Convert heading inline text to XHTML.
+    """Convert heading inline text while stripping bold markers.
 
-    This is a skeleton implementation for Task 1.1.
+    Heading behavior follows forward converter semantics where strong tags
+    are not emitted in headings.
     """
-    raise NotImplementedError("convert_heading_inline is not implemented yet")
+    without_bold_markers = _BOLD_RE.sub(r"\1", text)
+
+    placeholders: list[str] = []
+
+    def _stash_code(match: re.Match[str]) -> str:
+        placeholders.append(match.group(1))
+        return f"\x00CODE{len(placeholders) - 1}\x00"
+
+    converted = _CODE_SPAN_RE.sub(_stash_code, without_bold_markers)
+    converted = _LINK_RE.sub(r'<a href="\2">\1</a>', converted)
+
+    def _restore_code(match: re.Match[str]) -> str:
+        idx = int(match.group(1))
+        return f"<code>{placeholders[idx]}</code>"
+
+    converted = re.sub(r"\x00CODE(\d+)\x00", _restore_code, converted)
+    return converted

--- a/confluence-mdx/tests/test_mdx_to_storage/test_inline.py
+++ b/confluence-mdx/tests/test_mdx_to_storage/test_inline.py
@@ -1,0 +1,34 @@
+from mdx_to_storage.inline import convert_heading_inline, convert_inline
+
+
+def test_convert_inline_bold_italic_code_link():
+    src = "**bold** *italic* `code` [docs](https://example.com)"
+    got = convert_inline(src)
+    assert got == (
+        '<strong>bold</strong> <em>italic</em> '
+        '<code>code</code> <a href="https://example.com">docs</a>'
+    )
+
+
+def test_convert_inline_code_span_protects_markdown_tokens():
+    src = "`**not-bold** and [not-link](x)` and **bold**"
+    got = convert_inline(src)
+    assert got == "<code>**not-bold** and [not-link](x)</code> and <strong>bold</strong>"
+
+
+def test_convert_inline_preserves_html_entities_and_br():
+    src = "a &gt; b and c &lt; d<br/>next"
+    got = convert_inline(src)
+    assert got == "a &gt; b and c &lt; d<br/>next"
+
+
+def test_convert_inline_bold_italic_combo():
+    src = "***bold-italic***"
+    got = convert_inline(src)
+    assert got == "<strong><em>bold-italic</em></strong>"
+
+
+def test_convert_heading_inline_strips_bold_marker_and_converts_code_link():
+    src = "Heading **Bold** `code` [jump](/path)"
+    got = convert_heading_inline(src)
+    assert got == 'Heading Bold <code>code</code> <a href="/path">jump</a>'


### PR DESCRIPTION
## 요약
- `confluence-mdx/bin/mdx_to_storage/inline.py` 구현
- 코드 스팬 보호를 포함한 bold/italic/code-span/link 인라인 변환 추가
- heading 전용 인라인 변환(굵게 마커 제거 + code/link 변환) 추가
- `confluence-mdx/tests/test_mdx_to_storage/test_inline.py` 인라인 단위 테스트 추가

## 검증
- `pytest confluence-mdx/tests/test_mdx_to_storage/test_parser.py confluence-mdx/tests/test_mdx_to_storage/test_inline.py -q`
- 11 passed

## 범위
프로젝트 계획서의 Phase 1 / Task 1.3만 구현합니다.
