### PR TITLE
feat(mdx-storage): Phase1 Task1.4 XHTML 이미터 구현

### DIFF
--- a/confluence-mdx/bin/mdx_to_storage/emitter.py
+++ b/confluence-mdx/bin/mdx_to_storage/emitter.py
@@ -93,7 +93,7 @@ def _extract_code_body(content: str) -> str:
 def _emit_single_depth_list(content: str) -> str:
     parsed = _parse_list_items(content)
     if not parsed:
-        return "<ul></ul>"
+        return ""
 
     ordered = parsed[0][0]
     tag = "ol" if ordered else "ul"

--- a/confluence-mdx/tests/test_mdx_to_storage/test_emitter.py
+++ b/confluence-mdx/tests/test_mdx_to_storage/test_emitter.py
@@ -1,4 +1,6 @@
 from mdx_to_storage import emit_document, parse_mdx
+from mdx_to_storage.emitter import emit_block
+from mdx_to_storage.parser import Block
 
 
 def test_emit_heading_level_adjustment():
@@ -31,6 +33,17 @@ print("hello")
     assert "<ac:plain-text-body><![CDATA[print(\"hello\")]]></ac:plain-text-body>" in xhtml
 
 
+def test_emit_code_block_without_language():
+    mdx = """```
+some code
+```
+"""
+    xhtml = emit_document(parse_mdx(mdx))
+    assert '<ac:structured-macro ac:name="code">' in xhtml
+    assert '<ac:parameter ac:name="language">' not in xhtml
+    assert "<ac:plain-text-body><![CDATA[some code]]></ac:plain-text-body>" in xhtml
+
+
 def test_emit_list_ul_and_ol():
     ul = emit_document(parse_mdx("* a\n* b\n"))
     ol = emit_document(parse_mdx("1. a\n2. b\n"))
@@ -41,3 +54,59 @@ def test_emit_list_ul_and_ol():
 def test_emit_hr():
     xhtml = emit_document(parse_mdx("______\n"))
     assert xhtml == "<hr />"
+
+
+def test_emit_paragraph_with_inline():
+    mdx = "This is **bold** and `code` text.\n"
+    xhtml = emit_document(parse_mdx(mdx))
+    assert xhtml == "<p>This is <strong>bold</strong> and <code>code</code> text.</p>"
+
+
+def test_emit_html_block_passthrough():
+    html = '<div class="custom">content</div>'
+    block = Block(type="html_block", content=html)
+    result = emit_block(block)
+    assert result == html
+
+
+def test_emit_frontmatter_import_empty_skip():
+    block_fm = Block(type="frontmatter", content="---\ntitle: Test\n---", attrs={"title": "Test"})
+    block_imp = Block(type="import_statement", content="import X from 'y'")
+    block_empty = Block(type="empty", content="")
+    assert emit_block(block_fm) == ""
+    assert emit_block(block_imp) == ""
+    assert emit_block(block_empty) == ""
+
+
+def test_emit_document_mixed_blocks():
+    mdx = """---
+title: "My Page"
+---
+
+import { Callout } from 'nextra/components'
+
+# My Page
+
+## Introduction
+
+Welcome to the **documentation**.
+
+* item one
+* item two
+
+```bash
+echo hello
+```
+
+______
+"""
+    xhtml = emit_document(parse_mdx(mdx))
+    assert "<h1>Introduction</h1>" in xhtml
+    assert "<p>Welcome to the <strong>documentation</strong>.</p>" in xhtml
+    assert "<ul><li><p>item one</p></li><li><p>item two</p></li></ul>" in xhtml
+    assert '<ac:parameter ac:name="language">bash</ac:parameter>' in xhtml
+    assert "<![CDATA[echo hello]]>" in xhtml
+    assert "<hr />" in xhtml
+    # frontmatter, import, page title(# My Page)은 출력에 미포함
+    assert "My Page" not in xhtml
+    assert "import" not in xhtml


### PR DESCRIPTION
## Summary
- `mdx_to_storage.emitter`를 skeleton에서 실행 가능한 구현으로 전환합니다.
- `emit_block()` 구현: frontmatter/import/empty skip, heading level-1 보정, paragraph 인라인 변환, code block CDATA, list(단일 depth), hr, html_block passthrough
- `emit_document()` 구현: frontmatter title context 추출 후 block emit 조립
- page title skip: frontmatter title과 동일한 `# Title` heading 자동 제외
- 단위 테스트 5건 추가

## Test plan
- [x] `pytest -q tests/test_mdx_to_storage/test_emitter.py tests/test_mdx_to_storage/test_inline.py tests/test_mdx_to_storage/test_parser.py -v`
- [x] heading 레벨 보정 검증 (`##` → `<h1>`)
- [x] page title skip 검증 (frontmatter title 일치 시 heading 제외)
- [x] code block CDATA + language 파라미터 검증
- [x] ul/ol 리스트 생성 검증
- [x] hr 생성 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>