### PR TITLE
feat(mdx-storage): Phase1 Task1.6 단위 테스트 보강

### DIFF
--- a/confluence-mdx/tests/test_mdx_to_storage/test_emitter.py
+++ b/confluence-mdx/tests/test_mdx_to_storage/test_emitter.py
@@ -127,3 +127,17 @@ def test_emit_list_with_continuation_line():
 def test_emit_unknown_block_type_returns_empty():
     block = Block(type="unknown", content="x")
     assert emit_block(block) == ""
+
+
+def test_emit_heading_level1_without_frontmatter_emits_h1():
+    """# Heading (level 1) without matching frontmatter title → <h1> (clamped)."""
+    mdx = "# NonTitle\n"
+    xhtml = emit_document(parse_mdx(mdx))
+    assert xhtml == "<h1>NonTitle</h1>"
+
+
+def test_emit_heading_level6_emits_h5():
+    """###### Heading (level 6) → <h5> (level - 1 = 5)."""
+    mdx = "###### Deep\n"
+    xhtml = emit_document(parse_mdx(mdx))
+    assert xhtml == "<h5>Deep</h5>"

--- a/confluence-mdx/tests/test_mdx_to_storage/test_inline.py
+++ b/confluence-mdx/tests/test_mdx_to_storage/test_inline.py
@@ -44,3 +44,15 @@ def test_convert_heading_inline_keeps_non_bold_markdown_text():
     src = "Heading *italic* **Bold** [jump](/path) `x`"
     got = convert_heading_inline(src)
     assert got == 'Heading *italic* Bold <a href="/path">jump</a> <code>x</code>'
+
+
+def test_convert_inline_plain_text_passthrough():
+    src = "Just plain text without any markdown"
+    got = convert_inline(src)
+    assert got == src
+
+
+def test_convert_inline_bold_inside_link():
+    src = "[**bold link**](https://example.com)"
+    got = convert_inline(src)
+    assert got == '<a href="https://example.com"><strong>bold link</strong></a>'

--- a/confluence-mdx/tests/test_mdx_to_storage/test_parser.py
+++ b/confluence-mdx/tests/test_mdx_to_storage/test_parser.py
@@ -92,3 +92,27 @@ def test_parse_html_block_stops_before_heading():
     assert blocks[0].type == "html_block"
     assert "line2" in blocks[0].content
     assert blocks[1].type == "heading"
+
+
+def test_parse_frontmatter_unclosed_falls_through():
+    text = "---\ntitle: X\nNo closing\n"
+    blocks = parse_mdx(text)
+    # 닫히지 않은 frontmatter는 파싱되지 않고 다른 타입으로 처리
+    assert blocks[0].type != "frontmatter"
+
+
+def test_parse_code_block_unclosed_collects_to_end():
+    text = "```python\nline1\nline2\n"
+    blocks = parse_mdx(text)
+    assert blocks[0].type == "code_block"
+    assert blocks[0].language == "python"
+    assert "line1" in blocks[0].content
+    assert "line2" in blocks[0].content
+
+
+def test_parse_ordered_list_detected():
+    text = "1. first\n2. second\n"
+    blocks = parse_mdx(text)
+    assert blocks[0].type == "list"
+    assert "first" in blocks[0].content
+    assert "second" in blocks[0].content


### PR DESCRIPTION
## Summary
- Task 1.6 범위의 단위 테스트를 parser/inline/emitter 전반으로 보강합니다.
- 기존 테스트가 다루지 않던 경계/회귀성 케이스를 추가해 안정성을 높입니다.

## Test plan
- [x] `pytest tests/test_mdx_to_storage/ -v` — 38/38 pass
- [x] parser: frontmatter 미닫힘 fallthrough, 코드 블록 미닫힘, ordered list, import/empty 블록 분리, list continuation, html block 경계 검증
- [x] inline: 다중 code span+link 조합, heading italic 보존, plain text passthrough, 링크 내부 bold 변환 검증
- [x] emitter: multiline paragraph 병합, list continuation 병합, unknown block, heading level 1/6 경계 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>