### PR TITLE
feat(mdx-storage): Phase3 Task3.3 edge case 처리 및 verify 옵션 보강

### DIFF
--- a/confluence-mdx/bin/mdx_to_storage/emitter.py
+++ b/confluence-mdx/bin/mdx_to_storage/emitter.py
@@ -63,6 +63,8 @@ def emit_block(block: Block, context: Optional[dict] = None) -> str:
 
     if block.type == "paragraph":
         paragraph_text = _join_paragraph_lines(block.content)
+        if not paragraph_text:
+            return "<p />"
         return f"<p>{convert_inline(paragraph_text, link_resolver=context.get('link_resolver'))}</p>"
 
     if block.type == "code_block":
@@ -303,6 +305,8 @@ def _split_table_row(line: str) -> list[str]:
 
 def _emit_html_block(content: str, link_resolver: Optional[LinkResolver] = None) -> str:
     stripped = content.strip()
+    if stripped in {"<p></p>", "<p/>", "<p />"}:
+        return "<p />"
     if not stripped.startswith("<table"):
         return stripped
     pattern = re.compile(r"<(td|th)([^>]*)>(.*?)</\1>", flags=re.DOTALL)
@@ -342,7 +346,7 @@ def _emit_blockquote(content: str, link_resolver: Optional[LinkResolver] = None)
         paragraphs.append(" ".join(current))
 
     if not paragraphs:
-        return "<blockquote><p></p></blockquote>"
+        return "<blockquote><p /></blockquote>"
 
     body = "".join(f"<p>{convert_inline(text, link_resolver=link_resolver)}</p>" for text in paragraphs)
     return f"<blockquote>{body}</blockquote>"

--- a/confluence-mdx/bin/mdx_to_storage/inline.py
+++ b/confluence-mdx/bin/mdx_to_storage/inline.py
@@ -11,6 +11,7 @@ _LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _BOLD_ITALIC_RE = re.compile(r"\*\*\*(.+?)\*\*\*")
 _BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
 _ITALIC_RE = re.compile(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)")
+_BR_TAG_RE = re.compile(r"<br\s*/?>", flags=re.IGNORECASE)
 
 
 def convert_inline(text: str, link_resolver: LinkResolver | None = None) -> str:
@@ -33,6 +34,7 @@ def convert_inline(text: str, link_resolver: LinkResolver | None = None) -> str:
     converted = _BOLD_RE.sub(r"<strong>\1</strong>", converted)
     converted = _ITALIC_RE.sub(r"<em>\1</em>", converted)
     converted = _convert_links(converted, link_resolver=link_resolver)
+    converted = _BR_TAG_RE.sub("<br />", converted)
 
     def _restore_code(match: re.Match[str]) -> str:
         idx = int(match.group(1))

--- a/confluence-mdx/bin/mdx_to_storage_xhtml_verify_cli.py
+++ b/confluence-mdx/bin/mdx_to_storage_xhtml_verify_cli.py
@@ -45,6 +45,11 @@ def _build_parser() -> argparse.ArgumentParser:
         type=Path,
         help="Write markdown failure analysis report to file",
     )
+    parser.add_argument(
+        "--ignore-ri-filename",
+        action="store_true",
+        help="Ignore ri:filename attribute during XHTML comparison",
+    )
     return parser
 
 
@@ -109,7 +114,10 @@ def main() -> int:
         print("No testcase directories containing page.xhtml + expected.mdx found.")
         return 0
 
-    results = [verify_testcase_dir(case_dir) for case_dir in case_dirs]
+    results = [
+        verify_testcase_dir(case_dir, ignore_ri_filename=args.ignore_ri_filename)
+        for case_dir in case_dirs
+    ]
     summary = summarize_results(results)
     failed = [r for r in results if not r.passed]
 

--- a/confluence-mdx/tests/test_mdx_to_storage/test_emitter.py
+++ b/confluence-mdx/tests/test_mdx_to_storage/test_emitter.py
@@ -70,6 +70,11 @@ def test_emit_html_block_passthrough():
     assert result == html
 
 
+def test_emit_html_block_empty_p_normalized():
+    block = Block(type="html_block", content="<p></p>")
+    assert emit_block(block) == "<p />"
+
+
 def test_emit_frontmatter_import_empty_skip():
     block_fm = Block(type="frontmatter", content="---\ntitle: Test\n---", attrs={"title": "Test"})
     block_imp = Block(type="import_statement", content="import X from 'y'")
@@ -117,6 +122,11 @@ def test_emit_paragraph_multiline_joins_with_space():
     mdx = "line one\nline two\n"
     xhtml = emit_document(parse_mdx(mdx))
     assert xhtml == "<p>line one line two</p>"
+
+
+def test_emit_paragraph_empty_content_to_self_closing_p():
+    block = Block(type="paragraph", content="\n")
+    assert emit_block(block) == "<p />"
 
 
 def test_emit_list_with_continuation_line():
@@ -532,4 +542,4 @@ def test_emit_blockquote_empty_body():
     """Empty blockquote `>` only → blockquote with empty paragraph."""
     mdx = ">\n"
     xhtml = emit_document(parse_mdx(mdx))
-    assert xhtml == "<blockquote><p></p></blockquote>"
+    assert xhtml == "<blockquote><p /></blockquote>"

--- a/confluence-mdx/tests/test_mdx_to_storage/test_inline.py
+++ b/confluence-mdx/tests/test_mdx_to_storage/test_inline.py
@@ -20,7 +20,13 @@ def test_convert_inline_code_span_protects_markdown_tokens():
 def test_convert_inline_preserves_html_entities_and_br():
     src = "a &gt; b and c &lt; d<br/>next"
     got = convert_inline(src)
-    assert got == "a &gt; b and c &lt; d<br/>next"
+    assert got == "a &gt; b and c &lt; d<br />next"
+
+
+def test_convert_inline_normalizes_br_variants():
+    src = "a<br>b<br/>c<BR />d"
+    got = convert_inline(src)
+    assert got == "a<br />b<br />c<br />d"
 
 
 def test_convert_inline_bold_italic_combo():

--- a/confluence-mdx/tests/test_mdx_to_storage_xhtml_verify.py
+++ b/confluence-mdx/tests/test_mdx_to_storage_xhtml_verify.py
@@ -37,6 +37,15 @@ def test_verify_expected_mdx_against_page_xhtml_fail_has_diff():
     assert "+++ generated-from-expected.mdx.xhtml" in diff_report
 
 
+def test_verify_expected_mdx_ignore_ri_filename_option():
+    mdx = "<figure>\n<img src=\"/images/a.png\" alt=\"a\">\n</figure>\n"
+    page = '<ac:image ac:align="center"><ri:attachment ri:filename="b.png"></ri:attachment></ac:image>'
+    passed, _generated, _diff_report = verify_expected_mdx_against_page_xhtml(
+        mdx, page, ignore_ri_filename=True
+    )
+    assert passed is True
+
+
 def test_iter_testcase_dirs_filters_required_files(tmp_path: Path):
     valid = tmp_path / "100"
     valid.mkdir()


### PR DESCRIPTION
## Summary
- `<br>` 태그 변형을 `<br />`로 정규화합니다
- 빈 paragraph를 `<p />`로 출력합니다
- verify 파이프라인에 `--ignore-ri-filename` 옵션을 추가하여 이미지 파일명 불일치를 무시할 수 있도록 합니다

## Changes
- `inline.py`: `<br>`, `<br/>`, `<BR />` 등을 `<br />`로 정규화
- `emitter.py`: 빈 paragraph → `<p />`, HTML block `<p></p>` → `<p />`, 빈 blockquote → `<blockquote><p /></blockquote>`
- `mdx_to_storage_xhtml_verify.py`: `ignore_ri_filename` 옵션을 normalize/compare 경로에 전파
- `mdx_to_storage_xhtml_verify_cli.py`: `--ignore-ri-filename` CLI 플래그 추가

## Test plan
- [x] `pytest -q` — 111/111 pass
- [x] br 정규화 변형 검증 (`<br>`, `<br/>`, `<BR />`)
- [x] 빈 paragraph/self-closing 출력 검증
- [x] `ignore_ri_filename` verify 옵션 및 CLI 전파 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>