### PR TITLE
confluence-mdx: 미사용 첨부파일 삭제 시 인증 실패 버그를 수정합니다

### DIFF
--- a/confluence-mdx/bin/unused_attachments.py
+++ b/confluence-mdx/bin/unused_attachments.py
@@ -326,8 +326,11 @@ def main():
     # 삭제
     if args.delete and unused:
         sys.path.insert(0, str(_PROJECT_DIR / "bin"))
-        from fetch.config import Config
-        config = Config()
+        from reverse_sync.confluence_client import ConfluenceConfig
+        config = ConfluenceConfig()
+        if not config.email or not config.api_token:
+            logger.error("인증 정보를 찾을 수 없습니다. ~/.config/atlassian/confluence.conf를 확인하세요.")
+            sys.exit(1)
         print(f"\n{len(unused)}개 첨부파일을 삭제합니다...", file=sys.stderr)
         success, failure = delete_attachments(unused, config, logger)
         print(f"삭제 완료: 성공 {success}개, 실패 {failure}개", file=sys.stderr)


### PR DESCRIPTION
## Summary
- `unused_attachments.py --delete` 실행 시 `fetch.config.Config`가 환경변수 `ATLASSIAN_USERNAME` 미설정으로 인증에 실패(HTTP 403)하는 버그를 수정합니다
- `reverse_sync.confluence_client.ConfluenceConfig`를 사용하여 `~/.config/atlassian/confluence.conf`에서 인증 정보를 읽도록 변경합니다
- 인증 정보 누락 시 명확한 에러 메시지를 출력합니다

## Test plan
- [x] `--page-id 1911652402 --delete --verbose`로 실제 삭제 테스트 완료 (HTTP 204 성공)

🤖 Generated with [Claude Code](https://claude.com/claude-code)