### PR TITLE
confluence-mdx: Phase L1 Sidecar v2 블록 프래그먼트 추출 구현

### DIFF
--- a/confluence-mdx/bin/mdx_to_storage_roundtrip_sidecar_cli.py
+++ b/confluence-mdx/bin/mdx_to_storage_roundtrip_sidecar_cli.py
@@ -43,7 +43,7 @@ def _run_generate(args: argparse.Namespace) -> int:
 
     mdx_text = args.mdx.read_text(encoding="utf-8")
     xhtml_text = args.xhtml.read_text(encoding="utf-8")
-    sidecar = build_sidecar(mdx_text, xhtml_text, page_id=args.page_id)
+    sidecar = build_sidecar(xhtml_text, mdx_text, page_id=args.page_id)
     write_sidecar(sidecar, args.output)
     print(f"[sidecar] wrote: {args.output}")
     return 0
@@ -60,15 +60,23 @@ def _run_batch_generate(args: argparse.Namespace) -> int:
         return 0
 
     count = 0
+    errors = 0
     for case_dir in case_dirs:
         mdx_text = (case_dir / "expected.mdx").read_text(encoding="utf-8")
         xhtml_text = (case_dir / "page.xhtml").read_text(encoding="utf-8")
         output = case_dir / args.output_name
-        sidecar = build_sidecar(mdx_text, xhtml_text, page_id=case_dir.name)
-        write_sidecar(sidecar, output)
-        count += 1
+        try:
+            sidecar = build_sidecar(xhtml_text, mdx_text, page_id=case_dir.name)
+            write_sidecar(sidecar, output)
+            count += 1
+        except Exception as e:
+            errors += 1
+            print(f"[sidecar] ERROR {case_dir.name}: {e}", file=sys.stderr)
 
     print(f"[sidecar] generated {count} files (name={args.output_name})")
+    if errors:
+        print(f"[sidecar] {errors} errors", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/confluence-mdx/bin/reverse_sync/fragment_extractor.py
+++ b/confluence-mdx/bin/reverse_sync/fragment_extractor.py
@@ -1,0 +1,203 @@
+"""Fragment Extractor — XHTML에서 top-level block fragment를 byte-exact 추출한다.
+
+BS4로 DOM 구조를 파악한 뒤 원본 텍스트에서 태그 경계를 추적하여
+BeautifulSoup의 변형 없이 원본 그대로의 fragment를 추출한다.
+
+핵심 불변식:
+  prefix + fragments[0] + separators[0] + ... + fragments[-1] + suffix == xhtml_text
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Tuple
+
+from bs4 import BeautifulSoup, NavigableString, Tag
+
+from reverse_sync.mapping_recorder import _iter_block_children
+
+
+@dataclass
+class FragmentExtractionResult:
+    """XHTML fragment 추출 결과."""
+
+    prefix: str
+    fragments: List[str]
+    separators: List[str]  # len == len(fragments) - 1
+    suffix: str
+
+
+def extract_block_fragments(xhtml_text: str) -> FragmentExtractionResult:
+    """원본 XHTML 텍스트에서 top-level block fragment를 추출한다.
+
+    _iter_block_children()과 동일한 순서로 top-level 요소를 식별한 뒤,
+    원본 텍스트에서 태그 경계를 직접 추적하여 byte-exact fragment를 추출한다.
+
+    Returns:
+        FragmentExtractionResult (prefix, fragments, separators, suffix)
+
+    Raises:
+        ValueError: 태그 경계를 찾지 못한 경우
+    """
+    soup = BeautifulSoup(xhtml_text, "html.parser")
+
+    # Top-level element 순서 파악
+    top_elements: List[Tuple[str, str]] = []
+    for child in _iter_block_children(soup):
+        if isinstance(child, Tag):
+            top_elements.append(("tag", child.name))
+        elif isinstance(child, NavigableString):
+            text = str(child).strip()
+            if text:
+                top_elements.append(("text", text))
+
+    if not top_elements:
+        return FragmentExtractionResult(
+            prefix=xhtml_text, fragments=[], separators=[], suffix=""
+        )
+
+    # 원본 텍스트에서 위치 추적
+    positions: List[Tuple[int, int]] = []
+    search_pos = 0
+
+    for elem_type, elem_info in top_elements:
+        if elem_type == "tag":
+            start = _find_tag_start(xhtml_text, elem_info, search_pos)
+            if start < 0:
+                raise ValueError(
+                    f"Cannot find <{elem_info}> at or after position {search_pos}"
+                )
+            end = _find_element_end(xhtml_text, elem_info, start)
+            positions.append((start, end))
+            search_pos = end
+        else:
+            # NavigableString — 원본 텍스트에서 찾기
+            idx = xhtml_text.find(elem_info, search_pos)
+            if idx >= 0:
+                positions.append((idx, idx + len(elem_info)))
+                search_pos = idx + len(elem_info)
+
+    if not positions:
+        return FragmentExtractionResult(
+            prefix=xhtml_text, fragments=[], separators=[], suffix=""
+        )
+
+    # 결과 구성
+    prefix = xhtml_text[: positions[0][0]]
+    suffix = xhtml_text[positions[-1][1] :]
+    fragments = [xhtml_text[s:e] for s, e in positions]
+    separators = [
+        xhtml_text[positions[i][1] : positions[i + 1][0]]
+        for i in range(len(positions) - 1)
+    ]
+
+    return FragmentExtractionResult(
+        prefix=prefix,
+        fragments=fragments,
+        separators=separators,
+        suffix=suffix,
+    )
+
+
+def _find_tag_start(text: str, tag_name: str, start_pos: int) -> int:
+    """원본 텍스트에서 <tag_name 의 시작 위치를 찾는다.
+
+    <tag_name 뒤에 공백, >, / 중 하나가 와야 실제 태그로 인정한다.
+    (예: <p 를 찾을 때 <pre 를 건너뛴다.)
+    """
+    prefix = f"<{tag_name}"
+    pos = start_pos
+    while pos < len(text):
+        idx = text.find(prefix, pos)
+        if idx < 0:
+            return -1
+        next_pos = idx + len(prefix)
+        if next_pos >= len(text):
+            return idx
+        nc = text[next_pos]
+        if nc in (" ", ">", "/", "\t", "\n", "\r"):
+            return idx
+        pos = idx + 1
+    return -1
+
+
+def _find_tag_close_gt(text: str, start: int) -> int:
+    """Opening tag의 닫는 ``>`` 위치를 찾는다.
+
+    따옴표(``"`` / ``'``) 안의 ``>``는 건너뛴다.
+    """
+    in_quote = None
+    for i in range(start, len(text)):
+        c = text[i]
+        if in_quote:
+            if c == in_quote:
+                in_quote = None
+        elif c in ('"', "'"):
+            in_quote = c
+        elif c == ">":
+            return i
+    return -1
+
+
+def _find_element_end(text: str, tag_name: str, open_tag_start: int) -> int:
+    """Element의 끝 위치(exclusive)를 찾는다.
+
+    Self-closing tag (``<tag ... />``)와 중첩된 동일 이름 태그를 올바르게 처리한다.
+
+    Returns:
+        element 끝 위치 (exclusive)
+
+    Raises:
+        ValueError: 닫는 태그를 찾지 못한 경우
+    """
+    gt = _find_tag_close_gt(text, open_tag_start)
+    if gt < 0:
+        raise ValueError(f"No closing > for <{tag_name}> at {open_tag_start}")
+
+    # Self-closing 확인
+    if text[gt - 1] == "/":
+        return gt + 1
+
+    # Matching close tag 찾기 (depth counting)
+    close_tag = f"</{tag_name}>"
+    open_prefix = f"<{tag_name}"
+    depth = 1
+    pos = gt + 1
+
+    while depth > 0:
+        lt = text.find("<", pos)
+        if lt < 0:
+            raise ValueError(f"Unclosed <{tag_name}> (depth={depth})")
+
+        # Close tag 확인
+        if text.startswith(close_tag, lt):
+            depth -= 1
+            if depth == 0:
+                return lt + len(close_tag)
+            pos = lt + len(close_tag)
+            continue
+
+        # Same-name opening tag 확인
+        if text.startswith(open_prefix, lt):
+            next_char_pos = lt + len(open_prefix)
+            if next_char_pos < len(text) and text[next_char_pos] in (
+                " ",
+                ">",
+                "/",
+                "\t",
+                "\n",
+                "\r",
+            ):
+                inner_gt = _find_tag_close_gt(text, lt)
+                if inner_gt >= 0 and text[inner_gt - 1] == "/":
+                    pos = inner_gt + 1  # self-closing → depth 불변
+                else:
+                    depth += 1
+                    pos = inner_gt + 1 if inner_gt >= 0 else lt + 1
+            else:
+                pos = lt + 1
+            continue
+
+        pos = lt + 1
+
+    raise ValueError(f"Depth counting failed for <{tag_name}>")

--- a/confluence-mdx/bin/reverse_sync/rehydrator.py
+++ b/confluence-mdx/bin/reverse_sync/rehydrator.py
@@ -28,7 +28,7 @@ def rehydrate_xhtml(
     fallback_renderer: FallbackRenderer | None = None,
 ) -> str:
     if sidecar_matches_mdx(mdx_text, sidecar):
-        return sidecar.raw_xhtml
+        return sidecar.reassemble_xhtml()
 
     renderer = fallback_renderer or default_fallback_renderer
     return renderer(mdx_text)

--- a/confluence-mdx/tests/test_reverse_sync_byte_verify.py
+++ b/confluence-mdx/tests/test_reverse_sync_byte_verify.py
@@ -7,11 +7,11 @@ from reverse_sync.sidecar import build_sidecar, write_sidecar
 def test_verify_case_dir_passes_when_sidecar_raw_matches_page(tmp_path):
     case = tmp_path / "100"
     case.mkdir()
-    mdx = "## Title\n\nBody\n"
     xhtml = "<h1>Title</h1><p>Body</p>"
+    mdx = "## Title\n\nBody\n"
     (case / "expected.mdx").write_text(mdx, encoding="utf-8")
     (case / "page.xhtml").write_text(xhtml, encoding="utf-8")
-    write_sidecar(build_sidecar(mdx, xhtml, page_id="100"), case / "expected.roundtrip.json")
+    write_sidecar(build_sidecar(xhtml, mdx, page_id="100"), case / "expected.roundtrip.json")
 
     result = verify_case_dir(case)
     assert result.passed is True
@@ -33,13 +33,12 @@ def test_verify_case_dir_fails_when_sidecar_missing(tmp_path):
 def test_verify_case_dir_fails_with_mismatch_offset(tmp_path):
     case = tmp_path / "100"
     case.mkdir()
+    xhtml_original = "<h1>Title</h1><p>Body</p>"
+    xhtml_different = "<h1>Title</h1><p>Body!</p>"
     mdx = "## Title\n\nBody\n"
     (case / "expected.mdx").write_text(mdx, encoding="utf-8")
-    (case / "page.xhtml").write_text("<h1>Title</h1><p>Body!</p>", encoding="utf-8")
-    write_sidecar(
-        build_sidecar(mdx, "<h1>Title</h1><p>Body</p>", page_id="100"),
-        case / "expected.roundtrip.json",
-    )
+    (case / "page.xhtml").write_text(xhtml_different, encoding="utf-8")
+    write_sidecar(build_sidecar(xhtml_original, mdx, page_id="100"), case / "expected.roundtrip.json")
 
     result = verify_case_dir(case)
     assert result.passed is False

--- a/confluence-mdx/tests/test_reverse_sync_fragment_extractor.py
+++ b/confluence-mdx/tests/test_reverse_sync_fragment_extractor.py
@@ -1,0 +1,183 @@
+"""reverse_sync/fragment_extractor.py 유닛 테스트."""
+
+import pytest
+
+from reverse_sync.fragment_extractor import (
+    FragmentExtractionResult,
+    extract_block_fragments,
+    _find_element_end,
+    _find_tag_close_gt,
+    _find_tag_start,
+)
+
+
+class TestFindTagStart:
+    def test_finds_simple_tag(self):
+        assert _find_tag_start("<h1>Title</h1>", "h1", 0) == 0
+
+    def test_skips_prefix_match(self):
+        text = "<pre>code</pre><p>text</p>"
+        assert _find_tag_start(text, "p", 0) == 15
+
+    def test_finds_from_offset(self):
+        text = "<p>first</p><p>second</p>"
+        assert _find_tag_start(text, "p", 12) == 12
+
+    def test_returns_neg1_when_not_found(self):
+        assert _find_tag_start("<div>text</div>", "p", 0) == -1
+
+    def test_finds_namespace_tag(self):
+        text = '<ac:structured-macro ac:name="info">body</ac:structured-macro>'
+        assert _find_tag_start(text, "ac:structured-macro", 0) == 0
+
+    def test_self_closing_tag(self):
+        assert _find_tag_start("<hr />", "hr", 0) == 0
+
+    def test_tag_with_attrs(self):
+        text = '<p style="color:red">text</p>'
+        assert _find_tag_start(text, "p", 0) == 0
+
+
+class TestFindTagCloseGt:
+    def test_simple(self):
+        assert _find_tag_close_gt("<p>", 0) == 2
+
+    def test_with_attrs(self):
+        text = '<p class="x">'
+        assert _find_tag_close_gt(text, 0) == 12
+
+    def test_skips_gt_in_quotes(self):
+        text = '<p attr="a>b">text</p>'
+        assert _find_tag_close_gt(text, 0) == 13
+
+    def test_returns_neg1(self):
+        assert _find_tag_close_gt("<p no closing", 0) == -1
+
+
+class TestFindElementEnd:
+    def test_simple_element(self):
+        text = "<p>hello</p>"
+        assert _find_element_end(text, "p", 0) == len(text)
+
+    def test_self_closing(self):
+        text = "<hr />"
+        assert _find_element_end(text, "hr", 0) == 6
+
+    def test_self_closing_no_space(self):
+        text = "<br/>"
+        assert _find_element_end(text, "br", 0) == 5
+
+    def test_nested_same_tag(self):
+        text = "<div><div>inner</div></div>"
+        assert _find_element_end(text, "div", 0) == len(text)
+
+    def test_namespace_tag(self):
+        text = (
+            '<ac:structured-macro ac:name="info">'
+            "<ac:rich-text-body><p>hi</p></ac:rich-text-body>"
+            "</ac:structured-macro>"
+        )
+        assert _find_element_end(text, "ac:structured-macro", 0) == len(text)
+
+    def test_raises_on_unclosed(self):
+        with pytest.raises(ValueError, match="Unclosed"):
+            _find_element_end("<p>no close tag", "p", 0)
+
+
+class TestExtractBlockFragments:
+    def test_simple_blocks(self):
+        xhtml = "<h1>Title</h1>\n<p>Body</p>"
+        result = extract_block_fragments(xhtml)
+
+        assert len(result.fragments) == 2
+        assert result.fragments[0] == "<h1>Title</h1>"
+        assert result.fragments[1] == "<p>Body</p>"
+        assert result.prefix == ""
+        assert result.suffix == ""
+        assert result.separators == ["\n"]
+        assert _reassemble(result) == xhtml
+
+    def test_no_separator(self):
+        xhtml = "<h2>A</h2><p>B</p>"
+        result = extract_block_fragments(xhtml)
+
+        assert len(result.fragments) == 2
+        assert result.separators == [""]
+        assert _reassemble(result) == xhtml
+
+    def test_self_closing_tags(self):
+        xhtml = "<p>Done.</p><p />"
+        result = extract_block_fragments(xhtml)
+
+        assert len(result.fragments) == 2
+        assert result.fragments[0] == "<p>Done.</p>"
+        assert result.fragments[1] == "<p />"
+        assert _reassemble(result) == xhtml
+
+    def test_empty_input(self):
+        result = extract_block_fragments("")
+        assert result.fragments == []
+        assert result.prefix == ""
+        assert result.suffix == ""
+
+    def test_macro_block(self):
+        xhtml = (
+            '<ac:structured-macro ac:name="info" ac:schema-version="1">'
+            "<ac:rich-text-body><p>Info text</p></ac:rich-text-body>"
+            "</ac:structured-macro>"
+        )
+        result = extract_block_fragments(xhtml)
+        assert len(result.fragments) == 1
+        assert result.fragments[0] == xhtml
+        assert _reassemble(result) == xhtml
+
+    def test_hr_between_blocks(self):
+        xhtml = "<p>A</p><hr /><p>B</p>"
+        result = extract_block_fragments(xhtml)
+
+        assert len(result.fragments) == 3
+        assert result.fragments[0] == "<p>A</p>"
+        assert result.fragments[1] == "<hr />"
+        assert result.fragments[2] == "<p>B</p>"
+        assert _reassemble(result) == xhtml
+
+
+class TestExtractBlockFragmentsRealTestcases:
+    """실제 testcase 파일에 대한 integrity 테스트."""
+
+    @pytest.fixture
+    def testcases_dir(self):
+        from pathlib import Path
+
+        return Path(__file__).parent / "testcases"
+
+    def test_all_testcases_integrity(self, testcases_dir):
+        if not testcases_dir.is_dir():
+            pytest.skip("testcases directory not found")
+
+        ok = 0
+        for case_dir in sorted(testcases_dir.iterdir()):
+            if not case_dir.is_dir():
+                continue
+            xhtml_path = case_dir / "page.xhtml"
+            if not xhtml_path.exists():
+                continue
+
+            xhtml = xhtml_path.read_text(encoding="utf-8")
+            result = extract_block_fragments(xhtml)
+            reassembled = _reassemble(result)
+            assert reassembled == xhtml, f"Integrity failed for {case_dir.name}"
+            ok += 1
+
+        assert ok >= 21, f"Expected at least 21 testcases, got {ok}"
+
+
+def _reassemble(result: FragmentExtractionResult) -> str:
+    """Fragment extraction result를 재조립한다."""
+    text = result.prefix
+    for i, frag in enumerate(result.fragments):
+        text += frag
+        if i < len(result.separators):
+            text += result.separators[i]
+    text += result.suffix
+    return text

--- a/confluence-mdx/tests/test_reverse_sync_rehydrator.py
+++ b/confluence-mdx/tests/test_reverse_sync_rehydrator.py
@@ -9,21 +9,24 @@ from reverse_sync.sidecar import build_sidecar, write_sidecar
 
 
 def test_sidecar_matches_mdx_true_when_hash_same():
+    xhtml = "<h1>Title</h1><p>Body</p>"
     mdx = "## Title\n\nBody\n"
-    sidecar = build_sidecar(mdx, "<h1>Title</h1><p>Body</p>")
+    sidecar = build_sidecar(xhtml, mdx)
     assert sidecar_matches_mdx(mdx, sidecar) is True
 
 
 def test_rehydrate_xhtml_returns_raw_when_hash_matches():
+    xhtml = "<h1>Title</h1><p>Body</p>"
     mdx = "## Title\n\nBody\n"
-    raw = "<h1>Title</h1><p>Body</p>"
-    sidecar = build_sidecar(mdx, raw)
-    assert rehydrate_xhtml(mdx, sidecar) == raw
+    sidecar = build_sidecar(xhtml, mdx)
+    assert rehydrate_xhtml(mdx, sidecar) == xhtml
 
 
 def test_rehydrate_xhtml_fallback_when_hash_mismatch():
-    mdx = "## Changed\n\nBody\n"
-    sidecar = build_sidecar("## Title\n\nBody\n", "<h1>Title</h1><p>Body</p>")
+    xhtml = "<h1>Title</h1><p>Body</p>"
+    mdx_original = "## Title\n\nBody\n"
+    mdx_changed = "## Changed\n\nBody\n"
+    sidecar = build_sidecar(xhtml, mdx_original)
 
     called = {}
 
@@ -31,18 +34,18 @@ def test_rehydrate_xhtml_fallback_when_hash_mismatch():
         called["mdx"] = text
         return "<x-fallback />"
 
-    restored = rehydrate_xhtml(mdx, sidecar, fallback_renderer=_fallback)
+    restored = rehydrate_xhtml(mdx_changed, sidecar, fallback_renderer=_fallback)
     assert restored == "<x-fallback />"
-    assert called["mdx"] == mdx
+    assert called["mdx"] == mdx_changed
 
 
 def test_rehydrate_xhtml_from_files(tmp_path):
     mdx_path = tmp_path / "expected.mdx"
     sidecar_path = tmp_path / "expected.roundtrip.json"
+    xhtml = "<h1>Title</h1><p>Body</p>"
     mdx = "## Title\n\nBody\n"
-    raw = "<h1>Title</h1><p>Body</p>"
     mdx_path.write_text(mdx, encoding="utf-8")
-    write_sidecar(build_sidecar(mdx, raw, page_id="100"), sidecar_path)
+    write_sidecar(build_sidecar(xhtml, mdx, page_id="100"), sidecar_path)
 
     restored = rehydrate_xhtml_from_files(mdx_path, sidecar_path)
-    assert restored == raw
+    assert restored == xhtml

--- a/confluence-mdx/tests/test_reverse_sync_sidecar.py
+++ b/confluence-mdx/tests/test_reverse_sync_sidecar.py
@@ -1,7 +1,7 @@
 """Sidecar 통합 모듈 유닛 테스트.
 
 reverse_sync/sidecar.py의 핵심 기능을 검증한다:
-  - Roundtrip sidecar v1 스키마 (RoundtripSidecar, build/load/write)
+  - Block-level roundtrip sidecar (RoundtripSidecar, build/load/write)
   - mapping.yaml 파일 로드 및 SidecarEntry 생성
   - MDX block index → SidecarEntry 역인덱스 구축
   - xhtml_xpath → BlockMapping 인덱스 구축
@@ -32,7 +32,7 @@ from reverse_sync.sidecar import (
 from reverse_sync.mapping_recorder import BlockMapping
 
 
-# ── Roundtrip Sidecar v1 ─────────────────────────────────────
+# ── Roundtrip Sidecar (block-level) ──────────────────────────
 
 class TestSha256Text:
     def test_stable(self):
@@ -43,29 +43,30 @@ class TestSha256Text:
 
 
 class TestBuildSidecar:
-    def test_contains_hashes_and_payload(self):
-        mdx = "## Title\n\nBody\n"
+    def test_contains_hashes_and_fragments(self):
         xhtml = "<h1>Title</h1><p>Body</p>"
-        sidecar = build_sidecar(mdx, xhtml, page_id="123")
-        assert sidecar.roundtrip_schema_version == ROUNDTRIP_SCHEMA_VERSION
+        mdx = "## Title\n\nBody\n"
+        sidecar = build_sidecar(xhtml, mdx, page_id="123")
+        assert sidecar.schema_version == ROUNDTRIP_SCHEMA_VERSION
         assert sidecar.page_id == "123"
-        assert sidecar.raw_xhtml == xhtml
+        assert sidecar.reassemble_xhtml() == xhtml
         assert sidecar.mdx_sha256 == sha256_text(mdx)
         assert sidecar.source_xhtml_sha256 == sha256_text(xhtml)
+        assert len(sidecar.blocks) == 2
 
 
 class TestWriteAndLoadSidecar:
     def test_roundtrip(self, tmp_path):
-        mdx = "## T\n"
         xhtml = "<h1>T</h1>"
-        sidecar = build_sidecar(mdx, xhtml, page_id="case-1")
+        mdx = "## T\n"
+        sidecar = build_sidecar(xhtml, mdx, page_id="case-1")
         path = tmp_path / "expected.roundtrip.json"
         write_sidecar(sidecar, path)
 
         loaded = load_sidecar(path)
-        assert loaded.roundtrip_schema_version == ROUNDTRIP_SCHEMA_VERSION
+        assert loaded.schema_version == ROUNDTRIP_SCHEMA_VERSION
         assert loaded.page_id == "case-1"
-        assert loaded.raw_xhtml == xhtml
+        assert loaded.reassemble_xhtml() == xhtml
         assert loaded.mdx_sha256 == sha256_text(mdx)
 
 

--- a/confluence-mdx/tests/test_reverse_sync_sidecar_v2.py
+++ b/confluence-mdx/tests/test_reverse_sync_sidecar_v2.py
@@ -1,0 +1,197 @@
+"""reverse_sync/sidecar.py block-level sidecar 스키마 유닛 테스트."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reverse_sync.sidecar import (
+    DocumentEnvelope,
+    RoundtripSidecar,
+    SidecarBlock,
+    build_sidecar,
+    load_sidecar,
+    sha256_text,
+    verify_sidecar_integrity,
+    write_sidecar,
+)
+
+
+class TestSidecarSchema:
+    def test_create_sidecar(self):
+        sidecar = RoundtripSidecar(
+            page_id="test",
+            blocks=[
+                SidecarBlock(
+                    block_index=0,
+                    xhtml_xpath="h1[1]",
+                    xhtml_fragment="<h1>Title</h1>",
+                    mdx_content_hash="abc123",
+                    mdx_line_range=(1, 1),
+                )
+            ],
+            separators=[],
+            document_envelope=DocumentEnvelope(prefix="", suffix="\n"),
+        )
+        assert sidecar.schema_version == "2"
+        assert sidecar.page_id == "test"
+        assert len(sidecar.blocks) == 1
+
+    def test_to_dict_roundtrip(self):
+        original = RoundtripSidecar(
+            page_id="123",
+            mdx_sha256="mdx_hash",
+            source_xhtml_sha256="xhtml_hash",
+            blocks=[
+                SidecarBlock(0, "h2[1]", "<h2>A</h2>", "hash_a", (1, 1)),
+                SidecarBlock(1, "p[1]", "<p>B</p>", "hash_b", (3, 3)),
+            ],
+            separators=["\n"],
+            document_envelope=DocumentEnvelope(prefix="", suffix="\n"),
+        )
+        d = original.to_dict()
+        restored = RoundtripSidecar.from_dict(d)
+
+        assert restored.schema_version == "2"
+        assert restored.page_id == "123"
+        assert len(restored.blocks) == 2
+        assert restored.blocks[0].xhtml_fragment == "<h2>A</h2>"
+        assert restored.blocks[1].mdx_line_range == (3, 3)
+        assert restored.separators == ["\n"]
+        assert restored.document_envelope.suffix == "\n"
+
+    def test_json_serializable(self):
+        sidecar = RoundtripSidecar(
+            page_id="test",
+            blocks=[
+                SidecarBlock(0, "p[1]", "<p>한글</p>", "hash", (1, 1)),
+            ],
+        )
+        json_str = json.dumps(sidecar.to_dict(), ensure_ascii=False)
+        data = json.loads(json_str)
+        assert data["blocks"][0]["xhtml_fragment"] == "<p>한글</p>"
+
+    def test_reassemble_xhtml(self):
+        sidecar = RoundtripSidecar(
+            blocks=[
+                SidecarBlock(0, "h1[1]", "<h1>A</h1>", "", (1, 1)),
+                SidecarBlock(1, "p[1]", "<p>B</p>", "", (3, 3)),
+            ],
+            separators=["\n"],
+            document_envelope=DocumentEnvelope(prefix="", suffix="\n"),
+        )
+        assert sidecar.reassemble_xhtml() == "<h1>A</h1>\n<p>B</p>\n"
+
+
+class TestVerifySidecarIntegrity:
+    def test_passes_when_equal(self):
+        original = "<h1>A</h1>\n<p>B</p>\n"
+        sidecar = RoundtripSidecar(
+            blocks=[
+                SidecarBlock(0, "h1[1]", "<h1>A</h1>", "", (1, 1)),
+                SidecarBlock(1, "p[1]", "<p>B</p>", "", (3, 3)),
+            ],
+            separators=["\n"],
+            document_envelope=DocumentEnvelope(prefix="", suffix="\n"),
+        )
+        verify_sidecar_integrity(sidecar, original)
+
+    def test_fails_when_fragment_wrong(self):
+        original = "<h1>A</h1>\n<p>B</p>\n"
+        sidecar = RoundtripSidecar(
+            blocks=[
+                SidecarBlock(0, "h1[1]", "<h1>A</h1>", "", (1, 1)),
+                SidecarBlock(1, "p[1]", "<p>WRONG</p>", "", (3, 3)),
+            ],
+            separators=["\n"],
+            document_envelope=DocumentEnvelope(prefix="", suffix="\n"),
+        )
+        with pytest.raises(ValueError, match="integrity check failed"):
+            verify_sidecar_integrity(sidecar, original)
+
+    def test_fails_when_separator_wrong(self):
+        original = "<h1>A</h1>\n<p>B</p>"
+        sidecar = RoundtripSidecar(
+            blocks=[
+                SidecarBlock(0, "h1[1]", "<h1>A</h1>", "", (1, 1)),
+                SidecarBlock(1, "p[1]", "<p>B</p>", "", (3, 3)),
+            ],
+            separators=["  "],  # wrong separator
+            document_envelope=DocumentEnvelope(prefix="", suffix=""),
+        )
+        with pytest.raises(ValueError, match="integrity check failed"):
+            verify_sidecar_integrity(sidecar, original)
+
+
+class TestWriteAndLoadSidecar:
+    def test_roundtrip(self, tmp_path):
+        sidecar = RoundtripSidecar(
+            page_id="100",
+            mdx_sha256="mhash",
+            source_xhtml_sha256="xhash",
+            blocks=[
+                SidecarBlock(0, "h2[1]", "<h2>Title</h2>", "bhash", (1, 1)),
+            ],
+            separators=[],
+            document_envelope=DocumentEnvelope(prefix="", suffix=""),
+        )
+        path = tmp_path / "sidecar.json"
+        write_sidecar(sidecar, path)
+
+        loaded = load_sidecar(path)
+        assert loaded.page_id == "100"
+        assert loaded.blocks[0].xhtml_fragment == "<h2>Title</h2>"
+
+    def test_load_rejects_wrong_version(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text('{"schema_version": "1"}', encoding="utf-8")
+        with pytest.raises(ValueError, match="expected schema_version=2"):
+            load_sidecar(path)
+
+
+class TestBuildSidecar:
+    def test_simple_case(self):
+        xhtml = "<h2>Title</h2>\n<p>Body text</p>"
+        mdx = "## Title\n\nBody text\n"
+        sidecar = build_sidecar(xhtml, mdx, page_id="test")
+
+        assert sidecar.schema_version == "2"
+        assert sidecar.page_id == "test"
+        assert sidecar.mdx_sha256 == sha256_text(mdx)
+        assert sidecar.source_xhtml_sha256 == sha256_text(xhtml)
+        assert len(sidecar.blocks) == 2
+        assert sidecar.blocks[0].xhtml_fragment == "<h2>Title</h2>"
+        assert sidecar.blocks[1].xhtml_fragment == "<p>Body text</p>"
+        assert sidecar.separators == ["\n"]
+
+
+class TestBuildSidecarRealTestcases:
+    """실제 testcase 파일에 대한 build + integrity 테스트."""
+
+    @pytest.fixture
+    def testcases_dir(self):
+        return Path(__file__).parent / "testcases"
+
+    def test_all_testcases_build_and_verify(self, testcases_dir):
+        if not testcases_dir.is_dir():
+            pytest.skip("testcases directory not found")
+
+        ok = 0
+        for case_dir in sorted(testcases_dir.iterdir()):
+            if not case_dir.is_dir():
+                continue
+            xhtml_path = case_dir / "page.xhtml"
+            mdx_path = case_dir / "expected.mdx"
+            if not xhtml_path.exists() or not mdx_path.exists():
+                continue
+
+            xhtml = xhtml_path.read_text(encoding="utf-8")
+            mdx = mdx_path.read_text(encoding="utf-8")
+            sidecar = build_sidecar(xhtml, mdx, page_id=case_dir.name)
+
+            assert sidecar.schema_version == "2"
+            assert len(sidecar.blocks) > 0
+            assert len(sidecar.separators) == len(sidecar.blocks) - 1
+            ok += 1
+
+        assert ok >= 21, f"Expected at least 21 testcases, got {ok}"


### PR DESCRIPTION
## Summary
- block-level sidecar v2 스키마를 구현하고, XHTML 프래그먼트 추출기(`fragment_extractor.py`)를 추가합니다
- 기존 v1 sidecar(raw_xhtml 통째 저장)를 제거하고, 블록 단위 프래그먼트로 대체하여 `fragments + separators + envelope` 재조립이 원본과 byte-equal합니다
- 21개 실제 testcase 전체에서 integrity 검증을 통과합니다

## 변경 상세

### 신규 모듈
- **`fragment_extractor.py`**: BS4로 태그 시퀀스를 식별한 뒤, 원문을 직접 스캔하여 정확한 태그 경계를 추출합니다. BS4의 속성 재정렬/공백 정규화/self-closing 변환 문제를 회피합니다.

### 수정 모듈
- **`sidecar.py`**: v1(`raw_xhtml` 통째 저장) 제거, v2를 기본 `RoundtripSidecar`로 통합. `SidecarBlock`, `DocumentEnvelope`, `reassemble_xhtml()` 메서드 추가
- **`rehydrator.py`**: `sidecar.raw_xhtml` → `sidecar.reassemble_xhtml()` 전환
- **`mdx_to_storage_roundtrip_sidecar_cli.py`**: `--schema-version` 플래그 제거, v2 전용

### 테스트
- `test_reverse_sync_fragment_extractor.py`: 24개 테스트 (태그 검색, 프래그먼트 추출, 실제 testcase 검증)
- `test_reverse_sync_sidecar_v2.py`: 스키마, 직렬화, integrity, build, 실제 testcase 검증
- 기존 테스트 파일 API 변경 반영 (`build_sidecar(xhtml, mdx)` 인자 순서 변경)

## Test plan
- [x] 616개 전체 테스트 통과 확인
- [x] 21개 실제 testcase에 대한 build + integrity 검증 통과
- [x] v1 API 참조가 코드베이스에 남아있지 않음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)