### PR TITLE
feat(mdx-storage): Phase1 Task1.3 인라인 변환 구현

### DIFF
--- a/confluence-mdx/bin/mdx_to_storage/inline.py
+++ b/confluence-mdx/bin/mdx_to_storage/inline.py
@@ -1,17 +1,63 @@
 """Inline MDX -> XHTML conversion helpers."""
 
+import re
+
+_CODE_SPAN_RE = re.compile(r"`([^`]+)`")
+_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+_BOLD_ITALIC_RE = re.compile(r"\*\*\*(.+?)\*\*\*")
+_BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
+_ITALIC_RE = re.compile(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)")
+
 
 def convert_inline(text: str) -> str:
     """Convert inline MDX syntax to XHTML.
 
-    This is a skeleton implementation for Task 1.1.
+    Supported syntax:
+    - `code`
+    - **bold**
+    - *italic*
+    - [text](url)
     """
-    raise NotImplementedError("convert_inline is not implemented yet")
+    placeholders: list[str] = []
+
+    def _stash_code(match: re.Match[str]) -> str:
+        placeholders.append(match.group(1))
+        return f"\x00CODE{len(placeholders) - 1}\x00"
+
+    converted = _CODE_SPAN_RE.sub(_stash_code, text)
+    converted = _BOLD_ITALIC_RE.sub(r"<strong><em>\1</em></strong>", converted)
+    converted = _BOLD_RE.sub(r"<strong>\1</strong>", converted)
+    converted = _ITALIC_RE.sub(r"<em>\1</em>", converted)
+    converted = _LINK_RE.sub(r'<a href="\2">\1</a>', converted)
+
+    def _restore_code(match: re.Match[str]) -> str:
+        idx = int(match.group(1))
+        return f"<code>{placeholders[idx]}</code>"
+
+    converted = re.sub(r"\x00CODE(\d+)\x00", _restore_code, converted)
+    return converted
 
 
 def convert_heading_inline(text: str) -> str:
-    """Convert heading inline text to XHTML.
+    """Convert heading inline text while stripping bold markers.
 
-    This is a skeleton implementation for Task 1.1.
+    Heading behavior follows forward converter semantics where strong tags
+    are not emitted in headings.
     """
-    raise NotImplementedError("convert_heading_inline is not implemented yet")
+    without_bold_markers = _BOLD_RE.sub(r"\1", text)
+
+    placeholders: list[str] = []
+
+    def _stash_code(match: re.Match[str]) -> str:
+        placeholders.append(match.group(1))
+        return f"\x00CODE{len(placeholders) - 1}\x00"
+
+    converted = _CODE_SPAN_RE.sub(_stash_code, without_bold_markers)
+    converted = _LINK_RE.sub(r'<a href="\2">\1</a>', converted)
+
+    def _restore_code(match: re.Match[str]) -> str:
+        idx = int(match.group(1))
+        return f"<code>{placeholders[idx]}</code>"
+
+    converted = re.sub(r"\x00CODE(\d+)\x00", _restore_code, converted)
+    return converted

--- a/confluence-mdx/tests/test_mdx_to_storage/test_inline.py
+++ b/confluence-mdx/tests/test_mdx_to_storage/test_inline.py
@@ -1,0 +1,34 @@
+from mdx_to_storage.inline import convert_heading_inline, convert_inline
+
+
+def test_convert_inline_bold_italic_code_link():
+    src = "**bold** *italic* `code` [docs](https://example.com)"
+    got = convert_inline(src)
+    assert got == (
+        '<strong>bold</strong> <em>italic</em> '
+        '<code>code</code> <a href="https://example.com">docs</a>'
+    )
+
+
+def test_convert_inline_code_span_protects_markdown_tokens():
+    src = "`**not-bold** and [not-link](x)` and **bold**"
+    got = convert_inline(src)
+    assert got == "<code>**not-bold** and [not-link](x)</code> and <strong>bold</strong>"
+
+
+def test_convert_inline_preserves_html_entities_and_br():
+    src = "a &gt; b and c &lt; d<br/>next"
+    got = convert_inline(src)
+    assert got == "a &gt; b and c &lt; d<br/>next"
+
+
+def test_convert_inline_bold_italic_combo():
+    src = "***bold-italic***"
+    got = convert_inline(src)
+    assert got == "<strong><em>bold-italic</em></strong>"
+
+
+def test_convert_heading_inline_strips_bold_marker_and_converts_code_link():
+    src = "Heading **Bold** `code` [jump](/path)"
+    got = convert_heading_inline(src)
+    assert got == 'Heading Bold <code>code</code> <a href="/path">jump</a>'


### PR DESCRIPTION
## Summary
- `convert_inline()` 구현: bold, italic, bold-italic(`***`), code span, link 변환 및 HTML entity 보존
- `convert_heading_inline()` 구현: bold 마커 제거 후 code/link만 변환 (forward converter 시맨틱 일치)
- code span placeholder 보호로 내부 마크다운 토큰 간섭 방지
- 단위 테스트 5건 추가

## Test plan
- [x] `pytest tests/test_mdx_to_storage/test_inline.py` — 5/5 pass
- [x] bold, italic, code, link 개별 및 조합 변환 검증
- [x] code span 내부 마크다운 토큰 보호 검증
- [x] `***bold-italic***` 올바른 태그 중첩 검증
- [x] HTML entity (`&gt;`, `&lt;`) 및 `<br/>` 보존 검증
- [x] heading inline bold 마커 제거 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)