### PR TITLE
confluence-mdx: fetch_cli.py --recent 문서 누락 버그를 수정합니다

### DIFF
--- a/.github/workflows/generate-mdx-from-confluence.yml
+++ b/.github/workflows/generate-mdx-from-confluence.yml
@@ -57,9 +57,11 @@ jobs:
 
       - name: Generate MDX files
         working-directory: ./confluence-mdx
+        env:
+          ATLASSIAN_TOKEN: ${{ secrets.ATLASSIAN_TOKEN }}
         run: |
           set -o xtrace
-          docker compose run --rm confluence-mdx full ${{ inputs.arguments }}
+          docker compose run --rm -e ATLASSIAN_TOKEN confluence-mdx full ${{ inputs.arguments }}
 
       - name: Check for changes
         run: |

--- a/confluence-mdx/bin/fetch/processor.py
+++ b/confluence-mdx/bin/fetch/processor.py
@@ -71,7 +71,7 @@ class ConfluencePageProcessor:
                 data = self.file_manager.load_yaml(yaml_filepath)
                 if data:
                     child_ids = [child["id"] for child in data.get("results", [])]
-                    self.logger.info(f"Found {len(child_ids)} child pages for page ID {page_id}")
+                    self.logger.debug(f"Found {len(child_ids)} child pages for page ID {page_id}")
                     return child_ids
             else:
                 self.logger.warning(f"No children.v2.yaml found for page ID {page_id}")
@@ -83,7 +83,7 @@ class ConfluencePageProcessor:
     def fetch_page_tree_recursive(self, page_id: str, start_page_id: Optional[str] = None, use_local: bool = False) -> Generator[Page, None, None]:
         """Recursively fetch page tree through all 4 stages"""
         try:
-            self.logger.info(f"Processing page tree for page ID {page_id}")
+            self.logger.debug(f"Processing page tree for page ID {page_id}")
 
             # If start_page_id is not provided, use the current page_id as the starting point
             if start_page_id is None:
@@ -141,10 +141,12 @@ class ConfluencePageProcessor:
             if not v2_data or "version" not in v2_data:
                 return False
             local_version = v2_data["version"].get("number")
+            title = v2_data.get("title", "N/A")
+            created_at = v2_data["version"].get("createdAt", "N/A")
             if local_version is not None and int(local_version) == int(api_version_number):
-                self.logger.info(f"Skipped page {page_id} (local version {local_version} matches API)")
+                self.logger.info(f"Skipped page {page_id} (local version {local_version} matches API) {created_at} \"{title}\"")
                 return True
-            self.logger.info(f"Page {page_id} needs update: local version {local_version} != API version {api_version_number}")
+            self.logger.info(f"Page {page_id} needs update: local version {local_version} != API version {api_version_number} {created_at} \"{title}\"")
             return False
         except Exception:
             return False

--- a/confluence-mdx/bin/fetch/stages.py
+++ b/confluence-mdx/bin/fetch/stages.py
@@ -95,7 +95,7 @@ class Stage2Processor(StageBase):
     """Stage 2: Content Extraction - Extract and save page content."""
 
     def process(self, page_id: str) -> bool:
-        self.logger.info(f"Stage 2: Extracting content for page ID {page_id}")
+        self.logger.debug(f"Stage 2: Extracting content for page ID {page_id}")
         directory = self.get_page_directory(page_id)
 
         # Extract V1 content
@@ -108,7 +108,7 @@ class Stage2Processor(StageBase):
         if v2_data:
             self._extract_v2_content(page_id, v2_data, directory)
 
-        self.logger.info(f"Stage 2 completed for page ID {page_id}")
+        self.logger.debug(f"Stage 2 completed for page ID {page_id}")
         return True
 
     def _extract_v1_content(self, page_id: str, v1_data: Dict, directory: str) -> None:
@@ -119,26 +119,26 @@ class Stage2Processor(StageBase):
         xhtml_content = body.get("storage", {}).get("value", "")
         if xhtml_content:
             self.file_manager.save_file(os.path.join(directory, "page.xhtml"), xhtml_content)
-            self.logger.info(f"Extracted XHTML content for page ID {page_id} ({len(xhtml_content)} characters)")
+            self.logger.debug(f"Extracted XHTML content for page ID {page_id} ({len(xhtml_content)} characters)")
 
         # Extract HTML content
         html_content = body.get("view", {}).get("value", "")
         if html_content:
             self.file_manager.save_file(os.path.join(directory, "page.html"), html_content)
-            self.logger.info(f"Extracted HTML content for page ID {page_id} ({len(html_content)} characters)")
+            self.logger.debug(f"Extracted HTML content for page ID {page_id} ({len(html_content)} characters)")
 
         # Extract ancestors
         ancestors = v1_data.get("ancestors", [])
         if ancestors:
             self.file_manager.save_yaml(os.path.join(directory, "ancestors.v1.yaml"), {'results': ancestors})
-            self.logger.info(f"Extracted {len(ancestors)} ancestors for page ID {page_id}")
+            self.logger.debug(f"Extracted {len(ancestors)} ancestors for page ID {page_id}")
 
     def _extract_v2_content(self, page_id: str, v2_data: Dict, directory: str) -> None:
         """Extract content from V2 API data."""
         adf_content = v2_data.get("body", {}).get("atlas_doc_format", {}).get("value", "")
         if adf_content:
             self.file_manager.save_file(os.path.join(directory, "page.adf"), adf_content)
-            self.logger.info(f"Extracted ADF content for page ID {page_id} ({len(adf_content)} characters)")
+            self.logger.debug(f"Extracted ADF content for page ID {page_id} ({len(adf_content)} characters)")
 
 
 class Stage3Processor(StageBase):
@@ -240,7 +240,7 @@ class Stage4Processor(StageBase):
     """Stage 4: Document Listing - Generate document information for output listing."""
 
     def process(self, page_id: str, start_page_id: Optional[str] = None) -> Optional[Page]:
-        self.logger.info(f"Stage 4: Generating document list for page ID {page_id}")
+        self.logger.debug(f"Stage 4: Generating document list for page ID {page_id}")
 
         directory = self.get_page_directory(page_id)
         v1_data = self.file_manager.load_yaml(os.path.join(directory, "page.v1.yaml"))
@@ -264,7 +264,7 @@ class Stage4Processor(StageBase):
         # Build breadcrumbs
         breadcrumbs = self._build_breadcrumbs(page_id, ancestors, title, start_page_id)
 
-        self.logger.info(f"Stage 4 completed for page ID {page_id}: {title}")
+        self.logger.debug(f"Stage 4 completed for page ID {page_id}: {title}")
 
         return Page(
             page_id=page_id,


### PR DESCRIPTION
## Summary

- `fetch_cli.py --recent` 사용 시 CQL search limit(100건)과 CQL `lastModified`/`version.when` 불일치로 인해 문서가 누락되는 버그를 수정합니다
- CQL search limit을 500으로 증가하고(`CQL_SEARCH_LIMIT` 상수), sliding window stuck 시 1분 전진하여 계속 수집합니다
- GHA workflow에 `ATLASSIAN_TOKEN` secret을 전달하여 인증된 API 호출로 limit 제한을 해제합니다
- 반복적인 Stage 2/4 로그를 debug 레벨로 변경하고, skip 로그에 문서 제목과 변경일시를 추가합니다

## 근본 원인

CQL `lastModified`와 API 응답의 `version.when`이 다른 값입니다. CQL은 내부 `lastModified`(댓글, 라벨, 권한 변경 포함)로 정렬하지만, API 응답에는 해당 값이 노출되지 않아 `version.when` 기반 sliding window가 정확히 전진하지 못했습니다.

## 변경 파일

- `.github/workflows/generate-mdx-from-confluence.yml` — `ATLASSIAN_TOKEN` secret 전달
- `confluence-mdx/bin/fetch/api_client.py` — `CQL_SEARCH_LIMIT=500`, sliding window stuck 시 1분 전진
- `confluence-mdx/bin/fetch/processor.py` — skip 로그에 제목/변경일시 추가, 로그 레벨 조정
- `confluence-mdx/bin/fetch/stages.py` — Stage 2/4 로그를 debug 레벨로 변경

## Test plan

- [x] `bin/fetch_cli.py --log-level=INFO` 실행하여 161건 정상 수집 확인 (기존 100건)
- [ ] GitHub repository에 `ATLASSIAN_TOKEN` secret 설정 후 GHA workflow 실행 확인

Closes #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)