### PR TITLE
confluence-mdx: Phase L0 코드 통합 — reverse_sync 패키지 일원화

### DIFF
--- a/confluence-mdx/bin/mdx_to_storage_roundtrip_sidecar_cli.py
+++ b/confluence-mdx/bin/mdx_to_storage_roundtrip_sidecar_cli.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Generate roundtrip sidecar files for lossless restore."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from reverse_sync.sidecar import build_sidecar, write_sidecar
+from reverse_sync.mdx_to_storage_xhtml_verify import iter_testcase_dirs
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate expected.roundtrip.json files")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    single = sub.add_parser("generate", help="Generate sidecar from single mdx/xhtml pair")
+    single.add_argument("--mdx", type=Path, required=True, help="expected.mdx path")
+    single.add_argument("--xhtml", type=Path, required=True, help="page.xhtml path")
+    single.add_argument("--output", type=Path, required=True, help="output sidecar path")
+    single.add_argument("--page-id", default="", help="page id for metadata")
+
+    batch = sub.add_parser("batch-generate", help="Generate sidecars for testcase directories")
+    batch.add_argument(
+        "--testcases-dir",
+        type=Path,
+        default=Path("tests/testcases"),
+        help="root dir containing testcase folders",
+    )
+    batch.add_argument(
+        "--output-name",
+        default="expected.roundtrip.json",
+        help="sidecar filename per testcase",
+    )
+    return parser
+
+
+def _run_generate(args: argparse.Namespace) -> int:
+    if not args.mdx.exists() or not args.xhtml.exists():
+        print("Error: --mdx and --xhtml must exist", file=sys.stderr)
+        return 2
+
+    mdx_text = args.mdx.read_text(encoding="utf-8")
+    xhtml_text = args.xhtml.read_text(encoding="utf-8")
+    sidecar = build_sidecar(mdx_text, xhtml_text, page_id=args.page_id)
+    write_sidecar(sidecar, args.output)
+    print(f"[sidecar] wrote: {args.output}")
+    return 0
+
+
+def _run_batch_generate(args: argparse.Namespace) -> int:
+    if not args.testcases_dir.is_dir():
+        print(f"Error: testcases dir not found: {args.testcases_dir}", file=sys.stderr)
+        return 2
+
+    case_dirs = list(iter_testcase_dirs(args.testcases_dir))
+    if not case_dirs:
+        print("No testcase directories containing page.xhtml + expected.mdx found.")
+        return 0
+
+    count = 0
+    for case_dir in case_dirs:
+        mdx_text = (case_dir / "expected.mdx").read_text(encoding="utf-8")
+        xhtml_text = (case_dir / "page.xhtml").read_text(encoding="utf-8")
+        output = case_dir / args.output_name
+        sidecar = build_sidecar(mdx_text, xhtml_text, page_id=case_dir.name)
+        write_sidecar(sidecar, output)
+        count += 1
+
+    print(f"[sidecar] generated {count} files (name={args.output_name})")
+    return 0
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+    if args.command == "generate":
+        return _run_generate(args)
+    if args.command == "batch-generate":
+        return _run_batch_generate(args)
+    parser.print_help()
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/confluence-mdx/bin/mdx_to_storage_xhtml_byte_verify_cli.py
+++ b/confluence-mdx/bin/mdx_to_storage_xhtml_byte_verify_cli.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Byte-equal verify CLI for lossless roundtrip."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from reverse_sync.byte_verify import verify_case_dir
+from reverse_sync.mdx_to_storage_xhtml_verify import iter_testcase_dirs
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Byte-equal verify for MDX -> XHTML restore")
+    parser.add_argument(
+        "--testcases-dir",
+        type=Path,
+        default=Path("tests/testcases"),
+        help="Root directory containing testcase subdirectories",
+    )
+    parser.add_argument("--case-id", help="Only run one case directory")
+    parser.add_argument(
+        "--sidecar-name",
+        default="expected.roundtrip.json",
+        help="Sidecar file name inside each case dir",
+    )
+    parser.add_argument(
+        "--show-fail-limit",
+        type=int,
+        default=10,
+        help="Number of failed cases to print in detail",
+    )
+    return parser
+
+
+def _resolve_case_dirs(testcases_dir: Path, case_id: str | None) -> tuple[int, list[Path]]:
+    if not testcases_dir.is_dir():
+        print(f"Error: testcases dir not found: {testcases_dir}", file=sys.stderr)
+        return 2, []
+
+    if case_id:
+        case_dir = testcases_dir / case_id
+        if not case_dir.is_dir():
+            print(f"Error: case not found: {case_dir}", file=sys.stderr)
+            return 2, []
+        return 0, [case_dir]
+
+    case_dirs = list(iter_testcase_dirs(testcases_dir))
+    if not case_dirs:
+        print("No testcase directories containing page.xhtml + expected.mdx found.")
+    return 0, case_dirs
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    rc, case_dirs = _resolve_case_dirs(args.testcases_dir, args.case_id)
+    if rc != 0:
+        return rc
+    if not case_dirs:
+        return 0
+
+    results = [verify_case_dir(case_dir, sidecar_name=args.sidecar_name) for case_dir in case_dirs]
+    failed = [r for r in results if not r.passed]
+
+    print(
+        f"[mdx->xhtml-byte-verify] total={len(results)} passed={len(results)-len(failed)} failed={len(failed)}"
+    )
+
+    if failed:
+        print("Failed cases:", ", ".join(r.case_id for r in failed))
+        limit = max(0, args.show_fail_limit)
+        for idx, result in enumerate(failed[:limit], start=1):
+            print(
+                f"- fail#{idx} case={result.case_id} reason={result.reason} mismatch_offset={result.first_mismatch_offset}"
+            )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/confluence-mdx/bin/reverse_sync/__init__.py
+++ b/confluence-mdx/bin/reverse_sync/__init__.py
@@ -1,1 +1,8 @@
-"""Reverse Sync 패키지 — MDX ↔ Confluence XHTML 역반영 모듈."""
+"""Reverse Sync 패키지 — MDX ↔ Confluence XHTML 역반영 모듈.
+
+Sidecar 관련 기능(roundtrip sidecar v1, mapping lookup)은
+reverse_sync.sidecar 모듈에 통합되어 있다.
+
+Lossless rehydration은 reverse_sync.rehydrator 모듈에 있다.
+Byte-equal 검증은 reverse_sync.byte_verify 모듈에 있다.
+"""

--- a/confluence-mdx/bin/reverse_sync/byte_verify.py
+++ b/confluence-mdx/bin/reverse_sync/byte_verify.py
@@ -1,0 +1,62 @@
+"""Byte-equal 검증 — lossless roundtrip 결과를 page.xhtml과 비교한다."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .rehydrator import rehydrate_xhtml
+from .sidecar import load_sidecar
+
+
+@dataclass
+class ByteVerificationResult:
+    case_id: str
+    passed: bool
+    reason: str
+    first_mismatch_offset: int
+
+
+def _first_mismatch_offset(a: bytes, b: bytes) -> int:
+    limit = min(len(a), len(b))
+    for idx in range(limit):
+        if a[idx] != b[idx]:
+            return idx
+    if len(a) != len(b):
+        return limit
+    return -1
+
+
+def verify_case_dir(case_dir: Path, sidecar_name: str = "expected.roundtrip.json") -> ByteVerificationResult:
+    sidecar_path = case_dir / sidecar_name
+    if not sidecar_path.exists():
+        return ByteVerificationResult(
+            case_id=case_dir.name,
+            passed=False,
+            reason=f"sidecar_missing:{sidecar_name}",
+            first_mismatch_offset=-1,
+        )
+
+    expected_mdx = (case_dir / "expected.mdx").read_text(encoding="utf-8")
+    page_xhtml = (case_dir / "page.xhtml").read_text(encoding="utf-8")
+
+    sidecar = load_sidecar(sidecar_path)
+    generated = rehydrate_xhtml(expected_mdx, sidecar)
+
+    a = page_xhtml.encode("utf-8")
+    b = generated.encode("utf-8")
+    mismatch = _first_mismatch_offset(a, b)
+    if mismatch == -1:
+        return ByteVerificationResult(
+            case_id=case_dir.name,
+            passed=True,
+            reason="byte_equal",
+            first_mismatch_offset=-1,
+        )
+
+    return ByteVerificationResult(
+        case_id=case_dir.name,
+        passed=False,
+        reason="byte_mismatch",
+        first_mismatch_offset=mismatch,
+    )

--- a/confluence-mdx/bin/reverse_sync/patch_builder.py
+++ b/confluence-mdx/bin/reverse_sync/patch_builder.py
@@ -11,7 +11,7 @@ from reverse_sync.text_normalizer import (
     strip_for_compare,
 )
 from reverse_sync.text_transfer import transfer_text_changes
-from reverse_sync.sidecar_lookup import find_mapping_by_sidecar, SidecarEntry
+from reverse_sync.sidecar import find_mapping_by_sidecar, SidecarEntry
 from reverse_sync.mdx_to_xhtml_inline import mdx_block_to_xhtml_element
 
 

--- a/confluence-mdx/bin/reverse_sync/rehydrator.py
+++ b/confluence-mdx/bin/reverse_sync/rehydrator.py
@@ -1,0 +1,48 @@
+"""Lossless rehydration — MDX + sidecar → XHTML 복원."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+from mdx_to_storage import emit_document, parse_mdx
+
+from .sidecar import RoundtripSidecar, load_sidecar, sha256_text
+
+
+FallbackRenderer = Callable[[str], str]
+
+
+def default_fallback_renderer(mdx_text: str) -> str:
+    blocks = parse_mdx(mdx_text)
+    return emit_document(blocks)
+
+
+def sidecar_matches_mdx(mdx_text: str, sidecar: RoundtripSidecar) -> bool:
+    return sha256_text(mdx_text) == sidecar.mdx_sha256
+
+
+def rehydrate_xhtml(
+    mdx_text: str,
+    sidecar: RoundtripSidecar,
+    fallback_renderer: FallbackRenderer | None = None,
+) -> str:
+    if sidecar_matches_mdx(mdx_text, sidecar):
+        return sidecar.raw_xhtml
+
+    renderer = fallback_renderer or default_fallback_renderer
+    return renderer(mdx_text)
+
+
+def rehydrate_xhtml_from_files(
+    mdx_path: Path,
+    sidecar_path: Path,
+    fallback_renderer: FallbackRenderer | None = None,
+) -> str:
+    mdx_text = mdx_path.read_text(encoding="utf-8")
+    sidecar = load_sidecar(sidecar_path)
+    return rehydrate_xhtml(
+        mdx_text,
+        sidecar,
+        fallback_renderer=fallback_renderer,
+    )

--- a/confluence-mdx/bin/reverse_sync/sidecar.py
+++ b/confluence-mdx/bin/reverse_sync/sidecar.py
@@ -1,12 +1,98 @@
-"""Sidecar Mapping Lookup — mapping.yaml 로드 및 인덱스 구축."""
-from dataclasses import dataclass, field
+"""Sidecar 통합 모듈 — Roundtrip sidecar v1 스키마/IO + Mapping lookup/인덱스.
+
+lossless_roundtrip/sidecar.py와 sidecar_lookup.py를 통합한다.
+
+v1 (document-level):
+  RoundtripSidecar, build_sidecar, load_sidecar, write_sidecar, sha256_text
+
+Mapping lookup (mapping.yaml 기반):
+  SidecarEntry, load_sidecar_mapping, build_mdx_to_sidecar_index,
+  build_xpath_to_mapping, generate_sidecar_mapping, find_mapping_by_sidecar
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+import hashlib
+import json
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import yaml
 
 from reverse_sync.mapping_recorder import BlockMapping
 
+
+# ---------------------------------------------------------------------------
+# Roundtrip sidecar v1 — document-level hash + raw XHTML
+# ---------------------------------------------------------------------------
+
+ROUNDTRIP_SCHEMA_VERSION = "1"
+
+
+@dataclass
+class RoundtripSidecar:
+    roundtrip_schema_version: str
+    page_id: str
+    mdx_sha256: str
+    source_xhtml_sha256: str
+    raw_xhtml: str
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def build_sidecar(
+    expected_mdx: str,
+    source_xhtml: str,
+    page_id: str = "",
+) -> RoundtripSidecar:
+    return RoundtripSidecar(
+        roundtrip_schema_version=ROUNDTRIP_SCHEMA_VERSION,
+        page_id=page_id,
+        mdx_sha256=sha256_text(expected_mdx),
+        source_xhtml_sha256=sha256_text(source_xhtml),
+        raw_xhtml=source_xhtml,
+    )
+
+
+def write_sidecar(sidecar: RoundtripSidecar, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(asdict(sidecar), ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def load_sidecar(path: Path) -> RoundtripSidecar:
+    data: Any = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("invalid sidecar payload")
+
+    required = {
+        "roundtrip_schema_version",
+        "page_id",
+        "mdx_sha256",
+        "source_xhtml_sha256",
+        "raw_xhtml",
+    }
+    missing = sorted(required - set(data.keys()))
+    if missing:
+        raise ValueError(f"missing sidecar fields: {', '.join(missing)}")
+
+    return RoundtripSidecar(
+        roundtrip_schema_version=str(data["roundtrip_schema_version"]),
+        page_id=str(data["page_id"]),
+        mdx_sha256=str(data["mdx_sha256"]),
+        source_xhtml_sha256=str(data["source_xhtml_sha256"]),
+        raw_xhtml=str(data["raw_xhtml"]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mapping lookup — mapping.yaml 로드 및 인덱스 구축
+# ---------------------------------------------------------------------------
 
 @dataclass
 class SidecarEntry:

--- a/confluence-mdx/bin/reverse_sync_cli.py
+++ b/confluence-mdx/bin/reverse_sync_cli.py
@@ -221,7 +221,7 @@ def run_verify(
         yaml.dump(original_mapping_data, allow_unicode=True, default_flow_style=False))
 
     # Step 3.5: Sidecar mapping 생성 + 인덱스 구축
-    from reverse_sync.sidecar_lookup import (
+    from reverse_sync.sidecar import (
         SidecarEntry, generate_sidecar_mapping,
         build_mdx_to_sidecar_index, build_xpath_to_mapping,
     )

--- a/confluence-mdx/tests/test_mdx_to_storage_xhtml_byte_verify_cli.py
+++ b/confluence-mdx/tests/test_mdx_to_storage_xhtml_byte_verify_cli.py
@@ -1,0 +1,95 @@
+"""mdx_to_storage_xhtml_byte_verify_cli.py 유닛 테스트."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import mdx_to_storage_xhtml_byte_verify_cli as cli
+
+
+def test_main_returns_2_when_testcases_dir_missing(monkeypatch, capsys):
+    monkeypatch.setattr(
+        cli.argparse.ArgumentParser,
+        "parse_args",
+        lambda self: SimpleNamespace(
+            testcases_dir=Path("/tmp/not-found"),
+            case_id=None,
+            sidecar_name="expected.roundtrip.json",
+            show_fail_limit=10,
+        ),
+    )
+    rc = cli.main()
+    assert rc == 2
+    assert "Error: testcases dir not found" in capsys.readouterr().err
+
+
+def test_main_returns_0_when_all_pass(monkeypatch, tmp_path, capsys):
+    case = tmp_path / "100"
+    case.mkdir()
+
+    monkeypatch.setattr(
+        cli.argparse.ArgumentParser,
+        "parse_args",
+        lambda self: SimpleNamespace(
+            testcases_dir=tmp_path,
+            case_id=None,
+            sidecar_name="expected.roundtrip.json",
+            show_fail_limit=10,
+        ),
+    )
+    monkeypatch.setattr(cli, "iter_testcase_dirs", lambda _: [case])
+    monkeypatch.setattr(
+        cli,
+        "verify_case_dir",
+        lambda *args, **kwargs: SimpleNamespace(
+            case_id="100",
+            passed=True,
+            reason="byte_equal",
+            first_mismatch_offset=-1,
+        ),
+    )
+
+    rc = cli.main()
+    assert rc == 0
+    assert "total=1 passed=1 failed=0" in capsys.readouterr().out
+
+
+def test_main_returns_1_when_failures(monkeypatch, tmp_path, capsys):
+    case1 = tmp_path / "100"
+    case2 = tmp_path / "101"
+    case1.mkdir()
+    case2.mkdir()
+
+    monkeypatch.setattr(
+        cli.argparse.ArgumentParser,
+        "parse_args",
+        lambda self: SimpleNamespace(
+            testcases_dir=tmp_path,
+            case_id=None,
+            sidecar_name="expected.roundtrip.json",
+            show_fail_limit=1,
+        ),
+    )
+    monkeypatch.setattr(cli, "iter_testcase_dirs", lambda _: [case1, case2])
+
+    results = {
+        "100": SimpleNamespace(
+            case_id="100",
+            passed=False,
+            reason="byte_mismatch",
+            first_mismatch_offset=123,
+        ),
+        "101": SimpleNamespace(
+            case_id="101",
+            passed=False,
+            reason="sidecar_missing:expected.roundtrip.json",
+            first_mismatch_offset=-1,
+        ),
+    }
+
+    monkeypatch.setattr(cli, "verify_case_dir", lambda case_dir, sidecar_name=None: results[case_dir.name])
+
+    rc = cli.main()
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "total=2 passed=0 failed=2" in out
+    assert "mismatch_offset=123" in out

--- a/confluence-mdx/tests/test_reverse_sync_byte_verify.py
+++ b/confluence-mdx/tests/test_reverse_sync_byte_verify.py
@@ -1,0 +1,47 @@
+"""reverse_sync/byte_verify.py 유닛 테스트."""
+
+from reverse_sync.byte_verify import verify_case_dir
+from reverse_sync.sidecar import build_sidecar, write_sidecar
+
+
+def test_verify_case_dir_passes_when_sidecar_raw_matches_page(tmp_path):
+    case = tmp_path / "100"
+    case.mkdir()
+    mdx = "## Title\n\nBody\n"
+    xhtml = "<h1>Title</h1><p>Body</p>"
+    (case / "expected.mdx").write_text(mdx, encoding="utf-8")
+    (case / "page.xhtml").write_text(xhtml, encoding="utf-8")
+    write_sidecar(build_sidecar(mdx, xhtml, page_id="100"), case / "expected.roundtrip.json")
+
+    result = verify_case_dir(case)
+    assert result.passed is True
+    assert result.reason == "byte_equal"
+    assert result.first_mismatch_offset == -1
+
+
+def test_verify_case_dir_fails_when_sidecar_missing(tmp_path):
+    case = tmp_path / "100"
+    case.mkdir()
+    (case / "expected.mdx").write_text("## T\n", encoding="utf-8")
+    (case / "page.xhtml").write_text("<h1>T</h1>", encoding="utf-8")
+
+    result = verify_case_dir(case)
+    assert result.passed is False
+    assert result.reason.startswith("sidecar_missing")
+
+
+def test_verify_case_dir_fails_with_mismatch_offset(tmp_path):
+    case = tmp_path / "100"
+    case.mkdir()
+    mdx = "## Title\n\nBody\n"
+    (case / "expected.mdx").write_text(mdx, encoding="utf-8")
+    (case / "page.xhtml").write_text("<h1>Title</h1><p>Body!</p>", encoding="utf-8")
+    write_sidecar(
+        build_sidecar(mdx, "<h1>Title</h1><p>Body</p>", page_id="100"),
+        case / "expected.roundtrip.json",
+    )
+
+    result = verify_case_dir(case)
+    assert result.passed is False
+    assert result.reason == "byte_mismatch"
+    assert result.first_mismatch_offset >= 0

--- a/confluence-mdx/tests/test_reverse_sync_cli.py
+++ b/confluence-mdx/tests/test_reverse_sync_cli.py
@@ -509,7 +509,7 @@ def testbuild_patches_index_mapping():
     from reverse_sync.mdx_block_parser import MdxBlock
     from reverse_sync.block_diff import BlockChange
     from reverse_sync.mapping_recorder import BlockMapping
-    from reverse_sync.sidecar_lookup import SidecarEntry
+    from reverse_sync.sidecar import SidecarEntry
 
     original_blocks = [
         MdxBlock('frontmatter', '---\ntitle: T\n---\n', 1, 3),
@@ -769,7 +769,7 @@ def testbuild_patches_table_block():
     from reverse_sync.mdx_block_parser import MdxBlock
     from reverse_sync.block_diff import BlockChange
     from reverse_sync.mapping_recorder import BlockMapping
-    from reverse_sync.sidecar_lookup import SidecarEntry
+    from reverse_sync.sidecar import SidecarEntry
 
     old_table = '<table>\n<th>\n**Databased Access Control**\n</th>\n</table>\n'
     new_table = '<table>\n<th>\n**Database Access Control**\n</th>\n</table>\n'
@@ -810,7 +810,7 @@ def testbuild_patches_child_resolved():
     from reverse_sync.mdx_block_parser import MdxBlock
     from reverse_sync.block_diff import BlockChange
     from reverse_sync.mapping_recorder import BlockMapping
-    from reverse_sync.sidecar_lookup import SidecarEntry
+    from reverse_sync.sidecar import SidecarEntry
 
     original_blocks = [
         MdxBlock('paragraph', 'Old child text.\n', 1, 1),
@@ -858,7 +858,7 @@ def testbuild_patches_child_fallback_to_parent_containing():
     from reverse_sync.mdx_block_parser import MdxBlock
     from reverse_sync.block_diff import BlockChange
     from reverse_sync.mapping_recorder import BlockMapping
-    from reverse_sync.sidecar_lookup import SidecarEntry
+    from reverse_sync.sidecar import SidecarEntry
 
     original_blocks = [
         MdxBlock('paragraph', 'Unresolvable old text.\n', 1, 1),
@@ -909,7 +909,7 @@ def testbuild_patches_unmapped_block_skipped():
     from reverse_sync.mdx_block_parser import MdxBlock
     from reverse_sync.block_diff import BlockChange
     from reverse_sync.mapping_recorder import BlockMapping
-    from reverse_sync.sidecar_lookup import SidecarEntry
+    from reverse_sync.sidecar import SidecarEntry
 
     original_blocks = [
         MdxBlock('paragraph', 'Mapped text.\n', 1, 1),
@@ -946,7 +946,7 @@ def testbuild_patches_list_item_child_resolved():
     from reverse_sync.mdx_block_parser import MdxBlock
     from reverse_sync.block_diff import BlockChange
     from reverse_sync.mapping_recorder import BlockMapping
-    from reverse_sync.sidecar_lookup import SidecarEntry
+    from reverse_sync.sidecar import SidecarEntry
 
     old_list = '- Item A old\n- Item B\n'
     new_list = '- Item A new\n- Item B\n'
@@ -1008,7 +1008,7 @@ def testbuild_patches_list_item_fallback_to_parent():
     from reverse_sync.mdx_block_parser import MdxBlock
     from reverse_sync.block_diff import BlockChange
     from reverse_sync.mapping_recorder import BlockMapping
-    from reverse_sync.sidecar_lookup import SidecarEntry
+    from reverse_sync.sidecar import SidecarEntry
 
     old_list = '- 변경할 텍스트입니다\n'
     new_list = '- 변경된 텍스트입니다\n'

--- a/confluence-mdx/tests/test_reverse_sync_e2e.py
+++ b/confluence-mdx/tests/test_reverse_sync_e2e.py
@@ -9,7 +9,7 @@ from reverse_sync.mapping_recorder import record_mapping
 from reverse_sync.xhtml_patcher import patch_xhtml
 from reverse_sync_cli import run_verify, MdxSource
 from reverse_sync.patch_builder import build_patches
-from reverse_sync.sidecar_lookup import (
+from reverse_sync.sidecar import (
     SidecarEntry, generate_sidecar_mapping,
     build_mdx_to_sidecar_index, build_xpath_to_mapping,
 )

--- a/confluence-mdx/tests/test_reverse_sync_patch_builder.py
+++ b/confluence-mdx/tests/test_reverse_sync_patch_builder.py
@@ -8,7 +8,7 @@ build_table_row_patches, build_list_item_patches) 테스트.
 from reverse_sync.block_diff import BlockChange
 from reverse_sync.mapping_recorder import BlockMapping
 from reverse_sync.mdx_block_parser import MdxBlock
-from reverse_sync.sidecar_lookup import SidecarEntry
+from reverse_sync.sidecar import SidecarEntry
 from reverse_sync.patch_builder import (
     _find_containing_mapping,
     _resolve_child_mapping,

--- a/confluence-mdx/tests/test_reverse_sync_rehydrator.py
+++ b/confluence-mdx/tests/test_reverse_sync_rehydrator.py
@@ -1,0 +1,48 @@
+"""reverse_sync/rehydrator.py 유닛 테스트."""
+
+from reverse_sync.rehydrator import (
+    rehydrate_xhtml,
+    rehydrate_xhtml_from_files,
+    sidecar_matches_mdx,
+)
+from reverse_sync.sidecar import build_sidecar, write_sidecar
+
+
+def test_sidecar_matches_mdx_true_when_hash_same():
+    mdx = "## Title\n\nBody\n"
+    sidecar = build_sidecar(mdx, "<h1>Title</h1><p>Body</p>")
+    assert sidecar_matches_mdx(mdx, sidecar) is True
+
+
+def test_rehydrate_xhtml_returns_raw_when_hash_matches():
+    mdx = "## Title\n\nBody\n"
+    raw = "<h1>Title</h1><p>Body</p>"
+    sidecar = build_sidecar(mdx, raw)
+    assert rehydrate_xhtml(mdx, sidecar) == raw
+
+
+def test_rehydrate_xhtml_fallback_when_hash_mismatch():
+    mdx = "## Changed\n\nBody\n"
+    sidecar = build_sidecar("## Title\n\nBody\n", "<h1>Title</h1><p>Body</p>")
+
+    called = {}
+
+    def _fallback(text: str) -> str:
+        called["mdx"] = text
+        return "<x-fallback />"
+
+    restored = rehydrate_xhtml(mdx, sidecar, fallback_renderer=_fallback)
+    assert restored == "<x-fallback />"
+    assert called["mdx"] == mdx
+
+
+def test_rehydrate_xhtml_from_files(tmp_path):
+    mdx_path = tmp_path / "expected.mdx"
+    sidecar_path = tmp_path / "expected.roundtrip.json"
+    mdx = "## Title\n\nBody\n"
+    raw = "<h1>Title</h1><p>Body</p>"
+    mdx_path.write_text(mdx, encoding="utf-8")
+    write_sidecar(build_sidecar(mdx, raw, page_id="100"), sidecar_path)
+
+    restored = rehydrate_xhtml_from_files(mdx_path, sidecar_path)
+    assert restored == raw

--- a/confluence-mdx/tests/test_reverse_sync_structural.py
+++ b/confluence-mdx/tests/test_reverse_sync_structural.py
@@ -4,7 +4,7 @@ from reverse_sync.block_diff import diff_blocks
 from reverse_sync.mapping_recorder import record_mapping
 from reverse_sync.patch_builder import build_patches
 from reverse_sync.xhtml_patcher import patch_xhtml
-from reverse_sync.sidecar_lookup import (
+from reverse_sync.sidecar import (
     SidecarEntry, build_mdx_to_sidecar_index, build_xpath_to_mapping,
 )
 


### PR DESCRIPTION
## Summary

- `sidecar_lookup.py`를 `reverse_sync/sidecar.py`에 병합하여 sidecar 관련 코드를 단일 모듈로 통합합니다
- PR #790 (lossless_roundtrip)의 v1 sidecar 스키마(RoundtripSidecar, build/load/write)를 `reverse_sync/sidecar.py`에 직접 구현합니다
- `reverse_sync/rehydrator.py`, `reverse_sync/byte_verify.py` 신규 모듈을 추가합니다
- Sidecar 생성/검증 CLI(`mdx_to_storage_roundtrip_sidecar_cli.py`, `mdx_to_storage_xhtml_byte_verify_cli.py`)를 추가합니다

## Motivation

[계획서](https://github.com/jk-kim0/skills-jk/blob/main/projects/active/querypie-docs-mdx-to-storage-xhtml-cli.md)의 Phase L0에 해당합니다.

`lossless_roundtrip` 패키지를 별도로 만들지 않고 `reverse_sync`에 직접 통합하여:
- 중복 코드 제거 (`iter_case_dirs` vs `iter_testcase_dirs`)
- sidecar 관련 코드를 단일 진입점으로 통합 (`sidecar_lookup.py` + roundtrip sidecar v1)
- 후속 Phase L1(sidecar v2 스키마)의 확장 기반 마련

## Changes

| 파일 | 변경 |
|------|------|
| `reverse_sync/sidecar.py` | **신규** — sidecar_lookup.py 흡수 + roundtrip v1 스키마 통합 |
| `reverse_sync/rehydrator.py` | **신규** — MDX+sidecar → XHTML 복원 |
| `reverse_sync/byte_verify.py` | **신규** — byte-equal 검증 |
| `mdx_to_storage_roundtrip_sidecar_cli.py` | **신규** — sidecar 생성 CLI |
| `mdx_to_storage_xhtml_byte_verify_cli.py` | **신규** — byte-equal 검증 CLI |
| `reverse_sync/sidecar_lookup.py` | **삭제** → sidecar.py에 병합 |
| `patch_builder.py`, `reverse_sync_cli.py` 등 | import 경로 변경 |
| `test_reverse_sync_sidecar.py` 등 | rename + 신규 테스트 14개 추가 |

## Test plan

- [x] 기존 567개 테스트 전체 pass 확인 (import 경로 변경 후 regression 없음)
- [x] 신규 14개 테스트 추가 (sidecar v1 CRUD, rehydrator, byte_verify, CLI)
- [x] 총 581개 테스트 pass

> PR #790은 이 PR에 의해 대체되므로 close 예정입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)