### PR TITLE
feat(mdx-storage): Phase3 Task3.2 details/Badge 매크로 변환 구현

### DIFF
--- a/confluence-mdx/bin/mdx_to_storage/emitter.py
+++ b/confluence-mdx/bin/mdx_to_storage/emitter.py
@@ -19,6 +19,15 @@ _CALLOUT_TYPE_TO_MACRO = {
     "important": "note",
     "error": "warning",
 }
+_BADGE_COLOR_MAP = {
+    "green": "Green",
+    "blue": "Blue",
+    "red": "Red",
+    "yellow": "Yellow",
+    "grey": "Grey",
+    "gray": "Grey",
+    "purple": "Purple",
+}
 
 
 class _ListNode:
@@ -86,6 +95,12 @@ def emit_block(block: Block, context: Optional[dict] = None) -> str:
 
     if block.type == "blockquote":
         return _emit_blockquote(block.content)
+
+    if block.type == "details":
+        return _emit_details(block, context)
+
+    if block.type == "badge":
+        return _emit_badge(block)
 
     return ""
 
@@ -316,3 +331,40 @@ def _emit_blockquote(content: str) -> str:
 
     body = "".join(f"<p>{convert_inline(text)}</p>" for text in paragraphs)
     return f"<blockquote>{body}</blockquote>"
+
+
+def _emit_details(block: Block, context: dict) -> str:
+    summary = block.attrs.get("summary", "").strip()
+    children = block.children
+    if not children:
+        children = _parse_details_children_from_content(block.content)
+    body = "".join(emit_block(child, context=context) for child in children if child.type != "empty")
+    parts = ['<ac:structured-macro ac:name="expand">']
+    if summary:
+        parts.append(f'<ac:parameter ac:name="title">{convert_inline(summary)}</ac:parameter>')
+    parts.append(f"<ac:rich-text-body>{body}</ac:rich-text-body>")
+    parts.append("</ac:structured-macro>")
+    return "".join(parts)
+
+
+def _parse_details_children_from_content(content: str) -> list[Block]:
+    match = re.search(r"</summary>(.*?)</details>", content, flags=re.DOTALL)
+    if not match:
+        return []
+    inner = match.group(1).strip()
+    if not inner:
+        return []
+    from .parser import parse_mdx
+    return parse_mdx(inner)
+
+
+def _emit_badge(block: Block) -> str:
+    text = block.attrs.get("text", "").strip()
+    color = block.attrs.get("color", "").strip().lower()
+    colour = _BADGE_COLOR_MAP.get(color, "Grey")
+
+    parts = ['<ac:structured-macro ac:name="status">']
+    parts.append(f'<ac:parameter ac:name="title">{convert_inline(text)}</ac:parameter>')
+    parts.append(f'<ac:parameter ac:name="colour">{colour}</ac:parameter>')
+    parts.append("</ac:structured-macro>")
+    return "".join(parts)

--- a/confluence-mdx/tests/test_mdx_to_storage/test_emitter.py
+++ b/confluence-mdx/tests/test_mdx_to_storage/test_emitter.py
@@ -462,6 +462,27 @@ def test_emit_blockquote_multiple_paragraphs():
     assert xhtml == "<blockquote><p>first line</p><p>second line</p></blockquote>"
 
 
+def test_emit_details_to_expand_macro():
+    mdx = """<details>
+<summary>More Info</summary>
+First **paragraph**.
+</details>
+"""
+    xhtml = emit_document(parse_mdx(mdx))
+    assert '<ac:structured-macro ac:name="expand">' in xhtml
+    assert '<ac:parameter ac:name="title">More Info</ac:parameter>' in xhtml
+    assert "<ac:rich-text-body><p>First <strong>paragraph</strong>.</p></ac:rich-text-body>" in xhtml
+
+
+def test_emit_badge_to_status_macro():
+    mdx = '<Badge color="blue">Stable</Badge>\n'
+    xhtml = emit_document(parse_mdx(mdx))
+    assert (
+        xhtml
+        == '<ac:structured-macro ac:name="status"><ac:parameter ac:name="title">Stable</ac:parameter><ac:parameter ac:name="colour">Blue</ac:parameter></ac:structured-macro>'
+    )
+
+
 def test_emit_blockquote_multiline_single_paragraph():
     """Multiple `>` lines without blank separator → merged into one paragraph."""
     mdx = "> line one\n> line two\n> line three\n"

--- a/confluence-mdx/tests/test_mdx_to_storage/test_parser.py
+++ b/confluence-mdx/tests/test_mdx_to_storage/test_parser.py
@@ -94,7 +94,24 @@ def test_parse_paragraph_fallback():
 
 def test_parse_badge_not_html_block():
     blocks = parse_mdx('<Badge color="blue">Active</Badge> status\n')
-    assert blocks[0].type == "paragraph"
+    assert blocks[0].type == "badge"
+    assert blocks[0].attrs["color"] == "blue"
+    assert blocks[0].attrs["text"] == "Active"
+
+
+def test_parse_details_block_and_children():
+    mdx = """<details>
+<summary>More Info</summary>
+First paragraph.
+
+* item
+</details>
+"""
+    blocks = parse_mdx(mdx)
+    assert len(blocks) == 1
+    assert blocks[0].type == "details"
+    assert blocks[0].attrs["summary"] == "More Info"
+    assert [child.type for child in blocks[0].children] == ["paragraph", "empty", "list"]
 
 
 def test_parse_import_and_empty_blocks():


### PR DESCRIPTION
## Summary
- `<details><summary>` → `<ac:structured-macro ac:name="expand">` 변환을 구현합니다
- `<Badge color="X">text</Badge>` → `<ac:structured-macro ac:name="status">` 변환을 구현합니다

## Changes
- `parser.py`에 details 블록 파싱 추가: `type=details`, `attrs.summary`, 재귀 children 파싱
- `parser.py`에 badge 블록 파싱 추가: `type=badge`, `attrs.color`, `attrs.text`
- `emitter.py`에 details → expand 매크로 생성 추가: title 파라미터 + rich-text-body
- `emitter.py`에 badge → status 매크로 생성 추가: title/colour 파라미터, 색상 매핑(Blue, Green 등)
- 중복된 `_BADGE_ATTR_PATTERN`을 `_CALLOUT_ATTR_PATTERN`과 통합하여 `_ATTR_PATTERN`으로 정리합니다

## Test plan
- [x] `pytest -q confluence-mdx/tests/test_mdx_to_storage/` — 85/85 pass
- [x] details → expand 매크로 변환 검증 (summary + rich-text-body)
- [x] badge → status 매크로 변환 검증 (color 매핑)
- [x] details 블록 children 재귀 파싱 검증
- [x] badge 속성 파싱 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>