### PR TITLE
feat(mdx-storage): Phase3 Task3.1 pages.yaml 기반 내부 링크 해석 구현

### DIFF
--- a/confluence-mdx/bin/mdx_to_storage/__init__.py
+++ b/confluence-mdx/bin/mdx_to_storage/__init__.py
@@ -2,10 +2,12 @@
 
 from .emitter import emit_block, emit_document
 from .inline import convert_heading_inline, convert_inline
+from .link_resolver import LinkResolver
 from .parser import Block, parse_mdx
 
 __all__ = [
     "Block",
+    "LinkResolver",
     "convert_heading_inline",
     "convert_inline",
     "emit_block",

--- a/confluence-mdx/bin/mdx_to_storage/link_resolver.py
+++ b/confluence-mdx/bin/mdx_to_storage/link_resolver.py
@@ -1,0 +1,110 @@
+"""Resolve internal markdown links to Confluence storage link macros."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Optional
+from urllib.parse import unquote
+
+import yaml
+
+
+_EXTERNAL_SCHEME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
+
+
+class LinkResolver:
+    """Resolve markdown href to Confluence page title using pages.yaml."""
+
+    def __init__(self, pages_yaml_path: Optional[Path] = None) -> None:
+        if pages_yaml_path is None:
+            pages_yaml_path = Path(__file__).resolve().parents[2] / "var" / "pages.yaml"
+        self._path_to_title: dict[str, str] = {}
+        self._titles: set[str] = set()
+        self._load_pages_yaml(pages_yaml_path)
+
+    def has_pages(self) -> bool:
+        return bool(self._path_to_title)
+
+    def resolve(self, href: str, link_text: str = "") -> tuple[Optional[str], Optional[str]]:
+        """Resolve href to (content_title, anchor) or (None, None)."""
+        raw_href = href.strip()
+        if not raw_href:
+            return None, None
+        if _EXTERNAL_SCHEME_RE.match(raw_href):
+            return None, None
+        if raw_href.startswith("#"):
+            return None, None
+
+        path_part, anchor = self._split_anchor(raw_href)
+        normalized_path = self._normalize_path(path_part)
+
+        if not normalized_path and link_text:
+            title = self._resolve_by_title(link_text)
+            if title:
+                return title, anchor
+
+        title = self._path_to_title.get(normalized_path)
+        if title:
+            return title, anchor
+
+        if link_text:
+            title = self._resolve_by_title(link_text)
+            if title:
+                return title, anchor
+        return None, None
+
+    def _load_pages_yaml(self, pages_yaml_path: Path) -> None:
+        if not pages_yaml_path.exists():
+            return
+
+        data = yaml.safe_load(pages_yaml_path.read_text(encoding="utf-8"))
+        if not isinstance(data, list):
+            return
+
+        for row in data:
+            if not isinstance(row, dict):
+                continue
+            path_list = row.get("path")
+            if not isinstance(path_list, list) or not path_list:
+                continue
+
+            title = (
+                str(row.get("title_orig") or row.get("title") or "").strip()
+            )
+            if not title:
+                continue
+
+            normalized_path = self._normalize_path("/".join(str(p) for p in path_list))
+            if normalized_path:
+                self._path_to_title[normalized_path] = title
+            self._titles.add(title)
+
+    @staticmethod
+    def _split_anchor(href: str) -> tuple[str, Optional[str]]:
+        if "#" not in href:
+            return href, None
+        path_part, anchor = href.split("#", 1)
+        return path_part, anchor if anchor else None
+
+    @staticmethod
+    def _normalize_path(path: str) -> str:
+        raw = unquote(path).strip()
+        raw = raw.lstrip("/")
+        parts: list[str] = []
+        for token in raw.split("/"):
+            segment = token.strip()
+            if not segment or segment == ".":
+                continue
+            if segment == "..":
+                if parts:
+                    parts.pop()
+                continue
+            parts.append(segment)
+        return "/".join(parts)
+
+    def _resolve_by_title(self, link_text: str) -> Optional[str]:
+        title_candidate = link_text.strip()
+        if not title_candidate:
+            return None
+        return title_candidate if title_candidate in self._titles else None

--- a/confluence-mdx/tests/test_mdx_to_storage/test_inline.py
+++ b/confluence-mdx/tests/test_mdx_to_storage/test_inline.py
@@ -1,4 +1,5 @@
 from mdx_to_storage.inline import convert_heading_inline, convert_inline
+from mdx_to_storage.link_resolver import LinkResolver
 
 
 def test_convert_inline_bold_italic_code_link():
@@ -56,3 +57,31 @@ def test_convert_inline_bold_inside_link():
     src = "[**bold link**](https://example.com)"
     got = convert_inline(src)
     assert got == '<a href="https://example.com"><strong>bold link</strong></a>'
+
+
+def test_convert_inline_internal_link_to_ac_link(tmp_path):
+    pages_yaml = tmp_path / "pages.yaml"
+    pages_yaml.write_text(
+        """
+- page_id: "1"
+  title_orig: "My Dashboard"
+  path: ["user-manual", "my-dashboard"]
+""".strip(),
+        encoding="utf-8",
+    )
+    resolver = LinkResolver(pages_yaml)
+    src = "[My Dashboard](user-manual/my-dashboard#overview)"
+    got = convert_inline(src, link_resolver=resolver)
+    assert (
+        got
+        == '<ac:link ac:anchor="overview"><ri:page ri:content-title="My Dashboard"></ri:page><ac:link-body>My Dashboard</ac:link-body></ac:link>'
+    )
+
+
+def test_convert_inline_unresolved_link_keeps_anchor(tmp_path):
+    pages_yaml = tmp_path / "pages.yaml"
+    pages_yaml.write_text("[]", encoding="utf-8")
+    resolver = LinkResolver(pages_yaml)
+    src = "[Unknown](not/found)"
+    got = convert_inline(src, link_resolver=resolver)
+    assert got == '<a href="not/found">Unknown</a>'

--- a/confluence-mdx/tests/test_mdx_to_storage/test_link_resolver.py
+++ b/confluence-mdx/tests/test_mdx_to_storage/test_link_resolver.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+from mdx_to_storage.link_resolver import LinkResolver
+
+
+def test_resolve_relative_path_to_title(tmp_path: Path):
+    pages_yaml = tmp_path / "pages.yaml"
+    pages_yaml.write_text(
+        """
+- page_id: "1"
+  title_orig: "My Dashboard"
+  path: ["user-manual", "my-dashboard"]
+""".strip(),
+        encoding="utf-8",
+    )
+    resolver = LinkResolver(pages_yaml)
+
+    title, anchor = resolver.resolve("user-manual/my-dashboard", link_text="My Dashboard")
+    assert title == "My Dashboard"
+    assert anchor is None
+
+
+def test_resolve_relative_path_with_dotdot_and_anchor(tmp_path: Path):
+    pages_yaml = tmp_path / "pages.yaml"
+    pages_yaml.write_text(
+        """
+- page_id: "1"
+  title_orig: "My Dashboard"
+  path: ["user-manual", "my-dashboard"]
+""".strip(),
+        encoding="utf-8",
+    )
+    resolver = LinkResolver(pages_yaml)
+
+    title, anchor = resolver.resolve(
+        "../../user-manual/my-dashboard#querypie-web%EC%97%90",
+        link_text="My Dashboard",
+    )
+    assert title == "My Dashboard"
+    assert anchor == "querypie-web%EC%97%90"
+
+
+def test_resolve_dot_path_by_link_text(tmp_path: Path):
+    pages_yaml = tmp_path / "pages.yaml"
+    pages_yaml.write_text(
+        """
+- page_id: "1"
+  title_orig: "SQL Request 요청하기"
+  path: ["user-manual", "workflow", "requesting-sql"]
+""".strip(),
+        encoding="utf-8",
+    )
+    resolver = LinkResolver(pages_yaml)
+
+    title, anchor = resolver.resolve(".", link_text="SQL Request 요청하기")
+    assert title == "SQL Request 요청하기"
+    assert anchor is None
+
+
+def test_external_and_hash_links_are_not_resolved(tmp_path: Path):
+    pages_yaml = tmp_path / "pages.yaml"
+    pages_yaml.write_text("[]", encoding="utf-8")
+    resolver = LinkResolver(pages_yaml)
+
+    assert resolver.resolve("https://example.com", link_text="x") == (None, None)
+    assert resolver.resolve("mailto:test@example.com", link_text="x") == (None, None)
+    assert resolver.resolve("#section", link_text="x") == (None, None)


### PR DESCRIPTION
## Summary
- `LinkResolver` 클래스를 구현하여 `pages.yaml` 기반 내부 링크를 Confluence storage link 매크로로 변환합니다
- 상대 경로(`../`, `./`)와 앵커(`#section`) 해석을 지원합니다
- 미해석 링크는 기존 `<a href>` 형태를 유지합니다

## Changes
- `mdx_to_storage/link_resolver.py` 추가: pages.yaml 로딩, 경로 정규화, title fallback 해석
- `inline.py`에 `link_resolver` 파라미터를 추가하여 내부 링크를 `<ac:link><ri:page>` 매크로로 변환합니다
- `emitter.py`에서 paragraph, list, table, html_block, blockquote, figure caption 경로에 link_resolver를 전파합니다
- `__init__.py`에서 `LinkResolver` 클래스를 export합니다

## Test plan
- [x] `pytest -q confluence-mdx/tests/test_mdx_to_storage/` — 90/90 pass
- [x] 상대 경로 및 `..` 정규화 검증
- [x] 앵커 분리 및 `ac:anchor` 속성 생성 검증
- [x] `.` 경로의 title 기반 fallback 해석 검증
- [x] 외부 링크(`https://`, `mailto:`) 및 hash-only 링크 비해석 검증
- [x] emitter 통합 검증 (monkeypatch stub)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>