### PR TITLE
feat(mdx-storage): Phase2 Task2.6 verify 정규화 필터 구현

### DIFF
--- a/confluence-mdx/bin/reverse_sync/mdx_to_storage_xhtml_verify.py
+++ b/confluence-mdx/bin/reverse_sync/mdx_to_storage_xhtml_verify.py
@@ -24,10 +24,15 @@ _IGNORED_ATTRIBUTES = {
     "ac:original-height",
     "ac:original-width",
     "ac:custom-width",
+    "ac:alt",
+    "ac:layout",
     "data-table-width",
     "data-layout",
+    "data-highlight-colour",
+    "data-card-appearance",
     "ac:breakout-mode",
     "ac:breakout-width",
+    "ri:space-key",
     "style",
     "class",
 }
@@ -116,6 +121,11 @@ def _strip_decorations(soup: BeautifulSoup) -> None:
     for tag_name in ("ac:adf-mark", "ac:inline-comment-marker"):
         for tag in soup.find_all(tag_name):
             tag.unwrap()
+    for colgroup in soup.find_all("colgroup"):
+        colgroup.decompose()
+    for p in soup.find_all("p"):
+        if not p.get_text(strip=True) and not p.find_all(True):
+            p.decompose()
 
 
 def iter_testcase_dirs(testcases_dir: Path) -> Iterable[Path]:


### PR DESCRIPTION
## Summary

- batch-verify 비교 시 Confluence XHTML의 자동 생성 속성/요소를 정규화하여 노이즈 diff를 제거합니다
- BeautifulSoup 기반 4단계 정규화 파이프라인 구현:
  1. `ac:layout`/`ac:layout-section`/`ac:layout-cell` 래핑 제거 (내용 보존)
  2. `toc`/`view-file` 등 역변환 불가 매크로 제거
  3. `ac:adf-mark`/`ac:inline-comment-marker` 장식 요소 제거, `colgroup` 제거, 빈 `<p>` 제거
  4. 무시 속성 20개 제거 (ac:macro-id, local-id, ac:alt, ac:layout, style, class 등)
- 실제 testcase page.xhtml 분석으로 누락된 필터를 보강했습니다

## Test plan

- [x] 단위 테스트 13개 전체 통과 (기존 5 + 신규 8)
- [x] 속성 무시: local-id, class, data-highlight-colour, ac:alt, ac:layout, data-card-appearance, ri:space-key 검증
- [x] 구조 제거: layout 래핑, 역변환 불가 매크로, 장식 요소, colgroup, 빈 paragraph 검증
- [x] 기존 기능 보존: pass/fail 판정, diff 리포트, testcase 디렉토리 순회 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>