### PR TITLE
docs(mdx-storage): mdx_to_storage 배치 검증 분석 리포트를 업데이트합니다

### DIFF
--- a/confluence-mdx/reports/mdx_to_storage_batch_verify_analysis.md
+++ b/confluence-mdx/reports/mdx_to_storage_batch_verify_analysis.md
@@ -1,0 +1,46 @@
+# MDX -> Storage XHTML Batch Verify Analysis
+
+- total: 21
+- passed: 1
+- failed: 20
+
+## Priority Summary
+
+- P1: 11
+- P2: 5
+- P3: 4
+
+## Reason Summary
+
+- attachment_filename_mismatch: 9
+- internal_link_unresolved: 7
+- emoticon_representation_mismatch: 4
+- adf_extension_panel_mismatch: 3
+- image_block_structure_mismatch: 3
+- other: 2
+- table_cell_structure_mismatch: 2
+- underline_tag_mismatch: 1
+- verify_filter_noise: 1
+
+## Failed Cases
+
+- 1454342158: P1 (verify_filter_noise, internal_link_unresolved, adf_extension_panel_mismatch, underline_tag_mismatch, attachment_filename_mismatch)
+- 1844969501: P1 (internal_link_unresolved)
+- 1911652402: P1 (internal_link_unresolved)
+- 544145591: P1 (image_block_structure_mismatch, attachment_filename_mismatch)
+- 544178405: P1 (internal_link_unresolved, attachment_filename_mismatch)
+- 544211126: P1 (internal_link_unresolved)
+- 544377869: P1 (internal_link_unresolved)
+- 544384417: P1 (table_cell_structure_mismatch, emoticon_representation_mismatch, attachment_filename_mismatch)
+- 692355151: P1 (internal_link_unresolved, image_block_structure_mismatch)
+- 793608206: P1 (table_cell_structure_mismatch)
+- 883654669: P1 (image_block_structure_mismatch, emoticon_representation_mismatch, attachment_filename_mismatch)
+- 544112828: P2 (attachment_filename_mismatch)
+- 544379140: P2 (adf_extension_panel_mismatch, attachment_filename_mismatch)
+- 568918170: P2 (attachment_filename_mismatch)
+- 880181257: P2 (attachment_filename_mismatch)
+- panels: P2 (adf_extension_panel_mismatch)
+- 544113141: P3 (emoticon_representation_mismatch)
+- 544375741: P3 (other)
+- 544381877: P3 (emoticon_representation_mismatch)
+- 544382364: P3 (other)


### PR DESCRIPTION
## Summary
- 21건 testcase 대상 `mdx_to_storage` batch verify 분석 리포트를 업데이트합니다.
- `ordered_list_start_mismatch` 12건이 완전 해소되어 전체 품질이 개선되었습니다.

### 검증 결과 요약

| 항목 | 이전 | 현재 | 변화 |
|---|---|---|---|
| total | 21 | 21 | - |
| passed | 0 | 1 | **+1** |
| failed | 21 | 20 | **-1** |
| P1 | 13 | 11 | **-2** |
| P2 | 4 | 5 | +1 |
| P3 | 4 | 4 | - |

### 주요 변경 사항
- `ordered_list_start_mismatch` 12건 → **0건** (완전 해소)
- `lists` 케이스가 pass로 전환
- `880181257` 등 일부 케이스가 P1 → P2로 강등

### 현재 주요 실패 원인

| 원인 | 건수 |
|---|---|
| `attachment_filename_mismatch` | 9 |
| `internal_link_unresolved` | 7 |
| `emoticon_representation_mismatch` | 4 |
| `adf_extension_panel_mismatch` | 3 |
| `image_block_structure_mismatch` | 3 |

## Test plan
- [x] `mdx_to_storage_xhtml_cli.py batch-verify --show-analysis` 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)