### PR TITLE
feat(mdx-storage): Phase3 Task3.1 링크 리졸버 검증 파이프라인 정렬

### DIFF
--- a/confluence-mdx/bin/mdx_to_storage/__init__.py
+++ b/confluence-mdx/bin/mdx_to_storage/__init__.py
@@ -2,15 +2,17 @@
 
 from .emitter import emit_block, emit_document
 from .inline import convert_heading_inline, convert_inline
-from .link_resolver import LinkResolver
+from .link_resolver import LinkResolver, PageEntry, load_pages_yaml
 from .parser import Block, parse_mdx
 
 __all__ = [
     "Block",
     "LinkResolver",
+    "PageEntry",
     "convert_heading_inline",
     "convert_inline",
     "emit_block",
     "emit_document",
+    "load_pages_yaml",
     "parse_mdx",
 ]

--- a/confluence-mdx/bin/mdx_to_storage/emitter.py
+++ b/confluence-mdx/bin/mdx_to_storage/emitter.py
@@ -59,7 +59,11 @@ def emit_block(block: Block, context: Optional[dict] = None) -> str:
             return ""
 
         xhtml_level = max(1, min(6, block.level - 1))
-        return f"<h{xhtml_level}>{convert_heading_inline(heading_text)}</h{xhtml_level}>"
+        return (
+            f"<h{xhtml_level}>"
+            f"{convert_heading_inline(heading_text, link_resolver=context.get('link_resolver'))}"
+            f"</h{xhtml_level}>"
+        )
 
     if block.type == "paragraph":
         paragraph_text = _join_paragraph_lines(block.content)
@@ -108,9 +112,13 @@ def emit_block(block: Block, context: Optional[dict] = None) -> str:
     return ""
 
 
-def emit_document(blocks: list[Block]) -> str:
+def emit_document(
+    blocks: list[Block],
+    link_resolver: Optional[LinkResolver] = None,
+) -> str:
     """Emit XHTML for a full MDX document."""
-    link_resolver = LinkResolver()
+    if link_resolver is None:
+        link_resolver = LinkResolver()
     context: dict[str, object] = {"frontmatter_title": "", "link_resolver": link_resolver}
     for block in blocks:
         if block.type == "frontmatter":

--- a/confluence-mdx/bin/mdx_to_storage/inline.py
+++ b/confluence-mdx/bin/mdx_to_storage/inline.py
@@ -44,7 +44,10 @@ def convert_inline(text: str, link_resolver: LinkResolver | None = None) -> str:
     return converted
 
 
-def convert_heading_inline(text: str) -> str:
+def convert_heading_inline(
+    text: str,
+    link_resolver: LinkResolver | None = None,
+) -> str:
     """Convert heading inline text while stripping bold markers.
 
     Heading behavior follows forward converter semantics where strong tags
@@ -59,7 +62,7 @@ def convert_heading_inline(text: str) -> str:
         return f"\x00CODE{len(placeholders) - 1}\x00"
 
     converted = _CODE_SPAN_RE.sub(_stash_code, without_bold_markers)
-    converted = _convert_links(converted, link_resolver=None)
+    converted = _convert_links(converted, link_resolver=link_resolver)
 
     def _restore_code(match: re.Match[str]) -> str:
         idx = int(match.group(1))

--- a/confluence-mdx/bin/mdx_to_storage/link_resolver.py
+++ b/confluence-mdx/bin/mdx_to_storage/link_resolver.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+import posixpath
 import re
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 from urllib.parse import unquote
 
 import yaml
@@ -13,18 +15,61 @@ import yaml
 _EXTERNAL_SCHEME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
 
 
+@dataclass
+class PageEntry:
+    page_id: str
+    title_orig: str
+    path: list[str] = field(default_factory=list)
+
+
+def load_pages_yaml(yaml_path: Path) -> list[PageEntry]:
+    if not yaml_path.exists():
+        return []
+
+    loaded: Any = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, list):
+        return []
+
+    pages: list[PageEntry] = []
+    for row in loaded:
+        if not isinstance(row, dict):
+            continue
+        path_value = row.get("path")
+        if not isinstance(path_value, list):
+            continue
+        title_orig = str(row.get("title_orig") or row.get("title") or "").strip()
+        if not title_orig:
+            continue
+        pages.append(
+            PageEntry(
+                page_id=str(row.get("page_id") or ""),
+                title_orig=title_orig,
+                path=[str(p).strip("/") for p in path_value if str(p).strip("/")],
+            )
+        )
+    return pages
+
+
 class LinkResolver:
     """Resolve markdown href to Confluence page title using pages.yaml."""
 
-    def __init__(self, pages_yaml_path: Optional[Path] = None) -> None:
-        if pages_yaml_path is None:
-            pages_yaml_path = Path(__file__).resolve().parents[2] / "var" / "pages.yaml"
+    def __init__(self, pages: Optional[list[PageEntry] | Path] = None) -> None:
+        if pages is None:
+            pages = Path(__file__).resolve().parents[2] / "var" / "pages.yaml"
+        if isinstance(pages, Path):
+            pages = load_pages_yaml(pages)
+
+        self._by_id: dict[str, PageEntry] = {}
+        self._current_page: PageEntry | None = None
         self._path_to_title: dict[str, str] = {}
         self._titles: set[str] = set()
-        self._load_pages_yaml(pages_yaml_path)
+        self._load_pages(pages)
 
     def has_pages(self) -> bool:
         return bool(self._path_to_title)
+
+    def set_current_page(self, page_id: str) -> None:
+        self._current_page = self._by_id.get(str(page_id))
 
     def resolve(self, href: str, link_text: str = "") -> tuple[Optional[str], Optional[str]]:
         """Resolve href to (content_title, anchor) or (None, None)."""
@@ -38,6 +83,12 @@ class LinkResolver:
 
         path_part, anchor = self._split_anchor(raw_href)
         normalized_path = self._normalize_path(path_part)
+
+        current_page_path = self._resolve_from_current_page(path_part)
+        if current_page_path:
+            title = self._path_to_title.get(current_page_path)
+            if title:
+                return title, anchor
 
         if not normalized_path and link_text:
             title = self._resolve_by_title(link_text)
@@ -54,31 +105,14 @@ class LinkResolver:
                 return title, anchor
         return None, None
 
-    def _load_pages_yaml(self, pages_yaml_path: Path) -> None:
-        if not pages_yaml_path.exists():
-            return
-
-        data = yaml.safe_load(pages_yaml_path.read_text(encoding="utf-8"))
-        if not isinstance(data, list):
-            return
-
-        for row in data:
-            if not isinstance(row, dict):
-                continue
-            path_list = row.get("path")
-            if not isinstance(path_list, list) or not path_list:
-                continue
-
-            title = (
-                str(row.get("title_orig") or row.get("title") or "").strip()
-            )
-            if not title:
-                continue
-
-            normalized_path = self._normalize_path("/".join(str(p) for p in path_list))
+    def _load_pages(self, pages: list[PageEntry]) -> None:
+        for page in pages:
+            normalized_path = self._normalize_path("/".join(page.path))
             if normalized_path:
-                self._path_to_title[normalized_path] = title
-            self._titles.add(title)
+                self._path_to_title[normalized_path] = page.title_orig
+            self._titles.add(page.title_orig)
+            if page.page_id:
+                self._by_id[page.page_id] = page
 
     @staticmethod
     def _split_anchor(href: str) -> tuple[str, Optional[str]]:
@@ -108,3 +142,16 @@ class LinkResolver:
         if not title_candidate:
             return None
         return title_candidate if title_candidate in self._titles else None
+
+    def _resolve_from_current_page(self, path_part: str) -> Optional[str]:
+        if self._current_page is None:
+            return None
+        if not path_part or path_part.startswith("/"):
+            return None
+        if not (path_part.startswith(".") or path_part.startswith("..")):
+            return None
+
+        current_dir = "/" + "/".join(self._current_page.path[:-1])
+        joined = posixpath.normpath(posixpath.join(current_dir, path_part))
+        normalized = self._normalize_path(joined)
+        return normalized or None

--- a/confluence-mdx/tests/test_mdx_to_storage/test_inline.py
+++ b/confluence-mdx/tests/test_mdx_to_storage/test_inline.py
@@ -91,3 +91,22 @@ def test_convert_inline_unresolved_link_keeps_anchor(tmp_path):
     src = "[Unknown](not/found)"
     got = convert_inline(src, link_resolver=resolver)
     assert got == '<a href="not/found">Unknown</a>'
+
+
+def test_convert_heading_inline_with_link_resolver(tmp_path):
+    pages_yaml = tmp_path / "pages.yaml"
+    pages_yaml.write_text(
+        """
+- page_id: "1"
+  title_orig: "My Dashboard"
+  path: ["user-manual", "my-dashboard"]
+""".strip(),
+        encoding="utf-8",
+    )
+    resolver = LinkResolver(pages_yaml)
+    src = "Heading [My Dashboard](user-manual/my-dashboard#overview)"
+    got = convert_heading_inline(src, link_resolver=resolver)
+    assert (
+        got
+        == 'Heading <ac:link ac:anchor="overview"><ri:page ri:content-title="My Dashboard"></ri:page><ac:link-body>My Dashboard</ac:link-body></ac:link>'
+    )

--- a/confluence-mdx/tests/test_mdx_to_storage_xhtml_verify.py
+++ b/confluence-mdx/tests/test_mdx_to_storage_xhtml_verify.py
@@ -78,6 +78,28 @@ def test_verify_testcase_dir_reads_and_returns_case_result(tmp_path: Path):
     assert result.diff_report == ""
 
 
+def test_verify_testcase_dir_sets_current_page_on_link_resolver(tmp_path: Path):
+    case_dir = tmp_path / "544375741"
+    case_dir.mkdir()
+    (case_dir / "expected.mdx").write_text("## Heading\n\nBody\n", encoding="utf-8")
+    (case_dir / "page.xhtml").write_text("<h1>Heading</h1><p>Body</p>", encoding="utf-8")
+
+    class StubResolver:
+        def __init__(self) -> None:
+            self.current_page = None
+
+        def set_current_page(self, page_id: str) -> None:
+            self.current_page = page_id
+
+        def resolve(self, href: str, link_text: str = ""):
+            return None, None
+
+    resolver = StubResolver()
+    result = verify_testcase_dir(case_dir, link_resolver=resolver)
+    assert result.passed is True
+    assert resolver.current_page == "544375741"
+
+
 def test_verify_ignores_confluence_auto_attributes():
     mdx = "## Title\n\nBody\n"
     page = '<h1 local-id="x">Title</h1><p ac:local-id="y" class="media-group">Body</p>'


### PR DESCRIPTION
## Summary
- PR #785 계획서 기준으로 link resolver/verify 파이프라인 인터페이스를 정렬합니다.
- `--pages-yaml` 기반 resolver 주입 경로를 verify CLI에 추가합니다.
- `PageEntry`, `load_pages_yaml`, `set_current_page`를 도입해 상대 경로(`../`) 해석 기반을 보강합니다.

## Changes
- `confluence-mdx/bin/mdx_to_storage/link_resolver.py`
  - `PageEntry` dataclass 추가
  - `load_pages_yaml()` 추가
  - `set_current_page()` 추가
  - 현재 페이지 기준 상대경로(`./`, `../`) 해석 로직 추가
- `confluence-mdx/bin/mdx_to_storage/inline.py`
  - `convert_heading_inline(..., link_resolver=...)` 지원
- `confluence-mdx/bin/mdx_to_storage/emitter.py`
  - `emit_document(blocks, link_resolver=None)` 시그니처 추가
  - heading 변환 시 resolver 전달
- `confluence-mdx/bin/reverse_sync/mdx_to_storage_xhtml_verify.py`
  - resolver 주입 가능한 fragment/verify 함수 시그니처 확장
  - `verify_testcase_dir()`에서 `set_current_page(case_id)` 호출
- `confluence-mdx/bin/mdx_to_storage_xhtml_verify_cli.py`
  - `--pages-yaml` 옵션 추가
  - resolver 생성 후 `verify_testcase_dir(..., link_resolver=...)` 전달
- `confluence-mdx/bin/mdx_to_storage/__init__.py`
  - `PageEntry`, `load_pages_yaml` export 추가

## Test plan
- [x] `pytest -q confluence-mdx/tests/test_mdx_to_storage/test_link_resolver.py confluence-mdx/tests/test_mdx_to_storage/test_inline.py confluence-mdx/tests/test_mdx_to_storage/test_emitter.py confluence-mdx/tests/test_mdx_to_storage_xhtml_verify.py confluence-mdx/tests/test_mdx_to_storage_xhtml_verify_cli.py` — 107 passed
- [x] verify CLI `--pages-yaml` 옵션 전달 및 resolver 생성 검증
- [x] `set_current_page()` 호출 검증 (StubResolver 테스트)
- [x] 상대경로(`../sibling`) 해석 검증
- [x] heading inline에서 link resolver 전달 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)