### PR TITLE
confluence-mdx: Phase L2 블록 단위 splice rehydrator 구현

### DIFF
--- a/confluence-mdx/bin/reverse_sync/byte_verify.py
+++ b/confluence-mdx/bin/reverse_sync/byte_verify.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import List
 
-from .rehydrator import rehydrate_xhtml
+from .rehydrator import SpliceResult, rehydrate_xhtml, splice_rehydrate_xhtml
 from .sidecar import load_sidecar
 
 
@@ -15,6 +16,19 @@ class ByteVerificationResult:
     passed: bool
     reason: str
     first_mismatch_offset: int
+
+
+@dataclass
+class SpliceVerificationResult:
+    """Forced-splice 경로 byte-equal 검증 결과."""
+
+    case_id: str
+    passed: bool
+    reason: str
+    first_mismatch_offset: int
+    matched_count: int = 0
+    emitted_count: int = 0
+    total_blocks: int = 0
 
 
 def _first_mismatch_offset(a: bytes, b: bytes) -> int:
@@ -59,4 +73,54 @@ def verify_case_dir(case_dir: Path, sidecar_name: str = "expected.roundtrip.json
         passed=False,
         reason="byte_mismatch",
         first_mismatch_offset=mismatch,
+    )
+
+
+def verify_case_dir_splice(
+    case_dir: Path,
+    sidecar_name: str = "expected.roundtrip.json",
+) -> SpliceVerificationResult:
+    """Forced-splice 경로로 byte-equal 검증을 수행한다.
+
+    Document-level fast path를 거치지 않고, 블록 단위 splice 경로만으로
+    XHTML을 복원하여 원본과 byte-equal인지 검증한다.
+    """
+    sidecar_path = case_dir / sidecar_name
+    if not sidecar_path.exists():
+        return SpliceVerificationResult(
+            case_id=case_dir.name,
+            passed=False,
+            reason=f"sidecar_missing:{sidecar_name}",
+            first_mismatch_offset=-1,
+        )
+
+    expected_mdx = (case_dir / "expected.mdx").read_text(encoding="utf-8")
+    page_xhtml = (case_dir / "page.xhtml").read_text(encoding="utf-8")
+
+    sidecar = load_sidecar(sidecar_path)
+    splice_result = splice_rehydrate_xhtml(expected_mdx, sidecar)
+
+    a = page_xhtml.encode("utf-8")
+    b = splice_result.xhtml.encode("utf-8")
+    mismatch = _first_mismatch_offset(a, b)
+
+    if mismatch == -1:
+        return SpliceVerificationResult(
+            case_id=case_dir.name,
+            passed=True,
+            reason="byte_equal_splice",
+            first_mismatch_offset=-1,
+            matched_count=splice_result.matched_count,
+            emitted_count=splice_result.emitted_count,
+            total_blocks=splice_result.total_blocks,
+        )
+
+    return SpliceVerificationResult(
+        case_id=case_dir.name,
+        passed=False,
+        reason="byte_mismatch_splice",
+        first_mismatch_offset=mismatch,
+        matched_count=splice_result.matched_count,
+        emitted_count=splice_result.emitted_count,
+        total_blocks=splice_result.total_blocks,
     )

--- a/confluence-mdx/bin/reverse_sync/rehydrator.py
+++ b/confluence-mdx/bin/reverse_sync/rehydrator.py
@@ -1,16 +1,47 @@
-"""Lossless rehydration — MDX + sidecar → XHTML 복원."""
+"""Lossless rehydration — MDX + sidecar → XHTML 복원.
+
+세 가지 복원 경로:
+  1. Fast path     — MDX 전체 SHA256 일치 → reassemble_xhtml() (document-level)
+  2. Splice path   — 블록 단위 해시 매칭 → 원본 fragment / emitter 혼합 조립
+  3. Fallback path — 전체 emitter 재생성
+"""
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable
+from typing import Callable, List
 
 from mdx_to_storage import emit_document, parse_mdx
+from mdx_to_storage.emitter import emit_block as emit_single_block
+from mdx_to_storage.parser import Block
 
-from .sidecar import RoundtripSidecar, load_sidecar, sha256_text
+from .mdx_block_parser import MdxBlock, parse_mdx_blocks
+from .sidecar import RoundtripSidecar, SidecarBlock, load_sidecar, sha256_text
 
 
 FallbackRenderer = Callable[[str], str]
+
+_NON_CONTENT = frozenset(("empty", "frontmatter", "import_statement"))
+
+_MDX_TYPE_TO_PARSER_TYPE = {
+    "heading": "heading",
+    "paragraph": "paragraph",
+    "code_block": "code_block",
+    "list": "list",
+    "html_block": "html_block",
+}
+
+
+@dataclass
+class SpliceResult:
+    """Splice rehydration 결과."""
+
+    xhtml: str
+    matched_count: int
+    emitted_count: int
+    total_blocks: int
+    block_details: List[dict] = field(default_factory=list)
 
 
 def default_fallback_renderer(mdx_text: str) -> str:
@@ -20,6 +51,99 @@ def default_fallback_renderer(mdx_text: str) -> str:
 
 def sidecar_matches_mdx(mdx_text: str, sidecar: RoundtripSidecar) -> bool:
     return sha256_text(mdx_text) == sidecar.mdx_sha256
+
+
+def _mdx_block_to_parser_block(mdx_block: MdxBlock) -> Block:
+    """MdxBlock을 mdx_to_storage.parser.Block으로 변환한다."""
+    block_type = _MDX_TYPE_TO_PARSER_TYPE.get(mdx_block.type, mdx_block.type)
+    return Block(type=block_type, content=mdx_block.content)
+
+
+def splice_rehydrate_xhtml(
+    mdx_text: str,
+    sidecar: RoundtripSidecar,
+) -> SpliceResult:
+    """블록 단위 splice 경로로 XHTML을 복원한다.
+
+    Sidecar 블록을 기준으로 순회하면서, MDX 대응이 있는 블록은 해시를 비교한다.
+    - mdx_content_hash가 비어 있는 sidecar 블록 (이미지 등 MDX 대응 없음):
+      원본 xhtml_fragment를 그대로 사용
+    - 해시가 일치하는 블록: 원본 xhtml_fragment 사용
+    - 해시가 불일치하는 블록: emitter로 재생성
+    """
+    mdx_blocks = parse_mdx_blocks(mdx_text)
+    content_blocks = [b for b in mdx_blocks if b.type not in _NON_CONTENT]
+
+    matched_count = 0
+    emitted_count = 0
+    preserved_count = 0
+    fragments: List[str] = []
+    details: List[dict] = []
+    mdx_ptr = 0  # MDX content 블록 포인터
+
+    for i, sb in enumerate(sidecar.blocks):
+        if not sb.mdx_content_hash:
+            # MDX 대응 없는 XHTML 블록 (이미지, 빈 단락 등) → 원본 유지
+            fragments.append(sb.xhtml_fragment)
+            preserved_count += 1
+            details.append({
+                "index": i,
+                "method": "preserved",
+                "xpath": sb.xhtml_xpath,
+            })
+            continue
+
+        if mdx_ptr < len(content_blocks):
+            mdx_block = content_blocks[mdx_ptr]
+            content_hash = sha256_text(mdx_block.content)
+
+            if content_hash == sb.mdx_content_hash:
+                fragments.append(sb.xhtml_fragment)
+                matched_count += 1
+                details.append({
+                    "index": i,
+                    "type": mdx_block.type,
+                    "method": "sidecar",
+                    "xpath": sb.xhtml_xpath,
+                })
+            else:
+                parser_block = _mdx_block_to_parser_block(mdx_block)
+                emitted = emit_single_block(parser_block)
+                fragments.append(emitted)
+                emitted_count += 1
+                details.append({
+                    "index": i,
+                    "type": mdx_block.type,
+                    "method": "emitter",
+                    "hash_expected": sb.mdx_content_hash,
+                    "hash_actual": content_hash,
+                })
+            mdx_ptr += 1
+        else:
+            # MDX 블록 소진 — sidecar 블록의 원본 fragment 사용
+            fragments.append(sb.xhtml_fragment)
+            preserved_count += 1
+            details.append({
+                "index": i,
+                "method": "preserved",
+                "xpath": sb.xhtml_xpath,
+            })
+
+    # separators + envelope로 조립
+    parts = [sidecar.document_envelope.prefix]
+    for i, frag in enumerate(fragments):
+        parts.append(frag)
+        if i < len(sidecar.separators):
+            parts.append(sidecar.separators[i])
+    parts.append(sidecar.document_envelope.suffix)
+
+    return SpliceResult(
+        xhtml="".join(parts),
+        matched_count=matched_count,
+        emitted_count=emitted_count,
+        total_blocks=len(sidecar.blocks),
+        block_details=details,
+    )
 
 
 def rehydrate_xhtml(

--- a/confluence-mdx/tests/test_reverse_sync_byte_verify.py
+++ b/confluence-mdx/tests/test_reverse_sync_byte_verify.py
@@ -1,6 +1,14 @@
 """reverse_sync/byte_verify.py 유닛 테스트."""
 
-from reverse_sync.byte_verify import verify_case_dir
+from pathlib import Path
+
+import pytest
+
+from reverse_sync.byte_verify import (
+    SpliceVerificationResult,
+    verify_case_dir,
+    verify_case_dir_splice,
+)
 from reverse_sync.sidecar import build_sidecar, write_sidecar
 
 
@@ -44,3 +52,76 @@ def test_verify_case_dir_fails_with_mismatch_offset(tmp_path):
     assert result.passed is False
     assert result.reason == "byte_mismatch"
     assert result.first_mismatch_offset >= 0
+
+
+# ---------------------------------------------------------------------------
+# Forced-splice 검증 테스트
+# ---------------------------------------------------------------------------
+
+
+def test_verify_case_dir_splice_passes(tmp_path):
+    case = tmp_path / "100"
+    case.mkdir()
+    xhtml = "<h1>Title</h1><p>Body</p>"
+    mdx = "## Title\n\nBody\n"
+    (case / "expected.mdx").write_text(mdx, encoding="utf-8")
+    (case / "page.xhtml").write_text(xhtml, encoding="utf-8")
+    write_sidecar(build_sidecar(xhtml, mdx, page_id="100"), case / "expected.roundtrip.json")
+
+    result = verify_case_dir_splice(case)
+    assert isinstance(result, SpliceVerificationResult)
+    assert result.passed is True
+    assert result.reason == "byte_equal_splice"
+    assert result.matched_count == 2
+    assert result.emitted_count == 0
+
+
+def test_verify_case_dir_splice_fails_when_sidecar_missing(tmp_path):
+    case = tmp_path / "100"
+    case.mkdir()
+    (case / "expected.mdx").write_text("## T\n", encoding="utf-8")
+    (case / "page.xhtml").write_text("<h1>T</h1>", encoding="utf-8")
+
+    result = verify_case_dir_splice(case)
+    assert result.passed is False
+    assert result.reason.startswith("sidecar_missing")
+
+
+class TestSpliceRealTestcases:
+    """실제 testcase에 대한 forced-splice byte-equal 검증."""
+
+    @pytest.fixture
+    def testcases_dir(self):
+        return Path(__file__).parent / "testcases"
+
+    def test_all_testcases_splice_byte_equal(self, testcases_dir):
+        if not testcases_dir.is_dir():
+            pytest.skip("testcases directory not found")
+
+        ok = 0
+        failures = []
+        for case_dir in sorted(testcases_dir.iterdir()):
+            if not case_dir.is_dir():
+                continue
+            xhtml_path = case_dir / "page.xhtml"
+            mdx_path = case_dir / "expected.mdx"
+            sidecar_path = case_dir / "expected.roundtrip.json"
+            if not xhtml_path.exists() or not mdx_path.exists():
+                continue
+            if not sidecar_path.exists():
+                continue
+
+            result = verify_case_dir_splice(case_dir)
+            if result.passed:
+                ok += 1
+            else:
+                failures.append(
+                    f"{result.case_id}: {result.reason} "
+                    f"at offset {result.first_mismatch_offset}, "
+                    f"matched={result.matched_count}/{result.total_blocks}"
+                )
+
+        assert ok >= 21, (
+            f"Expected 21/21 splice byte-equal, got {ok}. "
+            f"Failures:\n" + "\n".join(failures)
+        )

--- a/confluence-mdx/tests/test_reverse_sync_rehydrator.py
+++ b/confluence-mdx/tests/test_reverse_sync_rehydrator.py
@@ -1,9 +1,15 @@
 """reverse_sync/rehydrator.py 유닛 테스트."""
 
+from pathlib import Path
+
+import pytest
+
 from reverse_sync.rehydrator import (
+    SpliceResult,
     rehydrate_xhtml,
     rehydrate_xhtml_from_files,
     sidecar_matches_mdx,
+    splice_rehydrate_xhtml,
 )
 from reverse_sync.sidecar import build_sidecar, write_sidecar
 
@@ -49,3 +55,112 @@ def test_rehydrate_xhtml_from_files(tmp_path):
 
     restored = rehydrate_xhtml_from_files(mdx_path, sidecar_path)
     assert restored == xhtml
+
+
+# ---------------------------------------------------------------------------
+# Splice rehydrator 테스트
+# ---------------------------------------------------------------------------
+
+
+class TestSpliceRehydrateXhtml:
+    def test_all_blocks_matched_returns_byte_equal(self):
+        xhtml = "<h1>Title</h1>\n<p>Body</p>"
+        mdx = "## Title\n\nBody\n"
+        sidecar = build_sidecar(xhtml, mdx)
+
+        result = splice_rehydrate_xhtml(mdx, sidecar)
+
+        assert result.xhtml == xhtml
+        assert result.matched_count == 2
+        assert result.emitted_count == 0
+        assert result.total_blocks == 2
+
+    def test_returns_splice_result_type(self):
+        xhtml = "<h1>A</h1>"
+        mdx = "## A\n"
+        sidecar = build_sidecar(xhtml, mdx)
+
+        result = splice_rehydrate_xhtml(mdx, sidecar)
+        assert isinstance(result, SpliceResult)
+
+    def test_block_details_contain_sidecar_method(self):
+        xhtml = "<h1>Title</h1>\n<p>Body</p>"
+        mdx = "## Title\n\nBody\n"
+        sidecar = build_sidecar(xhtml, mdx)
+
+        result = splice_rehydrate_xhtml(mdx, sidecar)
+
+        assert len(result.block_details) == 2
+        assert all(d["method"] == "sidecar" for d in result.block_details)
+
+    def test_changed_block_uses_emitter(self):
+        xhtml = "<h1>Title</h1>\n<p>Body</p>"
+        mdx_original = "## Title\n\nBody\n"
+        mdx_changed = "## Changed\n\nBody\n"
+        sidecar = build_sidecar(xhtml, mdx_original)
+
+        result = splice_rehydrate_xhtml(mdx_changed, sidecar)
+
+        assert result.matched_count == 1  # "Body" 블록만 매칭
+        assert result.emitted_count == 1  # "Changed" 블록은 emitter
+        assert result.block_details[0]["method"] == "emitter"
+        assert result.block_details[1]["method"] == "sidecar"
+
+    def test_preserves_envelope(self):
+        xhtml = "<h1>Only</h1>\n"
+        mdx = "## Only\n"
+        sidecar = build_sidecar(xhtml, mdx)
+
+        result = splice_rehydrate_xhtml(mdx, sidecar)
+        assert result.xhtml == xhtml
+
+
+class TestSpliceRealTestcases:
+    """실제 testcase에 대한 forced-splice byte-equal 검증."""
+
+    @pytest.fixture
+    def testcases_dir(self):
+        return Path(__file__).parent / "testcases"
+
+    def test_all_testcases_splice_byte_equal(self, testcases_dir):
+        if not testcases_dir.is_dir():
+            pytest.skip("testcases directory not found")
+
+        ok = 0
+        failures = []
+        for case_dir in sorted(testcases_dir.iterdir()):
+            if not case_dir.is_dir():
+                continue
+            xhtml_path = case_dir / "page.xhtml"
+            mdx_path = case_dir / "expected.mdx"
+            if not xhtml_path.exists() or not mdx_path.exists():
+                continue
+
+            xhtml = xhtml_path.read_text(encoding="utf-8")
+            mdx = mdx_path.read_text(encoding="utf-8")
+            sidecar = build_sidecar(xhtml, mdx, page_id=case_dir.name)
+
+            result = splice_rehydrate_xhtml(mdx, sidecar)
+
+            if result.xhtml == xhtml:
+                ok += 1
+            else:
+                # 최초 불일치 위치 진단
+                for j, (c1, c2) in enumerate(zip(result.xhtml, xhtml)):
+                    if c1 != c2:
+                        failures.append(
+                            f"{case_dir.name}: mismatch at offset {j}, "
+                            f"matched={result.matched_count}/{result.total_blocks}, "
+                            f"emitted={result.emitted_count}"
+                        )
+                        break
+                else:
+                    failures.append(
+                        f"{case_dir.name}: length diff "
+                        f"(got {len(result.xhtml)}, expected {len(xhtml)})"
+                    )
+
+        assert ok >= 21, (
+            f"Expected 21/21 splice byte-equal, got {ok}. "
+            f"Failures:\n" + "\n".join(failures)
+        )

--- a/confluence-mdx/tests/testcases/1454342158/expected.roundtrip.json
+++ b/confluence-mdx/tests/testcases/1454342158/expected.roundtrip.json
@@ -1,0 +1,1057 @@
+{
+  "schema_version": "2",
+  "page_id": "1454342158",
+  "mdx_sha256": "f6d8b90cf8d56186c0edc9789bead5d42a296399928cd9c5f190b71f057983e3",
+  "source_xhtml_sha256": "94e38b8adec78c652bec25688477c8ba2e1e15b5a7c16a7c7112ec7b9af3b8d7",
+  "blocks": [
+    {
+      "block_index": 0,
+      "xhtml_xpath": "macro-toc[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"toc\" ac:schema-version=\"1\" data-layout=\"default\" ac:local-id=\"a34579e0-6e7f-4fe8-8ceb-781a67dd1695\" ac:macro-id=\"4bf11cf0-a391-4df4-8bb5-cf9f8a69d4e3\"><ac:parameter ac:name=\"style\">none</ac:parameter></ac:structured-macro>",
+      "mdx_content_hash": "314cde3aff6aaf2f0da468c7455a2f9c68ce0cf9514899a279693870d5c6dfce",
+      "mdx_line_range": [
+        8,
+        8
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 1,
+      "xhtml_xpath": "h2[1]",
+      "xhtml_fragment": "<h2 local-id=\"b1ac29de-93b9-46c4-a63b-2210f3d9d3d6\">Overview</h2>",
+      "mdx_content_hash": "570f2c848432064a0ee7873e13333c111c0aeb41d4a26775907e952b18104d92",
+      "mdx_line_range": [
+        10,
+        10
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 2,
+      "xhtml_xpath": "p[1]",
+      "xhtml_fragment": "<p local-id=\"19194ec6-73a1-4442-a1e9-5bbabcd94fae\">QueryPie의 사용자 인증 방식은 QueryPie 사용자 계정(ID)과 암호를 사용하는 방식과 외부 Identity Provider(IdP)와 통합하는 방식 크게 두가지가 있습니다. 관리자는 IdP와의 Integration 설정을 통해 QueryPie가 Single-Sign-On을 통해 쉽게 사용자 인증을 처리하고 계정을 동기화 할 수 있습니다.</p>",
+      "mdx_content_hash": "51552a9e73df42bec15bf0f5b79e1a530405ef6106014f5c229b96a186b2f13a",
+      "mdx_line_range": [
+        12,
+        13
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 3,
+      "xhtml_xpath": "p[2]",
+      "xhtml_fragment": "<p local-id=\"81ef5935-d1f0-420b-992e-7771bb5943ab\">현재 지원되는 IdP와의 연동 설정은 다음과 같습니다.</p>",
+      "mdx_content_hash": "2d09ba51252af8cb1431798a8255008896d30f2f34424f47efdd6769839a5e35",
+      "mdx_line_range": [
+        15,
+        15
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 4,
+      "xhtml_xpath": "ul[1]",
+      "xhtml_fragment": "<ul local-id=\"1caf306a-3aa7-4f2c-a2fb-a1985b7dac2b\"><li local-id=\"f352fe8d-8b18-471b-900a-b1b89091923c\"><p local-id=\"ffd6e7dc-1d82-4ad6-b2f2-d5c70c3cad48\">LDAP</p></li><li local-id=\"16256ac7-678c-44cd-b6ae-eda9f84621f4\"><p local-id=\"243ee5a7-ac8f-49fc-8bcf-37df8bcd041c\">Okta</p></li><li local-id=\"b8c1ba67-8f4d-46b7-8816-940f57515607\"><p local-id=\"72298bf5-55a2-4a51-b81d-81a03139241f\">SAML 2.0</p></li><li local-id=\"dcd07f64-c68f-49aa-b77f-a806ae985405\"><p local-id=\"32ae0844-7298-4350-84f2-9ffb60598692\">OneLogin</p></li><li local-id=\"014459a9-fa2f-49ac-aaa6-58ba389ab13c\"><p local-id=\"e72b8b93-6e45-49d5-9108-36f5704c5ded\">Swivel Secure</p></li><li local-id=\"e8963695-a01c-490f-810c-7a4ebc354310\"><p local-id=\"7399e07d-e478-48e5-96b8-f0f62115cd3b\">Custom Identity Provider (특수 목적 사용)</p></li></ul>",
+      "mdx_content_hash": "792c7ea3a97c4673cd72c0594125f1d4fa7b0fd812ed398d4ad3ef9b1ca5ef14",
+      "mdx_line_range": [
+        17,
+        22
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 5,
+      "xhtml_xpath": "macro-info[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\" ac:local-id=\"d7d7fd61-ae0d-46db-924d-837a3652ee72\" ac:macro-id=\"616f8a9c-4ade-4281-af3a-0870ab195008\"><ac:rich-text-body><ul local-id=\"547528e7-aafd-430b-ba34-9ed1e900ca31\"><li local-id=\"15d5ccf9-dbfb-417a-b74f-508c0491b67f\"><p local-id=\"aed13c8a-9a60-4c1c-93ec-22e678f4dd8b\">현재 여러개의 Identity Provider를 동시에 지원하지 않습니다. Internal database (QueryPie 사용자 ID/PW) 인증외에 하나의 IdP를 사용해야 합니다.</p></li><li local-id=\"1c801a91-eaaf-400a-8ae7-5ca6128be941\"><p local-id=\"38d6b143-7ffb-4412-96b5-4a6ac945ee6e\">MFA (Multi-factor Authentication) 지원은 Internal DB, LDAP, Custom Identity Provider에서만 가능합니다. </p></li><li local-id=\"df6078f9-0c46-480a-92f0-65a778d5824c\"><p local-id=\"ba46e062-e86b-4f9c-9d64-8f0295758702\">11.5.0 부터 Internal DB와 LDAP 또는 Internal DB와 Custom Identity Provider를 설정해서 사용할 경우 각각의 설정에서 MFA를 사용할 수 있습니다.<br />예) LDAP에서 MFA를 설정하고 Internal DB에 MFA를 설정한 경우 사용자 계정이 LDAP 계정이면 LDAP의 MFA 설정에 의해 제어되고 Internal DB의 사용자 계정은 Internal DB의 MFA 설정에 의해 제어됩니다.</p></li><li local-id=\"f98093ff-8e09-4f18-aa7f-ffbe18d3ad3b\"><p local-id=\"cf109ff3-20ce-4eea-834b-451078901b40\">Schedule에 의한 주기적 동기화는 LDAP, Okta, One Login, Custom Identity Provider에서만 가능합니다.</p></li></ul></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "f9f2c1f5aed274494438610b6e2323c90d08bcbd3d1382f0a5072b34f3850b2e",
+      "mdx_line_range": [
+        24,
+        24
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 6,
+      "xhtml_xpath": "p[3]",
+      "xhtml_fragment": "<p local-id=\"96bfca74-58f1-4a03-8e63-ccf0aad4c0a8\">Admin &gt; General &gt; System &gt; Integration 에서 Authentication 하위 항목으로 Identity Providers 가 있습니다. 항목을 클릭하여 상세페이지로 이동하면 Identity Providers에 관련된 설정을 할 수 있습니다. 기본적으로 사용자 인증은 QueryPie의 Internal database에 저장된 ID / Password를 사용해서 처리되므로 목록에 Internal database 항목이 존재합니다. 이 항목은 삭제 할 수 없습니다.</p>",
+      "mdx_content_hash": "e9ffaa6a73e5ae1a648a2e387f2846c2e6801d294ee0ca7b1a4c0325068d3520",
+      "mdx_line_range": [
+        25,
+        28
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 7,
+      "xhtml_xpath": "ac:image[1]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"916\" ac:original-width=\"1463\" ac:custom-width=\"true\" ac:local-id=\"1fd21f29-384b-468a-82d4-f33609e3f113\" ac:alt=\"image-20251014-010700.png\" ac:width=\"760\"><ri:attachment ri:filename=\"image-20251014-010700.png\" ri:version-at-save=\"1\" /></ac:image>",
+      "mdx_content_hash": "b2da7f53a98160f9a467e89f4f04afbd6efa6caff1e00b4a072e5fd65d238800",
+      "mdx_line_range": [
+        29,
+        29
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 8,
+      "xhtml_xpath": "h3[1]",
+      "xhtml_fragment": "<h3 local-id=\"a2bef088-07cc-4422-b792-309f38972f74\">기본 인증의 상세 설정</h3>",
+      "mdx_content_hash": "3352b0df4c3f71f2b9b72d39dd8c67edf8d2153328113c1e2803789ce4676291",
+      "mdx_line_range": [
+        31,
+        34
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 9,
+      "xhtml_xpath": "ul[2]",
+      "xhtml_fragment": "<ul local-id=\"eabdcc33-edb4-4304-8c43-3b3734e64299\"><li local-id=\"3140631f-a5e1-4c99-b392-e896a235d0e5\"><p local-id=\"2caa5c85-e7e4-4c73-bf91-c21d2bbc2457\"><strong>Name</strong> : 목록에 표시되는 식별 가능한 이름입니다.</p></li><li local-id=\"ea52f8fd-a244-46f7-9685-e1bb92be04cc\"><p local-id=\"47413bce-b2a8-4cc6-8266-71683df89406\"><strong>Type</strong> : QueryPie에서 지원하는 IdP 유형 중 하나가 표시됩니다.</p></li><li local-id=\"123b8a45-d002-4fb8-87e3-78a5edfacba4\"><p local-id=\"6411cdca-2b5e-4508-a038-cebabdef5fe4\"><strong>Multi-Factor Authentication Setting </strong>: MFA 설정을 할 수 있습니다. Google Authenticator, Email을 지원합니다.</p></li></ul>",
+      "mdx_content_hash": "060d1a88aec407ac1530470f3c26247557c25b4e1e490ec8d6ebfd8f1254dbc1",
+      "mdx_line_range": [
+        36,
+        38
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 10,
+      "xhtml_xpath": "ac:image[2]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"316\" ac:original-width=\"532\" ac:custom-width=\"true\" ac:local-id=\"071fcdef-70a9-4596-9494-665586c4359f\" ac:alt=\"image-20251014-011706.png\" ac:width=\"532\"><ri:attachment ri:filename=\"image-20251014-011706.png\" ri:version-at-save=\"1\" /><ac:caption ac:local-id=\"14bea67b-b5fd-4210-a996-5a429f2956af\"><p>Internal database의 상세 설정</p></ac:caption><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "65586e571da811dbd7309ee8c9875148f2a6088beb9099ebc5a0d78c0fb50e8e",
+      "mdx_line_range": [
+        40,
+        40
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 11,
+      "xhtml_xpath": "macro-note[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"note\" ac:schema-version=\"1\" ac:local-id=\"043a4d66-8c4b-4576-90e1-dcc9628418ed\" ac:macro-id=\"1924e6a9-e6a0-4b6e-ac94-9d90a9ec56a9\"><ac:rich-text-body><p local-id=\"8928ed6d-12c8-4984-93c4-cfac592ba470\">주의: 설정 후 한번이라도 사용자를 동기화 했다면, 설정한 IdP를 삭제(삭제후 다른 IdP로 변경)하는 것이 불가능합니다. IdP를 변경하거나 삭제를 해야하는 경우 Customer Portal 을 통해 문의 부탁드립니다.</p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "ffdeb942f239f2a9b9e8bc62155a38c400b4aae7bdfd5f5cefaa8b50847c4b8b",
+      "mdx_line_range": [
+        42,
+        44
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 12,
+      "xhtml_xpath": "h2[2]",
+      "xhtml_fragment": "<h2 local-id=\"e55e5a31-fe15-4901-9742-38145d59c632\">LDAP 연동</h2>",
+      "mdx_content_hash": "7f87a56db2543c55148b39a884a91059c02c0ec2aae224c9275f714a7d85996b",
+      "mdx_line_range": [
+        46,
+        51
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 13,
+      "xhtml_xpath": "p[4]",
+      "xhtml_fragment": "<p local-id=\"2da2246d-0387-4ac9-b433-88d8439ecd80\">목록 우측 상단의 <code>+ Add</code> 버튼을 누르고 팝업되는 화면에서 Type을 LDAP으로 선택하면 LDAP을 IdP로 추가 할 수 있습니다.</p>",
+      "mdx_content_hash": "c1b0da5ba971afa10de1edbea0a2e853737a2d5263d610c12d1462f9fb0da0cc",
+      "mdx_line_range": [
+        53,
+        55
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 14,
+      "xhtml_xpath": "ul[3]",
+      "xhtml_fragment": "<ul local-id=\"aab52419-8353-48ea-be62-f7dc3e4fb686\"><li local-id=\"2ffb37f8-7f05-49eb-971f-94c476fa3b41\"><p local-id=\"4545a465-5710-413a-9d4e-8df869ee47bc\"><strong>Name</strong> : 식별에 용이하도록 적합한 IdP의 이름을 입력합니다.</p></li><li local-id=\"58059589-f7b4-48fa-8479-a6a8bbed32b7\"><p local-id=\"4139e9b4-9d34-4b6e-b822-f69b1523773d\"><strong>Type</strong>: LDAP를 선택합니다.</p></li><li local-id=\"c809f46f-7155-4433-8ba0-fae4830a6e60\"><p local-id=\"b98e4211-0d1d-4a61-8e5d-ef0b9b429d3e\"><strong>Server URL</strong> : <code>ldap://ldap.example.com:389</code> 과 같은 형식으로  LDAP server의 주소를 입력합니다. LDAPS의 경우 scheme을 ldaps:// 로 입력합니다.</p></li><li local-id=\"3ef9202c-2dd3-4a92-bb96-61dacf60be49\"><p local-id=\"2d47a4ae-286e-4a6f-8dc6-bf8fb36bba80\"><strong>BindDN</strong> :  LDAP 서버에 접속(바인드)할 때 사용할 서비스 계정의 고유 이름(Distinguished Name, DN)을 입력합니다. 이 계정은 최소한 사용자 정보를 검색(Read)할 수 있는 권한이 필요합니다.</p><p local-id=\"ae925ed0-1488-45b9-affd-1e0868b04a44\">예시: cn=admin,ou=Services,dc=example,dc=com</p></li><li local-id=\"2fcb3cf3-8b76-439e-910e-72ba0eafe048\"><p local-id=\"412a5041-aebf-45d9-8ac2-d1ccf9fd564f\"><strong>Bind Password</strong> : BindDN의 암호를 입력합니다.</p></li></ul>",
+      "mdx_content_hash": "b2da7f53a98160f9a467e89f4f04afbd6efa6caff1e00b4a072e5fd65d238800",
+      "mdx_line_range": [
+        56,
+        56
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 15,
+      "xhtml_xpath": "ac:image[3]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"776\" ac:original-width=\"481\" ac:custom-width=\"true\" ac:local-id=\"56eaaa18-2186-45b9-967c-68de67c23065\" ac:alt=\"image-20251014-012049.png\" ac:width=\"481\"><ri:attachment ri:filename=\"image-20251014-012049.png\" ri:version-at-save=\"1\" /><ac:caption ac:local-id=\"8dd473e8-6a7f-4eb6-ac9d-0ffb503255a8\"><p>LDAP 상세설정</p></ac:caption><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "55f94ee3bd78db84cde61d5297ac40416585420fd85fccb1f03d28c7880b6198",
+      "mdx_line_range": [
+        58,
+        58
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 16,
+      "xhtml_xpath": "p[5]",
+      "xhtml_fragment": "<p local-id=\"08a886e7-acfd-492f-851b-9b26472cc74b\">QueryPie 사용자 계정과 LDAP의 사용자 계정을 동기화하여 매핑할 내용을 입력합니다. </p>",
+      "mdx_content_hash": "7a36b39d96dd0997fb576f534af3d78d0ac20a58cb3232917dac5a120f14c072",
+      "mdx_line_range": [
+        60,
+        60
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 17,
+      "xhtml_xpath": "table[1]",
+      "xhtml_fragment": "<table data-table-width=\"760\" data-layout=\"default\" ac:local-id=\"91bf4962-93a1-4502-9ecd-6b9289c26d7e\"><colgroup><col style=\"width: 204.0px;\" /><col style=\"width: 103.0px;\" /><col style=\"width: 451.0px;\" /></colgroup><tbody><tr ac:local-id=\"1a1705b7-25f6-4e90-933a-d6fcccbbf25e\"><th ac:local-id=\"79f92dd8-5c7a-4465-818b-57366de42b3a\"><p local-id=\"856003c0-d1cd-450c-a6f1-36e707a4234a\"><strong>Attribute</strong></p></th><th ac:local-id=\"db194e23-4bb4-4322-8a03-416234ca5eab\"><p local-id=\"354b0e87-a530-4e63-a6b4-9f25334a064a\"><strong>필수 여부</strong></p></th><th ac:local-id=\"ee8eca02-767c-42c2-9f2d-796f9f02a274\"><p local-id=\"cd184ea8-bae5-4fd7-8d74-6d9695c06406\"><strong>Description</strong></p></th></tr><tr ac:local-id=\"3c59cdf7-d770-4546-a4a8-bc85c9280cc4\"><td ac:local-id=\"308ce979-4a78-47aa-a17a-cd687da8ca92\"><p local-id=\"00c872f9-5f12-4b62-bfd2-be889e757442\">User Base DN</p></td><td ac:local-id=\"14c308d5-77e3-4a66-9dac-6ede22bb05c5\"><p local-id=\"238870b9-2285-4b30-8304-ed0a1ffde5f1\">필수</p></td><td ac:local-id=\"7f90afc3-f3c2-4325-a206-e44ab7686f24\"><p local-id=\"5f04abec-63ce-4f6c-8921-a3486cb78e67\">LDAP 트리 내에서 사용자 계정들을 검색할 시작 위치입니다. 이 경로 하위에 있는 사용자들만 로그인 대상으로 간주됩니다.</p><p local-id=\"497b48a6-6ae3-4512-9615-d2757eb74db5\">예시: ou=People,dc=example,dc=com 또는 cn=Users,dc=example,dc=com</p></td></tr><tr ac:local-id=\"9fd14e7b-2772-4ef2-8c5f-1dcc08f3dd77\"><td ac:local-id=\"237bd477-1be2-4aa4-8bd4-0fa708727203\"><p local-id=\"202729dd-3c94-4da2-8041-a9bf99f1ce91\">User Search Filter</p></td><td ac:local-id=\"f1a8a0e7-1900-440e-bf40-154783b856d7\"><p local-id=\"5378217f-590e-403d-9436-563dd7989280\">필수</p></td><td ac:local-id=\"2e4965f0-d72a-43da-ab2c-7b035b1a5369\"><p local-id=\"878dd6d8-a199-425e-b8dd-f09033cc410e\">사용자가 로그인 시 입력한 아이디를 기반으로 LDAP에서 해당 사용자를 찾는 데 사용할 쿼리(필터)를 입력합니다. </p><p local-id=\"a18f1452-b638-4c47-a05c-33088cf53aef\">예시: (objectClass=inetOrgPerson)</p></td></tr><tr ac:local-id=\"ee854e5a-ea7c-4b52-af84-71cd1d4e6361\"><td ac:local-id=\"6dfed504-d8e0-4de5-9b56-242d322b3a2c\"><p local-id=\"490a6f22-83b2-442d-96f2-fc7970f6411a\">User Name</p></td><td ac:local-id=\"114df58d-55d2-4de0-9d7d-699fe0de0879\"><p local-id=\"066e171d-72a3-4eb0-86c2-1fea515b887b\">필수</p></td><td ac:local-id=\"4cecd77e-b08f-4433-a21e-ca1494b30860\"><p local-id=\"1aceca0b-3401-4172-b155-87bf03509b5f\">LDAP 서버에서 사용자의 로그인 아이디로 사용되는 속성(attribute)의 이름을 입력합니다. QueryPie와 동기화 할 때 QuerPie 사용자의 Login ID에 매핑됩니다.</p><p local-id=\"a283e0fd-86bb-437a-8ee3-5a1d3b1d3a9c\">예시: uid</p></td></tr><tr ac:local-id=\"3a87b88f-2377-460b-a9e7-ddc0fb49fcaa\"><td ac:local-id=\"de607a77-ae1d-46ad-87d6-a40740224f63\"><p local-id=\"e283c7be-6c82-4406-a5cb-8945cace82c7\">Email</p></td><td ac:local-id=\"1f084f9f-4040-4e0b-b598-bffee1e16cd9\"><p local-id=\"d2ff59a0-cb82-464e-b447-f9e61cf08027\">필수</p></td><td ac:local-id=\"53432ec3-d7b7-4772-a2b5-b046427a31a5\"><p local-id=\"d06ba1b7-ad80-4ce6-acab-76f589313871\">LDAP 서버에서 사용자의 Email 주소 항목으로 사용되는 속성(attribute)의 이름을 입력합니다. QueryPie와 동기화 할 때 QueryPie 사용자의 Email에 매핑됩니다.</p><p local-id=\"585f09ba-4b76-4871-9cf3-48e513e8cb0a\">예시: email</p></td></tr><tr ac:local-id=\"9d5342ec-81ed-4612-9552-452272751a44\"><td ac:local-id=\"48e35255-409d-44dd-8580-8c42a4c5ba33\"><p local-id=\"4d4e0d89-403c-4a3d-9bbb-faee3c3be5cb\">Display Name</p></td><td ac:local-id=\"f7425453-cac3-4530-a2a5-6e65e2fa408f\"><p local-id=\"dcef8d6a-a713-4bb5-8139-9b884fbf7243\">-</p></td><td ac:local-id=\"68c3cd10-bef2-4931-8356-49d70ab709b4\"><p local-id=\"22d39f27-ba79-422f-9bad-62576b30ee06\">QueryPie 사용자의 Display Name과 매핑할 LDAP 서버에서 사용하는 속성을 입력합니다.</p><p local-id=\"c9bc298d-a2ac-4495-9654-7c46680bbec8\">예시: cn 또는 displayName 등.</p></td></tr></tbody></table>",
+      "mdx_content_hash": "b0301bbd2c61918dd45a25d0d1470eb716bcdf5412dd08a6c502769a7e56d3ea",
+      "mdx_line_range": [
+        62,
+        66
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 18,
+      "xhtml_xpath": "p[6]",
+      "xhtml_fragment": "<p local-id=\"41fa5268-0b4b-4f2c-8114-8a0228629f13\">LDAP에서 사용자 그룹 정보 및 소속 정보를 동기화하려면 <strong>Use Group 옵션</strong>을 활성화(체크)하고 필수로 지정된 정보들을 입력합니다. </p>",
+      "mdx_content_hash": "d8ae855bbf9a38a4e927a74b7a9e4870d6f29bbe850d55dc46f21b1981cfc5d4",
+      "mdx_line_range": [
+        68,
+        73
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 19,
+      "xhtml_xpath": "ac:image[4]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"212\" ac:original-width=\"407\" ac:custom-width=\"true\" ac:local-id=\"942428ec-b972-4cfe-b75a-60fe123a839f\" ac:alt=\"image-20251014-075227.png\" ac:width=\"407\"><ri:attachment ri:filename=\"image-20251014-075227.png\" ri:version-at-save=\"1\" /><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "7e4b37da4d7c930b3f06921bec0870f195f556ecaa10aacfefcc2266ecc78ec5",
+      "mdx_line_range": [
+        75,
+        75
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 20,
+      "xhtml_xpath": "p[7]",
+      "xhtml_fragment": "<p local-id=\"ecfbd495-3619-41e9-b363-8fc6aed8cd2c\" />",
+      "mdx_content_hash": "9ca527f69d4c5b4e1eef7d435dcd021ed2eb848a45e97b1624a85c2dbd0fc4ba",
+      "mdx_line_range": [
+        77,
+        83
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 21,
+      "xhtml_xpath": "table[2]",
+      "xhtml_fragment": "<table data-table-width=\"760\" data-layout=\"default\" ac:local-id=\"56f8d1f8-9645-460d-a5cb-b6cce53606f2\"><colgroup><col style=\"width: 171.0px;\" /><col style=\"width: 89.0px;\" /><col style=\"width: 496.0px;\" /></colgroup><tbody><tr ac:local-id=\"cfa528d4-7ee6-483e-8b39-8d8a70310476\"><th data-highlight-colour=\"#f0f1f2\" ac:local-id=\"2cdeca85-1e14-4556-8faf-7e77b327d3b9\"><p local-id=\"61f6df6f-6caf-4198-9eaf-898ce09184f6\"><strong>Attribute</strong></p></th><th data-highlight-colour=\"#f0f1f2\" ac:local-id=\"53109c7a-a40d-4a4e-9d6a-73c4ddc826c4\"><p local-id=\"476880bd-30ff-4f99-9b69-cd49f428caf0\"><strong>필수 여부</strong></p></th><th data-highlight-colour=\"#f0f1f2\" ac:local-id=\"e24af88f-9192-424a-b43f-025bb31f869d\"><p local-id=\"39e9cfdb-7358-45d3-979e-f38ebc684a6a\"><strong>Description</strong></p></th></tr><tr ac:local-id=\"75805077-450e-4657-bfe4-3cf78a4d5928\"><td data-highlight-colour=\"#ffffff\" ac:local-id=\"ea2a1ab7-7f7f-496d-9a6c-da87bf25e27e\"><p local-id=\"e15f6072-1eea-4bb8-8415-0925e2be5f1a\">Group Base DN</p></td><td data-highlight-colour=\"#ffffff\" ac:local-id=\"b89474cb-0a96-449d-8a83-c1ca1e5a2b56\"><p local-id=\"f38ab132-36f5-4c36-bd67-4d92cfb0edcb\">필수</p></td><td data-highlight-colour=\"#ffffff\" ac:local-id=\"45f67115-11f7-474d-b15e-7189fd10c205\"><p local-id=\"362bc186-5206-4523-a803-2d8aedc2f4d6\">LDAP 서버의 그룹 Base DN 값을 입력합니다. 이 경로의 하위에 있는 그룹만 Group으로 동기화합니다. </p><ul local-id=\"cf8dfae6-81db-4442-9261-0c467ea2f02c\"><li local-id=\"6ef4255d-a6cd-47aa-a884-c7a821c7e627\"><p local-id=\"943d18d4-97dc-48ed-87fe-b964502fc64f\">예: <code>dc=example,dc=com</code></p></li></ul></td></tr><tr ac:local-id=\"acfd3ac8-1ccf-4790-87fa-969d15cf52d6\"><td data-highlight-colour=\"#ffffff\" ac:local-id=\"18032ff5-11ab-427f-85c6-a8246f91a155\"><p local-id=\"c5f3fe04-b258-45b0-96f0-ad61621d0bb2\">Group Search Filter</p></td><td data-highlight-colour=\"#ffffff\" ac:local-id=\"646d1d8d-c6ab-4445-976e-a92acb4ad672\"><p local-id=\"f009218a-07a4-48b9-b357-93f57da726f9\">필수</p></td><td data-highlight-colour=\"#ffffff\" ac:local-id=\"51af7682-029c-474f-b1d7-9658042490f0\"><p local-id=\"968aa711-f826-45e1-83b6-a95da883c7a9\">LDAP 서버의 그룹을 가져오기 위한 필터 값을 입력합니다.</p><ul local-id=\"33c2ae87-9ec7-46ad-8209-5f35f25e9c1b\"><li local-id=\"afdd0347-d329-481b-8623-069c8dfe863c\"><p local-id=\"433b7ced-b74a-48a8-984f-eb0facfa871d\">예: <code>objectclass=posixGroup</code></p></li></ul></td></tr><tr ac:local-id=\"5c723610-073d-4379-a2fe-ee2392355478\"><td ac:local-id=\"ec5bca28-b3ec-4bdb-be11-90e106ad68b3\"><p local-id=\"72795697-1b46-4a6d-b678-d14e79361cdc\">Group ID</p></td><td ac:local-id=\"7ae2e57e-9b05-42b5-a721-e2289dc4a1ea\"><p local-id=\"adf36fda-62d0-49c2-a9f4-e765807d790e\">필수</p></td><td ac:local-id=\"588d0912-0f58-4f46-9b25-c50c90650b50\"><p local-id=\"a28b2dbc-1cae-468c-8652-bb80a5f6143d\">그룹의 식별자로 사용할 속성 값을 입력합니다.</p><ul local-id=\"370186f9-817f-494c-b19e-62f0a8a462ba\"><li local-id=\"62c76406-2d0a-4037-b487-624c0842d14e\"><p local-id=\"5b05c77c-1198-4549-9b64-9b79d4907be3\">예: <code>gidNumber</code></p></li></ul></td></tr><tr ac:local-id=\"f6c5bd3a-d125-41ed-a76f-09b7ba17f1b1\"><td data-highlight-colour=\"#ffffff\" rowspan=\"2\" ac:local-id=\"22031ab0-9082-4f3f-bc9f-c375ce2a39a5\"><p local-id=\"c4718adc-a2ed-4bb1-8e32-614222524a65\">Membership Type</p></td><td data-highlight-colour=\"#ffffff\" rowspan=\"2\" ac:local-id=\"7db6a6a6-8fcc-4a8f-b59e-544ccd580c72\"><p local-id=\"bf90fa09-7db9-4940-b830-c1ac543b0cc8\">필수</p></td><td data-highlight-colour=\"#ffffff\" ac:local-id=\"1dc8e309-8401-4397-ba11-1dfda8f45536\"><p local-id=\"4b9ff187-a186-4d72-8d4d-a659e1b8def9\">사용자에 그룹 정보가 포함된 경우, <code>Include group information in user entries</code> 를 선택하고, 하단 필드에 참조할 Attribute를 입력합니다.</p><ul local-id=\"55c55671-2645-4660-9dd7-1d56015a3094\"><li local-id=\"b3e08ef1-bc14-4c26-801f-ebd5a1d7b19f\"><p local-id=\"3e135f07-f888-4555-9b0f-204eb0084e47\">예: <code>member</code>, <code>uniqueMember</code>, <code>memberUid</code> 등</p></li></ul></td></tr><tr ac:local-id=\"97e7cec3-7328-4f30-8b01-295ca445a63f\"><td data-highlight-colour=\"#ffffff\" ac:local-id=\"01bae4e3-5d99-4208-ba57-3880491c4780\"><p local-id=\"084f00e3-712c-49aa-8bba-9d866948f4a4\">그룹에 사용자 정보가 포함된 경우, <code>Include user information in group entries</code> 를 선택하고, 하단 필드에 참조할 Attribute를 입력합니다.</p><ul local-id=\"95aa4947-c0c9-49f9-a42d-4b4348e29672\"><li local-id=\"a3b5b242-733f-4026-a850-a8f3a544c31a\"><p local-id=\"c26e4763-b108-47b1-96dd-7a731194e434\">예: <code>gidNumber</code></p></li></ul></td></tr></tbody></table>",
+      "mdx_content_hash": "bb867e8b3f9ad9f6040030b3e0b209317d1e0f8bcbe1b545d4836440439360fc",
+      "mdx_line_range": [
+        85,
+        85
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 22,
+      "xhtml_xpath": "p[8]",
+      "xhtml_fragment": "<p local-id=\"cce3b8a8-f048-4768-9c48-65f9b0530d81\">LDAP 서버로부터 사용자 정보 동기화를 실행하려는 경우 <strong>Use Synchronization with the Authentication System</strong> 옵션을 활성화합니다.</p>",
+      "mdx_content_hash": "1ae30ff79d115deac70fdc6b643cdbdfe59eed523d0bc673ae6a8546646df5d1",
+      "mdx_line_range": [
+        87,
+        89
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 23,
+      "xhtml_xpath": "ac:image[5]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"726\" ac:original-width=\"408\" ac:custom-width=\"true\" ac:local-id=\"ceda6df7-6b78-4d66-ae57-03b5e71fbf8c\" ac:alt=\"image-20251014-075127.png\" ac:width=\"408\"><ri:attachment ri:filename=\"image-20251014-075127.png\" ri:version-at-save=\"1\" /><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "11cd1e4924a76aa43fcefe71a9b567850c407d65451966b8a36e3d202c7c2117",
+      "mdx_line_range": [
+        92,
+        166
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 24,
+      "xhtml_xpath": "p[9]",
+      "xhtml_fragment": "<p local-id=\"fc447349-4fc5-4d43-a574-435409ca59c7\" />",
+      "mdx_content_hash": "6240662ccad4806157146749f54bf893ed490eb6fd19d413b1ce59f1378dc99d",
+      "mdx_line_range": [
+        168,
+        168
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 25,
+      "xhtml_xpath": "ul[4]",
+      "xhtml_fragment": "<ul local-id=\"c2f5ad84-5707-40d1-a5fe-d794454851ec\"><li local-id=\"f3d9589b-7118-4e18-b18f-66e6853e4255\"><p local-id=\"bf2acb73-aa51-432d-8ddd-ea254727cee8\"><strong>Replication Frequency</strong> : 자동 동기화 기능 사용 여부를 설정합니다.</p><ul local-id=\"eaf66415-597e-4f9f-8803-b2534b7f28ad\"><li local-id=\"f3901d3e-1fc3-4fd7-b5e2-9670e69b0ec2\"><p local-id=\"5c63e214-64c6-4ab6-bc54-00a314ef7826\">Manual : 수동으로만 동기화를 수행합니다. 현재 페이지에서 <code>Synchronize</code> 버튼을 클릭할 때에만 LDAP 서버로부터 사용자 정보를 불러옵니다.</p></li><li local-id=\"78599de0-8714-4107-81b0-3043aa290070\"><p local-id=\"628b3e4b-6e49-4882-b9d0-1d9ffcc95297\">Scheduling : 주기적으로 동기화를 수행합니다. 하단 Use cron expression 필드가 활성화됩니다.</p></li></ul></li><li local-id=\"39bfe512-54a5-4f45-9c74-f1bf1840cc8f\"><p local-id=\"19bb31ed-7ba5-4933-b51c-204a8d80cfff\"><strong>Additional Settings</strong></p><ul local-id=\"3fbe79d4-8a87-439d-9b85-3175c305f05f\"><li local-id=\"3b4a2e51-80f3-463a-bcba-2fee6c3207be\"><p local-id=\"85da999c-af7f-4442-8305-250b4d9228df\"><strong>Make New Users Inactive by Default </strong>: 동기화 시 새로운 사용자를 비활성화 상태로 추가할지 여부를 선택합니다.</p><ul local-id=\"4c16d097-6a60-4727-91ab-4e084d93cde5\"><li local-id=\"e3a4a898-2b82-4dfd-bcdb-b01d4c2d5e9b\"><p local-id=\"1523dc52-ee3e-4862-a6d2-2e067dd6201c\">동기화할 사용자 수가 많거나, 사용자의 LDAP 인증을 통한 QueryPie 접근을 개별적으로 관리하고자 하는 경우 해당 옵션을 활성화하시기 바랍니다.</p></li></ul></li><li local-id=\"1f1020c9-22c9-44dc-b71f-3e4cb19bba90\"><p local-id=\"7608448e-3f00-4f45-b1ee-a60ed058ab95\"><strong>Use an Attribute for Privilege Revoke </strong>: 동기화 시 특정 Attribute에 따라 Privilege를 회수할지 여부를 선택합니다.</p><ul local-id=\"8056eaad-6550-4b11-b1a8-da71c42dbf0c\"><li local-id=\"c5f512dd-e4fe-4745-b42c-2de748b424e2\"><p local-id=\"05362b51-948f-4cdb-bfd0-5d2ae2e23554\">특정 LDAP Attribute의 변경에 의해 자동으로 DAC Privilege를 회수하고자 하는 경우 이 옵션을 활성화하세요.</p></li><li local-id=\"307dea71-efa3-44bb-b945-b16ce354f114\"><p local-id=\"061e86e1-8758-4e1a-a0b3-63e64b8376d5\">LDAP Attribute 입력 필드에 활성화 변경을 감지하려는 Attribute 이름을 입력합니다.</p></li></ul></li><li local-id=\"c5053ea5-db4b-44cd-a323-5ae049548947\"><p local-id=\"ffed4ba9-bea5-4709-9594-b882908c5e8a\"><strong>Enable Attribute Synchronization :</strong> LDAP 사용자 속성과 QueryPie 사용자 속성을 매핑하여 동기화할지 여부를 선택합니다.</p><ul local-id=\"e2b2c1f5-4ecf-4d9c-9786-1ae4c56a9240\"><li local-id=\"d78dbe73-cd92-411d-bc48-75824971791c\"><p local-id=\"d229e16c-9dd0-461a-adac-8bee63479dff\">LDAP에서 관리 중인 사용자 속성을 QueryPie 내 Attribute와 자동으로 연동하고자 하는 경우, 해당 옵션을 활성화하시기 바랍니다.</p></li><li local-id=\"db3bf0dd-b3e5-4d80-9cfa-a8d87eb201d2\"><p local-id=\"0de0f142-5ce5-4d4c-9eaf-d4aa04af2380\">옵션 활성화 시, 하단에 LDAP Attribute Mapping UI가 표시되며 매핑 작업을 통해 연동할 LDAP Attribute와 QueryPie Attribute를 지정할 수 있습니다.</p></li><li local-id=\"a90e3753-f823-47f9-8a4a-bb1113be7c15\"><p local-id=\"f983c9da-60b4-4d8f-91e7-3cb04e3f49be\">단, 해당 기능은 Profile Editor(Admin&gt; General &gt; User Management &gt; Profile Editor)에서 Source Priority가 Inherit from profile source로 설정된 Attribute에 한해 적용됩니다.</p></li></ul></li><li local-id=\"9f211a15-8738-4e57-ba97-114f7411d06e\"><p local-id=\"d778515d-17df-40d4-9705-c6961a8d9c2f\"><strong>Allowed User Deletion Rate Threshold : </strong></p><ul local-id=\"aa8a5808-5823-4fb1-b9b3-fd36e836b409\"><li local-id=\"a5c211af-efa8-4b71-a82f-b2f0a24549c8\"><p local-id=\"6d732a15-cdf0-4f23-82ef-a6de2a422cba\">동기화시 기존 유저가 이 값의 비율 이상으로 삭제되었을 경우에는 동기화를 실패하도록 하는 기능입니다.</p></li><li local-id=\"b48ee7ef-3b63-47c8-9230-f5958d45d5bf\"><p local-id=\"de1972e4-7172-415d-915c-fcba5923c251\">0.0 ~ 1.0 사이의 값을 입력합니다. (기본값은 0.1)</p><ul local-id=\"e33eb2f9-aa98-40b8-a700-1b75c9a45619\"><li local-id=\"c6463ab0-4b4b-44ff-aefd-9a1d67e80ed6\"><p local-id=\"8e72f932-0467-4fe2-88bd-0443ad8d4772\">예) 기존 유저가 100명이고, Allowed User Deletion Rate Threshold 0.1 인 경우, 다시 동기화 하였을 때, 삭제된 유저가 10명 이상이면 동기화가 실패합니다.</p></li><li local-id=\"ae2079a6-365d-40d4-84a8-395a1056d8aa\"><p local-id=\"91b568cb-ab57-4504-818d-b01528eeae81\">11.3.0 이전 버전에서 동기화 설정된 상태에서, 11.3.0으로 제품을 업그레이드하면 이 값이 1.0 으로 기본 설정됩니다.</p></li></ul></li></ul></li></ul></li></ul>",
+      "mdx_content_hash": "d13532a3faf92be121edbd09ed452bb47ed4a94f2ba79d092cb4c1863375ec75",
+      "mdx_line_range": [
+        170,
+        172
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 26,
+      "xhtml_xpath": "macro-info[2]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\" ac:local-id=\"f274adf5-56bf-4f3d-9ed5-a241501928b9\" ac:macro-id=\"4883a95a-4d82-4a3e-a459-f4ff9268bdfb\"><ac:rich-text-body><p local-id=\"0d3ca9eb-d222-4cea-83c1-c361de77c421\"><strong>LDAP Attribute Mapping</strong></p><p local-id=\"3ca4b1d9-800e-424a-aaec-32d0c66693ea\">LDAP에서 관리 중인 사용자 속성을 QueryPie 내 Attribute와 매핑하여 동기화하려면, Enable Attribute Synchronization 옵션을 활성화하고 아래 정보를 입력합니다.</p><p local-id=\"20b36119-12a8-42c7-ba7e-02da385c9828\">우측 상단의 <code>Add Row</code> 버튼을 클릭하면 새로운 매핑 행이 추가되며, 각 행마다 LDAP Attribute와 대응되는 QueryPie Attribute를 지정할 수 있습니다.</p><ol start=\"1\" local-id=\"571c3c3b-cc85-4876-bb70-703f9f1ccf68\"><li local-id=\"33079fcd-4944-4136-af93-05e4606832f0\"><p local-id=\"a0cbbc66-233d-49ac-8c2c-d2b0cbe7ab65\">해당 기능은 Admin &gt; General &gt; User Management &gt; Profile Editor에서 Source Priority가 Inherit from profile source로 설정된 QueryPie Attribute에 한해 적용됩니다.</p></li><li local-id=\"ff9e5c76-2fa7-47ba-b395-c048124fe8c0\"><p local-id=\"b3835627-f4b3-4c2c-8513-d88714b38494\">QueryPie Attribute인 <code>Username (loginId)</code>, <code>Primary Email (email)</code> 항목은 LDAP 연동 설정 시 별도로 입력되므로, 해당 항목은 LDAP&ndash;QueryPie Attribute Mapping UI에는 노출되지 않습니다.</p></li><li local-id=\"ba3c265b-a2c8-4738-b3f6-34cb6f821972\"><p local-id=\"5ba4ad57-cab6-484c-9a81-6bfdd019183f\"> 매핑 행 삭제 또는 변경 시, Save 버튼을 클릭해야 UI 상에서 변경 사항이 반영되며, Synchronize를 추가로 클릭해야 LDAP과 실제 동기화가 수행됩니다. 즉, Save는 화면상 변경, Synchronize는 시스템 반영을 의미합니다.</p></li></ol></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "386e6d7391782bc55203ea2e3e536e0cda64c356a97adaa53044de80e6eeac09",
+      "mdx_line_range": [
+        175,
+        192
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 27,
+      "xhtml_xpath": "ac:adf-extension[1]",
+      "xhtml_fragment": "<ac:adf-extension><ac:adf-node type=\"panel\"><ac:adf-attribute key=\"panel-type\">note</ac:adf-attribute><ac:adf-attribute key=\"local-id\">d956bb1e-9c00-4e80-bb4b-e233f5ed72b9</ac:adf-attribute><ac:adf-content><p local-id=\"c9b7ee04-1638-4c6d-a7ae-b0814cd90bd1\">Active Directory를 LDAP 연동할 경우 Anonymous 항목을 반드시 false로 설정해야합니다. AD는 기본적으로 익명 바인드 상태에서의 검색 작업을 허용하지 않습니다.</p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"776\" ac:original-width=\"481\" ac:custom-width=\"true\" ac:local-id=\"2c94be62-2ca7-423e-b1df-202d0d779704\" ac:alt=\"image-20251222-023912.png\" ac:width=\"491\"><ri:attachment ri:filename=\"image-20251222-023912.png\" ri:version-at-save=\"1\" /></ac:image></ac:adf-content></ac:adf-node><ac:adf-fallback><div class=\"panel conf-macro output-block\" style=\"background-color: rgb(234,230,255);border-color: rgb(153,141,217);border-width: 1.0px;\"><div class=\"panelContent\" style=\"background-color: rgb(234,230,255);\">\n<p local-id=\"c9b7ee04-1638-4c6d-a7ae-b0814cd90bd1\">Active Directory를 LDAP 연동할 경우 Anonymous 항목을 반드시 false로 설정해야합니다. AD는 기본적으로 익명 바인드 상태에서의 검색 작업을 허용하지 않습니다.</p><span class=\"confluence-embedded-file-wrapper image-center-wrapper confluence-embedded-manual-size\"><img class=\"confluence-embedded-image image-center\" alt=\"image-20251222-023912.png\" width=\"491\" src=\"https://querypie.atlassian.net/wiki/download/thumbnails/1454342158/image-20251222-023912.png?version=1&amp;modificationDate=1766371160916&amp;cacheVersion=1&amp;api=v2&amp;width=491&amp;height=792\" /></span>\n</div></div></ac:adf-fallback></ac:adf-extension>",
+      "mdx_content_hash": "bfd618c7b016fb050bb7bf5ed73635ca40f51dcef17159fc424d2889011af42b",
+      "mdx_line_range": [
+        194,
+        195
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 28,
+      "xhtml_xpath": "h2[3]",
+      "xhtml_fragment": "<h2 local-id=\"88217bbf-9522-43ee-89d5-c4adb2cd5c29\">Okta 연동</h2>",
+      "mdx_content_hash": "279b5503dfb2e99d0eb3eebc1587eab375fbd069b48a67bdfe33353be40399be",
+      "mdx_line_range": [
+        197,
+        197
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 29,
+      "xhtml_xpath": "h3[2]",
+      "xhtml_fragment": "<h3 local-id=\"36281952-d30e-44a4-baea-9df36bb640d6\">Okta에서 QueryPie 를 애플리케이션으로 추가</h3>",
+      "mdx_content_hash": "9985d8164a897fc1a0e88b2857bcd85510c68fbb19c46b6fab90d1f5a2a0cee0",
+      "mdx_line_range": [
+        199,
+        199
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 30,
+      "xhtml_xpath": "ac:image[6]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"1800\" ac:original-width=\"2880\" ac:custom-width=\"true\" ac:local-id=\"e315448a-98d5-4a48-a231-17ceb4d1273d\" ac:alt=\"image-20240723-064242.png\" ac:width=\"760\"><ri:attachment ri:filename=\"image-20240723-064242.png\" ri:version-at-save=\"1\" /><ac:caption ac:local-id=\"6c053004-5978-4883-9ff1-baa10aaf9bc2\"><p>Okta Admin &gt; Applications &gt; Applications &gt; Browse App Catalog &gt; QueryPie 검색</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "547a11928907828898b795dec42ad0b0d57d18dca415357aad56798addd2cde3",
+      "mdx_line_range": [
+        201,
+        203
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 31,
+      "xhtml_xpath": "ul[5]",
+      "xhtml_fragment": "<ul local-id=\"2a2f8cd7-fede-4345-bbfa-d417217a71a5\"><li local-id=\"939ce070-e2ec-4200-b214-6e857a00a2e6\"><p local-id=\"b2670226-2074-45d9-82ca-a5ff925604a5\"><a href=\"https://login.okta.com/\"><u>Okta 서비스</u></a>에 접속하여 관리자 계정으로 로그인합니다.</p></li><li local-id=\"0dda8451-7e94-4f7d-b615-57773e3c5f08\"><p local-id=\"24d1165e-23a3-42f0-8b5d-4e0ccabc0ff8\">우측 상단의 프로필을 클릭하여 Your Org로 접속합니다.</p></li><li local-id=\"7dba717f-ba9d-4e7f-b914-d0d91b2aefa7\"><p local-id=\"0c88adc1-551c-47bd-a058-d6770284dcd1\">Okta 관리자 페이지의 좌측 패널에서 Applications &gt; Applications 메뉴로 이동합니다.</p></li><li local-id=\"94fefc04-3618-4d40-982d-7760d694e2d9\"><p local-id=\"27f4a0b8-e36c-4e38-8e27-52a877b99459\"><code>Browse App Catalog</code> 버튼을 클릭하여 QueryPie 를 검색합니다.</p></li><li local-id=\"9a9979f2-9e3c-42bb-9bfe-7f25ec51c3cc\"><p local-id=\"ee2f608f-ea04-48a3-92e3-d34b46e5a8be\">QueryPie 애플리케이션 페이지로 들어가 <code>Add Integration</code> 버튼을 클릭합니다.</p></li><li local-id=\"b3166851-f141-4ef7-8c27-afa527bbd80a\"><p local-id=\"25b5a488-e2f4-41ff-9107-54a4de81a61c\">Application Label에 QueryPie 로 입력된 것을 확인 후, <code>Done</code> 버튼을 클릭하여 애플리케이션을 추가합니다.</p></li></ul>",
+      "mdx_content_hash": "b2da7f53a98160f9a467e89f4f04afbd6efa6caff1e00b4a072e5fd65d238800",
+      "mdx_line_range": [
+        204,
+        204
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 32,
+      "xhtml_xpath": "h3[3]",
+      "xhtml_fragment": "<h3 local-id=\"6ee88d9f-8432-4e83-aab9-ea0e394367d5\">Okta 계정 연동을 위한 Profile 설정</h3>",
+      "mdx_content_hash": "b958d239d1495b346c37f28966152ef264d34bdf134215c18b3a026b943aeaeb",
+      "mdx_line_range": [
+        206,
+        208
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 33,
+      "xhtml_xpath": "ac:image[7]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"1800\" ac:original-width=\"2880\" ac:custom-width=\"true\" ac:local-id=\"08c3b276-5c79-40b7-9974-86a1e1706559\" ac:alt=\"image-20240723-064424.png\" ac:width=\"760\"><ri:attachment ri:filename=\"image-20240723-064424.png\" ri:version-at-save=\"1\" /><ac:caption ac:local-id=\"33fd9202-9dab-4a8d-aa73-247e60770333\"><p>Okta Admin &gt; Directory &gt; Profile Editor &gt; QueryPie User &gt; Add Attribute</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "9be1880a428a36a2d5936af41f096896addcc33ca373e3c469ecadfb97cad309",
+      "mdx_line_range": [
+        209,
+        212
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 34,
+      "xhtml_xpath": "ul[6]",
+      "xhtml_fragment": "<ul local-id=\"a612d4fd-ce2f-40cc-bca5-88c583318e33\"><li local-id=\"4e1d8f3f-12db-4190-adfe-c14b61f11e9f\"><p local-id=\"e6e3d831-a386-4982-be8e-54d7dcc0fe2c\">Okta 관리자 페이지의 좌측 패널에서 Directory &gt; Profile Editor 메뉴로 이동합니다.</p></li><li local-id=\"1edec981-f826-478c-9cf8-b8ff029444c1\"><p local-id=\"76a83d03-b7da-4fba-ab15-d3048c12f423\">Profile 목록 중 &lsquo;QueryPie User&rsquo; 를 클릭합니다.</p></li><li local-id=\"d40ff0a7-1d22-4284-8c7f-1f8e376d9d73\"><p local-id=\"584776ac-fc42-430f-9647-5e0ed8b026f9\">Attributes 설정에서 <code>Add Attribute</code> 버튼을 클릭합니다.</p></li><li local-id=\"164ed9fe-2987-418f-bbea-abc630e52c71\"><p local-id=\"db1ed5c9-f848-46c7-b250-fb307e609291\">Attribute 추가 화면에서 아래 4가지 항목을 차례대로 입력 후 저장합니다.</p><ul local-id=\"3f3930c0-98a8-4901-8d28-55368b9cd022\"><li local-id=\"446f91f0-7a96-4958-b079-4a3b9fda0386\"><p local-id=\"b55cf1f1-0763-4b19-ba8f-8f5c521c71a3\">Display name : firstName / Variable name : firstName 항목 입력 후 <code>Save and Add Another</code></p></li><li local-id=\"1ae330fd-71b5-4ba0-b675-308b62ba000a\"><p local-id=\"eaa9b1dc-1610-489c-b7f8-ba18cf25c614\">Display name : lastName / Variable name : lastName 항목 입력 후 <code>Save and Add Another</code></p></li><li local-id=\"906796d7-9b5f-4843-9cb5-ca3693085eb5\"><p local-id=\"a5cb77e9-d7c1-4203-872c-264134511cfd\">Display name : email / Variable name : email 항목 입력 후 <code>Save and Add Another</code></p></li><li local-id=\"d05fbdef-9a84-491a-84df-4195cb1edc8e\"><p local-id=\"65720323-04b9-41ed-bd6e-ff91698e94e6\">Display name : loginId / Variable name : loginId 항목 입력 후 <code>Save</code>  클릭</p></li></ul></li></ul>",
+      "mdx_content_hash": "0ec7348bba0d8e2439150f9eb64141bce3a65761bd35cf46235e6d73d861681b",
+      "mdx_line_range": [
+        214,
+        214
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 35,
+      "xhtml_xpath": "ac:image[8]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"1800\" ac:original-width=\"2880\" ac:custom-width=\"true\" ac:local-id=\"ea2580a0-f85e-421e-8d4d-e4b35667d16e\" ac:alt=\"image-20240723-064721.png\" ac:width=\"760\"><ri:attachment ri:filename=\"image-20240723-064721.png\" ri:version-at-save=\"1\" /><ac:caption ac:local-id=\"28c7e3e1-48ee-418e-85d0-3c052c6f102c\"><p>Okta Admin &gt; Directory &gt; Profile Editor &gt; QueryPie User &gt; Mappings</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "c21d8958701db28699a8f258343e68a9df996ae7184a13a913c5d28d4203638e",
+      "mdx_line_range": [
+        216,
+        216
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 36,
+      "xhtml_xpath": "ul[7]",
+      "xhtml_fragment": "<ul local-id=\"86bff399-fb99-4cee-baa4-ac56e094b0eb\"><li local-id=\"d437d0f5-dba4-46ba-9b84-41058e231ec5\"><p local-id=\"1e9b422e-1ed6-440e-b451-83559f89ec42\">4가지 Attribute 가 추가된 것을 확인 후 <code>Mappings</code> 버튼을 클릭합니다.</p></li><li local-id=\"d56ce34f-d0ff-465a-b932-e4a9cdfa19d6\"><p local-id=\"1393f2b0-cf1e-4dbb-b0dc-47e750d4e9e9\">Okta User Profile Attribute 항목을 아래와 같이 QueryPie User Profile의 Attribute 와 연결합니다.</p><ul local-id=\"c4f5de20-7302-4617-906f-63597bae7839\"><li local-id=\"dd921e90-2a69-43cc-8ec5-63ea3d398914\"><p local-id=\"17bd63ba-f902-42db-ab6c-4d3433d73c76\">user.firstName &harr;︎ firstName</p></li><li local-id=\"b6de401e-f12e-450f-9f24-36527aa3b7dd\"><p local-id=\"d321c2b8-096c-497d-aab0-17107219c8f6\">user.lastName &harr;︎ lastName</p></li><li local-id=\"c183d519-01e9-4d71-bb7c-8a07b9429d0b\"><p local-id=\"3faa4703-c024-4b38-8a89-7c7f2d20c2ef\">user.email &harr;︎ email</p></li><li local-id=\"3c198a0d-1abb-4b38-8046-f98afc3ce1dc\"><p local-id=\"2492acdd-7985-4591-8d1a-04969e3ff09c\">user.email &harr;︎ loginId (Okta 의 email 항목을 QueryPie 의 로그인 Id 로 사용합니다.)</p></li></ul></li><li local-id=\"94570a38-0c21-4b07-adb6-54e42829fea1\"><p local-id=\"12c3089d-c0a2-4a1c-97c6-fe5843d0e453\"><code>Save Mappings</code> 버튼을 클릭하여 저장합니다.</p></li></ul>",
+      "mdx_content_hash": "e6f00a74a5896c6aaa99e4db4cf29eaf673c2b272768d368bc1eac5d110c7579",
+      "mdx_line_range": [
+        218,
+        223
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 37,
+      "xhtml_xpath": "p[10]",
+      "xhtml_fragment": "<p local-id=\"a4e3b530-2bdc-4b21-9d4f-723b251688b8\">&nbsp;</p>",
+      "mdx_content_hash": "b5b6ddc231b21a35e71fcf68d1a7866d205ea481c2c17bef3a4076207e524cc6",
+      "mdx_line_range": [
+        225,
+        230
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 38,
+      "xhtml_xpath": "h3[4]",
+      "xhtml_fragment": "<h3 local-id=\"5861f265-8be0-4349-9792-86f1429b5031\">Okta에 추가된 QueryPie 애플리케이션에 사용자 할당</h3>",
+      "mdx_content_hash": "6a961fb218dfcfa740aaa780ac4ccdc1f19583ebd147ffb7e273f5ae39e1e721",
+      "mdx_line_range": [
+        232,
+        232
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 39,
+      "xhtml_xpath": "ac:image[9]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"1800\" ac:original-width=\"2880\" ac:custom-width=\"true\" ac:local-id=\"f07ab4f1-e646-4a90-87e7-b8a9e86a6a06\" ac:alt=\"image-20240723-065134.png\" ac:width=\"760\"><ri:attachment ri:filename=\"image-20240723-065134.png\" ri:version-at-save=\"1\" /><ac:caption ac:local-id=\"926af8b6-dcf1-45bb-b1fd-7fc5311b399d\"><p>Okta Admin &gt; Applications &gt; Applications &gt; QueryPie App</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "b55aba8571a3160e1f3df86dbc58bb56f4694b2969b162885bdfb7ccfe806c2b",
+      "mdx_line_range": [
+        234,
+        239
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 40,
+      "xhtml_xpath": "ul[8]",
+      "xhtml_fragment": "<ul local-id=\"52f3c443-059e-46ad-9cd3-b9dd1429ea24\"><li local-id=\"f3518e63-427d-41c7-be0a-cdf3fbbcca0a\"><p local-id=\"f63c5f97-9c82-4217-b70d-7ee60673e138\">Okta 관리자 페이지의 좌측 패널에서 Applications &gt; Applications 메뉴로 이동합니다.</p></li><li local-id=\"c1bcabf0-3716-4b4c-9e0d-81f8c74536d0\"><p local-id=\"7eb35527-3e1e-4cd9-970e-2f86c5d7e80d\">리스트에서 QueryPie 애플리케이션을 클릭합니다.</p></li><li local-id=\"8785aece-d024-4624-bcc9-5209dd4da8e1\"><p local-id=\"c3add963-b9fc-48e7-8b6e-fa6357e4672e\">Assignments 탭으로 이동한 뒤 <code>Assign</code> 버튼을 클릭하여 <code>Assign to People</code> 또는 <code>Assign to Group</code>을 선택합니다.</p></li><li local-id=\"3f3e859d-23d2-4d67-b3fd-efbe91036a4e\"><p local-id=\"684893dd-08eb-4f60-9019-9a639619d995\">Okta 계정으로 QueryPie 접근을 허용할 사용자 또는 그룹을 할당한 뒤 Done 버튼을 클릭합니다.</p><ul local-id=\"ffd21c42-077f-42b8-ac20-5a0b843567c8\"><li local-id=\"199fa757-5ea0-4cba-940e-fb2e1c28b100\"><p local-id=\"0bd5628e-3296-4611-a0e7-580d4d78b92d\">People 할당시 사용자 정보 확인 후 <code>Sava and Go Back</code> 버튼을 클릭합니다.</p></li><li local-id=\"24033203-d8dc-493e-85c1-f3e640c2a398\"><p local-id=\"94907314-d8a2-4ab1-8808-b6a85e521ee5\">Group 할당시 loginId 항목을 빈 칸으로 두고 <code>Save and Go Back</code> 버튼을 클릭합니다.</p></li></ul></li><li local-id=\"1ee49a04-6840-4685-9c49-45677643b07a\"><p local-id=\"9c2dfd60-590e-482e-8350-9c571e2b96c4\">사용자 또는 그룹이 QueryPie 애플리케이션에 할당되어 추가된 내역을 확인하실 수 있습니다.</p></li></ul>",
+      "mdx_content_hash": "bea14244f3ada90c9d45c7abd01b493fb16f75e3457952b7227e402029b03f5f",
+      "mdx_line_range": [
+        241,
+        248
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 41,
+      "xhtml_xpath": "p[11]",
+      "xhtml_fragment": "<p local-id=\"c16a2872-2a97-4d9c-9d55-aff2780fe297\">&nbsp;</p>",
+      "mdx_content_hash": "9a57ec36601481c91c348cd9aa970c87224895c223ba964a92d796a77c79a48c",
+      "mdx_line_range": [
+        250,
+        255
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 42,
+      "xhtml_xpath": "h3[5]",
+      "xhtml_fragment": "<h3 local-id=\"bca75f44-667a-4c6d-8b29-d3846b4c7a62\">Okta에서 QueryPie 애플리케이션 연동 정보 설정</h3>",
+      "mdx_content_hash": "f505a65eb73c455b94b58eb0986306128c9a80f705151bee02663174a1e4955e",
+      "mdx_line_range": [
+        257,
+        263
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 43,
+      "xhtml_xpath": "ac:image[10]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"1800\" ac:original-width=\"2880\" ac:custom-width=\"true\" ac:local-id=\"fb537cf6-f329-4304-8e76-e5595387a5d5\" ac:alt=\"image-20240723-065346.png\" ac:width=\"760\"><ri:attachment ri:filename=\"image-20240723-065346.png\" ri:version-at-save=\"1\" /><ac:caption ac:local-id=\"677ebc2f-2e8c-40b8-bb6b-863b16112444\"><p>Okta Admin &gt; Applications &gt; Applications &gt; QueryPie App</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "bc967f45b35aac18dffe3613299ba51f4ba2cb488bba44f5b06da5c87f4fc176",
+      "mdx_line_range": [
+        266,
+        266
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 44,
+      "xhtml_xpath": "ul[9]",
+      "xhtml_fragment": "<ul local-id=\"f65bf592-81a9-442c-945c-fbcbe7638945\"><li local-id=\"1193e095-289c-48d2-9d46-d4c8bfd8f7a2\"><p local-id=\"759fa864-3906-4476-9dd9-9965120ee9f2\">Okta 내의 QueryPie 애플리케이션 페이지에서 Sign On 탭으로 이동합니다.</p></li><li local-id=\"d35fd180-54eb-4efd-91a8-e12c0559b56e\"><p local-id=\"9ee530ee-5130-4ff9-bd13-588da4b09a5b\">Settings 영역의 <code>Edit</code> 버튼을 클릭하여 QueryPie 가 설치된 도메인 주소를 Base URL 항목에 입력하고 저장합니다.</p></li><li local-id=\"3b2ce36e-252f-4821-aa96-117b80169d6c\"><p local-id=\"05ac5441-57d5-406a-acc6-5b888a6102d2\">Metadata URL에 표기된 주소로 별도 탭에서 접근하여 표시되는 XML 정보를 복사합니다.</p></li></ul>",
+      "mdx_content_hash": "78edbd2ce296759dab4fb5f404d8b753154b85d5b5f4d87ced768022298d39e9",
+      "mdx_line_range": [
+        268,
+        273
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 45,
+      "xhtml_xpath": "p[12]",
+      "xhtml_fragment": "<p local-id=\"d042eb64-a23f-4743-9ac6-bcb3a0401bad\">&nbsp;</p>",
+      "mdx_content_hash": "254c6c50c1074637c144290dcabcca29cdb57543fbb7953fd04050a82bf91619",
+      "mdx_line_range": [
+        275,
+        281
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 46,
+      "xhtml_xpath": "h3[6]",
+      "xhtml_fragment": "<h3 local-id=\"ee367613-c45f-4145-94a5-f1ec237820b1\">최소 권한의 Okta API 토큰 발급</h3>",
+      "mdx_content_hash": "16fe8325f6f9088a574a75c3e3b8a0d2edbd0cebf18bc8f23e6a07991caf6ce3",
+      "mdx_line_range": [
+        284,
+        284
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 47,
+      "xhtml_xpath": "p[13]",
+      "xhtml_fragment": "<p local-id=\"f2ab1744-d0f6-4061-b5d1-e267d27db7cc\">QueryPie-Okta 간 사용자 및 그룹, 그룹 멤버십의 동기화를 위해 Okta Admin API 토큰 발급이 필요합니다. 일반적인 방법으로는 이용하고 계신 Okta 최고관리자(Super Administrator)/읽기권한관리자(Read-Only Administrator) 계정으로 API 토큰을 이하의 방법으로 발급하여 적용하는 방법이 있습니다:</p>",
+      "mdx_content_hash": "1e6938ffe63c8d63dacd8cf9329502ec277055862bbce6632f85a15f2622e8fb",
+      "mdx_line_range": [
+        286,
+        291
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 48,
+      "xhtml_xpath": "ul[10]",
+      "xhtml_fragment": "<ul local-id=\"91ce3471-a505-4b97-95f7-6cc359428961\"><li local-id=\"a067662b-24d6-4a41-8937-f39eee5c3b6b\"><p local-id=\"49a0c43d-5e6a-4898-a089-d0da9cbe2e72\">Okta 관리자 페이지 좌측 패널에서 Security &gt; API 메뉴로 이동합니다.</p></li><li local-id=\"c69a88a0-562c-45f6-b318-db6eec7e7d19\"><p local-id=\"9063fae3-51ef-43e0-abc7-3048bfb3332b\">API 메뉴에서 Tokens 탭으로 이동합니다.</p></li><li local-id=\"1d05f0da-4a9d-4618-8501-e7dccc1c06f4\"><p local-id=\"d6efbac8-715b-4080-89a1-50df2746669f\">Create Token 버튼을 클릭하여 인증 토큰을 생성할 수 있습니다.</p></li></ul>",
+      "mdx_content_hash": "2d97dc8126a1d64f2fd99e9b92d6b54c25364eecab36203f7059bcedba9a4455",
+      "mdx_line_range": [
+        293,
+        295
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 49,
+      "xhtml_xpath": "p[14]",
+      "xhtml_fragment": "<p local-id=\"4f00e1a4-7aaf-4dd7-9789-8947d0c84b7d\">다만, 보안 수준 향상을 위해 Okta API 토큰의 권한을 최소한으로 부여하도록 조정해야 하는 경우, 이하의 권한 및 방법에 따라 API 토큰을 생성하실 것을 권장드립니다.</p>",
+      "mdx_content_hash": "c79d9d158d54d81d4c85700530c3476466677509eec96f260794b44216889c31",
+      "mdx_line_range": [
+        298,
+        298
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 50,
+      "xhtml_xpath": "ac:image[11]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"800\" ac:original-width=\"997\" ac:custom-width=\"true\" ac:local-id=\"ef0e193d-ad31-4465-9345-2502d032753f\" ac:alt=\"image-20240110-042233.png\" ac:width=\"762\"><ri:attachment ri:filename=\"image-20240110-042233.png\" ri:version-at-save=\"1\" /><ac:caption ac:local-id=\"df583eb7-8ccb-445c-86a8-a0ece754dafd\"><p>Okta Admin Console &gt; Security &gt; Administrators &gt; Roles &gt; Create new role</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "0d57f0e08eff427b2b04f4861dd8f16c86e4804763787feec6246f3a7f6a2ff2",
+      "mdx_line_range": [
+        300,
+        301
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 51,
+      "xhtml_xpath": "ul[11]",
+      "xhtml_fragment": "<ul local-id=\"bd4d8d20-0c67-4838-95f7-a2faa333c028\"><li local-id=\"0d7aa352-0583-4cca-a8a9-a68c32a53759\"><p local-id=\"feaff031-fc6c-45a4-a6fb-2c66ce388eb7\">Okta 관리자 페이지 좌측 패널에서 Directory &gt; People 메뉴로 이동하여 Add Person을 눌러 전용 시스템 연동용 계정을 생성합니다.</p><ul local-id=\"9ff9dfa3-0802-4ab6-b541-0144f8e97f81\"><li local-id=\"6f17c99e-8244-4886-9a0d-ad5943e790f8\"><p local-id=\"3ad0bf38-932c-4213-b25e-af6fda008ae0\">이미 쿼리파이 연동용으로 사용 가능한 계정이 있다면 본 단계를 넘어갑니다.</p></li></ul></li><li local-id=\"3dc163f2-9e2e-42a0-85c7-545bea834318\"><p local-id=\"1c668964-1080-4ecb-b2be-283613754704\">Okta 관리자 페이지 좌측 패널에서 Security &gt; Administrators 메뉴로 이동하여 Roles탭으로 이동합니다.</p></li><li local-id=\"426e38b7-67fa-4c43-a5ec-947c07e7c2f5\"><p local-id=\"a582fa4a-8164-46a3-a399-badf2a83b4f1\">Create new role을 선택합니다.</p></li><li local-id=\"a45621fe-c0c7-4db3-a0c4-3ff8af0ac18e\"><p local-id=\"fe1e902d-97ae-4e36-b17a-a4b44ccb9fee\">Role name (예. MinimumAdminRole) 및 Role description을 정의한 뒤, Select Permisions에서 이하의 권한만 체크합니다.</p><ul local-id=\"490a47e3-7782-4409-a42d-febb568a4cef\"><li local-id=\"851d3e89-95df-4e4e-a32d-5f2c6eb340b2\"><p local-id=\"2477792c-adbe-4121-9143-bc9a051e5a86\"><strong>User</strong></p><ul local-id=\"8b8fce47-d4c4-41e1-b7b9-fe8c794fa897\"><li local-id=\"b43fe0ad-4275-442f-b0c1-2589fee8431a\"><p local-id=\"4b9e61eb-fc84-4667-aa25-867a7bfb99e0\">View users and their details</p></li></ul></li><li local-id=\"c353acbc-5a72-4c7a-9b2b-2e4b2790b4ca\"><p local-id=\"91c61fa0-125b-4836-83b0-dfc2777e26cb\"><strong>Group</strong></p><ul local-id=\"63ada6c3-ca8c-41d7-b14f-7d26634effbe\"><li local-id=\"d9e9a5af-86cc-4f89-9bf1-be5f8ecb5a23\"><p local-id=\"95ee7268-3783-42d9-aee4-5f19c365d7d5\">View groups and their details</p></li></ul></li><li local-id=\"5d7096c9-6823-45b7-95f2-d0efc0a719ac\"><p local-id=\"0bfa0159-0a39-4910-8332-bf26e5d2682b\"><strong>Application</strong></p><ul local-id=\"eee5a883-978d-483b-8a2b-1b7004ba446c\"><li local-id=\"696360ac-5229-49ac-adf0-120909478a8a\"><p local-id=\"7b5e5ee1-c279-4a48-940f-afc54f1f7d16\">View application and their details</p></li></ul></li></ul></li><li local-id=\"a197f01b-8fdb-42a0-8068-0cc41fc00a08\"><p local-id=\"216e401f-c33c-4e2e-9bc8-60078ddc1e06\">Save role을 눌러 커스텀 롤을 저장합니다.</p></li><li local-id=\"5fcd910d-3fe2-47dc-b5c2-412d305c7ab9\"><p local-id=\"6fa271ff-cdec-47dc-b22f-6d8fbb22b3bf\">Resources 탭으로 이동합니다.</p></li><li local-id=\"6d47a252-b528-48c1-83d4-22589e1648f7\"><p local-id=\"e0a47b87-4435-4c57-98b8-47133c8d7bd0\">Create new resource set을 선택합니다.</p><ul local-id=\"1c4322a8-2162-43ab-96c3-a801e7e126cd\"><li local-id=\"e69a19dc-df17-496f-b901-644b4c12e4dd\"><p local-id=\"faca2603-7a67-443b-aea3-620f0aafca89\">이미 할당할 권한 범위 지정을 위해 만들어두신 resource set이 있다면 본 단계를 넘어가 10번 단계를 진행합니다.</p></li></ul></li><li local-id=\"6fabeb69-f87b-439c-b2b1-207ebf38aa96\"><p local-id=\"f45edbb5-0e90-4616-b2f4-08342383fcc0\">Name (예. MinimumResources) 및 Description을 정의한 뒤 이하의 범위를 검색하여 지정합니다.</p><ul local-id=\"9fe2cd8c-341b-4547-ab1f-a731794362b1\"><li local-id=\"62e669ab-ea66-459f-bea1-e58a5af4d824\"><p local-id=\"28192c74-2877-49b8-aa10-f4108fad6801\">User : 쿼리파이 사용자 전부 선택</p></li><li local-id=\"bb51f49e-341d-41cf-8650-d6da609fbc76\"><p local-id=\"1d2340d0-4b81-45dc-a31c-adfde153df99\">Group : 쿼리파이 사용 그룹 전부 선택</p></li><li local-id=\"93c34fb0-f59a-47d4-9ab0-3c627829c417\"><p local-id=\"1246e6e7-3f76-4736-b7ee-5b4f2b1afab7\">Application : 쿼리파이 앱으로 한정</p></li></ul></li><li local-id=\"83bd826c-2970-4b30-8ea9-e96eb7f27417\"><p local-id=\"c3a6fd88-45fa-49d1-98e4-09d73ca7fbe6\">Create를 선택하여 생성합니다.</p></li><li local-id=\"0cfdfd5e-f03f-4d83-95b4-c90327cfa166\"><p local-id=\"eadd409d-a52e-472a-84be-7a855b49cca9\">Admins 탭으로 이동하여 쿼리파이 연동용 계정에 이하의 권한을 할당합니다.</p><ul local-id=\"ac4a164d-f4c1-4317-a228-6ea1fdd63801\"><li local-id=\"a49903b8-7553-4f04-b84f-a47e16229dff\"><p local-id=\"3466e226-26d0-4127-924b-98048d090f32\">Role: MinimumAdminRole | Resource: MinimumResources</p></li><li local-id=\"cd97ba28-b404-4dfe-8b60-f9701e3e04b4\"><p local-id=\"648c28a9-cff1-4938-9767-54dd31886aa0\">Role: Read-Only Administrator</p><ul local-id=\"7e088562-b500-4f4b-bf4e-e7ac85bec28e\"><li local-id=\"1ca2298a-34bf-4f9a-a265-a82db7a3db54\"><p local-id=\"b45daa14-6c36-44f1-911a-10afcaaafcae\">API 토큰 생성메뉴 접근을 위한 임시 부여</p></li></ul></li></ul></li><li local-id=\"dac66fb0-e45d-43cf-9ab7-80a7d9ad6bcd\"><p local-id=\"074e44ae-cf9e-482a-b6f1-32a2efba6205\">쿼리파이 연동용 계정으로 옥타 관리자 콘솔 페이지로 인증 후 접근합니다.</p></li><li local-id=\"109c30a1-8e67-4f5b-a350-a0f3b2bf972f\"><p local-id=\"2dd0f32f-fb30-4595-81e0-6381b0115daf\">Security &gt; API 메뉴에서 Tokens 탭으로 이동합니다.</p></li><li local-id=\"8064c917-857c-44ce-acf0-f55304d646f8\"><p local-id=\"217b1212-316f-4772-88e7-85ef9fd15f2c\">Create Token 버튼을 클릭하여 인증 토큰을 생성하여 이를 보관합니다.</p></li><li local-id=\"85088b06-9fa5-4ab5-bca3-4ab1401122fd\"><p local-id=\"dc380fc7-15fd-44d1-9c82-e461496b8630\">이후 다시 초기 작업하였던 관리자 계정으로 접속하여 Security &gt; Administrators &gt; Admins 탭에서 연동용 계정을 편집하여 Read-Only Adminstrator 권한을 회수합니다.</p></li></ul>",
+      "mdx_content_hash": "01da7d5af88304cb040b6418f31dae7136703625fa6ff8357e168fbc2c12a262",
+      "mdx_line_range": [
+        303,
+        305
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 52,
+      "xhtml_xpath": "h3[7]",
+      "xhtml_fragment": "<h3 local-id=\"bcbf3745-3525-4f33-86ab-c137b11e08ea\">QueryPie에서 Okta 연동 및 동기화 설정</h3>",
+      "mdx_content_hash": "e44bda34cdf44ec50a7e780714649d07e95a76668db54dfafc911056d025f222",
+      "mdx_line_range": [
+        307,
+        307
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 53,
+      "xhtml_xpath": "p[15]",
+      "xhtml_fragment": "<p local-id=\"211e06af-e8c5-4d34-b755-45ce684dbcdb\">목록 우측 상단의 <code>+ Add</code> 버튼을 누르고 팝업되는 화면에서 Type을 Okta로 선택하면 Okta를 IdP로 추가 할 수 있습니다.</p>",
+      "mdx_content_hash": "2f7a8f5c6313a5781f23d8cd91a4b27564d3e9babf105f61ebb1808c156cbf22",
+      "mdx_line_range": [
+        309,
+        314
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 54,
+      "xhtml_xpath": "ac:image[12]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"725\" ac:original-width=\"481\" ac:custom-width=\"true\" ac:local-id=\"e2b94f40-2c20-4957-b8e8-b1cd08adc9a5\" ac:alt=\"image-20251014-014729.png\" ac:width=\"481\"><ri:attachment ri:filename=\"image-20251014-014729.png\" ri:version-at-save=\"1\" /><ac:caption ac:local-id=\"0f85908f-8d1c-41ef-b57a-789232041814\"><p>Okta 상세설정 (1)</p></ac:caption><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "39932343f49c09393da81c84433652012f7e44f411a0aad21f26d772ae35e4ee",
+      "mdx_line_range": [
+        316,
+        343
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 55,
+      "xhtml_xpath": "ul[12]",
+      "xhtml_fragment": "<ul local-id=\"d82641dc-e0ab-463a-9d6e-af5efb5b25de\"><li local-id=\"4430a11a-2178-4f75-9f3a-467a5edcb450\"><p local-id=\"90314a5c-2dfb-4b14-bb38-097f83ca07fa\"><strong>Name</strong> : 식별에 용이하도록 적합한 IdP의 이름을 입력합니다.</p></li><li local-id=\"ceba9cea-ed69-4fe7-9de8-294fb66eef2d\"><p local-id=\"63a96e04-de92-49b2-b006-587a5ac75079\"><strong>Type</strong>: Okta를 선택합니다.</p></li><li local-id=\"ce513bfb-8db1-4cc8-ac0e-3da5baf08d64\"><p local-id=\"5decc6f1-5677-436c-9471-fa7203647cb3\"><strong>Identity Provider Metadata</strong> : <br /><a href=\"https://querypie.atlassian.net/wiki/spaces/QM/pages/1454342158/Identity+Providers#Okta%EC%97%90%EC%84%9C-QueryPie-%EC%95%A0%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98-%EC%97%B0%EB%8F%99-%EC%A0%95%EB%B3%B4-%EC%84%A4%EC%A0%95\" local-id=\"a91d0714-d152-47c4-99af-b66571579021\" data-card-appearance=\"inline\">https://querypie.atlassian.net/wiki/spaces/QM/pages/1454342158/Identity+Providers#Okta%EC%97%90%EC%84%9C-QueryPie-%EC%95%A0%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98-%EC%97%B0%EB%8F%99-%EC%A0%95%EB%B3%B4-%EC%84%A4%EC%A0%95</a> 단계에서 복사한 XML 정보를 Identity Provider Metadata 항목에 붙여넣기합니다.</p></li><li local-id=\"98240cd5-0365-4cbd-9920-885d97a1dac8\"><p local-id=\"feeb482f-317b-40ea-a908-7b403c54525b\"><strong>Use SAML Assertion Consumer Service Index</strong> : Service Provider에서 여러개의 Endpoint 를 사용하는 경우 ACS Index를 사용하여 endpoint를 각각 지정할 수 있습니다.</p><ul local-id=\"f147427c-27ba-40d0-a571-b6d47e0268eb\"><li local-id=\"79a46e2c-c084-4fc4-a60f-61622cbe620f\"><p local-id=\"b9950836-a017-4a6c-96d6-f0ad0a46fc77\">Entity ID : <code>https://your-domain.com/saml/sp/metadata</code> 의 형식으로 입력합니다. Okta SAML 2.0 설정의 Audience URI (SP Entity ID) 값입니다. </p></li><li local-id=\"bd8a653f-e3a8-4788-ba11-61abefcb0c6f\"><p local-id=\"7b6ae443-4c2e-4b25-91ff-598afc2cf504\">ACS Index :  0 ~ 2,147,483,647 사이의 값을 입력합니다. 기본값은 0 입니다.</p></li></ul></li></ul>",
+      "mdx_content_hash": "a66c117424adca39ec2e5be9b53a7ed3405906b3975428fef0bd98630aaa4433",
+      "mdx_line_range": [
+        345,
+        345
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 56,
+      "xhtml_xpath": "macro-info[3]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\" ac:local-id=\"07adb3b7-c972-4dbd-93ec-eb4e6de7c37a\" ac:macro-id=\"f890a6f8-1d2b-4287-aaf7-71ca32cb5e6a\"><ac:rich-text-body><p local-id=\"25539719-c103-4734-b6f5-b927bf6bcb46\"><strong>Assertion Consumer Service (ACS)</strong>: SP(Service provider)에 위치한 특정 Endpoint(URL)로, IdP로부터 SAML Assertion을 수신하여 검증하고 사용자의 로그인을 처리하는 역할을 합니다.</p><p local-id=\"23c401f0-b8fe-4d6e-b172-dd21c5e63e77\"><br /><strong>Assertion Consumer Service Index의 필요성 및 역할</strong></p><p local-id=\"3e4b69b0-dca2-4f38-b79f-823ecc8ab8e7\">하나의 SP는 다양한 이유로 여러 개의 ACS URL을 가질 수 있습니다. 이때AssertionConsumerServiceIndex가 필수적인 역할을 합니다.</p><p local-id=\"6236e1d6-7d18-406f-88fd-db7bb6a5d931\">SP가 인증을 요청하는 SAML 메시지(AuthnRequest)에 이 인덱스 값을 포함하여 IdP에 보내면, IdP는 해당 인덱스에 매핑된 ACS URL로 정확하게 SAML 어설션을 전송합니다. 만약 이 인덱스가 명시되지 않으면, 일반적으로 미리 약속된 기본(Default) ACS URL로 어설션을 보내게 됩니다.</p><p local-id=\"b270db97-2fa5-468b-adf8-8b4f09bcec63\">이러한 인덱스 기반의 라우팅은 다음과 같은 구체적인 상황에서 매우 유용합니다.</p><p local-id=\"ce1d538f-9ddf-4b86-9af0-1db9a209934f\"><strong>주요 사용 사례</strong></p><ul local-id=\"5bab435f-eac7-477b-8b68-0c79cacf242a\"><li local-id=\"fc84509a-eaf6-4423-aaf2-0c14e0413f1d\"><p local-id=\"9add9093-a1f2-4123-9af5-759947631579\">다양한 프로토콜 바인딩(Binding) 지원:</p></li></ul><p local-id=\"c73a544d-b65b-49b7-8409-9d68aa218d93\">SAML 어설션은 HTTP POST, HTTP-Artifact 등 여러 방식으로 전송될 수 있습니다. SP는 각 바인딩 방식에 따라 별도의 ACS URL을 운영할 수 있습니다. 예를 들어, index=&quot;0&quot;은 HTTP POST를 위한 ACS URL을, index=&quot;1&quot;은 HTTP-Artifact를 위한 ACS URL을 가리키도록 설정할 수 있습니다.</p><ul local-id=\"af72bf57-8f3c-4387-849b-04691d324149\"><li local-id=\"fb23141a-9fc5-45e1-b0cb-d09b681b40ce\"><p local-id=\"c1b361f5-b7d9-4e05-aa60-7629761eb5d8\">다중 테넌트(Multi-tenant) 아키텍처 지원:</p></li></ul><p local-id=\"b8e9f64d-6339-4948-8f28-16eeb0c380d3\">하나의 SaaS 애플리케이션이 여러 고객사(테넌트)를 지원하는 경우, 각 테넌트별로 고유한 ACS URL을 할당할 수 있습니다. 이를 통해 각 고객사의 인증 흐름을 격리하고 맞춤형으로 관리할 수 있습니다.</p><ul local-id=\"6236af1c-30d7-417a-9583-d241f2981f64\"><li local-id=\"1c87f554-ac5b-4420-96ac-98d5aa43d53f\"><p local-id=\"c5d27ab9-1e1c-4575-a061-fdf3912eb45b\">애플리케이션 내 다른 인증 흐름 구분:</p></li></ul><p local-id=\"1316536c-a3a9-41ea-9983-2574f19a329b\">같은 애플리케이션이라도 사용자의 역할이나 접근 경로에 따라 다른 인증 후 처리가 필요할 수 있습니다. 예를 들어, 일반 사용자와 관리자의 로그인 후 리디렉션 페이지를 다르게 설정하고 싶을 때, 각각 다른 ACS URL을 사용하고 이를 인덱스로 구분할 수 있습니다.</p><ul local-id=\"5bca6c79-7185-46f4-997e-5e262f0dc302\"><li local-id=\"937b7b13-a750-4640-b3dd-c3d2c4bd7000\"><p local-id=\"22652b66-ffcb-4a4a-9be8-97af864027d3\">동적 또는 특수한 ACS URL 처리:</p></li></ul><p local-id=\"5d580d33-639a-4ab1-8b95-92f2ac7a65cf\">특정 상황이나 클라이언트의 요구에 따라 동적으로 생성된 ACS URL로 어설션을 받아야 할 때, 인덱스를 통해 정적으로 정의된 여러 URL 중 하나를 선택하도록 유도할 수 있습니다.</p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"2224\" ac:original-width=\"2784\" ac:custom-width=\"true\" ac:local-id=\"bda697a7-d60e-4ab6-98a1-dba02eaeed64\" ac:alt=\"스크린샷 2025-01-24 오후 4.42.55.png\" ac:width=\"690\"><ri:attachment ri:filename=\"스크린샷 2025-01-24 오후 4.42.55.png\" ri:version-at-save=\"1\" /><ac:caption ac:local-id=\"d9311e5e-73b1-475d-a8c0-1ed2c48e4def\"><p>okta app 설정의 Audience URI(SP Entity ID) </p></ac:caption></ac:image><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"2224\" ac:original-width=\"2784\" ac:custom-width=\"true\" ac:local-id=\"b2b1ef03-330b-4c89-9296-a18eecdd548f\" ac:alt=\"스크린샷 2025-01-24 오후 4.45.53.png\" ac:width=\"694\"><ri:attachment ri:filename=\"스크린샷 2025-01-24 오후 4.45.53.png\" ri:version-at-save=\"1\" /><ac:caption ac:local-id=\"e7477d9b-de79-4938-ae02-b0d5e357dea1\"><p>Other Requestable SSO URLs 의 Index</p></ac:caption></ac:image></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "1caaf323f7fe3603660baecf1ae95ee7f53ceffcb03fbaa181ba074ccb70c0c3",
+      "mdx_line_range": [
+        347,
+        347
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 57,
+      "xhtml_xpath": "ac:image[13]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"473\" ac:original-width=\"481\" ac:custom-width=\"true\" ac:local-id=\"4e02d82b-86ea-4bfe-8a60-afd5e499ee21\" ac:alt=\"image-20251014-014805.png\" ac:width=\"481\"><ri:attachment ri:filename=\"image-20251014-014805.png\" ri:version-at-save=\"1\" /><ac:caption ac:local-id=\"2e64ed2e-dc77-4743-bcf0-902e4fd26e81\"><p>Okta 상세설정 (2)</p></ac:caption><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "90b6729da71f2f004b53b76cb8210e09a7c6d4ea748e7b67923c9828fa79b4e5",
+      "mdx_line_range": [
+        349,
+        354
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 58,
+      "xhtml_xpath": "p[16]",
+      "xhtml_fragment": "<p local-id=\"00af5494-f11f-45cd-9035-d9497a9573ca\" />",
+      "mdx_content_hash": "e7560374372a3bf8cd338197033495b6c4da3ceaefcba16d2a7a2e6a26dcf1b0",
+      "mdx_line_range": [
+        356,
+        361
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 59,
+      "xhtml_xpath": "ul[13]",
+      "xhtml_fragment": "<ul local-id=\"1cdcbe2f-dba4-4c63-bdb4-fea14da71567\"><li local-id=\"812b33ba-fe81-460f-aff3-dbb5f4aa3287\"><p local-id=\"ab121eee-2578-46cb-94bf-bea7e5c6f5f7\">동기화를 설정하고자 하는 경우, &ldquo;Use Synchronization with the Authentication System&rdquo; 옵션을 활성화(체크)합니다.</p><ul local-id=\"e79fa936-b39c-4cf1-b129-06ced44a99f6\"><li local-id=\"de6700ff-f044-4715-8532-89490fe23c19\"><p local-id=\"a84e145b-5ecc-4ef8-b45a-d213fafd28fd\"><strong>API URL</strong>: Okta 관리자 페이지 우측 상단의 프로필을 클릭하면 {domain}.okta.com 형식의 URL 을 확인할 수 있습니다.</p></li><li local-id=\"e34ab429-84eb-4ea6-81d5-ffeb02d77c32\"><p local-id=\"343cc504-ef0d-4fe0-b17a-95ce59235a4a\"><strong>API Token</strong>: Okta 관리자 API 토큰을 기입합니다.</p></li><li local-id=\"412dd35a-d64c-474d-8a1a-f352c18e34f9\"><p local-id=\"fa30e44d-8d28-47ee-b708-50c7b927ec5e\"><strong>Application ID</strong>: Okta 내에서 2개 이상의 QueryPie App 을 사용할 경우 입력합니다.</p></li></ul></li><li local-id=\"6a4a816d-627d-4e41-87ca-5dcc1057b72b\"><p local-id=\"0ce66525-967e-44c8-af9b-9daf5c7b492c\">주기적인 동기화 기능을 사용하고자 할 경우<strong> Replication Frequency</strong> 항목에서 Scheduling 을 설정합니다.</p></li><li local-id=\"e0ce9dae-e774-4a43-a01b-2a9bcb4575d3\"><p local-id=\"b70f10ba-eb9b-47c3-a0dd-dd6d4bc49250\"><strong>Additional Settings</strong></p><ul local-id=\"94a2d09b-fb56-47d7-aab3-8cf3bd5988d4\"><li local-id=\"cd851b41-7038-4bab-b0ad-b19ca5ef64e8\"><p local-id=\"dda858f8-83b2-4d48-bca4-796a74a370a4\"><strong>Make New Users Inactive by Default </strong>: 동기화 시 새로운 사용자를 비활성화 상태로 추가할지 여부를 선택합니다.</p><p local-id=\"5c6ceec3-ab60-43f4-9359-ecfe679d4158\">동기화할 사용자 수가 많거나, 사용자의 인증을 통한 QueryPie 접근을 개별적으로 관리하고자 하는 경우 해당 옵션을 활성화하시기 바랍니다.</p></li><li local-id=\"c27f7485-663e-4c11-90ad-9d9c87f14366\"><p local-id=\"fa9568cf-3197-4f92-ab1c-01a5c8fe5955\"><strong>Use an Attribute for Privilege Revoke</strong> : 동기화 시 특정 Attribute에 따라 Privilege를 회수할지 여부를 선택합니다.</p><p local-id=\"7dc77d91-b960-4186-bc14-87b06c695da6\">특정 Attribute의 변경에 의해 자동으로 DAC Privilege를 회수하고자 하는 경우 이 옵션을 활성화하세요.</p><p local-id=\"692cccab-3fed-4c74-8752-c960d37db20b\">Attribute 입력 필드에 활성화 변경을 감지하려는 Attribute 이름을 입력합니다.</p></li><li local-id=\"011af9b1-e935-4f57-b919-49ea58302071\"><p local-id=\"d9dd7da3-c3c8-4fe5-abf3-5e77153a4ade\"><strong>Enable Attribute Synchronization</strong> : IdP의 사용자 속성과 QueryPie 사용자 속성을 매핑하여 동기화할지 여부를 선택합니다.</p><p local-id=\"b2dc7751-5904-4855-82a2-c5f3af883247\">IdP에서 관리 중인 사용자 속성을 QueryPie 내 Attribute와 자동으로 연동하고자 하는 경우, 해당 옵션을 활성화하시기 바랍니다.</p><p local-id=\"da93bdad-e851-45ff-99bd-34eaabf92eb3\">옵션 활성화 시, 하단에 Attribute Mapping UI가 표시되며 매핑 작업을 통해 연동할 IdP Attribute와 QueryPie Attribute를 지정할 수 있습니다.</p><p local-id=\"97fb1f24-9902-4456-b39c-981bf482d0bb\">단, 해당 기능은 Profile Editor(Admin&gt; General &gt; User Management &gt; Profile Editor)에서 Source Priority가 Inherit from profile source로 설정된 Attribute에 한해 적용됩니다.</p></li><li local-id=\"83a8acd5-70dd-4c84-9630-9832fb5b8094\"><p local-id=\"26746e39-03b5-4b13-a0d0-a959281632d7\"><strong>Allowed User Deletion Rate Threshold : </strong></p><ul local-id=\"c64e0454-5370-4456-8a17-a3e7599bdbcb\"><li local-id=\"829c02cb-b243-441f-8d57-33b92e3d2ba1\"><p local-id=\"cd49b970-43a9-4f25-8ef1-522f9d85306b\">동기화시 기존 유저가 이 값의 비율 이상으로 삭제되었을 경우에는 동기화를 실패하도록 하는 기능입니다.</p></li><li local-id=\"cbae955f-0a60-4efd-8ace-5e35e192dd1a\"><p local-id=\"8b20ab57-ce1c-4d20-98c0-96e8e2d08bf0\">0.0 ~ 1.0 사이의 값을 입력합니다. (기본값은 0.1)</p><ul local-id=\"eb81a75e-1bac-4d32-bfbb-44e25d803ef0\"><li local-id=\"22588f39-1628-497c-ac50-31a8b18e5385\"><p local-id=\"044d0fa4-c3ab-49cc-a154-dd8911c84e26\">예) 기존 유저가 100명이고, Allowed User Deletion Rate Threshold 0.1 인 경우, 다시 동기화 하였을 때, 삭제된 유저가 10명 이상이면 동기화가 실패합니다.</p></li><li local-id=\"6b7cb6d0-4c28-4892-850e-0a86589e39c9\"><p local-id=\"d926ab4c-ae15-44bf-a993-437eb1d79735\">11.3.0 이전 버전에서 동기화 설정된 상태에서, 11.3.0으로 제품을 업그레이드하면 이 값이 1.0 으로 기본 설정됩니다.</p></li></ul></li></ul></li></ul></li><li local-id=\"9c790849-a6c6-4e88-8709-c38ca89fc1ab\"><p local-id=\"d9b9890e-8b88-4495-be53-0059ecfcddef\"><code>Dry Run</code> 버튼을 클릭하여 연동 정보가 정상적으로 입력되었는지 확인합니다.</p></li><li local-id=\"434216b9-3069-47f7-8a34-7d1fc2631403\"><p local-id=\"dc2a551a-8cc8-4f21-afca-1e00555a03df\"><code>Save</code> 버튼을 눌러 저장합니다.</p></li></ul>",
+      "mdx_content_hash": "ba51cccc449374887a02c1f2ff384d45cf500fa9adaeb4369d09aec7bc0c9e69",
+      "mdx_line_range": [
+        363,
+        364
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 60,
+      "xhtml_xpath": "macro-info[4]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\" ac:local-id=\"318fe127-350a-478f-bbc7-ee840f7f94ed\" ac:macro-id=\"edf70d6a-cb84-47b4-bf3f-cca8c8170c77\"><ac:rich-text-body><p local-id=\"e8ffb179-8020-46ef-89a4-7ac022e3c383\"><strong>Application ID 확인하는 방법</strong></p><p local-id=\"6c4c9441-b313-4111-b169-2c14c19d2428\">2개 이상의 QueryPie Application 을 사용하는 경우, Okta Admin &gt; Applications 으로 이동하여 QueryPie 앱의 디테일 화면으로 들어가면 상단 URL 에서 위의 스크린샷에 표시된 것과 같은 Application ID 를 확인하실 수 있습니다.</p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "7de45a2108c098776511bd3d6246876e3be571117096c2ef2a6b20af034c821a",
+      "mdx_line_range": [
+        366,
+        366
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 61,
+      "xhtml_xpath": "ac:image[14]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"364\" ac:original-width=\"827\" ac:custom-width=\"true\" ac:local-id=\"b01cb13a-1a9e-4504-9406-34103df4c418\" ac:width=\"760\"><ri:attachment ri:filename=\"Authentication-Okta-02.png\" ri:version-at-save=\"1\" /><ac:caption ac:local-id=\"f861cbba-5ef4-49ce-8d06-af62cc5d0493\"><p>Okta Admin &gt; Applications &gt; QueryPie App 상단 URL</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "4066e36ae4d32f7b2babb6e23ced50e684ea3dcfbce1ebfc31a8c63dbde8b49c",
+      "mdx_line_range": [
+        368,
+        369
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 62,
+      "xhtml_xpath": "p[17]",
+      "xhtml_fragment": "<p local-id=\"9a457f57-5e66-4169-9186-c8d85e2e59bb\">&nbsp;</p>",
+      "mdx_content_hash": "c0612f292ef2940c1062bb1a5ec44914f7949b47c77439c78d76f6dfbd3c4eb2",
+      "mdx_line_range": [
+        371,
+        372
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 63,
+      "xhtml_xpath": "h3[8]",
+      "xhtml_fragment": "<h3 local-id=\"5e2b8bb8-9110-4ec9-9e15-31448c19132f\">QueryPie에서 Okta 로그인</h3>",
+      "mdx_content_hash": "fa1c350918251fd97dbb5b0e066907b78f52990fe43ce797ca6877595cd51d4a",
+      "mdx_line_range": [
+        374,
+        374
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 64,
+      "xhtml_xpath": "ol[1]",
+      "xhtml_fragment": "<ol start=\"1\" local-id=\"5cfcb4b5-0648-4bd7-a52e-ce55f0cf60e7\"><li local-id=\"32f72632-110a-4f56-8632-1fa6ece8b64f\"><p local-id=\"c9f75c6c-44bd-4a25-9508-3acc6a962517\">General Settings &gt; Users 또는 Groups 메뉴에서 동기화된 사용자 및 그룹을 확인할 수 있습니다.</p></li><li local-id=\"c8346e27-78d5-4cd6-a52b-785fe3b8de32\"><p local-id=\"faf5a49a-e8ea-4525-9692-d9cbb502c802\">이제 로그인 페이지에서 <code>Login with Okta</code> 버튼을 통해 Okta 계정으로 QueryPie에 로그인할 수 있습니다.</p></li></ol>",
+      "mdx_content_hash": "53cadf847d29691cc4c0e317de8b13fdc327a19fc2119b5752c678954c29daa2",
+      "mdx_line_range": [
+        376,
+        376
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 65,
+      "xhtml_xpath": "ac:image[15]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"922\" ac:original-width=\"1462\" ac:custom-width=\"true\" ac:local-id=\"d888dff9-d4ed-4fd0-904e-0df60d8bbd86\" ac:alt=\"image-20251014-082704.png\" ac:width=\"760\"><ri:attachment ri:filename=\"image-20251014-082704.png\" ri:version-at-save=\"1\" /><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "90a5a5cad25afc7805547ec377c3a9c48be1d7ec7e5da24372fdc14c4edc3e16",
+      "mdx_line_range": [
+        378,
+        378
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 66,
+      "xhtml_xpath": "macro-info[5]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\" ac:local-id=\"22b57ba2-a194-470b-ba2d-f0143fa0dbc5\" ac:macro-id=\"b8dcb71c-caf6-4901-865d-c1bf1aa4ca78\"><ac:rich-text-body><p local-id=\"477d6cee-e036-48cb-a0ab-2d7a5e634837\">해당 연동 방식으로는 사용자 및 그룹은 Okta &rarr; QueryPie로의 단방향 동기화를 지원합니다.</p><p local-id=\"931a5d14-764d-45ce-a395-0bfccfeabd9b\">SCIM 프로비저닝 연동까지 구현하고자 하는 경우, <a href=\"https://chequer.atlassian.net/wiki/spaces/QM/pages/544376394\"><u>[Okta] 프로비저닝 연동 가이드</u></a> 내 절차대로 대신 진행하여 주시기 바랍니다.</p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "2801b5d07ae300c7b0b3ff89e2558d2d65177e566d8651a2c84c55f1eeefb933",
+      "mdx_line_range": [
+        380,
+        382
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 67,
+      "xhtml_xpath": "h2[4]",
+      "xhtml_fragment": "<h2 local-id=\"201b5f13-31e1-4260-95c5-d5a286408c1a\">One Login 연동</h2>",
+      "mdx_content_hash": "36acd58dfe02acd1c0e5551b770fe99c620f9f66ac116427472f4d7baab3ed6a",
+      "mdx_line_range": [
+        384,
+        384
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 68,
+      "xhtml_xpath": "p[18]",
+      "xhtml_fragment": "<p local-id=\"d0f8748b-73bf-40aa-9be6-93acf507b5e9\">목록 우측 상단의 <code>+ Add</code> 버튼을 누르고 팝업되는 화면에서 Type을 One Login으로 선택하면 One Login를 IdP로 추가 할 수 있습니다.</p>",
+      "mdx_content_hash": "81c7387139e818fd240aa71545d57944be4322bd7a79d5b373acf4524477fbf6",
+      "mdx_line_range": [
+        386,
+        387
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 69,
+      "xhtml_xpath": "ul[14]",
+      "xhtml_fragment": "<ul local-id=\"e05420b9-8d10-4b2a-9b5f-f506da0470be\"><li local-id=\"06d641c5-0559-4c40-bd65-73bc35f69898\"><p local-id=\"40aa05bf-a885-4741-900b-e8573f740e24\"><strong>Name</strong> : 식별에 용이하도록 적합한 IdP의 이름을 입력합니다.</p></li><li local-id=\"2753e66a-10a3-4b1a-93f7-ff79b31ca828\"><p local-id=\"60e4bf1c-7440-428a-bb4f-a7b0c2a5e74b\"><strong>Type</strong>: One Login을 선택합니다.</p></li></ul>",
+      "mdx_content_hash": "e89821993f9ddf2878d851da17433861dd5cdf6d3aa2eb50dfd84e5693ed443c",
+      "mdx_line_range": [
+        389,
+        389
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 70,
+      "xhtml_xpath": "macro-info[6]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\" ac:local-id=\"899e5a2d-a485-4bc7-b92d-8467f21579c8\" ac:macro-id=\"0499a765-c98b-4827-80ca-8518f2652b0e\"><ac:rich-text-body><p local-id=\"b6c3a5ba-6128-43a0-bc20-3480b634773d\">One Login SAML Custom Connector 설정 및 Metadata XML 다운로드 </p><ul local-id=\"89238760-f0e9-4a52-9615-fbce9a3a9d88\"><li local-id=\"8d114134-ba87-4d6f-aba9-9f708741e3b4\"><p local-id=\"dae1231d-73f2-4e3f-a40a-130cd0b34a84\">OneLogin에 접속한 후 화면 상단의 Applications &gt; Applications 메뉴를 클릭합니다.</p></li><li local-id=\"c120ffef-09c6-4e4a-bcce-3adfc60bc8a9\"><p local-id=\"3644ce3b-bb37-401d-996a-0e5c15b645d4\"><code>Add App</code> 버튼을 클릭합니다.</p></li><li local-id=\"989ea0b8-6ee6-4fa6-913e-9c6d5f018be1\"><p local-id=\"58b12de2-95d5-447b-96a2-89fc14466a8d\">검색 영역에 'SAML Custom Connector (Advanced)'을 입력한 후 검색 결과를 클릭합니다.</p></li><li local-id=\"a3cf81ec-3002-4f85-81e6-a6c5ac3a02f3\"><p local-id=\"0698f378-67e8-4158-9e39-058e86abde83\">Display Name에 QueryPie에서 확인된 Application Name to be used in OneLogin의 내용을 복사해서 붙여넣고 Audiance (Entity ID), Recipient, ACS (Consumer) URL Validator,  ACS (Consumer) URL도 각각 정보를 복사하여 One Login 설정에 붙여 넣습니다.</p></li><li local-id=\"950211e4-e8a3-48e6-beda-b9d8a00b915f\"><p local-id=\"37c9f49a-ba48-415a-9702-4884f1237f0a\"><code>Save</code> 버튼을 눌러 저장합니다. </p></li><li local-id=\"3a4000f9-38e7-4708-9b5b-055d78599df4\"><p local-id=\"ce96dd6f-e43d-4532-aaf3-8358bd6aca25\">화면 좌측의 Configuration 메뉴를 선택한 뒤 화면 우측 상단의 More Actions &gt; SAML Metadata를 클릭합니다.</p></li><li local-id=\"2276d0e5-d4d9-4d11-b551-e64e4575dda8\"><p local-id=\"91c09747-22da-4c1d-a071-5d83a50e9e42\">다운로드된 XML 파일을 확인합니다.</p></li></ul><p local-id=\"5fde0355-784e-4e48-9f65-1b6810d0c76e\">One Login SAML Custom Connector 설정에 대한 자세한 내용은 <a href=\"https://onelogin.service-now.com/support?id=kb_article&amp;sys_id=8a1f3d501b392510c12a41d5ec4bcbcc&amp;kb_category=de885d2187372d10695f0f66cebb351f\" local-id=\"c63fb6aa-e140-448f-8909-9298951a9783\" data-card-appearance=\"inline\">https://onelogin.service-now.com/support?id=kb_article&amp;sys_id=8a1f3d501b392510c12a41d5ec4bcbcc&amp;kb_category=de885d2187372d10695f0f66cebb351f</a> 의 내용을 참고 바랍니다.</p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "924664c9753f2ef422e794dee088d7fa00a3c9533817905c56577d2fe8b1ed12",
+      "mdx_line_range": [
+        391,
+        392
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 71,
+      "xhtml_xpath": "ul[15]",
+      "xhtml_fragment": "<ul local-id=\"b6c709ad-c679-4991-a7fd-67698b421d14\"><li local-id=\"91daa80d-746e-4c53-a25f-2c4066878157\"><p local-id=\"6fcf02a4-ae7c-4c30-b2df-5fe2aaed8639\"><strong>Identity Provider Metadata</strong> : One Login에서 다운로드한 XML 파일의 내용을 복사해서 붙여넣습니다.</p></li></ul>",
+      "mdx_content_hash": "a41458f4462746db04cd331d4a69d6584fa5ee270d6ee85cec04625f6523d164",
+      "mdx_line_range": [
+        394,
+        394
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 72,
+      "xhtml_xpath": "ac:image[16]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"688\" ac:original-width=\"480\" ac:custom-width=\"true\" ac:local-id=\"f18a5d41-6721-4fe2-9dce-4ee001e11588\" ac:alt=\"image-20251020-001435.png\" ac:width=\"480\"><ri:attachment ri:filename=\"image-20251020-001435.png\" ri:version-at-save=\"1\" /><ac:caption ac:local-id=\"551076dd-cb63-4dcc-b806-94203ca3ecb1\"><p>One Login 상세설정 (1)</p></ac:caption><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "cf57c658cebb58be7d60564da9ec83102297544cbf03f4c854c6d5a662fca1b1",
+      "mdx_line_range": [
+        396,
+        396
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 73,
+      "xhtml_xpath": "ul[16]",
+      "xhtml_fragment": "<ul local-id=\"ca40341b-40ec-41f0-9a0a-637b0577c827\"><li local-id=\"c724dda1-56f8-4f69-b9b4-3b0634bdad16\"><p local-id=\"c586772f-f5a2-4db7-a3d4-baff29444c28\">동기화를 설정하고자 하는 경우, &ldquo;Use Synchronization with the Authentication System&rdquo; 옵션을 활성화(체크)합니다.</p></li><li local-id=\"dd43541e-312d-465e-abd2-d5b649894ece\"><p local-id=\"3f5c5aad-35a4-4933-ad3d-27940487346a\">주기적인 동기화 기능을 사용하고자 할 경우 Replication Frequency 항목에서 Scheduling 을 설정합니다.</p></li></ul>",
+      "mdx_content_hash": "033fd80b16565c731671a05c0050b1c5ad3452d57728107282567029ad7e0f43",
+      "mdx_line_range": [
+        398,
+        403
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 74,
+      "xhtml_xpath": "ac:image[17]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"471\" ac:original-width=\"481\" ac:custom-width=\"true\" ac:local-id=\"c13fecc0-c023-4886-af5f-9c8af2e1ed6f\" ac:alt=\"image-20251014-014949.png\" ac:width=\"481\"><ri:attachment ri:filename=\"image-20251014-014949.png\" ri:version-at-save=\"1\" /><ac:caption ac:local-id=\"1e2de297-d24c-4211-a193-5cc21f27c2d0\"><p>One Login 상세설정 (2)</p></ac:caption><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "7d3fb4dd882b9c02b06567ab06b98c37ee8ffe927d0c8602d0f9b05561cb2ca5",
+      "mdx_line_range": [
+        405,
+        411
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 75,
+      "xhtml_xpath": "ul[17]",
+      "xhtml_fragment": "<ul local-id=\"43faf7fc-06c5-4d55-8b50-3554d51cc41e\"><li local-id=\"e384b2f5-8f0d-48b8-8062-ca1f7b06eaef\"><p local-id=\"b9535b5b-f243-4650-9333-76f61ae13225\"><strong>Additional Settings</strong></p><ul local-id=\"5adff487-e1c4-4e1b-9d65-209635ea9ccf\"><li local-id=\"0ddb6ad2-0a63-4812-85ac-6f90e9d6df96\"><p local-id=\"02572332-f57a-42d1-ad39-6572850cbcd6\"><strong>Make New Users Inactive by Default </strong>: 동기화 시 새로운 사용자를 비활성화 상태로 추가할지 여부를 선택합니다.</p><p local-id=\"2db8300e-7318-4b32-8812-ce62142763c4\">동기화할 사용자 수가 많거나, 사용자의 인증을 통한 QueryPie 접근을 개별적으로 관리하고자 하는 경우 해당 옵션을 활성화하시기 바랍니다.</p></li><li local-id=\"38300ced-9fe5-4254-9a20-31e70d9bf696\"><p local-id=\"5f968a07-7315-4414-8d1f-c843212f5e35\"><strong>Use an Attribute for Privilege Revoke</strong> : 동기화 시 특정 Attribute에 따라 Privilege를 회수할지 여부를 선택합니다.</p><p local-id=\"f11992b6-45df-47e9-a1ce-062f92150120\">특정 Attribute의 변경에 의해 자동으로 DAC Privilege를 회수하고자 하는 경우 이 옵션을 활성화하세요.</p><p local-id=\"98778f6e-af9c-4dfb-bb61-75e1b69363cb\">Attribute 입력 필드에 활성화 변경을 감지하려는 Attribute 이름을 입력합니다.</p></li><li local-id=\"50790995-689f-49b0-a645-37dfa5dd581b\"><p local-id=\"87543926-dc12-4e61-8786-df3f49b1fcc7\"><strong>Enable Attribute Synchronization</strong> : IdP의 사용자 속성과 QueryPie 사용자 속성을 매핑하여 동기화할지 여부를 선택합니다.</p><p local-id=\"d8ab43e9-61dd-44a2-a47e-76d4bf08a5d7\">IdP에서 관리 중인 사용자 속성을 QueryPie 내 Attribute와 자동으로 연동하고자 하는 경우, 해당 옵션을 활성화하시기 바랍니다.</p><p local-id=\"d7d2fee3-7c4b-49da-a58c-399d69222d50\">옵션 활성화 시, 하단에 Attribute Mapping UI가 표시되며 매핑 작업을 통해 연동할 IdP Attribute와 QueryPie Attribute를 지정할 수 있습니다.</p><p local-id=\"5e15e8cc-7550-4c6c-9673-acf992a0b1dc\">단, 해당 기능은 Profile Editor(Admin&gt; General &gt; User Management &gt; Profile Editor)에서 Source Priority가 Inherit from profile source로 설정된 Attribute에 한해 적용됩니다.</p></li><li local-id=\"8f73a8a1-d4a7-4438-9418-2839366dac05\"><p local-id=\"69c33b98-3139-438f-b060-7ffa9a16490d\"><strong>Allowed User Deletion Rate Threshold : </strong></p><ul local-id=\"f05077b7-ad07-4700-951a-96bae75cef09\"><li local-id=\"3d2755d1-420c-41b5-ba4f-1dc452438be9\"><p local-id=\"9f312f70-969e-4c5c-8ff8-9aa50ace71b7\">동기화시 기존 유저가 이 값의 비율 이상으로 삭제되었을 경우에는 동기화를 실패하도록 하는 기능입니다.</p></li><li local-id=\"5b8c34ba-1935-4404-8acb-6b0b777f3356\"><p local-id=\"d5620706-5940-43c8-a667-a24ae8059db0\">0.0 ~ 1.0 사이의 값을 입력합니다. (기본값은 0.1)</p><ul local-id=\"7988ba4f-ab08-4e6d-aa61-d58e57054563\"><li local-id=\"77db4f16-ff18-4fc6-a2d3-c05cc44cf58c\"><p local-id=\"ce9a4769-11ad-448e-8e2a-87a47bcc314f\">예) 기존 유저가 100명이고, Allowed User Deletion Rate Threshold 0.1 인 경우, 다시 동기화 하였을 때, 삭제된 유저가 10명 이상이면 동기화가 실패합니다.</p></li><li local-id=\"e1dbe3bc-b494-4c79-8e25-76eb2ad5dc02\"><p local-id=\"667f1d94-b7c8-40a1-ac70-9167738d9531\">11.3.0 이전 버전에서 동기화 설정된 상태에서, 11.3.0으로 제품을 업그레이드하면 이 값이 1.0 으로 기본 설정됩니다.</p></li></ul></li></ul></li></ul></li></ul>",
+      "mdx_content_hash": "edc8df91239862554592f4152c8ae2815f13bc267e9cb30533386194ed60053c",
+      "mdx_line_range": [
+        413,
+        418
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 76,
+      "xhtml_xpath": "h2[5]",
+      "xhtml_fragment": "<h2 local-id=\"d2fa7f54-35fa-44fb-ad8f-66d556dc78c0\">SAML 2.0 연동 (주기적 동기화 없는 1회용)</h2>",
+      "mdx_content_hash": "0126b71ad202cd4ffe761a95a8ecc47595b7c8e49e0bada8fdf90e31fe1fa293",
+      "mdx_line_range": [
+        421,
+        436
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 77,
+      "xhtml_xpath": "p[19]",
+      "xhtml_fragment": "<p local-id=\"1e74cb53-f79c-4b70-8964-89a539b8fe9f\">주기적인 동기화 없이 1회만 SAML 연동하는 경우 SAML metadata 만 입력하여 설정합니다.</p>",
+      "mdx_content_hash": "ff7e2d32c82056c8ff53a9ba2624042977b42ff8049a231f7a67247de1a54012",
+      "mdx_line_range": [
+        438,
+        440
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 78,
+      "xhtml_xpath": "ul[18]",
+      "xhtml_fragment": "<ul local-id=\"dc50ffec-dfc8-4c36-828c-840148b29d1d\"><li local-id=\"1ae95943-a4ea-440d-a236-dd2444ba2ba1\"><p local-id=\"39065f26-927b-4d67-aef8-ecdbc276bf21\"><strong>Name</strong> : 식별에 용이하도록 적합한 IdP의 이름을 입력합니다.</p></li><li local-id=\"315c937d-e887-4466-bde4-0592b5facf20\"><p local-id=\"852b2906-ea36-49ab-80e0-cf892f623f50\"><strong>Type </strong>: SAML 을 선택합니다.</p></li><li local-id=\"7013ef1a-42c7-46b4-ab14-bddd2000ccc7\"><p local-id=\"1a69a06d-19f6-4c72-afc6-358d76dd5713\"><strong>Identity Provider Metadata</strong> : IdP에서 확인한 SML metadata XML의 내용을 복사해서 붙여 넣습니다. </p></li></ul>",
+      "mdx_content_hash": "b2da7f53a98160f9a467e89f4f04afbd6efa6caff1e00b4a072e5fd65d238800",
+      "mdx_line_range": [
+        441,
+        441
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 79,
+      "xhtml_xpath": "ac:image[18]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"581\" ac:original-width=\"481\" ac:custom-width=\"true\" ac:local-id=\"8cfb0bba-72dd-4e56-b3f7-6f8c23a655ce\" ac:alt=\"image-20251014-015015.png\" ac:width=\"481\"><ri:attachment ri:filename=\"image-20251014-015015.png\" ri:version-at-save=\"1\" /><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "b960c486ef4a4fa9fe8de01f59281ab34a5481f42c593325518e9357b6017632",
+      "mdx_line_range": [
+        443,
+        448
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 80,
+      "xhtml_xpath": "p[20]",
+      "xhtml_fragment": "<p local-id=\"c74fa862-d4e9-4922-ac72-d3bcb99508cb\">&lt; 참고 &gt; <ac:link><ri:page ri:content-title=\"AWS SSO 연동하기 (SAML 2.0)\" ri:version-at-save=\"2\" /><ac:link-body>AWS SSO 연동</ac:link-body></ac:link> </p>",
+      "mdx_content_hash": "dc62e023909240bdf600883f6c52267f11f02d1a7eb45a55953c610fd01e76c9",
+      "mdx_line_range": [
+        451,
+        451
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 81,
+      "xhtml_xpath": "h2[6]",
+      "xhtml_fragment": "<h2 local-id=\"15136b36-31b1-400b-bd75-c10637feac29\">Custom Identity Provider</h2>",
+      "mdx_content_hash": "2fb894920fa6f52b1f1f66a71c4987c4e9533d30b6556e3324a32790fc5229c5",
+      "mdx_line_range": [
+        453,
+        454
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 82,
+      "xhtml_xpath": "p[21]",
+      "xhtml_fragment": "<p local-id=\"17bc779c-6223-4bdf-b9b2-05a2a9b080ff\">Custom Identity Provider는 인증 API서버를 사용하는 특수한 경우에만 사용합니다.</p>",
+      "mdx_content_hash": "16a0a1294d342e7caefe21758435c6b9bfac8250caeb748cdb384e50dc22cd11",
+      "mdx_line_range": [
+        456,
+        458
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 83,
+      "xhtml_xpath": "ul[19]",
+      "xhtml_fragment": "<ul local-id=\"07b6f676-cd36-4d30-9dd7-53822ae3c585\"><li local-id=\"485b8ca1-9772-4a25-aaeb-1695ee418892\"><p local-id=\"c4efae49-8023-40b9-b2bd-6b681d555f78\"><strong>Name</strong> : 식별에 용이하도록 적합한 IdP의 이름을 입력합니다.</p></li><li local-id=\"10b50081-b1f8-40cc-accc-83fcde7c6b7d\"><p local-id=\"485bb97b-19e5-45d4-bb00-86aa1de1c810\"><strong>Type </strong>: Custom Identity Provider 를 선택합니다.</p></li><li local-id=\"f6a6c9ec-b939-4897-ae6b-cf8d58c53a06\"><p local-id=\"ab5bb769-d554-46fe-8193-88ddedd7069b\"><strong>API URL</strong> : API서버의 End-point URL을 입력합니다. </p></li><li local-id=\"5c1578b9-c252-46b0-a990-0a1e38758fcf\"><p local-id=\"8f204698-5d47-4274-8ef9-e1a1fbaef450\"> 사용자 정보 동기화를 실행하려는 경우 Use Synchronization with the Authentication System 옵션을 활성화합니다.</p></li></ul>",
+      "mdx_content_hash": "d43ebce7ca2669648bd7eefcafa834ef23edecc609488d111ed8165a398a2ff8",
+      "mdx_line_range": [
+        460,
+        462
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 84,
+      "xhtml_xpath": "ac:image[19]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"581\" ac:original-width=\"481\" ac:custom-width=\"true\" ac:local-id=\"ed5ffb55-0ffc-48e3-986f-a4e7b7eeb760\" ac:alt=\"image-20251014-015047.png\" ac:width=\"481\"><ri:attachment ri:filename=\"image-20251014-015047.png\" ri:version-at-save=\"1\" /><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "b2da7f53a98160f9a467e89f4f04afbd6efa6caff1e00b4a072e5fd65d238800",
+      "mdx_line_range": [
+        463,
+        463
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 85,
+      "xhtml_xpath": "ul[20]",
+      "xhtml_fragment": "<ul local-id=\"fc66289c-2511-430a-ae52-739a42ff237b\"><li local-id=\"405918b9-ab5d-45be-a833-0150d09f7e55\"><p local-id=\"4a9cf30f-caf4-46d6-bf49-ca71de7be649\"><strong>Additional Settings</strong></p><ul local-id=\"7df64d18-e809-486d-a5ae-44b4fc4471be\"><li local-id=\"2cb0f891-1094-4d90-97e0-420bb80f215a\"><p local-id=\"728588d5-28a5-41f9-8e2d-d7676bb2c4a1\"><strong>Make New Users Inactive by Default </strong>: 동기화 시 새로운 사용자를 비활성화 상태로 추가할지 여부를 선택합니다.</p><p local-id=\"fc5ee0b1-6f5a-40dd-a84e-9eecab2606db\">동기화할 사용자 수가 많거나, 사용자의 인증을 통한 QueryPie 접근을 개별적으로 관리하고자 하는 경우 해당 옵션을 활성화하시기 바랍니다.</p></li><li local-id=\"a1e45257-8479-41c8-9c20-5142473bc665\"><p local-id=\"dd3b7508-8d53-4d70-9013-68bb02c48494\"><strong>Use an Attribute for Privilege Revoke</strong> : 동기화 시 특정 Attribute에 따라 Privilege를 회수할지 여부를 선택합니다.</p><p local-id=\"18306950-fab2-4005-9ce0-e478e27c70bd\">특정 Attribute의 변경에 의해 자동으로 DAC Privilege를 회수하고자 하는 경우 이 옵션을 활성화하세요.</p><p local-id=\"ee906509-47ae-424b-ba9e-563f85fb01ef\">Attribute 입력 필드에 활성화 변경을 감지하려는 Attribute 이름을 입력합니다.</p></li><li local-id=\"62664dc5-8697-4483-9531-30500cf314cb\"><p local-id=\"b24f8473-8289-4277-b9eb-2a2f65e95e86\"><strong>Enable Attribute Synchronization</strong> : IdP의 사용자 속성과 QueryPie 사용자 속성을 매핑하여 동기화할지 여부를 선택합니다.</p><p local-id=\"06a025e5-54bb-4999-8c48-a490d0a13634\">IdP에서 관리 중인 사용자 속성을 QueryPie 내 Attribute와 자동으로 연동하고자 하는 경우, 해당 옵션을 활성화하시기 바랍니다.</p><p local-id=\"4728776c-ff40-4d50-b69d-586fb9be5df2\">옵션 활성화 시, 하단에 Attribute Mapping UI가 표시되며 매핑 작업을 통해 연동할 IdP Attribute와 QueryPie Attribute를 지정할 수 있습니다.</p><p local-id=\"846ebea8-f153-4809-ba78-1ade073e5905\">단, 해당 기능은 Profile Editor(Admin&gt; General &gt; User Management &gt; Profile Editor)에서 Source Priority가 Inherit from profile source로 설정된 Attribute에 한해 적용됩니다.</p></li><li local-id=\"1e9e04e3-64fe-44e6-8fc9-305221a05e54\"><p local-id=\"15d7194d-a210-4c7b-afb0-8d23d501bf67\"><strong>Allowed User Deletion Rate Threshold : </strong></p><ul local-id=\"2c2e695b-dbed-4cd9-b61e-48e6bac0e476\"><li local-id=\"b88cd542-bbbd-49c4-ab41-5b6d3ca9b4b5\"><p local-id=\"96dad8cc-61f7-4fe2-81f6-8a23c2c725eb\">동기화시 기존 유저가 이 값의 비율 이상으로 삭제되었을 경우에는 동기화를 실패하도록 하는 기능입니다.</p></li><li local-id=\"47cdf98a-ae89-4d7c-be09-f14f99b95c14\"><p local-id=\"ef274842-7f58-47f3-994f-817924ce8668\">0.0 ~ 1.0 사이의 값을 입력합니다. (기본값은 0.1)</p><ul local-id=\"e2532552-f23f-49fa-95d2-28c7b1419eb4\"><li local-id=\"0e7ff511-2d7f-4135-b17f-361a5e5d0b8e\"><p local-id=\"b94521d9-6d74-4193-bbd1-a51381a97df0\">예) 기존 유저가 100명이고, Allowed User Deletion Rate Threshold 0.1 인 경우, 다시 동기화 하였을 때, 삭제된 유저가 10명 이상이면 동기화가 실패합니다.</p></li><li local-id=\"9f77123f-344f-4f62-ace8-d372f0892de2\"><p local-id=\"0ad270f5-3ad0-4d52-a6ec-b478830ca40e\">11.3.0 이전 버전에서 동기화 설정된 상태에서, 11.3.0으로 제품을 업그레이드하면 이 값이 1.0 으로 기본 설정됩니다.</p></li></ul></li></ul></li></ul></li></ul>",
+      "mdx_content_hash": "cc372f7acb077322434c8ea99191f25514a4fdef15aa0c6f91cb1ef4eb32855f",
+      "mdx_line_range": [
+        465,
+        465
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 86,
+      "xhtml_xpath": "p[22]",
+      "xhtml_fragment": "<p local-id=\"1e0537aa-06f7-434f-bc53-1585da5db3a8\" />",
+      "mdx_content_hash": "6e823ba7c7a4843a116f8f7c3637adc86dee79b0b91dad5c72ad9c363fd3ee1b",
+      "mdx_line_range": [
+        467,
+        467
+      ],
+      "lost_info": {}
+    }
+  ],
+  "separators": [
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ],
+  "document_envelope": {
+    "prefix": "",
+    "suffix": ""
+  }
+}

--- a/confluence-mdx/tests/testcases/1844969501/expected.roundtrip.json
+++ b/confluence-mdx/tests/testcases/1844969501/expected.roundtrip.json
@@ -1,0 +1,205 @@
+{
+  "schema_version": "2",
+  "page_id": "1844969501",
+  "mdx_sha256": "fb4733fe5a0ebbcfe6a20af3b5c9f3d84a075a7b4d253f2e23260b5426a74d58",
+  "source_xhtml_sha256": "94e15b644935393ee8893708987d235462108a6e137afbf178f44f1411ac08a3",
+  "blocks": [
+    {
+      "block_index": 0,
+      "xhtml_xpath": "macro-toc[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"toc\" ac:schema-version=\"1\" data-layout=\"default\" ac:local-id=\"e73631cc-f0eb-448b-9354-c7ec94a27e77\" ac:macro-id=\"7bdc2ece-abbc-4741-a900-a08feb04a9a2\"><ac:parameter ac:name=\"style\">none</ac:parameter></ac:structured-macro>",
+      "mdx_content_hash": "fcc8ac1511d6a276bd920cc13c666072875a70d6bc4d7259c8e99d2a1bf34115",
+      "mdx_line_range": [
+        6,
+        6
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 1,
+      "xhtml_xpath": "h2[1]",
+      "xhtml_fragment": "<h2 local-id=\"da628dd2-12f3-4651-ab59-c77494309797\">공통 리소스</h2>",
+      "mdx_content_hash": "6e7728abf78a94c9a3500a8baf1f65b2a77090824a3060bf179ffd7d77094348",
+      "mdx_line_range": [
+        8,
+        8
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 2,
+      "xhtml_xpath": "p[1]",
+      "xhtml_fragment": "<p local-id=\"7aeaf0a8-a18a-4de2-9abf-78d440337552\">모든 QueryPie 고객이 이용할 수 있는 자료입니다.</p>",
+      "mdx_content_hash": "85019d5465fad808bff24a529a2f174c0fca68608964f50d26a0bd25572c0dc0",
+      "mdx_line_range": [
+        10,
+        10
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 3,
+      "xhtml_xpath": "h3[1]",
+      "xhtml_fragment": "<h3 local-id=\"edf077b3-5199-49e6-8392-6fd115decf62\">Documentation</h3>",
+      "mdx_content_hash": "39869635a7c7cb4e06bcef86d3fa2b5a3f9e66570029f94f91ac7d7070be607d",
+      "mdx_line_range": [
+        12,
+        12
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 4,
+      "xhtml_xpath": "p[2]",
+      "xhtml_fragment": "<p local-id=\"1405d1f5-07b4-4058-a676-97f9b3a66479\">이 웹사이트, <a href=\"http://docs.querypie.com\">docs.querypie.com</a> 에서 다음 자료를 확인할 수 있습니다:</p>",
+      "mdx_content_hash": "93c1c6d39eb0c9d4cb61580dcb414f0b93bee3b3932bd14d62384047ba086ec8",
+      "mdx_line_range": [
+        14,
+        14
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 5,
+      "xhtml_xpath": "ul[1]",
+      "xhtml_fragment": "<ul local-id=\"9ef82e17-4026-4cbe-9696-e3226a7357b1\"><li local-id=\"a4dae406-dcd8-40dc-95ec-424085d2a50c\"><p local-id=\"07de2fcc-6c47-4e84-a213-bc5e28bea2b8\">이용자 매뉴얼</p></li><li local-id=\"56c6e2fe-e0df-4f66-986e-684355eb9dbd\"><p local-id=\"27a26caa-20d9-47ff-85d8-97deba0d7593\">관리자 매뉴얼</p></li><li local-id=\"f877543f-6756-4036-9150-4c61e8fe1a7d\"><p local-id=\"bea6b957-601b-44fe-baa8-a8e4aaa3b2c0\">API Reference</p></li><li local-id=\"8b26ca51-0984-47fa-ada6-8b6467c18b9e\"><p local-id=\"fbe95a8b-88ee-4f0d-97ca-4f4bb4de47e9\">릴리스 노트</p></li></ul>",
+      "mdx_content_hash": "085dc830df54ef090b463f5b7fae4ffcbd30ee48748bfc127c1311c4e911806f",
+      "mdx_line_range": [
+        16,
+        19
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 6,
+      "xhtml_xpath": "p[3]",
+      "xhtml_fragment": "<p local-id=\"711c3c85-02f2-422b-b768-5296b59156b5\">기술지원을 위한 <ac:link><ri:space ri:space-key=\"QCP\" /><ac:link-body>Confluence Space</ac:link-body></ac:link> 에서 상세한 기술지원 자료를 확인할 수 있습니다.</p>",
+      "mdx_content_hash": "5afb5c4e027fa482a3a000fdf17633a1728996715c3b48b1d36a7916954b97fb",
+      "mdx_line_range": [
+        21,
+        21
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 7,
+      "xhtml_xpath": "ul[2]",
+      "xhtml_fragment": "<ul local-id=\"1dc6fa88-2805-4e4e-a0de-3bb29c246c62\"><li local-id=\"30c1a3a7-8ebb-4c88-ae8d-31b94e59a68b\"><p local-id=\"dec58e05-5910-4e21-985b-560b5f70e229\"><ac:link><ri:page ri:space-key=\"QCP\" ri:content-title=\"QueryPie Architecture (KO)\" ri:version-at-save=\"6\" /><ac:link-body>QueryPie Architecture</ac:link-body></ac:link></p></li><li local-id=\"9f7893d4-abad-4a93-b9bf-14e5cedbd44c\"><p local-id=\"37c3db5a-5873-466c-808a-68a83e62f57a\"><ac:link><ri:page ri:space-key=\"QCP\" ri:content-title=\"Advanced Environment Setup (KO)\" ri:version-at-save=\"4\" /><ac:link-body>Advanced Environment Setup</ac:link-body></ac:link></p></li><li local-id=\"6b8334f2-b334-487b-9539-f19ae402bf96\"><p local-id=\"9e849d92-d344-4ec4-9478-f0bb3c64867e\"><ac:link><ri:page ri:space-key=\"QCP\" ri:content-title=\"Advanced Integration Guide (KO)\" ri:version-at-save=\"5\" /><ac:link-body>Advanced Integration Guide</ac:link-body></ac:link></p></li><li local-id=\"92aa4792-7e4f-4522-8fba-a66e26afbc58\"><p local-id=\"994e1893-08ee-4242-ba5b-0b803ef22dac\"><ac:link ac:local-id=\"2c6f6eb0-6fc2-4900-aa7f-6ecc3fd87d57\" ac:card-appearance=\"inline\"><ri:page ri:space-key=\"QCP\" ri:content-title=\"릴리스 버전 별 문서\" ri:version-at-save=\"1\" /><ac:link-body>릴리스 버전 별 문서</ac:link-body></ac:link></p></li><li local-id=\"4cb99bfb-1f32-4ed2-a2d0-a7c61ae9fc17\"><p local-id=\"683eb18e-d18b-418e-83cf-3fe165846630\"><ac:link><ri:page ri:space-key=\"QCP\" ri:content-title=\"Troubleshooting (KO)\" ri:version-at-save=\"5\" /><ac:link-body>Troubleshooting</ac:link-body></ac:link></p></li></ul>",
+      "mdx_content_hash": "b615c52c55a739e64730079b41893df725f5ffdeec327a7251f524aad4217eab",
+      "mdx_line_range": [
+        23,
+        27
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 8,
+      "xhtml_xpath": "h3[2]",
+      "xhtml_fragment": "<h3 local-id=\"44974faa-fab5-416c-87d5-664d7219f126\">Product Demo - YouTube</h3>",
+      "mdx_content_hash": "575190eb1ab5d24a0c4f0c1e2eb7e9eb4104b97915f525cfcce4870c1ab80ab3",
+      "mdx_line_range": [
+        29,
+        29
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 9,
+      "xhtml_xpath": "p[4]",
+      "xhtml_fragment": "<p local-id=\"ff1d3c6f-ff30-4a5e-85c3-b78ee962bf03\"><a href=\"https://www.youtube.com/playlist?list=PLB6l6itD4YrpMXRtprvUdR3hIHVbT8IhZ\">Product Demo - YouTube</a> 채널에서 QueryPie ACP 제품의 여러 기능을 영상으로 살펴볼 수 있습니다.</p>",
+      "mdx_content_hash": "cb37ae9cf6b9a67d42bcf75ce7d1d5e36fc6b773df6c77f28525b634c6f246ed",
+      "mdx_line_range": [
+        31,
+        31
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 10,
+      "xhtml_xpath": "ul[3]",
+      "xhtml_fragment": "<ul local-id=\"44e8c253-aceb-45f0-bd97-f18771246887\"><li local-id=\"6cc45ec1-65d8-4bd3-ace9-0924e0b5fc9c\"><p local-id=\"2d3aeeb4-6426-40cf-992c-17f8b59bafe8\">DAC: 데이터베이스 접근 제어 기능 튜토리얼</p></li><li local-id=\"6cc45ec1-65d8-4bd3-ace9-0924e0b5fc9c\"><p local-id=\"2d3aeeb4-6426-40cf-992c-17f8b59bafe8\">SAC: 서버 접근 제어 기능 튜토리얼</p></li><li local-id=\"de0dde4b-8ae2-4b41-b6ce-557f972db058\"><p local-id=\"52268ffc-bc5a-47f0-b1f0-3cd5ae6aa123\">KAC: Kubernetes 접근 제어 기능 튜토리얼</p></li><li local-id=\"ae112e65-e714-4dbf-b7a4-6013a99e2311\"><p local-id=\"27e21136-ba15-465f-b039-26163ddaa103\">General: SSO 통합, 감사 로그, BI 도구 연동 (Tableau, Redash)</p></li></ul>",
+      "mdx_content_hash": "dca6d4290941d8f11b04bacaf3877f4c859c4c8339f1c93becf5ade9e20a21d5",
+      "mdx_line_range": [
+        33,
+        36
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 11,
+      "xhtml_xpath": "h2[2]",
+      "xhtml_fragment": "<h2 local-id=\"4561f9b5-2678-4159-8991-7ffbff223048\">커뮤니티 지원</h2>",
+      "mdx_content_hash": "71f602b035be9f52082b60e29d912b28321d1433edfd42bb264bbcd3e01b85eb",
+      "mdx_line_range": [
+        38,
+        38
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 12,
+      "xhtml_xpath": "p[5]",
+      "xhtml_fragment": "<p local-id=\"6fe65f82-af0d-4894-b0ac-5508285bc762\">대상: Community Edition, Standard Edition 을 이용하는 고객</p>",
+      "mdx_content_hash": "25225599e62f48a3283b5c4d8749ab1464a74706664130989133baf7566dfcf8",
+      "mdx_line_range": [
+        40,
+        40
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 13,
+      "xhtml_xpath": "h3[3]",
+      "xhtml_fragment": "<h3 local-id=\"68d99482-0c37-450d-892e-2143a15addba\">GitHub Discussion</h3>",
+      "mdx_content_hash": "b3aa0c081f9a75d18272f5913ab62e77a28cd33bfab69d738860bef978529ef5",
+      "mdx_line_range": [
+        42,
+        42
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 14,
+      "xhtml_xpath": "p[6]",
+      "xhtml_fragment": "<p local-id=\"328c698b-d652-484a-9a2b-21addf7e26fc\">설치 및 사용 중 궁금한 점을 <a href=\"https://github.com/querypie/querypie-community/discussions\">GitHub Discussion</a> 에서 문의하거나, 다른 사용자들과 경험을 공유할 수 있습니다.</p>",
+      "mdx_content_hash": "90a23bcd55a971d1c034ea7e1bb3ab9eb3dd7805b58536dc5c5e641a6a034893",
+      "mdx_line_range": [
+        44,
+        44
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 15,
+      "xhtml_xpath": "p[7]",
+      "xhtml_fragment": "<p local-id=\"bd55c917-a378-4083-8710-9e8b75b3a7b3\" />",
+      "mdx_content_hash": "",
+      "mdx_line_range": [
+        0,
+        0
+      ],
+      "lost_info": {}
+    }
+  ],
+  "separators": [
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ],
+  "document_envelope": {
+    "prefix": "",
+    "suffix": ""
+  }
+}

--- a/confluence-mdx/tests/testcases/1911652402/expected.roundtrip.json
+++ b/confluence-mdx/tests/testcases/1911652402/expected.roundtrip.json
@@ -1,0 +1,217 @@
+{
+  "schema_version": "2",
+  "page_id": "1911652402",
+  "mdx_sha256": "4c8e770601d5fac4d74c9214a8773f27cbd86fcd5de6a22e553ae9080e57b28d",
+  "source_xhtml_sha256": "dd7e858544cbe4c994c4844b5d55812b3effdaeb21538e4ff12e0f014e86cbc9",
+  "blocks": [
+    {
+      "block_index": 0,
+      "xhtml_xpath": "p[1]",
+      "xhtml_fragment": "<p local-id=\"88f68dcf91fb\">QueryPie ACP 제품을 설치하는 방법은 Container 실행방식, 설치 도우미 프로그램의 버전에 따라, 안내 문서가 구분되어 제공됩니다.</p>",
+      "mdx_content_hash": "c144af9852edf8a18afc7c2cb6ec98ce1b91449dbcd7768ce8c93feaa4e05562",
+      "mdx_line_range": [
+        6,
+        6
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 1,
+      "xhtml_xpath": "h2[1]",
+      "xhtml_fragment": "<h2 local-id=\"295b880c-7b06-46cd-b817-e11745599e4d\">Compose Tool 로 Container 를 실행하기</h2>",
+      "mdx_content_hash": "9d5361ed1cdb915ce34cb1d342ad6ea41d9e39d49af72903fee2dc4f715b8d0f",
+      "mdx_line_range": [
+        8,
+        8
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 2,
+      "xhtml_xpath": "p[2]",
+      "xhtml_fragment": "<p local-id=\"92a3757fa85d\">일반적인 설치, 실행 방법이며, 제조사에서 권장하는 설치 방법입니다. Docker Compose 를 활용하여, Container Image 를 내려받고, 실행, 종료하는 방식입니다.</p>",
+      "mdx_content_hash": "ded3bfc08f6d724bdb0e6630ef088d9e33ddacd7b5e164b4c2a7a0f43a78435e",
+      "mdx_line_range": [
+        10,
+        10
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 3,
+      "xhtml_xpath": "p[3]",
+      "xhtml_fragment": "<p local-id=\"d872ddaf0cf7\">이 경우, 설치 도우미 프로그램의 버전에 따라, 두 가지 설치 방식이 제공됩니다.</p>",
+      "mdx_content_hash": "67e620d0a803bd736a72f523f293c87c3c518e49a08ea1714be317c389d74dfd",
+      "mdx_line_range": [
+        12,
+        13
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 4,
+      "xhtml_xpath": "h3[1]",
+      "xhtml_fragment": "<h3 local-id=\"9fd29aa7927d\">setup.v2.sh 로 설치하기</h3>",
+      "mdx_content_hash": "e5fba69229829a32b47dfd97d761ff5d91a690675865542fefb927b4d83cc64e",
+      "mdx_line_range": [
+        15,
+        15
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 5,
+      "xhtml_xpath": "p[4]",
+      "xhtml_fragment": "<p local-id=\"adf8f0375431\">2025년 8월 출시된 QueryPie ACP Community Edition 의 출시와 함께 최종 고객사와 파트너 엔지니어에게 제공되는 설치 도우미 프로그램입니다. Docker Hub 에 공개된 Container Image 를 내려받아 설치하는 방식입니다.</p>",
+      "mdx_content_hash": "b51bc10842a77cf252330d0e5110b318f638aa39156c371f168c72f01f0b503c",
+      "mdx_line_range": [
+        17,
+        17
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 6,
+      "xhtml_xpath": "p[5]",
+      "xhtml_fragment": "<p local-id=\"3a7aa77ca0c7\">설치 과정이 자동화되어, 처음 설치하는 이용자가 제품을 쉽게 설치할 수 있습니다. setup.v2.sh 가 실제로 실행하는 설치 과정은 setup.sh 의 설치 방식과 동등합니다. setup.v2.sh 는 그 과정이 자동화되었고, Version 10 등 구버전의 설치를 지원하지 않는다는 차이가 있습니다. 더 상세한 차이점은 이 문서를 참조하세요: <ac:link ac:local-id=\"af972ffe-4ea0-411c-91b5-eb9fcf92df45\" ac:card-appearance=\"inline\"><ri:page ri:content-title=\"setup.sh, setup.v2.sh 비교\" ri:version-at-save=\"6\" /><ac:link-body>setup.sh, setup.v2.sh 비교</ac:link-body></ac:link></p>",
+      "mdx_content_hash": "542a49571bd6a1388d80e50a36d74e9a7c475fb4e9f9952017fc24c0302105c5",
+      "mdx_line_range": [
+        19,
+        20
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 7,
+      "xhtml_xpath": "p[6]",
+      "xhtml_fragment": "<p local-id=\"3dc3c03f0a63\">Apple Silicon 을 사용하는 macOS 환경의 설치를 지원합니다.</p>",
+      "mdx_content_hash": "424f940490f288228663451f8911226776a4bb73a3c03966f1b0dbfca80aedca",
+      "mdx_line_range": [
+        22,
+        25
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 8,
+      "xhtml_xpath": "p[7]",
+      "xhtml_fragment": "<p local-id=\"891425652a71\">자세한 설치 방법은 이 문서를 참조하세요: <ac:link ac:local-id=\"7dca62d4-0f35-4664-bde0-49f59210d90e\" ac:card-appearance=\"inline\"><ri:page ri:content-title=\"설치 가이드 - setup.v2.sh\" ri:version-at-save=\"30\" /><ac:link-body>설치 가이드 - setup.v2.sh</ac:link-body></ac:link></p>",
+      "mdx_content_hash": "674d0b17840f07494da5758e8c4e34fb2958f0574cf8b937bf000f36dae84f15",
+      "mdx_line_range": [
+        27,
+        27
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 9,
+      "xhtml_xpath": "h3[2]",
+      "xhtml_fragment": "<h3 local-id=\"8eba8a81-c6fc-4f1f-b18a-43153cee4747\">setup.sh 로 설치하기</h3>",
+      "mdx_content_hash": "cee19b6b0a7b643113ad8b0fac08115cc4afd1ca5b1b2ce0deb37b6f9e5ff828",
+      "mdx_line_range": [
+        29,
+        29
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 10,
+      "xhtml_xpath": "p[8]",
+      "xhtml_fragment": "<p local-id=\"7bce0f5ca1d1\">QueryPie ACP Version 9 시절부터 파트너 엔지니어에게 제공된 설치 도우미 프로그램입니다. Harbor 라는 Container Registry 에 계정을 발급받아 Container Image 를 내려받을 수 있습니다.</p>",
+      "mdx_content_hash": "79ad96798878d0ca319b91566f3df29427b0d72b610bf05a3d64d8c26ea56555",
+      "mdx_line_range": [
+        31,
+        31
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 11,
+      "xhtml_xpath": "p[9]",
+      "xhtml_fragment": "<p local-id=\"ba5fa9b87d96\">자세한 설치 방법은 이 문서를 참조하세요: <ac:link ac:local-id=\"4599bf9f-cf7c-4699-99fe-ac48128efd92\" ac:card-appearance=\"inline\"><ri:page ri:content-title=\"설치 가이드 - 간단한 구성\" ri:version-at-save=\"14\" /><ac:link-body>설치 가이드 - 간단한 구성</ac:link-body></ac:link></p>",
+      "mdx_content_hash": "f9aa23d49043802f28b8537753dd410a61257bf25d906eaa79e72b480c7050fa",
+      "mdx_line_range": [
+        33,
+        34
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 12,
+      "xhtml_xpath": "h2[2]",
+      "xhtml_fragment": "<h2 local-id=\"a3928fd5-e4b6-4b8f-b158-aca089401767\">Kubernetes 환경에 설치하기</h2>",
+      "mdx_content_hash": "71a9b5f835d25cef2501a59cc3f4f8f013b4f5db58e7944f327f38eac5c931a1",
+      "mdx_line_range": [
+        36,
+        36
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 13,
+      "xhtml_xpath": "p[10]",
+      "xhtml_fragment": "<p local-id=\"8b65e7a4b44a\">QueryPie ACP 는 Container 환경에서 작동하는 소프트웨어 제품입니다. Compose Tool 을 이용해 설치, 실행하는 것이 일반적이지만, Kubernetes 환경에서도 매끄럽게 작동합니다.</p>",
+      "mdx_content_hash": "55612b24e11ec92f9e192762c902be3106ab51e365eeb7073ebe7e6146a60ce8",
+      "mdx_line_range": [
+        38,
+        38
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 14,
+      "xhtml_xpath": "p[11]",
+      "xhtml_fragment": "<p local-id=\"cf6bccb44758\">Kubenetes 환경에서 제품을 설치하는 경우, AWS EKS, GCP GKE 등 Managed Kubernetes Cluster 와 Self-Hosted Cluster, 모두 사용 가능합니다.</p>",
+      "mdx_content_hash": "6571c12692bd88d2deb3ef4e754fac47082e1f76dea38840fdaf8b8ca7a9f771",
+      "mdx_line_range": [
+        40,
+        41
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 15,
+      "xhtml_xpath": "ul[1]",
+      "xhtml_fragment": "<ul local-id=\"7460d9b4-35a0-4f98-8637-724391d4c7a0\"><li local-id=\"9288d6aa-077f-4639-848e-7375d83e4ada\"><p local-id=\"22b709c0d310\">AWS EKS 환경 : <ac:link ac:local-id=\"2aa65d2a-300b-4e8f-8818-953c28d9481f\" ac:card-appearance=\"inline\"><ri:page ri:content-title=\"AWS EKS 환경에서 설치하기\" ri:version-at-save=\"36\" /><ac:link-body>AWS EKS 환경에서 설치하기</ac:link-body></ac:link> </p></li><li local-id=\"f9425b39-37a3-473d-b0c1-b59523f81c9a\"><p local-id=\"6512b1edb160\">Helm Chart : <a href=\"https://github.com/chequer-io/querypie-deployment\" local-id=\"39207560-10d4-4ec7-9c01-921457a5d9bf\" data-card-appearance=\"inline\">https://github.com/chequer-io/querypie-deployment</a> </p></li></ul>",
+      "mdx_content_hash": "dde31d27d1b45e121ef670205acec9712a52a80680448e76a701035d49e8c0d8",
+      "mdx_line_range": [
+        43,
+        43
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 16,
+      "xhtml_xpath": "p[12]",
+      "xhtml_fragment": "<p local-id=\"bd4a0ef67f9f\" />",
+      "mdx_content_hash": "ba7398e3e1b5abe2f58708fb940fe98ea849453ec816b2611ecad47054cf3ec1",
+      "mdx_line_range": [
+        45,
+        46
+      ],
+      "lost_info": {}
+    }
+  ],
+  "separators": [
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ],
+  "document_envelope": {
+    "prefix": "",
+    "suffix": ""
+  }
+}

--- a/confluence-mdx/tests/testcases/544112828/expected.roundtrip.json
+++ b/confluence-mdx/tests/testcases/544112828/expected.roundtrip.json
@@ -1,0 +1,1093 @@
+{
+  "schema_version": "2",
+  "page_id": "544112828",
+  "mdx_sha256": "38c92a80991ff35f4bed2235caea6114bc2a38f9e7f56e96a16520f325e4d343",
+  "source_xhtml_sha256": "b31f4552fd924f4299dfd7dc6edea8f00bfefbf403f5f96011e17a553b24ff67",
+  "blocks": [
+    {
+      "block_index": 0,
+      "xhtml_xpath": "h2[1]",
+      "xhtml_fragment": "<h2>Overview</h2>",
+      "mdx_content_hash": "a5e5f18c3e84f97f5fd0ead2ddd93c76c858df321c9d607a00a41113211cc7e5",
+      "mdx_line_range": [
+        8,
+        8
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 1,
+      "xhtml_xpath": "p[1]",
+      "xhtml_fragment": "<p>QueryPie Agent를 설치하면, DataGrip, DBeaver와 같은 SQL Client, iTerm/SecureCRT와 같은 SSH Client, Lens, k9s와 같은 3rd Party 애플리케이션을 사용할 수 있습니다.</p>",
+      "mdx_content_hash": "570f2c848432064a0ee7873e13333c111c0aeb41d4a26775907e952b18104d92",
+      "mdx_line_range": [
+        10,
+        10
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 2,
+      "xhtml_xpath": "macro-toc[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"toc\" ac:schema-version=\"1\" data-layout=\"default\" ac:local-id=\"93991f90-344b-497e-8886-42bac10548aa\" ac:macro-id=\"334477e7-dc7b-494d-9513-c21c2ccabe57\"><ac:parameter ac:name=\"maxLevel\">2</ac:parameter><ac:parameter ac:name=\"minLevel\">1</ac:parameter><ac:parameter ac:name=\"include\" /><ac:parameter ac:name=\"outline\">false</ac:parameter><ac:parameter ac:name=\"indent\" /><ac:parameter ac:name=\"exclude\">Overview</ac:parameter><ac:parameter ac:name=\"style\">default</ac:parameter><ac:parameter ac:name=\"type\">list</ac:parameter><ac:parameter ac:name=\"printable\">true</ac:parameter><ac:parameter ac:name=\"class\" /></ac:structured-macro>",
+      "mdx_content_hash": "d0cf56ffad88ebc0fe39c272fe413c008bc7253562cfb33a78b4853bd241aa12",
+      "mdx_line_range": [
+        12,
+        12
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 3,
+      "xhtml_xpath": "p[2]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "732df919b1859569d6a34abfea7993cd8dc6914ac020ae819402620edfdb2084",
+      "mdx_line_range": [
+        15,
+        15
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 4,
+      "xhtml_xpath": "h2[2]",
+      "xhtml_fragment": "<h2>에이전트 앱 다운로드 및 실행하기</h2>",
+      "mdx_content_hash": "c403170507708789aba8ec992cb5fc2a53e70dabe7852aab115453b95b00f242",
+      "mdx_line_range": [
+        17,
+        17
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 5,
+      "xhtml_xpath": "p[3]",
+      "xhtml_fragment": "<p>1. QueryPie 로그인 후 우측 상단 프로필을 클릭하여 <code>Agent Download</code> 버튼을 클릭합니다. </p>",
+      "mdx_content_hash": "af9e3ec3cae70c0d3353ec2270222cb3c2c631f23f88d40e60be49e516772b2f",
+      "mdx_line_range": [
+        19,
+        24
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 6,
+      "xhtml_xpath": "ac:image[1]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"555\" ac:original-width=\"785\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-08-04 오후 5.30.02.png\" ac:width=\"760\"><ri:attachment ri:filename=\"스크린샷 2024-08-04 오후 5.30.02.png\" ri:version-at-save=\"1\" /><ac:caption><p>QueryPie Web &gt; 프로필 메뉴</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "f85bec6fedbc6b1c9e8be80a3901fc53aef029307b0877a62691b64f007a907a",
+      "mdx_line_range": [
+        26,
+        26
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 7,
+      "xhtml_xpath": "p[4]",
+      "xhtml_fragment": "<p>2. QueryPie Agent Downloads 팝업창이 실행되면 Step 1에서 사용 중인 PC 운영체제에 맞는 설치 파일을 다운로드한 후 Step 3에 있는 QueryPie URL을 복사해 둡니다. </p>",
+      "mdx_content_hash": "fe34d68dab0f9f7947dfd2167c7968b0828fabbf4bf5ebe62df0a07c4ea28b78",
+      "mdx_line_range": [
+        28,
+        33
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 8,
+      "xhtml_xpath": "ac:image[2]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"712\" ac:original-width=\"1280\" ac:custom-width=\"true\" ac:alt=\"image-20240723-154847.png\" ac:width=\"760\"><ri:attachment ri:filename=\"image-20240723-154847.png\" ri:version-at-save=\"1\" /><ac:caption><p>QueryPie Web &gt; Agent Downloads 팝업창</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "a5fa008c4cfdcaffd0c66add55ec3c089d0ca61bf2942d836529c92184995776",
+      "mdx_line_range": [
+        35,
+        36
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 9,
+      "xhtml_xpath": "macro-info[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\" ac:macro-id=\"f99b0d05-b4a8-4196-bae8-511d886ab316\"><ac:rich-text-body><p>QueryPie Agent는 Mac, Windows, Linux OS를 지원합니다.</p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "b2da7f53a98160f9a467e89f4f04afbd6efa6caff1e00b4a072e5fd65d238800",
+      "mdx_line_range": [
+        37,
+        37
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 10,
+      "xhtml_xpath": "p[5]",
+      "xhtml_fragment": "<p>3. 다운로드받은 QueryPie Agent 설치 프로그램을 실행하여 설치를 완료합니다. </p>",
+      "mdx_content_hash": "fc0258dbd77895dcc8fbe50aebc4b7cd2f11fc3dc4aed7500225959590efee5d",
+      "mdx_line_range": [
+        39,
+        39
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 11,
+      "xhtml_xpath": "ac:image[3]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"750\" ac:original-width=\"1070\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-08-04 오후 5.40.02.png\" ac:width=\"760\"><ri:attachment ri:filename=\"스크린샷 2024-08-04 오후 5.40.02.png\" ri:version-at-save=\"1\" /><ac:caption><p>Mac OS 설치 프로그램</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "9e728f4a63891935d13cda34fb59cc691ca7f31c0ccb03e847348b39fbd45602",
+      "mdx_line_range": [
+        41,
+        46
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 12,
+      "xhtml_xpath": "p[6]",
+      "xhtml_fragment": "<p>4. 설치 완료된 QueryPie Agent를 실행합니다. QueryPie Host 입력란에 미리 복사해뒀던 QueryPie URL을 입력하고 <code>Next</code> 버튼을 클릭하면 로그인 화면으로 진입하게 됩니다. </p>",
+      "mdx_content_hash": "f5eebe03e4ba50a95a648456368a0978e54a5f273bda70ac238008d16d0da6b3",
+      "mdx_line_range": [
+        48,
+        48
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 13,
+      "xhtml_xpath": "ac:image[4]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"461\" ac:original-width=\"827\" ac:custom-width=\"true\" ac:width=\"760\"><ri:attachment ri:filename=\"agent-03.png\" ri:version-at-save=\"2\" /><ac:caption><p>Agent &gt; QueryPie Host 입력</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "94d13c7b4ae6690f1f6f8489a1600775f27c7db4f22dbff677f11dc680f561dc",
+      "mdx_line_range": [
+        49,
+        49
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 14,
+      "xhtml_xpath": "p[7]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "264cc8334bde7b742e331ed7bff2267209cd4eaf8e63b0ab607ff53d3b42724b",
+      "mdx_line_range": [
+        51,
+        56
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 15,
+      "xhtml_xpath": "h2[3]",
+      "xhtml_fragment": "<h2>QueryPie Agent에 로그인하기</h2>",
+      "mdx_content_hash": "f1f7d8e69f211ed000b6a90ddbada9a2c1ed8467e0aca9a182e4fdf2af5bbee5",
+      "mdx_line_range": [
+        59,
+        59
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 16,
+      "xhtml_xpath": "p[8]",
+      "xhtml_fragment": "<p>1. Agent 앱 내 로그인 화면에서 <code>Login</code> 버튼을 클릭합니다.</p>",
+      "mdx_content_hash": "307cf31f85bdc33b6d72215c083a29ebbc3cb836d05d79bf5281ef9971ba4d93",
+      "mdx_line_range": [
+        61,
+        61
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 17,
+      "xhtml_xpath": "ac:image[5]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"961\" ac:original-width=\"1494\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-08-04 오후 5.37.13.png\" ac:width=\"760\"><ri:attachment ri:filename=\"스크린샷 2024-08-04 오후 5.37.13.png\" ri:version-at-save=\"1\" /><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "621e53b50c01319b3dc7dc5c12a3c5b4e016fcb4cc7025e5e448270f274391ab",
+      "mdx_line_range": [
+        63,
+        65
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 18,
+      "xhtml_xpath": "p[9]",
+      "xhtml_fragment": "<p>2. 웹 브라우저가 열리면, 로그인 페이지에서 인증정보를 입력하고, <code>Continue</code> 버튼을 클릭합니다.</p>",
+      "mdx_content_hash": "f018d51e2e93f2ba92405d32eb2d90f812c26a1c4aebc60cd4e565bcbe5b5c1c",
+      "mdx_line_range": [
+        67,
+        67
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 19,
+      "xhtml_xpath": "ac:image[6]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"917\" ac:original-width=\"1548\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-07-29 오후 5.12.36.png\" ac:width=\"760\"><ri:attachment ri:filename=\"스크린샷 2024-07-29 오후 5.12.36.png\" ri:version-at-save=\"1\" /><ac:caption><p>QueryPie Web &gt; Agent Login Page</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "fc0b9df3ea6847ea8d4966982f1fac6a2c08b517e01c7731b68700142e5f5917",
+      "mdx_line_range": [
+        69,
+        74
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 20,
+      "xhtml_xpath": "p[10]",
+      "xhtml_fragment": "<p>3. 로그인을 성공하면 아래와 같이 로그인 성공 화면이 표시되며 이후 Agent로 돌아갑니다.</p>",
+      "mdx_content_hash": "9ded8fe47a695270ee43127e79cd3269ad02b22cbb3dc6d4689d61ca06503b7c",
+      "mdx_line_range": [
+        76,
+        76
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 21,
+      "xhtml_xpath": "ac:image[7]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"wide\" ac:original-height=\"917\" ac:original-width=\"1548\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-07-29 오후 5.13.14.png\" ac:width=\"764\"><ri:attachment ri:filename=\"스크린샷 2024-07-29 오후 5.13.14.png\" ri:version-at-save=\"1\" /><ac:caption><p>QueryPie Web &gt; Agent Login Success Page</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "0c988964d4b3979bdf93de3eeab628d04d0ae7a40e3a82f559523fb1a2b64f76",
+      "mdx_line_range": [
+        78,
+        83
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 22,
+      "xhtml_xpath": "p[11]",
+      "xhtml_fragment": "<p>4. Agent 열기를 명시적으로 수행하여 인증정보를 Agent로 전달합니다.</p>",
+      "mdx_content_hash": "b7c356da1d5364d9a5ae44775da67909d67bf1fdd2fe558707a03b78edafced2",
+      "mdx_line_range": [
+        85,
+        85
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 23,
+      "xhtml_xpath": "ac:image[8]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"383\" ac:original-width=\"1063\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-08-04 오후 5.42.09.png\" ac:width=\"760\"><ri:attachment ri:filename=\"스크린샷 2024-08-04 오후 5.42.09.png\" ri:version-at-save=\"1\" /><ac:caption><p>Chrome - Agent App 열기 모달</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "2a047dfe38b0811c6a235bf76463ed19511bc4cd1a11e0b4ca6a682df96661d3",
+      "mdx_line_range": [
+        87,
+        92
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 24,
+      "xhtml_xpath": "h2[4]",
+      "xhtml_fragment": "<h2>에이전트로 데이터베이스 접속하기</h2>",
+      "mdx_content_hash": "480abe9bf08f951da8467404c4871d345cebc646d95fb0af2e87b0c88c53f0e8",
+      "mdx_line_range": [
+        94,
+        94
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 25,
+      "xhtml_xpath": "p[12]",
+      "xhtml_fragment": "<p>1. 로그인이 정상적으로 완료되면 Agent 앱 내 Databases 탭에서 권한 있는 커넥션들의 접속 정보를 확인할 수 있습니다.<br />접속할 커넥션에 할당된 <code>Port</code> 를 클릭하면, 해당 커넥션의 <code>Proxy Credentials</code> 정보를 확인할 수 있습니다.</p>",
+      "mdx_content_hash": "f8579294c2589300864f72b12ba9d6c4e4a36b733885c5cbbef0f071cbcd6eec",
+      "mdx_line_range": [
+        96,
+        96
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 26,
+      "xhtml_xpath": "ac:image[9]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"wide\" ac:original-height=\"814\" ac:original-width=\"983\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-07-30 오후 3.10.01.png\" ac:width=\"764\"><ri:attachment ri:filename=\"스크린샷 2024-07-30 오후 3.10.01.png\" ri:version-at-save=\"1\" /><ac:caption><p>Agent &gt; DB Connection Information</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "2efd19ecff5043dcc5426a74f872c1007647cf9652654abfa0e651546468b091",
+      "mdx_line_range": [
+        98,
+        103
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 27,
+      "xhtml_xpath": "p[13]",
+      "xhtml_fragment": "<p>2. 위의 접속 정보를 3rd Party 클라이언트에 입력하면 DB 커넥션 접속이 가능합니다.</p>",
+      "mdx_content_hash": "53de54194bbc6cf85dcbd1e3b693d0245b143a8ef39106f276c1283a6bd2575d",
+      "mdx_line_range": [
+        105,
+        105
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 28,
+      "xhtml_xpath": "ac:image[10]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"wide\" ac:original-height=\"461\" ac:original-width=\"827\" ac:custom-width=\"true\" ac:alt=\"agent-07.png\" ac:width=\"764\"><ri:attachment ri:filename=\"agent-07.png\" ri:version-at-save=\"2\" /><ac:caption><p>3rd Party Client를 이용한 DB 커넥션 접속</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "38de5c6dd27420aeda974faa9a5b73263f0fabdd470c61a2987097004a7a5aad",
+      "mdx_line_range": [
+        107,
+        112
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 29,
+      "xhtml_xpath": "p[14]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "746d850c2e76f65f805760a6af9d76ca3e04be11e50c15befeee8ad093291f7d",
+      "mdx_line_range": [
+        115,
+        115
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 30,
+      "xhtml_xpath": "h2[5]",
+      "xhtml_fragment": "<h2>에이전트를 통한 서버 접속</h2>",
+      "mdx_content_hash": "ed00bdfb7a2453c822594ec306cc87fc66ad203de56605c397d4ee036aa14e27",
+      "mdx_line_range": [
+        117,
+        117
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 31,
+      "xhtml_xpath": "p[15]",
+      "xhtml_fragment": "<p>로그인이 정상적으로 완료되면 Agent 앱 내 Server 탭에서 권한 있는 서버를 확인할 수 있습니다.</p>",
+      "mdx_content_hash": "263ef0255d11960db0c9c5ebb57a50a5a5c638805f5fad7ee06b6875bc35b3a2",
+      "mdx_line_range": [
+        119,
+        119
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 32,
+      "xhtml_xpath": "h3[1]",
+      "xhtml_fragment": "<h3>1. 서버 역할 선택하기</h3>",
+      "mdx_content_hash": "b62bfc649cac24538e66b72a49a4739213a824abeb7202b83ff49e1acc745846",
+      "mdx_line_range": [
+        121,
+        122
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 33,
+      "xhtml_xpath": "ul[1]",
+      "xhtml_fragment": "<ul><li><p>사용자 프로필 영역 하단의 <code>Role</code> 버튼을 클릭하여 원하는 역할을 고르고 <code>OK</code> 버튼을 클릭하세요.</p></li><li><p>Default 역할 선택시, Workflow &gt; Server Access Request 요청에 의해 할당받은 서버 권한을 사용합니다. </p></li></ul>",
+      "mdx_content_hash": "96008ac7d8b0b5e7116e8b764269b1ae903084b7780526f6f4b1f77aae74bb47",
+      "mdx_line_range": [
+        124,
+        129
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 34,
+      "xhtml_xpath": "ac:image[11]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"wide\" ac:original-height=\"542\" ac:original-width=\"939\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-07-30 오후 4.26.53.png\" ac:width=\"764\"><ri:attachment ri:filename=\"스크린샷 2024-07-30 오후 4.26.53.png\" ri:version-at-save=\"1\" /><ac:caption><p>Agent &gt; Server &gt; Select a Role</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "c6df452eb7e2d03e907edb9138830d092df15e813e946da1059f3d7fa615eaf4",
+      "mdx_line_range": [
+        131,
+        132
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 35,
+      "xhtml_xpath": "macro-info[2]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\" ac:macro-id=\"d1ce310c-4526-4911-b6fd-15e1c369a767\"><ac:rich-text-body><p>역할이 두 개 이상이라면, Agent 로그인 후 Server 기능 사용을 위해 역할 선택을 먼저 완료해야 합니다.</p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "b2da7f53a98160f9a467e89f4f04afbd6efa6caff1e00b4a072e5fd65d238800",
+      "mdx_line_range": [
+        133,
+        133
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 36,
+      "xhtml_xpath": "h3[2]",
+      "xhtml_fragment": "<h3><br />2. <ac:inline-comment-marker ac:ref=\"50b132b2-0b7d-413a-805b-ec80489a780b\">Agent로 서버 접속하기</ac:inline-comment-marker></h3>",
+      "mdx_content_hash": "48fdfe9f603875e8150faeb15e7bb62d52ef9e6eaae0da72bb11f37780265cae",
+      "mdx_line_range": [
+        135,
+        135
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 37,
+      "xhtml_xpath": "ul[2]",
+      "xhtml_fragment": "<ul><li><p>접속할 서버를 우클릭 후 Open Connection with 메뉴를 선택하여, 사용하려는 터미널 툴을 선택합니다.</p></li></ul>",
+      "mdx_content_hash": "baebde213d50cbbe8fec4e07701c53b2c5b196b88a434adf1f361bb32b49a2ed",
+      "mdx_line_range": [
+        137,
+        137
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 38,
+      "xhtml_xpath": "ac:image[12]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"553\" ac:original-width=\"774\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-07-30 오후 4.17.29.png\" ac:width=\"760\"><ri:attachment ri:filename=\"스크린샷 2024-07-30 오후 4.17.29.png\" ri:version-at-save=\"1\" /><ac:caption><p>Agent &gt; Server &gt; Open Connection with</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "819e1c972ea7e39b77548c548469cb02a5d224fdb1d5bddc4747df47356ded9b",
+      "mdx_line_range": [
+        139,
+        144
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 39,
+      "xhtml_xpath": "ul[3]",
+      "xhtml_fragment": "<ul><li><p>이후 해당 서버에 접속 가능한 계정이 여러개라면, Account 선택창이 열립니다. </p></li><li><p>사용하려는 계정을 선택하고 필요시 비밀번호를 입력한 뒤, <code>OK</code> 버튼을 클릭하여 세션을 엽니다.</p></li></ul>",
+      "mdx_content_hash": "ed4121be7e6161a4d66b6521bb69c1a5a8d79d12acb60c6d3c100f9dce594617",
+      "mdx_line_range": [
+        146,
+        147
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 40,
+      "xhtml_xpath": "ac:image[13]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"567\" ac:original-width=\"848\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-07-30 오후 4.25.32.png\" ac:width=\"746\"><ri:attachment ri:filename=\"스크린샷 2024-07-30 오후 4.25.32.png\" ri:version-at-save=\"1\" /><ac:caption><p>Agent &gt; Server &gt;  Open New Session</p></ac:caption></ac:image>",
+      "mdx_content_hash": "e56ad66aefea18ee34bd71e2092adc4d8d8d0ba888caa89146cc72f10fa434d3",
+      "mdx_line_range": [
+        149,
+        154
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 41,
+      "xhtml_xpath": "h3[3]",
+      "xhtml_fragment": "<h3>3. Seamless SSH 설정하기</h3>",
+      "mdx_content_hash": "ff6f613f26faaa222d423eb48267109e73fc4e58a049d4ffdcab3d263c803cb1",
+      "mdx_line_range": [
+        156,
+        156
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 42,
+      "xhtml_xpath": "p[16]",
+      "xhtml_fragment": "<p>Seamless SSH란 기존 터미널 사용성을 그대로 유지하면서 QueryPie를 통해 서버에 접속할 수 있는 기능입니다. 다음음의 방법으로 .ssh 폴더에 config 파일을 생성하여 손쉽게 seamless SSH 설정이 가능합니다.</p>",
+      "mdx_content_hash": "82204e22af9a183f2a82f296f64ef4c2191d1dfe58fffa8f1a90b6c7c73629a9",
+      "mdx_line_range": [
+        158,
+        159
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 43,
+      "xhtml_xpath": "p[17]",
+      "xhtml_fragment": "<p>1) 터미널을 열고, .ssh 폴더로 이동합니다.</p>",
+      "mdx_content_hash": "7bd5dfb7e64e0992bef9e80247a5912ccea31f389eb6487a82e9a76dcd647c8b",
+      "mdx_line_range": [
+        161,
+        161
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 44,
+      "xhtml_xpath": "macro-code[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"code\" ac:schema-version=\"1\" ac:macro-id=\"ae17bd7b-36ca-4bac-9f76-a2a80df69ed8\"><ac:parameter ac:name=\"breakoutMode\">wide</ac:parameter><ac:parameter ac:name=\"breakoutWidth\">760</ac:parameter><ac:plain-text-body><![CDATA[$ cd .ssh]]></ac:plain-text-body></ac:structured-macro>",
+      "mdx_content_hash": "23143c8492dd8243a3361433f2d2d0aeee1ffe06ab3f82c584bd5a7c75cc7bd4",
+      "mdx_line_range": [
+        162,
+        164
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 45,
+      "xhtml_xpath": "p[18]",
+      "xhtml_fragment": "<p>2) ssh 폴더에서 config 파일을 생성하기 위해 vi 에디터를 엽니다.</p>",
+      "mdx_content_hash": "394aaf9e4e9de68bc79cc075c03dae87e155e00d127d43f6ce090a7b2ebd84c8",
+      "mdx_line_range": [
+        166,
+        166
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 46,
+      "xhtml_xpath": "macro-code[2]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"code\" ac:schema-version=\"1\" ac:macro-id=\"4ac2ea9a-8d66-4197-bc03-8304a9a0b2a7\"><ac:parameter ac:name=\"breakoutMode\">wide</ac:parameter><ac:parameter ac:name=\"breakoutWidth\">760</ac:parameter><ac:plain-text-body><![CDATA[$ vi config]]></ac:plain-text-body></ac:structured-macro>",
+      "mdx_content_hash": "575eac4d5826942186e7ce4f63e815f8604d3b5da254550f10ccb5461007e3ec",
+      "mdx_line_range": [
+        167,
+        169
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 47,
+      "xhtml_xpath": "p[19]",
+      "xhtml_fragment": "<p><ac:inline-comment-marker ac:ref=\"9346ce2e-a893-4aa6-8a8e-808d683cd275\">3) 아래의 내용을 입력 후, </ac:inline-comment-marker><code><ac:inline-comment-marker ac:ref=\"9346ce2e-a893-4aa6-8a8e-808d683cd275\">wq</ac:inline-comment-marker></code><ac:inline-comment-marker ac:ref=\"9346ce2e-a893-4aa6-8a8e-808d683cd275\"> 키를 입력하여 vi 에디터를 나옵니다.</ac:inline-comment-marker></p>",
+      "mdx_content_hash": "b2c43181ade24361522b86902a13447fd39a6ef310d6d1e65d6d52b46423d052",
+      "mdx_line_range": [
+        171,
+        171
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 48,
+      "xhtml_xpath": "macro-code[3]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"code\" ac:schema-version=\"1\" ac:macro-id=\"23e5d969-15b1-4d4b-a7f2-0c2c38a4dee1\"><ac:parameter ac:name=\"breakoutMode\">wide</ac:parameter><ac:parameter ac:name=\"breakoutWidth\">760</ac:parameter><ac:plain-text-body><![CDATA[Host {{Server Name}}\n  Hostname {{Server URL}}\n  Port {{Server SSH Port}}\n  ProxyCommand qpa ssh %r %h %p]]></ac:plain-text-body></ac:structured-macro>",
+      "mdx_content_hash": "d4079d26d008eb4c33ff7969405c46e966ed3d3f5f6faed0691cb7b3a6e7f285",
+      "mdx_line_range": [
+        172,
+        177
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 49,
+      "xhtml_xpath": "macro-info[3]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\" ac:macro-id=\"56253dda-2fdc-40de-ba7d-2165a1c14c7e\"><ac:rich-text-body><p>config 파일 작성 시 Seamless SSH 설정하고자 하는 서버마다 서버 이름, URL, 포트를 입력함으로써 서버를 특정합니다. 서버 간에 URL, 포트가 겹치지 않는 경우 아래와 같이 입력하여도 접속이 가능합니다.</p><ac:structured-macro ac:name=\"code\" ac:schema-version=\"1\" ac:macro-id=\"f8478be5-90b8-4d3c-9c06-7b8dba0b96ad\"><ac:plain-text-body><![CDATA[Host *\n  ProxyCommand qpa ssh %r %h %p]]></ac:plain-text-body></ac:structured-macro></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "0233e37d0ee8ec99850ae36c5ed3524463a1f76bb043feb7dcc83081a0b34684",
+      "mdx_line_range": [
+        179,
+        181
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 50,
+      "xhtml_xpath": "p[20]",
+      "xhtml_fragment": "<p>4) 이상으로 설정이 완료됩니다. Agent &gt; Server 탭에서 역할을 선택하면 기존 ssh 명령어로 서버에 접속할 수 있습니다.</p>",
+      "mdx_content_hash": "353d3f2d2acd55769ae22c64d3e4817e859fbf259d698912db6040763cb4f46c",
+      "mdx_line_range": [
+        182,
+        185
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 51,
+      "xhtml_xpath": "macro-code[4]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"code\" ac:schema-version=\"1\" ac:macro-id=\"1c851681-79bb-4775-b25d-ff504b3b7e81\"><ac:parameter ac:name=\"breakoutMode\">wide</ac:parameter><ac:parameter ac:name=\"breakoutWidth\">760</ac:parameter><ac:plain-text-body><![CDATA[$ ssh deploy@{{Server Name}}]]></ac:plain-text-body></ac:structured-macro>",
+      "mdx_content_hash": "b2da7f53a98160f9a467e89f4f04afbd6efa6caff1e00b4a072e5fd65d238800",
+      "mdx_line_range": [
+        186,
+        186
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 52,
+      "xhtml_xpath": "p[21]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "513a4a3d5b1b3ded882765c88baab473bb8962ba5c54042877bf00de4f44c292",
+      "mdx_line_range": [
+        188,
+        189
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 53,
+      "xhtml_xpath": "h2[6]",
+      "xhtml_fragment": "<h2>에이전트를 통한 쿠버네티스 접속 </h2>",
+      "mdx_content_hash": "b9a2d688821f8fd4767b12b1854b18c5f4944977610c3950406d73e0cd35f6f5",
+      "mdx_line_range": [
+        190,
+        192
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 54,
+      "xhtml_xpath": "ac:image[14]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"wide\" ac:original-height=\"900\" ac:original-width=\"1800\" ac:custom-width=\"true\" ac:width=\"764\"><ri:attachment ri:filename=\"kubernetes-agent-access-flow.png\" ri:version-at-save=\"1\" /><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "46c766761609c30c58fd28f85c9dcb9d88ea365b33af080f938f61b516064a56",
+      "mdx_line_range": [
+        195,
+        195
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 55,
+      "xhtml_xpath": "ul[4]",
+      "xhtml_fragment": "<ul><li><p>권한을 부여 받은 사용자는 에이전트 실행 시 현재 정책에 따른 <code>kubeconfig</code> 파일이 자동으로 수신됩니다.</p></li><li><p>이를 통해 Kubernetes Client(kubectl, lens, k9s 등) 툴로 Kubernetes API 리소스에 접근할 수 있습니다.</p></li><li><p>에이전트에서는 접근 가능한 클러스트 리스트를 표시하며, 각 클러스터에 적용된 정책을 확인할 수 있습니다.</p></li><li><p>또한 설정 메뉴를 통해 kubeconfig파일의 위치를 확인 및 수정할 수 있습니다.</p></li></ul>",
+      "mdx_content_hash": "1c73eb3e1aa4da5177e29e25ee0d9339e826a7c12df9c9f62b1375a917bb5df6",
+      "mdx_line_range": [
+        197,
+        199
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 56,
+      "xhtml_xpath": "h3[4]",
+      "xhtml_fragment": "<h3>1. Kubernetes 역할 선택하기</h3>",
+      "mdx_content_hash": "08e497bdb5fef9e02b8bbb5fa536334e30ccec29a78e1dde6f865e0d831a98eb",
+      "mdx_line_range": [
+        201,
+        204
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 57,
+      "xhtml_xpath": "p[22]",
+      "xhtml_fragment": "<p>사용자 프로필 영역 하단의 <code>Role</code> 버튼을 클릭하면 역할 선택 모달이 열립니다. 원하는 역할을 고르고 <code>OK</code> 버튼을 클릭하세요.</p>",
+      "mdx_content_hash": "0061d76bdb0fc13d74844d19af9dde66137bf9f168af6b51ad30ba18c70e232f",
+      "mdx_line_range": [
+        206,
+        206
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 58,
+      "xhtml_xpath": "ac:image[15]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"572\" ac:original-width=\"958\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-07-30 오후 3.27.05.png\" ac:width=\"760\"><ri:attachment ri:filename=\"스크린샷 2024-07-30 오후 3.27.05.png\" ri:version-at-save=\"1\" /><ac:caption><p>Agent &gt; Kubernetes &gt; Select a Role</p></ac:caption><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "15155b3b5ab4743f377acffa80fa62a67ba48cf40093e9462bedafa8bbe4f7ec",
+      "mdx_line_range": [
+        208,
+        209
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 59,
+      "xhtml_xpath": "macro-info[4]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\" ac:macro-id=\"a7a2eaa6-16ef-4ce8-8fbc-ca87a927d4a2\"><ac:rich-text-body><p>역할이 두 개 이상이라면, Agent 로그인 후 Kubernetes 기능 사용을 위해 역할 선택을 먼저 완료해야 합니다.</p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "4838ebec6140fbdc298948ce994950a7d64b7b51e002895043723755985ce960",
+      "mdx_line_range": [
+        211,
+        216
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 60,
+      "xhtml_xpath": "p[23]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "f22fc83006d540e064450d70141ee5e8c027eb14cef30c775df3c70f6aade89d",
+      "mdx_line_range": [
+        218,
+        219
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 61,
+      "xhtml_xpath": "h3[5]",
+      "xhtml_fragment": "<h3>2. Policy 조회하기</h3>",
+      "mdx_content_hash": "b2da7f53a98160f9a467e89f4f04afbd6efa6caff1e00b4a072e5fd65d238800",
+      "mdx_line_range": [
+        220,
+        220
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 62,
+      "xhtml_xpath": "p[24]",
+      "xhtml_fragment": "<p>선택된 역할에 따라 접근 가능한 리소스가 표시됩니다. 각 클러스터 우측의 <code>🔍</code> 버튼을 누르면 Policy Information 팝업창이 나타나며 이곳에서 해당 클러스터에 적용된 정책 목록을 자세히 확인할 수 있습니다.</p>",
+      "mdx_content_hash": "b4d7bfaf10699c3c5c5b3b1f56601ce53fb3e5167a460e546dab6fb49860ef61",
+      "mdx_line_range": [
+        223,
+        223
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 63,
+      "xhtml_xpath": "ac:image[16]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"959\" ac:original-width=\"1024\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-07-30 오후 4.11.41.png\" ac:width=\"760\"><ri:attachment ri:filename=\"스크린샷 2024-07-30 오후 4.11.41.png\" ri:version-at-save=\"1\" /><ac:caption><p>Agent &gt; Policy Information</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "24f3b8dc4c1a3981379a4d7c3fa021b13fdd7a8f90dc90baee991d34fd32afe9",
+      "mdx_line_range": [
+        225,
+        226
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 64,
+      "xhtml_xpath": "h3[6]",
+      "xhtml_fragment": "<h3>3. Kubeconfig 경로 설정하기</h3>",
+      "mdx_content_hash": "00aecde6bde9fb7eecb6fa162d0a2b3255c16a72bb44e554c537649534d61430",
+      "mdx_line_range": [
+        228,
+        233
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 65,
+      "xhtml_xpath": "p[25]",
+      "xhtml_fragment": "<p>Agent 설정 메뉴에서 <code>KubeConfig Path</code> 버튼을 클릭하여 Kubeconfig 경로 설정 모달을 엽니다.</p>",
+      "mdx_content_hash": "aeb0093166cfae4e3a51df144058b0d4b73a3d5dc93c26876bb7134f6a3d5eb0",
+      "mdx_line_range": [
+        235,
+        235
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 66,
+      "xhtml_xpath": "ac:image[17]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"wide\" ac:original-height=\"520\" ac:original-width=\"585\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-07-30 오후 3.46.23.png\" ac:width=\"764\"><ri:attachment ri:filename=\"스크린샷 2024-07-30 오후 3.46.23.png\" ri:version-at-save=\"1\" /><ac:caption><p>Agent &gt; Settings &gt; Configure Kubeconfig Path</p></ac:caption><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "ee12869bcdc70fd841bcdb788786e96a93bf30304c95b22e3398124716b28f21",
+      "mdx_line_range": [
+        237,
+        237
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 67,
+      "xhtml_xpath": "ul[5]",
+      "xhtml_fragment": "<ul><li><p><strong>Path Configuration</strong> : Kubeconfig 파일 저장 경로를 사용자가 지정할 수 있습니다.</p><ul><li><p>기본값은 <code>$HOME/.kube/querypie-kubeconfig</code> 입니다.</p></li><li><p>경로 필드 우측 <code>Upload</code> 버튼을 누르면 로컬 파일 경로를 지정할 수 있는 팝업이 나타납니다. </p></li></ul></li></ul>",
+      "mdx_content_hash": "8b9e1188bd56fe8d6c66423e6e5d1a0ba9c29d84fb0b7d7abbed10ecbb9828db",
+      "mdx_line_range": [
+        239,
+        244
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 68,
+      "xhtml_xpath": "p[26]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "9465b5ab429ba91ae3067b998e40b3a59bee4fe66a06dc3a6d6d3b26b4fc6001",
+      "mdx_line_range": [
+        246,
+        248
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 69,
+      "xhtml_xpath": "ac:image[18]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"244\" ac:original-width=\"475\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-07-30 오후 4.35.30.png\" ac:width=\"760\"><ri:attachment ri:filename=\"스크린샷 2024-07-30 오후 4.35.30.png\" ri:version-at-save=\"1\" /><ac:caption><p>경로 지정 팝업</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "554933aa5a9f697e0adc0e15f4b7ace19e4531a09b3ab1b2fa1b25c45b9c38dd",
+      "mdx_line_range": [
+        251,
+        256
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 70,
+      "xhtml_xpath": "ul[6]",
+      "xhtml_fragment": "<ul><li><p><strong>Where</strong> : 우측의 <code>🔽</code> 버튼을 클릭하여 원하는 폴더를 지정합니다.</p></li><li><p><strong>Save As</strong> : Kubeconfig 파일의 이름을 입력합니다. 변경하지 않으면 기본값으로 적용됩니다.</p></li><li><p><strong>Command Line</strong> : KUBECONFIG 환경 변수를 선언하기 위한 커맨드 라인을 제공합니다.</p></li></ul>",
+      "mdx_content_hash": "304c0dd80de01214bd5ac870e6dd7792975503d57d3e170cff10532ce79efaca",
+      "mdx_line_range": [
+        258,
+        260
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 71,
+      "xhtml_xpath": "p[27]",
+      "xhtml_fragment": "<p>1) KUBECONFIG 환경 변수를 최초 설정하는 경우, 명령 줄 내의 디폴트 &quot;<code>${KUBECONFIG}</code>&quot; 값을 사용 전에 &quot;<code>${HOME}/.kube/config</code>&quot;로 변경해야 합니다. </p>",
+      "mdx_content_hash": "6bdf4916a2f727bf9bf4805040cf705b7116435b65895bec79a120833b1d0059",
+      "mdx_line_range": [
+        262,
+        262
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 72,
+      "xhtml_xpath": "macro-code[5]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"code\" ac:schema-version=\"1\" ac:macro-id=\"80e6e84a-7525-4179-b33a-07b411e24941\"><ac:parameter ac:name=\"breakoutMode\">wide</ac:parameter><ac:parameter ac:name=\"breakoutWidth\">760</ac:parameter><ac:plain-text-body><![CDATA[export KUBECONFIG=\"${HOME}/.kube/config:${HOME}/.kube/querypie-kubeconfig\"]]></ac:plain-text-body></ac:structured-macro>",
+      "mdx_content_hash": "ca89adb5a14ecef61296af7440328a8670953ae51ad3f66833f076da0ef1d44c",
+      "mdx_line_range": [
+        263,
+        265
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 73,
+      "xhtml_xpath": "p[28]",
+      "xhtml_fragment": "<p><ac:inline-comment-marker ac:ref=\"489e3194-1605-43db-8b78-366b9f36e6ec\">2) QueryPie에서 제공된 사용자 지정 kubeconfig 경로를 변경한 경우 새 경로로 환경 변수를 다시 선언해야 합니다.</ac:inline-comment-marker></p>",
+      "mdx_content_hash": "213ec784591308663b22938f6c95ae7bdd22cb70f59689204ff0964e55701dbf",
+      "mdx_line_range": [
+        267,
+        267
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 74,
+      "xhtml_xpath": "macro-code[6]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"code\" ac:schema-version=\"1\" ac:macro-id=\"f4c96fe4-8f50-4714-8e1c-1259b38c84a7\"><ac:parameter ac:name=\"breakoutMode\">wide</ac:parameter><ac:parameter ac:name=\"breakoutWidth\">760</ac:parameter><ac:plain-text-body><![CDATA[export KUBECONFIG=\"${KUBECONFIG}:<user-specified-path>\"]]></ac:plain-text-body></ac:structured-macro>",
+      "mdx_content_hash": "6c0dbc533bc534c075f5690dcbf8417c8c32748d0dc5a9bbea0a82391eaf92c7",
+      "mdx_line_range": [
+        268,
+        270
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 75,
+      "xhtml_xpath": "p[29]",
+      "xhtml_fragment": "<p>3) 보다 자세한 kubeconfig에 대한 내용은 다음 링크를 참조해주시기 바랍니다.</p>",
+      "mdx_content_hash": "ef1d403f2bfdc99ca076ea5c6caf3f9b6e63f3f1b1a0828d585c461ba66c3f65",
+      "mdx_line_range": [
+        272,
+        272
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 76,
+      "xhtml_xpath": "ul[7]",
+      "xhtml_fragment": "<ul><li><p>참고: <a href=\"https://kubernetes.io/ko/docs/concepts/configuration/organize-cluster-access-kubeconfig/#kubeconfig-%ED%8C%8C%EC%9D%BC-%EB%B3%91%ED%95%A9\">kubeconfig 파일 병합</a></p></li><li><p>참고: <a href=\"https://kubernetes.io/ko/docs/tasks/access-application-cluster/configure-access-multiple-clusters/#kubeconfig-%ED%99%98%EA%B2%BD-%EB%B3%80%EC%88%98-%EC%84%A4%EC%A0%95\">KUBECONFIG 환경 변수 설정</a></p></li></ul>",
+      "mdx_content_hash": "724160b650a573b0357ca61e916bb873d75de77bd3f82ce2185e577feef38fc0",
+      "mdx_line_range": [
+        274,
+        275
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 77,
+      "xhtml_xpath": "p[30]",
+      "xhtml_fragment": "<p>4) <code>Copy</code> 로 커맨드라인을 복사하여 클라이언트에 선언하고 컨텍스트를 접근 가능한 클러스터로 스위칭할 수 있습니다 </p>",
+      "mdx_content_hash": "786d368b667e6999cac146b88bb21b1e6d28c29faf660d98449566e27583701e",
+      "mdx_line_range": [
+        277,
+        277
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 78,
+      "xhtml_xpath": "macro-code[7]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"code\" ac:schema-version=\"1\" ac:macro-id=\"7cf36161-3eb5-4ac5-bc55-4b047bcac967\"><ac:parameter ac:name=\"breakoutMode\">wide</ac:parameter><ac:parameter ac:name=\"breakoutWidth\">760</ac:parameter><ac:plain-text-body><![CDATA[export KUBECONFIG=\"${KUBECONFIG}:${HOME}/.kube/querypie-kubeconfig\"]]></ac:plain-text-body></ac:structured-macro>",
+      "mdx_content_hash": "01d665d971b363fb8e22fb9be396021e4ed73ddd0d936f4621c1684f92f6803b",
+      "mdx_line_range": [
+        278,
+        280
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 79,
+      "xhtml_xpath": "p[31]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "f7583a09395c9b9924805188ed894d54f05cdedc33d9f327e79ce7c5351a0427",
+      "mdx_line_range": [
+        283,
+        283
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 80,
+      "xhtml_xpath": "h2[7]",
+      "xhtml_fragment": "<h2>QueryPie Agent 세팅 초기화하기</h2>",
+      "mdx_content_hash": "8b39e365023a3e6b700d06f451e6c422ece9aa0aabb74e519a2661f72b1ebe6a",
+      "mdx_line_range": [
+        285,
+        285
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 81,
+      "xhtml_xpath": "p[32]",
+      "xhtml_fragment": "<p>세팅을 초기화하면 입력하였던 QueryPie Host 정보가 초기화되어 다시 입력할 수 있게 됩니다. </p>",
+      "mdx_content_hash": "f982fd01869da21e6403be3f38dd2aa26ee515ce2a073b19b6d729e96549cc4b",
+      "mdx_line_range": [
+        286,
+        286
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 82,
+      "xhtml_xpath": "h3[7]",
+      "xhtml_fragment": "<h3>Agent 내 설정 메뉴에서 초기화</h3>",
+      "mdx_content_hash": "72d8f2e0fab25da37aa1c9d9f21d52a941cbb4349bc0e0ec588e247631ba5df2",
+      "mdx_line_range": [
+        288,
+        288
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 83,
+      "xhtml_xpath": "p[33]",
+      "xhtml_fragment": "<p>프로필 영역 우측  <code>⚙️</code> 버튼을 클릭하여 설정 메뉴를 엽니다. <code>Reset All Settings</code> 버튼을 클릭합니다.</p>",
+      "mdx_content_hash": "cc6a6974e567e7718e1ed78f49c94ff8b85a9c9f7616456b1c882e728ed03730",
+      "mdx_line_range": [
+        290,
+        295
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 84,
+      "xhtml_xpath": "ac:image[19]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"557\" ac:original-width=\"476\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-07-30 오후 3.35.18.png\" ac:width=\"361\"><ri:attachment ri:filename=\"스크린샷 2024-07-30 오후 3.35.18.png\" ri:version-at-save=\"1\" /><ac:caption><p>Agent &gt; Settings</p></ac:caption><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "ee39522d9965e5dd3fc52db1c60d04b7896dafa935b9adb57345a48a92a667d3",
+      "mdx_line_range": [
+        298,
+        298
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 85,
+      "xhtml_xpath": "p[34]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "21ba015469e509998c7859f3a4cb9e0b4cb45d0bb4a49eba6098e5a183509232",
+      "mdx_line_range": [
+        300,
+        300
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 86,
+      "xhtml_xpath": "h3[8]",
+      "xhtml_fragment": "<h3>(Mac) 메뉴 막대 내 앱 메뉴에서 초기화</h3>",
+      "mdx_content_hash": "b51971a4c3f1924a00c8387ccb9a770dc82d99be651ed25be05954c04ea3c662",
+      "mdx_line_range": [
+        302,
+        307
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 87,
+      "xhtml_xpath": "p[35]",
+      "xhtml_fragment": "<p>메뉴 막대에서 QueryPie Agent 아이콘을 클릭하여 앱 메뉴를 엽니다. <code>Reset All Settings</code> 버튼을 클릭합니다.</p>",
+      "mdx_content_hash": "",
+      "mdx_line_range": [
+        0,
+        0
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 88,
+      "xhtml_xpath": "ac:image[20]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"285\" ac:original-width=\"247\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-07-30 오후 3.35.24.png\" ac:width=\"363\"><ri:attachment ri:filename=\"스크린샷 2024-07-30 오후 3.35.24.png\" ri:version-at-save=\"2\" /><ac:caption><p>Agent &gt; App menu</p></ac:caption><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "",
+      "mdx_line_range": [
+        0,
+        0
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 89,
+      "xhtml_xpath": "p[36]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "",
+      "mdx_line_range": [
+        0,
+        0
+      ],
+      "lost_info": {}
+    }
+  ],
+  "separators": [
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "</ac:layout-cell></ac:layout-section><ac:layout-section ac:type=\"two_equal\" ac:breakout-mode=\"wide\" ac:breakout-width=\"760\"><ac:layout-cell>",
+    "",
+    "",
+    "",
+    "</ac:layout-cell><ac:layout-cell>",
+    "",
+    "",
+    ""
+  ],
+  "document_envelope": {
+    "prefix": "<ac:layout><ac:layout-section ac:type=\"fixed-width\" ac:breakout-mode=\"default\"><ac:layout-cell>",
+    "suffix": "</ac:layout-cell></ac:layout-section></ac:layout>"
+  }
+}

--- a/confluence-mdx/tests/testcases/544113141/expected.roundtrip.json
+++ b/confluence-mdx/tests/testcases/544113141/expected.roundtrip.json
@@ -1,0 +1,121 @@
+{
+  "schema_version": "2",
+  "page_id": "544113141",
+  "mdx_sha256": "2ca07c352f16219ff70ed69b7fba4f226bb6d7b96ef1023ac229e39a7a6d5f50",
+  "source_xhtml_sha256": "4ae9cf549fddbc8f6fa3a9164f51a99fb22474f470f2c8f8a6a71b48830927f6",
+  "blocks": [
+    {
+      "block_index": 0,
+      "xhtml_xpath": "h2[1]",
+      "xhtml_fragment": "<h2>Overview</h2>",
+      "mdx_content_hash": "eb60517ec0f24ef9513faa01731c224f02eecebcadac4a092725489519568ac1",
+      "mdx_line_range": [
+        6,
+        6
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 1,
+      "xhtml_xpath": "p[1]",
+      "xhtml_fragment": "<p>조직에서 관리하는 DB 커넥션 연결 및 연결해제 이력을 기록합니다.</p>",
+      "mdx_content_hash": "570f2c848432064a0ee7873e13333c111c0aeb41d4a26775907e952b18104d92",
+      "mdx_line_range": [
+        8,
+        8
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 2,
+      "xhtml_xpath": "h2[2]",
+      "xhtml_fragment": "<h2>DB Access History 조회하기 </h2>",
+      "mdx_content_hash": "9f0ba1d678646e93cd26295309a9eead4144b6220a93fa06475bc2d4b5668aa1",
+      "mdx_line_range": [
+        10,
+        10
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 3,
+      "xhtml_xpath": "ac:image[1]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"1800\" ac:original-width=\"2880\" ac:custom-width=\"true\" ac:alt=\"image-20240730-070842.png\" ac:width=\"760\"><ri:attachment ri:filename=\"image-20240730-070842.png\" ri:version-at-save=\"1\" /><ac:caption><p>Administrator &gt; Audit &gt; Databases &gt; DB Access History</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "e8a2c2567747c018b7cff3598c8c8fa20594a9eab806f2f6bb8e3d891ccbad13",
+      "mdx_line_range": [
+        12,
+        12
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 4,
+      "xhtml_xpath": "ol[1]",
+      "xhtml_fragment": "<ol start=\"1\"><li><p>Administrator &gt; Audit &gt; Databases &gt; DB Access History 메뉴로 이동합니다.</p></li><li><p>현재 월 기준으로 로그가 내림차순으로 조회됩니다.</p></li><li><p>테이블 좌측 상단의 검색란을 통해 이하의 조건으로 검색이 가능합니다.</p><ol start=\"1\"><li><p><strong>Name</strong> : 사용자 이름</p></li><li><p><strong>Error Message</strong> : 접근 에러 메시지 내 구문 </p></li><li><p><strong>Client IP</strong> : 사용자 IP</p></li></ol></li><li><p>검색 필드 우측 필터 버튼을 클릭하여 AND/OR 조건으로 이하의 필터링이 가능합니다.</p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"488\" ac:original-width=\"1488\" ac:custom-width=\"true\" ac:alt=\"image-20240730-064139.png\" ac:width=\"736\"><ri:attachment ri:filename=\"image-20240730-064139.png\" ri:version-at-save=\"1\" /><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image><ol start=\"1\"><li><p><strong>Connection Name</strong> : 접속한 DB 커넥션명</p></li><li><p><strong>Database Type </strong>: 데이터베이스 유형</p></li><li><p><strong>Action Type </strong>: Connect / Disconnect 여부</p></li><li><p><strong>Result </strong>: 접속 성공/실패 여부</p></li><li><p><strong>Action At</strong> : 접속 시점</p></li></ol></li><li><p>테이블 우측 상단의 새로고침 버튼을 통해 로그 목록을 최신화할 수 있습니다.</p></li><li><p>테이블에서 이하의 컬럼 정보를 제공합니다:</p><ol start=\"1\"><li><p><strong>No</strong> : 이벤트 식별 번호</p></li><li><p><strong>Action At</strong> : 서버 접속 시도 일시</p></li><li><p><strong>Action Type</strong> : Connect / Disconnect 여부</p></li><li><p><strong>Result</strong> : 접속 성공/실패 여부</p><ol start=\"1\"><li><p><ac:emoticon ac:name=\"tick\" ac:emoji-shortname=\":check_mark:\" ac:emoji-id=\"atlassian-check_mark\" ac:emoji-fallback=\":check_mark:\" /> Success</p></li><li><p><ac:emoticon ac:name=\"cross\" ac:emoji-shortname=\":cross_mark:\" ac:emoji-id=\"atlassian-cross_mark\" ac:emoji-fallback=\":cross_mark:\" /> Failure</p></li></ol></li><li><p><strong>Name</strong> : 대상 사용자 이름</p></li><li><p><strong>Email</strong> : 대상 사용자 이메일</p></li><li><p><strong>Cloud Provider</strong> : 대상 클라우드 프로바이더명</p></li><li><p><strong>Connection Name</strong> : 대상 DB 커넥션명</p></li><li><p><strong>Database Type</strong> : 대상 데이터베이스 유형</p></li><li><p><strong>Privilege</strong> <strong>Name</strong> : 사용자 접속 권한 </p></li><li><p><strong>Client IP</strong> : 사용자 클라이언트 IP 주소</p></li><li><p><strong>Replication Type</strong> : DB Replication 유형</p></li><li><p><strong>DB Host</strong> : 접속한 DB 호스트</p></li><li><p><strong>DB User</strong> : DB 사용자 ID</p></li><li><p><strong>DB Name</strong> : DB명</p></li><li><p><strong>Client</strong> <strong>Name</strong> : 이용 클라이언트명 (DataGrip 등)</p></li><li><p><strong>Error Message</strong> : 접속 실패 등 특이사항에 대한 기록</p></li><li><p><strong>Connected</strong> <strong>From</strong> : 접속 방식</p></li></ol></li></ol>",
+      "mdx_content_hash": "f71dcdbe62e32f2aeb6220987253a3b4e8a07eb87d5f9113ebbb3a1383520e8e",
+      "mdx_line_range": [
+        14,
+        19
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 5,
+      "xhtml_xpath": "h2[3]",
+      "xhtml_fragment": "<h2>DB Access History 상세 내역 조회하기</h2>",
+      "mdx_content_hash": "0ce172be587d70504230ce1f647d678c4917e2bbb2f54ccd24207d43f6ce7ae0",
+      "mdx_line_range": [
+        21,
+        57
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 6,
+      "xhtml_xpath": "p[2]",
+      "xhtml_fragment": "<p>각 행을 클릭하면 세부 정보 조회가 가능합니다. </p>",
+      "mdx_content_hash": "3fc074477e08e250a06101440dce4c846e21bdf56d755a25707ddab288f6ab77",
+      "mdx_line_range": [
+        59,
+        59
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 7,
+      "xhtml_xpath": "ac:image[2]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"1800\" ac:original-width=\"2880\" ac:custom-width=\"true\" ac:alt=\"image-20240730-065045.png\" ac:width=\"760\"><ri:attachment ri:filename=\"image-20240730-065045.png\" ri:version-at-save=\"1\" /><ac:caption><p>Administrator &gt; Audit &gt; Databases &gt; DB Access History &gt; DB Access History Details</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "b81451c3fb737fb9fc19843ff37c00705b8c29b9f82867fd611d6ec8dc21a403",
+      "mdx_line_range": [
+        61,
+        61
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 8,
+      "xhtml_xpath": "ul[1]",
+      "xhtml_fragment": "<ul><li><p>우측 드로워에는 이하의 정보를 노출합니다:</p><ol start=\"1\"><li><p><strong>Result</strong> : 접속 성공/실패 여부</p><ol start=\"1\"><li><p><ac:emoticon ac:name=\"tick\" ac:emoji-shortname=\":check_mark:\" ac:emoji-id=\"atlassian-check_mark\" ac:emoji-fallback=\":check_mark:\" /> Success</p></li><li><p><ac:emoticon ac:name=\"cross\" ac:emoji-shortname=\":cross_mark:\" ac:emoji-id=\"atlassian-cross_mark\" ac:emoji-fallback=\":cross_mark:\" /> Failure</p></li></ol></li><li><p><strong>Name</strong> : 대상 사용자 이름</p></li><li><p><strong>Action At</strong> : 접속 시점</p></li><li><p><strong>Action Type </strong>: Connect / Disconnect 여부</p></li><li><p><strong>Privilege</strong> <strong>Name</strong> : 사용자 접속 권한 </p></li><li><p><strong>Connection Name</strong> : 대상 DB 커넥션명</p></li><li><p><strong>Host</strong> <strong>Name </strong>: 접속 실행 호스트명</p></li><li><p><strong>Connected From</strong> : 접속 방식</p></li><li><p><strong>Client</strong> <strong>Name</strong> : 이용 클라이언트명 (DataGrip 등)</p></li><li><p><strong>Client IP</strong> : 사용자 클라이언트 IP 주소</p></li><li><p><strong>Replication Type</strong> : DB Replication 유형</p></li><li><p><strong>Database Type</strong> : 대상 데이터베이스 유형</p></li><li><p><strong>DB Host</strong> : 접속한 DB 호스트</p></li><li><p><strong>DB Name</strong> : DB명</p></li><li><p><strong>DB User</strong> : DB 사용자 ID</p></li><li><p><strong>Error Message</strong> : 접속 실패 등 특이사항에 대한 기록</p></li></ol></li></ul>",
+      "mdx_content_hash": "3c56b2f215e68a047366f9ca7419ae138810f59037dd4b4cd0890879eacd176c",
+      "mdx_line_range": [
+        63,
+        68
+      ],
+      "lost_info": {}
+    }
+  ],
+  "separators": [
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ],
+  "document_envelope": {
+    "prefix": "",
+    "suffix": ""
+  }
+}

--- a/confluence-mdx/tests/testcases/544145591/expected.roundtrip.json
+++ b/confluence-mdx/tests/testcases/544145591/expected.roundtrip.json
@@ -1,0 +1,841 @@
+{
+  "schema_version": "2",
+  "page_id": "544145591",
+  "mdx_sha256": "43556e368b14c8badd00bd2c96d8f41aedafcadf0ddd3486064ef8dbb229f98f",
+  "source_xhtml_sha256": "cbc830bacea9231f83d9d4414a69f79e32a0fb414596a648fd9326688b5598c3",
+  "blocks": [
+    {
+      "block_index": 0,
+      "xhtml_xpath": "h2[1]",
+      "xhtml_fragment": "<h2>Overview</h2>",
+      "mdx_content_hash": "3c9cc81f33d4e1529f559381d400f87363fc42b060111ceb77dc0273c4f10e3e",
+      "mdx_line_range": [
+        8,
+        8
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 1,
+      "xhtml_xpath": "p[1]",
+      "xhtml_fragment": "<p>General 페이지에서는 QueryPie 전체의 기본 설정을 변경할 수 있습니다. </p>",
+      "mdx_content_hash": "570f2c848432064a0ee7873e13333c111c0aeb41d4a26775907e952b18104d92",
+      "mdx_line_range": [
+        10,
+        10
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 2,
+      "xhtml_xpath": "ac:image[1]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"952\" ac:original-width=\"908\" ac:custom-width=\"true\" ac:alt=\"image-20250822-103044.png\" ac:width=\"760\"><ri:attachment ri:filename=\"image-20250822-103044.png\" ri:version-at-save=\"1\" /><ac:caption><p>Administrator &gt; General &gt; Company Management &gt; General</p></ac:caption><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "82c32a6041e628e9790c0ee4892c09dbcf72eed08094eed79eeca467c4f4e41f",
+      "mdx_line_range": [
+        12,
+        12
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 3,
+      "xhtml_xpath": "macro-toc[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"toc\" ac:schema-version=\"1\" data-layout=\"default\" ac:local-id=\"454bb818-ff05-4fd2-b617-5d2d7943c70e\" ac:macro-id=\"0fbab51a-0a60-4ccb-abe1-80e8ff989f27\"><ac:parameter ac:name=\"minLevel\">1</ac:parameter><ac:parameter ac:name=\"maxLevel\">2</ac:parameter><ac:parameter ac:name=\"outline\">false</ac:parameter><ac:parameter ac:name=\"style\">disc</ac:parameter><ac:parameter ac:name=\"exclude\">Overview</ac:parameter><ac:parameter ac:name=\"type\">list</ac:parameter><ac:parameter ac:name=\"printable\">true</ac:parameter></ac:structured-macro>",
+      "mdx_content_hash": "4553b15344e4a08e488d5c85d782dac079b6f271bd73d4b3d87a40755a911c1e",
+      "mdx_line_range": [
+        14,
+        19
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 4,
+      "xhtml_xpath": "h2[2]",
+      "xhtml_fragment": "<h2>기본 설정</h2>",
+      "mdx_content_hash": "e60bbfb943d889c34160a336e24db93a93c273931915215fc74d3da9aa8004c4",
+      "mdx_line_range": [
+        21,
+        21
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 5,
+      "xhtml_xpath": "ul[1]",
+      "xhtml_fragment": "<ul><li><p><strong>Company Name</strong> : 프로필 영역 등에 표시할 회사 이름을 입력합니다.</p></li><li><p><strong>Web Base URL</strong> : QueryPie 서비스에 접근하기 위해 사용하는 기본 도메인 주소</p></li><li><p><strong>Timezone</strong> : QueryPie 전체에서 표시될 날짜 및 시각 정보에 적용될 타임존을 설정합니다.</p></li><li><p><strong>Date Format</strong> : 날짜 표기 방식을 지정합니다.</p></li><li><p><strong>Default Display Language</strong> : QueryPie의 기본 언어 설정을 설정합니다. (디폴트: 영어) </p></li><li><p><strong>Audit Log Retention Period </strong>: 감사로그 보존 주기를 설정합니다. 현재는 5년으로 고정되어 있습니다.</p></li><li><p><strong>Go to System Properties</strong> : 클릭 시 시스템 설정값 내역을 확인할 수 있습니다. </p></li></ul>",
+      "mdx_content_hash": "19a8614a798ef2d156809360c8ef5d76a360c3e383920ce5dc45f6bd20a9d5bb",
+      "mdx_line_range": [
+        23,
+        29
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 6,
+      "xhtml_xpath": "p[2]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "92f3cc4574cb37373de212ad62e8ecae5022d6da0736c1618f1d19f5ac116ab7",
+      "mdx_line_range": [
+        32,
+        32
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 7,
+      "xhtml_xpath": "h2[3]",
+      "xhtml_fragment": "<h2>System Properties</h2>",
+      "mdx_content_hash": "a3b0346a63d5693c20c5a0e5563089e87f6a329eb19441ee34d3bfdf97e366a8",
+      "mdx_line_range": [
+        34,
+        34
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 8,
+      "xhtml_xpath": "p[3]",
+      "xhtml_fragment": "<p>System Properties 페이지에서는 QueryPie 시스템 컴포넌트들의 설정값을 확인하고, 파일로 저장할 수 있습니다.</p>",
+      "mdx_content_hash": "72b8dba71029f4fdcb945b289af836937fe27d7b10c206b964ffd69304fd1aca",
+      "mdx_line_range": [
+        36,
+        41
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 9,
+      "xhtml_xpath": "ac:image[2]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"1028\" ac:original-width=\"1747\" ac:custom-width=\"true\" ac:alt=\"image-20240805-014838.png\" ac:width=\"760\"><ri:attachment ri:filename=\"image-20240805-014838.png\" ri:version-at-save=\"1\" /><ac:caption><p>Administrator &gt; General &gt; Company Management &gt; General &gt; System Properties</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "a274a7a48009ef687a8fed757e22e637760bcc9d002288559f6c7359df24276c",
+      "mdx_line_range": [
+        44,
+        44
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 10,
+      "xhtml_xpath": "p[4]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "6481a2d975ed470e702f36c8219337d1871f0e297346aa70197e6abeea2d17e5",
+      "mdx_line_range": [
+        46,
+        46
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 11,
+      "xhtml_xpath": "h2[4]",
+      "xhtml_fragment": "<h2>Workflow Configuration</h2>",
+      "mdx_content_hash": "2cfa7ed0b4ee8d5e9061fa0bbf171854a5baf5970e111c149fa31dd842b6d896",
+      "mdx_line_range": [
+        48,
+        50
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 12,
+      "xhtml_xpath": "p[5]",
+      "xhtml_fragment": "<p>Workflow Configurations에서는 결재 상신 및 승인 관련 설정을 변경합니다.</p>",
+      "mdx_content_hash": "d9ff071078407c3fac34fc64e06347a456d5aaf0861f15840558c01b4bd25cab",
+      "mdx_line_range": [
+        52,
+        52
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 13,
+      "xhtml_xpath": "ac:image[3]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"1040\" ac:original-width=\"755\" ac:custom-width=\"true\" ac:width=\"543\"><ri:attachment ri:filename=\"Screenshot 2025-08-25 at 5.36.19 PM.png\" ri:version-at-save=\"2\" /><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "3694b9bd458f28292ce28b68d8b61350e89a13a4172296f39be5e7bf2dfa212f",
+      "mdx_line_range": [
+        54,
+        54
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 14,
+      "xhtml_xpath": "h2[5]",
+      "xhtml_fragment": "<h2>최대 승인 기간 설정 </h2>",
+      "mdx_content_hash": "05f46ef0bb72e32f143e761e79167fcbd704991b4f7f75625a4409ac82b243bf",
+      "mdx_line_range": [
+        56,
+        57
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 15,
+      "xhtml_xpath": "p[6]",
+      "xhtml_fragment": "<p>모든 워크플로우 요청의 승인 만료일을 일괄적으로 제한하는 최대 기간을 설정합니다.</p>",
+      "mdx_content_hash": "b063c7fc91c224496c99cafdd2403795d3d23d27ef947d35e3a4b285e4436497",
+      "mdx_line_range": [
+        59,
+        59
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 16,
+      "xhtml_xpath": "p[7]",
+      "xhtml_fragment": "<p>관리자는 Maximum Approval Duration 항목에서 승인 대기 요청이 자동으로 만료될 때까지의 기간을 1일에서 최대 14일까지 설정할 수 있습니다. 이곳에 설정된 기간은 사용자가 워크플로우를 상신할 때 선택하는 Approval Expiration Date (승인 만료일)의 최대값으로 적용됩니다.</p>",
+      "mdx_content_hash": "df37324bb2030fc9cf7da0ffdd12c92936bf3ea8f966bb768b284258c6ba3c1f",
+      "mdx_line_range": [
+        61,
+        61
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 17,
+      "xhtml_xpath": "ul[2]",
+      "xhtml_fragment": "<ul><li><p>Admin &gt; Databases &gt; Configurations의 Maximum Access Duration 또는 Admin &gt; Servers &gt; Configurations의 Maximum Access Duration이 Maximum Approval Duration보다 짧게 설정된 경우, 권한이 이미 만료된 후에 승인이 처리되는 상황을 방지하기 위해 Approval Expiration Date은 더 짧은 Access Expiration Date (권한 만료일)을 따라갑니다. </p></li></ul>",
+      "mdx_content_hash": "5576de4266dd2d47e78e0c86585cbf7b464cfa61d317a963fdc0303c0579899c",
+      "mdx_line_range": [
+        63,
+        64
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 18,
+      "xhtml_xpath": "h2[6]",
+      "xhtml_fragment": "<h2>워크플로우 사유입력 글자 수 제한 설정</h2>",
+      "mdx_content_hash": "e7f58ae58f76c68094d604e0f41ed5f6051538d5d11404be0485de9908653383",
+      "mdx_line_range": [
+        66,
+        69
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 19,
+      "xhtml_xpath": "p[8]",
+      "xhtml_fragment": "<p>워크플로우의 요청 사유Reason for Request와 승인, 거부, 취소, 확인 시 입력하는 Comment의 최소 및 최대 글자 수를 설정하는 기능입니다. 이 설정을 통해 관리자는 조직의 정책에 맞춰 입력 글자 수를 관리할 수 있습니다.</p>",
+      "mdx_content_hash": "6ce9ba047de050ad9c1bc72fa75c03a17b980fa819458e77dc2fadf460ffaec1",
+      "mdx_line_range": [
+        71,
+        71
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 20,
+      "xhtml_xpath": "ul[3]",
+      "xhtml_fragment": "<ul><li><p>관리자는 Workflow Configurations 페이지에서 다음 항목에 대한 글자 수 범위를 지정할 수 있습니다.</p><ul><li><p>Reason for Request: 워크플로우 상신 시 사유 입력에 대한 최소, 최대 글자 수를 설정합니다. (기본값: 최소 3자, 최대 1000자)</p></li><li><p>Comments: 워크플로우 승인, 거부, 실행 취소, 리뷰 확인 시 입력값에 대한 최소, 최대 글자 수를 설정합니다. (기본값: 최소 3자, 최대 300자)</p></li></ul></li><li><p>글자 수 범위는 최소 3자에서 최대 1000자 사이에서만 설정할 수 있습니다.</p></li></ul>",
+      "mdx_content_hash": "9fb5b62d21ca1240d2c4acd83ede186a922d63bb8dc0ab36ed961746ae8645d3",
+      "mdx_line_range": [
+        73,
+        73
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 21,
+      "xhtml_xpath": "h2[7]",
+      "xhtml_fragment": "<h2>참조자 지정 활성화</h2>",
+      "mdx_content_hash": "7cbb152b602034f5f3f32bd426f03a60002082ed15d3b886f04d45c0d566f6d1",
+      "mdx_line_range": [
+        75,
+        77
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 22,
+      "xhtml_xpath": "p[9]",
+      "xhtml_fragment": "<p>Activate Review Step to collaborate with others 토글로 활성화합니다.</p>",
+      "mdx_content_hash": "9ee77865a51f77659a1c18091dbf6ea4b7ab61c6cb9a23a8a8c9821df7758cfe",
+      "mdx_line_range": [
+        79,
+        79
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 23,
+      "xhtml_xpath": "ul[4]",
+      "xhtml_fragment": "<ul><li><p>Workflow 요청을 상신할 때 참조자를 지정하도록 허용할지 결정합니다.</p></li><li><p>토글을 켜면 요청 생성 화면의 결재 규칙 지정 영역에서 참조자 지정 버튼이 표시됩니다.</p></li><li><p>토글을 끄면 해당 버튼이 제거됩니다. (기존에 지정한 내역은 유지되며, 여전히 목록을 확인할 수 있습니다.)</p></li></ul>",
+      "mdx_content_hash": "9166b7caff9ec6cd9b4eeae47002d75253e165606224388931775dec762473b7",
+      "mdx_line_range": [
+        81,
+        81
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 24,
+      "xhtml_xpath": "h2[8]",
+      "xhtml_fragment": "<h2>사후 승인 허용</h2>",
+      "mdx_content_hash": "4b9c86d416999591b047899ab5245af42241f3a3557746f3255de73883fb72d4",
+      "mdx_line_range": [
+        83,
+        87
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 25,
+      "xhtml_xpath": "p[10]",
+      "xhtml_fragment": "<p>Allow users to submit requests in Urgent mode 토글로 활성화합니다.</p>",
+      "mdx_content_hash": "5b7ce143eff042852e877bd5f6abe65b420d7acecbdba8183a73e1139f953a2f",
+      "mdx_line_range": [
+        89,
+        89
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 26,
+      "xhtml_xpath": "ul[5]",
+      "xhtml_fragment": "<ul><li><p>Workflow 요청을 상신할 때 사후 승인 모드(Urgent Mode)를 허용할지 결정합니다.</p></li><li><p>토글을 켜면 다음의 영역에서 사후 승인 관련 토글이 표시됩니다.</p><ul><li><p>Approval Rules : 결재 규칙 생성 및 수정</p></li><li><p>Submit Request : 요청 생성 화면의 결재 규칙 지정 영역</p></li></ul></li><li><p>토글을 끄면 위 영역에서 사후 승인 관련 토글이 더 이상 표시되지 않습니다. 단, 기존에 이미 사후 승인 모드로 요청한 내역은 그대로 남아 있으며, 실행 가능합니다.</p></li></ul>",
+      "mdx_content_hash": "5c4612a935e63c43ead6317ad3c24443488bf4d99747b8e9126115120e7401f3",
+      "mdx_line_range": [
+        91,
+        92
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 27,
+      "xhtml_xpath": "h2[9]",
+      "xhtml_fragment": "<h2>Attribute 기반 승인자 지정 기능</h2>",
+      "mdx_content_hash": "68d421e7d64a73b495a184738e232b663988d782b08be850ed1145abe5b8e83a",
+      "mdx_line_range": [
+        93,
+        94
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 28,
+      "xhtml_xpath": "macro-info[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\" ac:macro-id=\"761a1bb7-13c0-403d-8614-5a77bbbad0ad\"><ac:rich-text-body><p>11.4.0부터 속성 기반 승인자 지정시 여러개의 속성을 지정할 수 있도록 개선되었습니다. </p><ul><li><p>Admin &gt; General &gt; Company Management &gt; General &gt; Workflow Configurations의 Use User Attribute-Based Approval 옵션 스위치가 제거되었습니다.</p></li><li><p>기존 Attribute 기반 승인자 지정시 하나의 Attribute만 지정할 수 있었으나 다른 Attribute를 선택할 수 있도록 하여 각 승인 단계별 각각 다른 속성의 승인자가 매핑되도록 개선되었습니다.  </p></li></ul></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "b2da7f53a98160f9a467e89f4f04afbd6efa6caff1e00b4a072e5fd65d238800",
+      "mdx_line_range": [
+        95,
+        95
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 29,
+      "xhtml_xpath": "p[11]",
+      "xhtml_fragment": "<p>사용자 프로필의 특정 Attribute(예: 팀 리더, 부서장)를 기준으로 승인자를 자동으로 지정할 수 있습니다. </p>",
+      "mdx_content_hash": "26e274f0b2f705677b05aa1a027d8e6f46b17f34369672ea4c19eb6300afc132",
+      "mdx_line_range": [
+        97,
+        97
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 30,
+      "xhtml_xpath": "ul[6]",
+      "xhtml_fragment": "<ul><li><p>중요: </p><ul><li><p>선택된 Attribute의 값으로는 승인자의 QueryPie Login ID가 입력되어 있어야 합니다.</p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"86\" ac:original-width=\"820\" ac:custom-width=\"true\" ac:width=\"712\"><ri:attachment ri:filename=\"Screenshot 2025-06-12 at 1.33.58 PM.png\" ri:version-at-save=\"1\" /><ac:caption><p>Admin &gt; General &gt; Users &gt; Detail page &gt; Profile 탭<br /></p></ac:caption></ac:image></li></ul></li><li><p>Administrator &gt; General &gt; Workflow Management &gt; Approval Rules 페이지에서 새로운 승인 규칙을 추가하거나 기존 규칙을 수정할 때, 'Assignee for Approval' 항목에 'Allow Assignee selection (Attribute-Based)'를 선택한 뒤 승인자와 매핑하기 위한 Attribute (예: teamLeader)를 지정합니다.<br /></p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"832\" ac:original-width=\"1524\" ac:custom-width=\"true\" ac:alt=\"image-20251110-030113.png\" ac:width=\"736\"><ri:attachment ri:filename=\"image-20251110-030113.png\" ri:version-at-save=\"1\" /></ac:image><ul><li><p>자가 승인 비활성화 시 연동: 만약 Approval Rules 설정에서 'Self Approval (자가 승인)' 옵션이 비활성화된 경우, Attribute 기반으로 결정된 승인자가 요청자 자신일 경우에는 해당 요청자를 승인자로 자동 지정할 수 없습니다. 이 경우, 워크플로우 설정 또는 시스템 정책에 따라 승인자 지정이 실패하거나 다른 경로로 처리될 수 있으니 주의가 필요합니다.</p></li></ul></li><li><p>Attribute 값 부재 시 알림</p><ul><li><p>만약 상신자 User Profile에 해당 Attribute 값이 비어 있는 경우(즉, 승인자의 Login ID가 지정되지 않은 경우), 워크플로우 상신 시 다음과 같은 내용의 알림 모달이 표시되며 요청 제출이 중단됩니다. 상신자는 관리자에게 문의하여 프로필의 Attribute 값을 설정해야 합니다.</p><ul><li><p>에러 메시지 예시: </p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"512\" ac:original-width=\"942\" ac:custom-width=\"true\" ac:alt=\"image-20250508-022114.png\" ac:width=\"688\"><ri:attachment ri:filename=\"image-20250508-022114.png\" ri:version-at-save=\"2\" /></ac:image></li></ul></li></ul></li><li><p>Attribute 값은 있지만 해당 사용자가 비활성화된 경우</p><ul><li><p>만약 상신자 User Profile에 해당 Attribute 값으로 지정된 승인자가 비활성화된 경우, 워크플로우 상신 시 Approver란에 지정된 승인자가 표기되지 않으며 아래와 같은 내용의 알림 모달이 표시되며 요청 제출이 중단됩니다.</p><ul><li><p>에러 메세지 예시:</p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"260\" ac:original-width=\"615\" ac:custom-width=\"true\" ac:width=\"615\"><ri:attachment ri:filename=\"Screenshot 2025-06-16 at 10.30.14 AM.png\" ri:version-at-save=\"1\" /><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image></li></ul></li></ul></li></ul>",
+      "mdx_content_hash": "d245f17d5107b869fe8730323e1c16f6e3e6b6321988de3560e4b0ddb48e144e",
+      "mdx_line_range": [
+        99,
+        123
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 31,
+      "xhtml_xpath": "h2[10]",
+      "xhtml_fragment": "<h2>Attribute 기반 워크플로우 메뉴 숨김 기능 (Use User Attribute to Hide Workflow Menu)</h2>",
+      "mdx_content_hash": "11cd48278ea0ff17293f89889b0706306827c914762de243d56b7b89c215f096",
+      "mdx_line_range": [
+        125,
+        125
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 32,
+      "xhtml_xpath": "p[12]",
+      "xhtml_fragment": "<p>Use User Attribute to Hide Workflow Menu 토글을 활성화합니다.</p>",
+      "mdx_content_hash": "5a47c0d8a288b04ab1ede44a007809034d7f8422e74d9b107b7b4feb275ca2aa",
+      "mdx_line_range": [
+        127,
+        127
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 33,
+      "xhtml_xpath": "ac:image[4]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"90\" ac:original-width=\"484\" ac:custom-width=\"true\" ac:width=\"670\"><ri:attachment ri:filename=\"Screenshot 2025-06-26 at 6.35.32 PM.png\" ri:version-at-save=\"1\" /></ac:image>",
+      "mdx_content_hash": "57057b468761e2f877b804d491204b53f89fbae4f19ec30385681ab41a3f1d10",
+      "mdx_line_range": [
+        129,
+        131
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 34,
+      "xhtml_xpath": "p[13]",
+      "xhtml_fragment": "<p>특정 사용자 속성(User Attribute)을 기준으로 사용자 대시보드에서 Workflow 메뉴를 보이지 않도록 설정하는 기능입니다.</p>",
+      "mdx_content_hash": "e7dd355d4411afafc911bab2988e59134edb4f9bab5dedb79399fc170fac2d01",
+      "mdx_line_range": [
+        133,
+        133
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 35,
+      "xhtml_xpath": "ul[7]",
+      "xhtml_fragment": "<ul><li><p>토글을 활성화하면 <code>User Attribute</code>의 <code>Key</code>와 <code>Value</code>를 한 쌍으로 선택하고 입력할 수 있습니다.</p></li><li><p>여기에 설정된 <code>Key:Value</code> 조건과 일치하는 사용자는 사용자 대시보드에 <code>Workflow</code> 메뉴가 표시되지 않습니다.</p></li><li><p><strong>예시:</strong> <code>User Attribute Key</code>로 '부서코드'를 선택하고, <code>Value</code>로 '부서 A'를 입력하면 해당 부서코드 소속의 사용자에게는 <code>Workflow</code> 메뉴가 보이지 않습니다.</p></li></ul>",
+      "mdx_content_hash": "8b915dc83121e9ebabe718c6d272480b320a2885d640d6c4ab532e583899d031",
+      "mdx_line_range": [
+        135,
+        137
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 36,
+      "xhtml_xpath": "h2[11]",
+      "xhtml_fragment": "<h2>대리결재 기능 활성화 / 비활성화 옵션 (Allow Delegated Approval)</h2>",
+      "mdx_content_hash": "42c14b76f35503bc2fdc8d9e2776f3e542a70180d395cce0272330fa551ad76f",
+      "mdx_line_range": [
+        139,
+        139
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 37,
+      "xhtml_xpath": "macro-info[2]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\" ac:macro-id=\"090050c3-368a-432c-8a9c-ced74bd0d3b8\"><ac:rich-text-body><p>대리결재 기능 활성화 / 비활성화 옵션은 11.3.0에 추가되었습니다.<br />11.4.0 부터 사용자의 대리결재자 지정 / 해제 이벤트에 대해 감사로그를 기록합니다. 해당 로그는 External API ( /api/external/v2/workflows/approval-delegations/logs) 를 사용해서 조회 할 수 있습니다.</p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "90f448d3a6b0aa99c940ab95c3a21829d923d7ba3c51e5b0c58398c0fbc3980f",
+      "mdx_line_range": [
+        141,
+        143
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 38,
+      "xhtml_xpath": "p[14]",
+      "xhtml_fragment": "<p>승인자 역할을 일정기간 다른 사용자에게 위임하는 기능인 대리결재 기능을 관리자가 활성화 또는 비활성화 할 수 있는 옵션입니다. 만약 비활성화 할 경우 사용자 preference 화면에서 Approver setting 메뉴가 노출되지 않습니다. </p>",
+      "mdx_content_hash": "b2da7f53a98160f9a467e89f4f04afbd6efa6caff1e00b4a072e5fd65d238800",
+      "mdx_line_range": [
+        144,
+        144
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 39,
+      "xhtml_xpath": "ac:image[5]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"36\" ac:original-width=\"225\" ac:custom-width=\"true\" ac:alt=\"image-20250926-112444.png\" ac:width=\"253\"><ri:attachment ri:filename=\"image-20250926-112444.png\" ri:version-at-save=\"1\" /><ac:caption><p>Allow Delegated Approval 스위치</p></ac:caption><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "c07c46328ca08e7dc041002fb101d13c53e08f020865b1f352cf4cb9d6e1bf76",
+      "mdx_line_range": [
+        146,
+        147
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 40,
+      "xhtml_xpath": "ac:image[6]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"649\" ac:original-width=\"888\" ac:custom-width=\"true\" ac:alt=\"image-20250926-112201.png\" ac:width=\"516\"><ri:attachment ri:filename=\"image-20250926-112201.png\" ri:version-at-save=\"1\" /><ac:caption><p>대리결재 기능을 비활성화한 상태의 preference</p></ac:caption><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "477da8c911f578b38f7c1bd15689b8ab17992741fab14e2d8fe64bce3422f2cf",
+      "mdx_line_range": [
+        149,
+        154
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 41,
+      "xhtml_xpath": "h2[12]",
+      "xhtml_fragment": "<h2>SQL 요청 실행 시 쓰로틀링 활성화 (Use throttling when submitting SQL Request in Workflow)</h2>",
+      "mdx_content_hash": "b9c7c0cf17d21816e1d08930c9e9651b4e5a7111cef95e123c58e9e99d01f56e",
+      "mdx_line_range": [
+        156,
+        161
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 42,
+      "xhtml_xpath": "p[15]",
+      "xhtml_fragment": "<p>토글을 켜면 Workflow에서 상신된 SQL 요청 실행시 쓰로틀링을 적용합니다.</p>",
+      "mdx_content_hash": "0273975eb82cb85dd53a5a1d696def57ec7f1f34696a25d45b6b70077982fafb",
+      "mdx_line_range": [
+        163,
+        163
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 43,
+      "xhtml_xpath": "ac:image[7]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"159\" ac:original-width=\"604\" ac:custom-width=\"true\" ac:width=\"604\"><ri:attachment ri:filename=\"Screenshot 2025-05-09 at 3.18.32 PM.png\" ri:version-at-save=\"1\" /><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "1c3a571e8ca93c4789a01c359f25994636dcc4816ec8c64117b6c64733b18070",
+      "mdx_line_range": [
+        165,
+        165
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 44,
+      "xhtml_xpath": "p[16]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "ed2bff0435b61f5a39c13ce59f249b4458b2625826187f31bc315108cac03824",
+      "mdx_line_range": [
+        167,
+        169
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 45,
+      "xhtml_xpath": "p[17]",
+      "xhtml_fragment": "<p>이 옵션을 활성화하는 경우, 명시된 갯수만큼 쿼리를 연속적으로 실행한 뒤, 명시된 간격(ms)만큼 대기합니다. 이를 통해 대용량 쿼리 실행에 따르는 DB 부하를 방지할 수 있습니다.</p>",
+      "mdx_content_hash": "8dbb8175ba07f4622955a8dc14d1b97f0f8f88b11e9183191a048336b61a52b3",
+      "mdx_line_range": [
+        172,
+        173
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 46,
+      "xhtml_xpath": "ul[8]",
+      "xhtml_fragment": "<ul><li><p><strong>Query chunk size</strong> : 1~999,999 사이의 값으로 설정되며, 다수의 쿼리를 해당 개수만큼 나누어 순차적으로 실행하는 기능</p><ul><li><p>예) 100개의 쿼리가 있을 때, Query chunk size가 10으로 설정되어 있다면 한번에 10개의 Query를 실행합니다. </p></li></ul></li><li><p><strong>Query throttle interval </strong>: 연속 쿼리 실행 후, 다음 연속 쿼리 실행 간의 간격 (1 ~ 9,999 ms)</p></li></ul>",
+      "mdx_content_hash": "ae650614ba0d29e97f84ddf084c72c900c4361f7f79717524154a2238e52a2b1",
+      "mdx_line_range": [
+        175,
+        177
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 47,
+      "xhtml_xpath": "h2[13]",
+      "xhtml_fragment": "<h2>Ledger 테이블 DML 워크플로우 커스텀 URL 리디렉션 기능</h2>",
+      "mdx_content_hash": "4ef4f08a6bc89d7b71f695826cda77c776905cc5aa85bab62c8ec2d4f04b2f77",
+      "mdx_line_range": [
+        179,
+        179
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 48,
+      "xhtml_xpath": "p[18]",
+      "xhtml_fragment": "<p>Redirect to custom page for SQL Requests 토글을 활성화합니다.</p>",
+      "mdx_content_hash": "da3d823d27efcd758628ae9e3728e82741e5151243575974b2c7b0d77c270bbd",
+      "mdx_line_range": [
+        181,
+        181
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 49,
+      "xhtml_xpath": "ac:image[8]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"92\" ac:original-width=\"468\" ac:custom-width=\"true\" ac:width=\"516\"><ri:attachment ri:filename=\"Screenshot 2025-05-09 at 8.33.07 PM.png\" ri:version-at-save=\"1\" /></ac:image>",
+      "mdx_content_hash": "ca4bf4375816c11dc8a87e2da57250c752d8e943e9c0377f6217363db19c6e2f",
+      "mdx_line_range": [
+        183,
+        185
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 50,
+      "xhtml_xpath": "p[19]",
+      "xhtml_fragment": "<p>이 옵션을 통해 User Agent에서 Ledger 테이블 대상으로 INSERT, UPDATE, DELETE 쿼리 실행으로 인해 워크플로 승인 요청이 발생할 경우, <code>Send Request</code> 버튼 클릭 시 사용자를 사전에 정의된 커스텀 URL 페이지로 리디렉션할지 여부를 결정합니다. 이를 통해 고객사는 자체 운영 중인 외부 워크플로 시스템과의 연동을 강화할 수 있습니다.</p>",
+      "mdx_content_hash": "0dc111d7c73289915e77f15b8a9825d9f4a8f8eadaeb039e8da6677b7f94a39e",
+      "mdx_line_range": [
+        187,
+        188
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 51,
+      "xhtml_xpath": "ul[9]",
+      "xhtml_fragment": "<ul><li><p>토글을 활성화한 경우</p><ul><li><p>Administrator &gt; General &gt; Workflow Configurations 페이지에 커스텀 URL을 입력할 수 있는 필드가 나타납니다.</p></li><li><p>User Agent 사용자가 Ledger 테이블에 대해 변경 쿼리를 실행하고 승인 요청을 보낼 경우, <code>Send Request</code> 클릭 시 해당 커스텀 URL로 리디렉션되며, 이때 쿼리나 사용자 정보는 전달되지 않습니다.</p></li></ul></li><li><p>토글을 비활성화한 경우</p><ul><li><p>Administrator &gt; General &gt; Workflow Configurations 페이지에 커스텀 URL을 입력할 수 있는 필드가 표시되지 않습니다.</p></li><li><p>User Agent 사용자가 Ledger 테이블에 대해 INSERT, UPDATE, DELETE 쿼리를 실행하여 워크플로 승인 요청 모달이 표시될 때, <code>Send Request</code> 버튼을 클릭하면 기존과 같이 QueryPie 내부의 표준 워크플로 페이지로 이동합니다</p></li></ul></li></ul>",
+      "mdx_content_hash": "cdbb980bef9a52b0ec6ec17bfe27d1930efa7b1e1f5b0c073d072cbd09efe18f",
+      "mdx_line_range": [
+        190,
+        195
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 52,
+      "xhtml_xpath": "h2[14]",
+      "xhtml_fragment": "<h2>워크플로우 Request 타입별 사용자 노출 제어 기능</h2>",
+      "mdx_content_hash": "ecdfdbe0e8f99a612b3e4466d213c15b7e24aa9b708288b102de476595768bb0",
+      "mdx_line_range": [
+        197,
+        197
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 53,
+      "xhtml_xpath": "p[20]",
+      "xhtml_fragment": "<p>Select Request Types Allowed for Users 토글을 활성화합니다. </p>",
+      "mdx_content_hash": "7d8acfbe08fcb207eb5fe678d4438dbdea9540b21adce992d827e04e0d2a2ac8",
+      "mdx_line_range": [
+        199,
+        199
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 54,
+      "xhtml_xpath": "ac:image[9]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"574\" ac:original-width=\"352\" ac:custom-width=\"true\" ac:width=\"352\"><ri:attachment ri:filename=\"Screenshot 2025-05-09 at 8.40.28 PM.png\" ri:version-at-save=\"1\" /></ac:image>",
+      "mdx_content_hash": "549f23106fc350b31d3fb8f22ef966fe579b85015811a649745d54b7411864dc",
+      "mdx_line_range": [
+        201,
+        203
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 55,
+      "xhtml_xpath": "p[21]",
+      "xhtml_fragment": "<p>이 옵션을 통해 관리자가 사용자가 접근하고 요청할 수 있는 워크플로우의 요청(Request) 타입을 선택적으로 제어할 수 있도록 합니다. </p>",
+      "mdx_content_hash": "9c01e81a0ce9c09d63a169af7a024674ee5e0f598e7f38fdf8e9165d62810945",
+      "mdx_line_range": [
+        205,
+        205
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 56,
+      "xhtml_xpath": "ul[10]",
+      "xhtml_fragment": "<ul><li><p>토글을 활성화(On)한 경우:</p><ul><li><p>Administrator &gt; General &gt; Workflow Configurations 페이지에서:</p><ul><li><p>Select Request Types Allowed for Users 토글 아래에 제품별(Databases (DAC), Servers (SAC), Kubernetes (KAC), Web Apps (WAC))로 분류된 요청 타입 목록이 체크박스 형태로 표시됩니다.</p></li><li><p>관리자는 이 체크박스를 사용하여 사용자에게 노출할 요청 타입을 선택적으로 지정할 수 있습니다. 기본적으로 모든 요청 타입이 선택된 상태로 표시됩니다.</p></li></ul></li><li><p>사용자 워크플로우 상신 화면:</p><ul><li><p>관리자가 선택한(체크한) 요청 타입만 사용자에게 표시되며 요청 가능합니다.</p></li></ul></li><li><p>Access Role Request의 특별 동작:</p><ul><li><p>Servers (SAC), Kubernetes (KAC), Web Apps (WAC) 중 하나 이상의 제품에서 Access Role Request가 선택되어야 사용자에게 Access Role Request 항목이 노출됩니다.</p></li><li><p>Access Role Request 요청 시, 내부 Service 항목에는 관리자가 선택한 제품(예: &quot;Server Access Control&quot;)만 표시됩니다.</p></li></ul></li></ul></li><li><p>토글을 비활성화(Off)한 경우 (기본값):</p><ul><li><p>Administrator &gt; General &gt; Workflow Configurations 페이지에서:</p><ul><li><p>요청 타입 선택을 위한 체크박스 목록이 표시되지 않습니다.</p></li></ul></li><li><p>사용자 워크플로우 상신 화면:</p><ul><li><p>기존과 동일하게, 사용자에게 할당된 라이선스에 따라 모든 관련 제품의 워크플로우 요청 타입이 노출되고 요청 가능합니다.</p></li><li><p>Access Role Request 내의 Service 항목도 라이선스에 따라 모두 노출됩니다.</p></li></ul></li></ul></li></ul>",
+      "mdx_content_hash": "038127c27b947a1f5e4911b2e96e681578c195ac4a0280d2ce38089d7fb98e9e",
+      "mdx_line_range": [
+        207,
+        221
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 57,
+      "xhtml_xpath": "h2[15]",
+      "xhtml_fragment": "<h2>DB access 요청 권한 별 결재선 지정 기능</h2>",
+      "mdx_content_hash": "e5a73f9de2eccaaa9a6a038bc3f73327b4ccf25abc25617914e0c01007e4e50a",
+      "mdx_line_range": [
+        223,
+        223
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 58,
+      "xhtml_xpath": "p[22]",
+      "xhtml_fragment": "<p>Workflow를 통해 DB Access Request 를 상신할 경우 요청하는 권한에 따라 결재선 (Approval Rule)을 특정할 수 있도록 하려면 &ldquo;Use DB Privilege Type Based Approval&rdquo; 토글을 활성화합니다.</p>",
+      "mdx_content_hash": "23f6fa3d08178cc1017845ec2f925bb432276caae240b6ef7dfe30f594bd855f",
+      "mdx_line_range": [
+        225,
+        225
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 59,
+      "xhtml_xpath": "ac:image[10]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"350\" ac:original-width=\"623\" ac:custom-width=\"true\" ac:alt=\"image-20250822-111454.png\" ac:width=\"507\"><ri:attachment ri:filename=\"image-20250822-111454.png\" ri:version-at-save=\"1\" /><ac:caption><p>Use DB Privilege Type Based Approval</p></ac:caption><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "af5be3116afc392d394d3a4f7f4ea199d59a8aae201ee73e864c03a910586794",
+      "mdx_line_range": [
+        227,
+        232
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 60,
+      "xhtml_xpath": "p[23]",
+      "xhtml_fragment": "<p><code>+Routing Rule</code> 버튼을 누르면 privilege 에 대한 조건을 지정하여 결재선에 대한 라우팅을 지정할 수 있습니다.</p>",
+      "mdx_content_hash": "130c161ed0fb3fa0b0f96fbaf49622d9616dae21e6d58255c523886c004fcb88",
+      "mdx_line_range": [
+        234,
+        234
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 61,
+      "xhtml_xpath": "ac:image[11]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"427\" ac:original-width=\"512\" ac:custom-width=\"true\" ac:alt=\"image-20250822-112026.png\" ac:width=\"432\"><ri:attachment ri:filename=\"image-20250822-112026.png\" ri:version-at-save=\"1\" /><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "cf2103a62f65cb712a1f530b11057717ff296f560be3d8222119e011091965b0",
+      "mdx_line_range": [
+        236,
+        238
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 62,
+      "xhtml_xpath": "ul[11]",
+      "xhtml_fragment": "<ul><li><p><strong>Routing Rule Name</strong> : 식별하기 쉬운 라우팅 규칙의 이름을 입력합니다.</p></li><li><p><strong>Condition</strong> : Privilege에 대한 조건을 지정합니다.</p><ul><li><p><strong>All Match</strong> : 사용자가 DB Access Request 를 상신할 때 지정한 Privilege Type이 모두 같은 종류인 경우 동작하는 조건입니다.</p></li><li><p><strong>Contains </strong>: 사용자가 DB Access Request 를 상신할 때 지정한 Privilege Type이 하나라도 지정한 종류를 포함 했을 때 동작하는 조건입니다.</p></li></ul></li><li><p> <strong>Requested Privilege Type</strong> : Administrator &gt; Databases &gt; DB Access Control &gt; Privilege Type에 정의 되어 있는 Privilege 유형 중 하나를 선택합니다.</p></li><li><p><strong>Approval Rule</strong> : 위 조건이 만족했을 경우 강제할 결재선(Approval Rule)을 지정합니다.</p></li></ul>",
+      "mdx_content_hash": "14c0c57462d9611ab3e9214ff50357352eb14ec15d35b494d356b4aa60933a5a",
+      "mdx_line_range": [
+        240,
+        245
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 63,
+      "xhtml_xpath": "h3[1]",
+      "xhtml_fragment": "<h3>Routing Rule 지정 예시</h3>",
+      "mdx_content_hash": "4cbda45cf9f95e284fa72d8a05956dc8e32dbc8731a562390da60143c13340e7",
+      "mdx_line_range": [
+        247,
+        247
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 64,
+      "xhtml_xpath": "ul[12]",
+      "xhtml_fragment": "<ul><li><p>만약 사용자가 Workflow의 DB Access Request를 통해 요청한 대상 커넥션에 지정한 privilege가 모두  &ldquo;Read-Only&rdquo; 인 경우 특정 Approval rule을 사용하도록 강제하기 원한다면, 아래와 같이 설정하고 <code>Add</code> 버튼을 누릅니다.</p><ul><li><p>Condition: All Match 선택.</p></li><li><p>Requested Privilege Type : Read-Only 선택.</p></li><li><p>Approval Rule : 강제하기 원하는 Approval Rule 선택. </p></li></ul></li><li><p>만약 사용자가 Workflow의 DB Access Request를 통해 요청한 대상 커넥션에 지정한 privilege가 하나라도 Read/Write가 포함되어 있는 경우 특정 Approval rule을 사용하도록 강제하기 원한다면, 아래와 같이 설정하고 <code>Add</code> 버튼을 누릅니다.</p><ul><li><p>Condition: Contains 선택.</p></li><li><p>Requested Privilege Type : Read/Write 선택.</p></li><li><p>Approval Rule : 강제하기 원하는 Approval Rule 선택.</p></li></ul></li></ul>",
+      "mdx_content_hash": "77591667fd4615cb7bd5d3e1852ed2083f7a958306f7c2a3daf2e6efc73c18e0",
+      "mdx_line_range": [
+        249,
+        256
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 65,
+      "xhtml_xpath": "h2[16]",
+      "xhtml_fragment": "<h2>SQL Request에서 실행계획 첨부기능 활성 / 비활성 옵션 </h2>",
+      "mdx_content_hash": "84a7ae6642803a81e9fe728adfa40aad3fdcf7077cf79c838c1038ab17227540",
+      "mdx_line_range": [
+        258,
+        258
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 66,
+      "xhtml_xpath": "p[24]",
+      "xhtml_fragment": "<p>Workflow의 SQL Request를 통해 수행할 쿼리를 상신할 때 실행 계획 결과를 첨부하는 &ldquo;Attach Explain Results&rdquo; 기능을 활성 또는 비활성화 할 수 있도록 옵션을 제공합니다.</p>",
+      "mdx_content_hash": "ae964f9e6c798d40c2516ae5a6155fa8a756438dc0f25d53630aec455a872334",
+      "mdx_line_range": [
+        260,
+        260
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 67,
+      "xhtml_xpath": "ac:image[12]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"46\" ac:original-width=\"425\" ac:custom-width=\"true\" ac:alt=\"image-20250825-002423.png\" ac:width=\"425\"><ri:attachment ri:filename=\"image-20250825-002423.png\" ri:version-at-save=\"1\" /></ac:image>",
+      "mdx_content_hash": "c114aaf5357dc5ba50ac1bf500be5a89cd35a352a54ee7f4f744a7346ee27488",
+      "mdx_line_range": [
+        262,
+        264
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 68,
+      "xhtml_xpath": "p[25]",
+      "xhtml_fragment": "<p>관리자가 이 옵션을 활성화 하더라도 Workflow의 SQL Request 양식에서 &ldquo;Attach Explain Results&rdquo; 는 Off로 되어 있으므로 사용자가 필요시 명시적으로 &ldquo;Attatch Explain Results&rdquo; 토글 스위치를 On으로 변경해야 실행계획 결과가 첨부됩니다.</p>",
+      "mdx_content_hash": "92a3fceaa1a78114b64ed20897645d75b26fe8f6fe9548f71c69df3d2a0c9c88",
+      "mdx_line_range": [
+        266,
+        266
+      ],
+      "lost_info": {}
+    }
+  ],
+  "separators": [
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ],
+  "document_envelope": {
+    "prefix": "",
+    "suffix": ""
+  }
+}

--- a/confluence-mdx/tests/testcases/544178405/expected.roundtrip.json
+++ b/confluence-mdx/tests/testcases/544178405/expected.roundtrip.json
@@ -1,0 +1,181 @@
+{
+  "schema_version": "2",
+  "page_id": "544178405",
+  "mdx_sha256": "f772f1250c30b99ffab64e2f29740d077da38eb3377a616fb562170530388488",
+  "source_xhtml_sha256": "4fe7ffbbcee2a5a22ee29bc64cd3f4eaac99a48ae71bae70ed58b41e562e246e",
+  "blocks": [
+    {
+      "block_index": 0,
+      "xhtml_xpath": "h2[1]",
+      "xhtml_fragment": "<h2>환영합니다.</h2>",
+      "mdx_content_hash": "f28e55048a2a0cac36f9dcc923232ec3919244c5a2a4c47127893c7b01817017",
+      "mdx_line_range": [
+        6,
+        6
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 1,
+      "xhtml_xpath": "p[1]",
+      "xhtml_fragment": "<p>QueryPie의 관리자는 QueryPie Web 또는 API를 통하여 리소스 및 권한, 솔루션 보안, 알림 설정 등 쿼리파이 전반 솔루션 관리를 진행할 수 있습니다. 공급된 라이선스 및 관리자 역할 권한에 따라 관리자에게 보여지는 설정 메뉴가 상이합니다.</p>",
+      "mdx_content_hash": "253483cd7cb7ecf82eb0d2d61fb602aaf56ad5fba9e25419f1798fb9f82a5104",
+      "mdx_line_range": [
+        8,
+        8
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 2,
+      "xhtml_xpath": "p[2]",
+      "xhtml_fragment": "<p>관리자 페이지를 진입하기 위해서는 먼저 QueryPie 로그인을 진행합니다. 로그인이 정상적으로 완료되었다면 사용자 대시보드 이동하게 되며 만약 QueryPie 관리자 역할을 할당받은 사용자일 경우 우측 상단에 <code>Go to Admin Page</code> 버튼이 표시됩니다. 이 버튼을 클릭하여 관리자 페이지를 새 탭으로 열 수 있습니다. </p>",
+      "mdx_content_hash": "129da1224b4c0e76211cce8755e773fe4f2f63ceeddf2fedcb3a9c727275e502",
+      "mdx_line_range": [
+        10,
+        11
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 3,
+      "xhtml_xpath": "ac:image[1]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"wide\" ac:original-height=\"98\" ac:original-width=\"698\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-08-01 오후 2.50.06.png\" ac:width=\"762\"><ri:attachment ri:filename=\"스크린샷 2024-08-01 오후 2.50.06.png\" ri:version-at-save=\"1\" /><ac:caption><p>GNB 내 관리자 페이지 진입점</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "3008887a039218bfd790a581bf05d4ff5ba8189378f0f2844bc3d872dd10c84a",
+      "mdx_line_range": [
+        13,
+        15
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 4,
+      "xhtml_xpath": "p[3]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "5bfebae731a0135bfe259889a6e87abd876c0a12725153da3f8f1062e00b545e",
+      "mdx_line_range": [
+        17,
+        22
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 5,
+      "xhtml_xpath": "h2[2]",
+      "xhtml_fragment": "<h2>QueryPie 관리자 설정이 처음이신가요?</h2>",
+      "mdx_content_hash": "2c0bef50efd49b303da69a1839a94cd7a65cc4737023b705b8230c454ceca4a0",
+      "mdx_line_range": [
+        25,
+        25
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 6,
+      "xhtml_xpath": "p[4]",
+      "xhtml_fragment": "<p>Databases, Servers, Kubernetes 등 각 서비스 설정을 진행하기 전에 기본적으로 설정해야하는 항목들이 있습니다. 특히 보안 설정, 사용자 설정, 관리자 역할 할당은 필수적으로 설정하시는 것을 권장해 드립니다. </p>",
+      "mdx_content_hash": "0d457e7d51227aa0f598bfe369790f475e553a1cae82d706870b7e78f2ec0114",
+      "mdx_line_range": [
+        27,
+        28
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 7,
+      "xhtml_xpath": "table[1]",
+      "xhtml_fragment": "<table data-table-width=\"760\" data-layout=\"default\" ac:local-id=\"96d34ea4-8772-49af-9ba2-14ea36b1f3e1\"><colgroup><col /><col style=\"width: 242.0px;\" /><col style=\"width: 518.0px;\" /></colgroup><tbody><tr><th class=\"numberingColumn\" /><th data-highlight-colour=\"var(--ds-background-accent-gray-subtlest, #F4F5F7)\"><p style=\"text-align: center;\"><strong>설정 순서</strong></p></th><th data-highlight-colour=\"var(--ds-background-accent-gray-subtlest, #F4F5F7)\"><p style=\"text-align: center;\"><strong>설정 항목</strong></p></th></tr><tr><td class=\"numberingColumn\">1</td><th><p><strong>기본 정보 설정하기</strong></p></th><td><ul><li><p><ac:link><ri:page ri:content-title=\"General​\" ri:version-at-save=\"35\" /><ac:link-body>General</ac:link-body></ac:link> </p><ul><li><p>회사 이름, 타임존, 날짜 표기 방식 등</p></li></ul></li></ul></td></tr><tr><td class=\"numberingColumn\">2</td><th><p><strong>보안 정보 설정하기 </strong></p></th><td><ul><li><p><ac:link><ri:page ri:content-title=\"Security\" ri:version-at-save=\"39\" /><ac:link-body>Security</ac:link-body></ac:link> </p><ul><li><p>잠금 정책, 비밀번호 변경 주기, 타임아웃 등</p></li></ul></li><li><p><ac:link><ri:page ri:content-title=\"Allowed Zones\" ri:version-at-save=\"9\" /><ac:link-body>Allowed Zones</ac:link-body></ac:link> </p><ul><li><p>허용할 IP 대역 생성 및 관리</p></li></ul></li></ul></td></tr><tr><td class=\"numberingColumn\">3</td><th><p><strong>사용자 및 사용자 그룹 생성하기</strong></p></th><td><ul><li><p>Authentication </p><ul><li><p><ac:link><ri:page ri:content-title=\"LDAP 연동하기\" ri:version-at-save=\"13\" /><ac:link-body>LDAP 연동하기</ac:link-body></ac:link></p></li><li><p><ac:link><ri:page ri:content-title=\"Okta 연동하기\" ri:version-at-save=\"12\" /><ac:link-body>Okta 연동하기 </ac:link-body></ac:link></p></li><li><p><ac:link><ri:page ri:content-title=\"AWS SSO 연동하기\" ri:version-at-save=\"9\" /><ac:link-body>AWS SSO 연동하기 </ac:link-body></ac:link></p></li></ul></li><li><p>Users </p><ul><li><p><ac:link><ri:page ri:content-title=\"사용자 프로필\" ri:version-at-save=\"13\" /><ac:link-body>사용자 프로필 </ac:link-body></ac:link></p></li></ul></li><li><p><ac:link><ri:page ri:content-title=\"Groups\" ri:version-at-save=\"10\" /><ac:link-body>Groups</ac:link-body></ac:link> </p></li></ul></td></tr><tr><td class=\"numberingColumn\">4</td><th><p><strong>관리자 역할 할당하기 </strong></p></th><td><ul><li><p><ac:link><ri:page ri:content-title=\"Roles\" ri:version-at-save=\"9\" /><ac:link-body>Roles</ac:link-body></ac:link></p></li></ul></td></tr><tr><td class=\"numberingColumn\">5</td><th><p><strong>결재 규칙 설정하기</strong></p></th><td><ul><li><p><ac:link><ri:page ri:content-title=\"Approval Rules\" ri:version-at-save=\"22\" /><ac:link-body>Approval Rules</ac:link-body></ac:link></p></li></ul></td></tr><tr><td class=\"numberingColumn\">6</td><th><p><strong>알림 설정하기</strong></p></th><td><ul><li><p><ac:link><ri:page ri:content-title=\"Channels\" ri:version-at-save=\"17\" /><ac:link-body>Channels</ac:link-body></ac:link></p></li><li><p><ac:link><ri:page ri:content-title=\"Alerts\" ri:version-at-save=\"22\" /><ac:link-body>Alerts</ac:link-body></ac:link></p></li></ul></td></tr><tr><td class=\"numberingColumn\">7</td><th><p><strong>외부 보안 솔루션 연동하기 </strong></p></th><td><ul><li><p><ac:link><ri:page ri:content-title=\"Integrations\" ri:version-at-save=\"8\" /><ac:link-body>Integrations</ac:link-body></ac:link></p></li></ul></td></tr></tbody></table>",
+      "mdx_content_hash": "c14d9173ff369cd34f7efaa564f53ecd27b82ae601f009527df7b98f0ad2d3fa",
+      "mdx_line_range": [
+        30,
+        136
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 8,
+      "xhtml_xpath": "p[5]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "aa1a1003324db99621c5c0151482a7259802325ae0e8c9412943d3b6e0026c5a",
+      "mdx_line_range": [
+        139,
+        139
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 9,
+      "xhtml_xpath": "h2[3]",
+      "xhtml_fragment": "<h2>자, 이제 기본 설정을 마쳤습니다. 이제 서비스별 설정을 해볼까요?</h2>",
+      "mdx_content_hash": "86f67c1f133ff5c720387dcf066e0c3bc62e0e630d6fcfd37d7e6c3090f2b71a",
+      "mdx_line_range": [
+        141,
+        144
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 10,
+      "xhtml_xpath": "p[6]",
+      "xhtml_fragment": "<p>기본 설정을 마쳤다면 서비스별 설정이 남았습니다. QueryPie의 세분화된 접근 제어 기능을 통해 강력한 권한 관리를 경험해 보세요. 서비스별 설정이 끝난 후에는 관리자/사용자의 접속 및 실행 이력들을 Audit 메뉴에서 자세히 확인하실 수 있습니다. 뿐만 아니라 민감 정보를 식별할 수 있는 Discovery 기능 또한 제공하니 차세대 디스커버리 기능을 경험해 보세요.</p>",
+      "mdx_content_hash": "55f5aba0d2250b845d234cfdab934b04cef0d9a4fe0fb3107d79723c1a67417a",
+      "mdx_line_range": [
+        146,
+        216
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 11,
+      "xhtml_xpath": "table[2]",
+      "xhtml_fragment": "<table data-table-width=\"760\" data-layout=\"default\" ac:local-id=\"1c770267-da7f-48dc-b1e3-817744eeec38\"><colgroup><col /><col style=\"width: 344.0px;\" /><col style=\"width: 415.0px;\" /></colgroup><tbody><tr><th class=\"numberingColumn\" /><th data-highlight-colour=\"var(--ds-background-accent-gray-subtlest, #F4F5F7)\"><p style=\"text-align: center;\"><strong>설정 순서</strong></p></th><th data-highlight-colour=\"var(--ds-background-accent-gray-subtlest, #F4F5F7)\"><p style=\"text-align: center;\"><strong>설정 항목</strong></p></th></tr><tr><td class=\"numberingColumn\">1</td><th><p><strong>Databased Access Control 설정하기</strong></p></th><td><ul><li><p><ac:link><ri:page ri:content-title=\"Connection Management\" ri:version-at-save=\"17\" /><ac:link-body>Connection Management</ac:link-body></ac:link></p></li><li><p><ac:link><ri:page ri:content-title=\"DB Access Control​\" ri:version-at-save=\"7\" /><ac:link-body>DB Access Control</ac:link-body></ac:link></p></li><li><p><ac:link><ri:page ri:content-title=\"Policies\" ri:version-at-save=\"14\" /><ac:link-body>Policies</ac:link-body></ac:link></p></li><li><p><ac:link><ri:page ri:content-title=\"Ledger Management\" ri:version-at-save=\"5\" /><ac:link-body>Ledger Management</ac:link-body></ac:link></p></li></ul></td></tr><tr><td class=\"numberingColumn\">2</td><th><p><strong>Server Access Control 설정하기</strong></p></th><td><ul><li><p><ac:link><ri:page ri:content-title=\"Connection Management​\" ri:version-at-save=\"10\" /><ac:link-body>Connection Management</ac:link-body></ac:link></p></li><li><p><ac:link><ri:page ri:content-title=\"Server Access Control\" ri:version-at-save=\"12\" /><ac:link-body>Server Access Control </ac:link-body></ac:link></p></li></ul></td></tr><tr><td class=\"numberingColumn\">3</td><th><p><strong>Kubernetes Access Control 설정하기</strong></p></th><td><ul><li><p><ac:link><ri:page ri:content-title=\"Connection Management​​\" ri:version-at-save=\"11\" /><ac:link-body>Connection Management</ac:link-body></ac:link></p></li><li><p><ac:link><ri:page ri:content-title=\"K8s Access Control\" ri:version-at-save=\"8\" /><ac:link-body>K8s Access Control </ac:link-body></ac:link></p></li></ul></td></tr><tr><td class=\"numberingColumn\">4</td><th><p><strong>감사 로그 확인하기</strong></p></th><td><ul><li><p><ac:link><ri:page ri:content-title=\"General Logs\" ri:version-at-save=\"14\" /><ac:link-body>General Logs</ac:link-body></ac:link></p></li><li><p><ac:link><ri:page ri:content-title=\"Database Logs\" ri:version-at-save=\"6\" /><ac:link-body>Database Logs</ac:link-body></ac:link></p></li><li><p><ac:link><ri:page ri:content-title=\"Server Logs\" ri:version-at-save=\"6\" /><ac:link-body>Server Logs</ac:link-body></ac:link></p></li><li><p><ac:link><ri:page ri:content-title=\"Kubernetes Logs\" ri:version-at-save=\"8\" /><ac:link-body>Kubernetes Logs</ac:link-body></ac:link></p></li></ul></td></tr></tbody></table>",
+      "mdx_content_hash": "",
+      "mdx_line_range": [
+        0,
+        0
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 12,
+      "xhtml_xpath": "p[7]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "",
+      "mdx_line_range": [
+        0,
+        0
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 13,
+      "xhtml_xpath": "p[8]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "",
+      "mdx_line_range": [
+        0,
+        0
+      ],
+      "lost_info": {}
+    }
+  ],
+  "separators": [
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ],
+  "document_envelope": {
+    "prefix": "",
+    "suffix": ""
+  }
+}

--- a/confluence-mdx/tests/testcases/544211126/expected.roundtrip.json
+++ b/confluence-mdx/tests/testcases/544211126/expected.roundtrip.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": "2",
+  "page_id": "544211126",
+  "mdx_sha256": "230f78eab9325ac91918b9de8cb688a0d75805598dea194c5825e2aacbc6d3e2",
+  "source_xhtml_sha256": "dbe191b85ab99880b209776f4e806bdcb333550e2c1d71325b701536a8cef73f",
+  "blocks": [
+    {
+      "block_index": 0,
+      "xhtml_xpath": "h2[1]",
+      "xhtml_fragment": "<h2>환영합니다.</h2>",
+      "mdx_content_hash": "0f9d1126d4baf8e7a0e601c2e89f8b56d145e7e304451a5461d7db0e6a3d65c4",
+      "mdx_line_range": [
+        6,
+        6
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 1,
+      "xhtml_xpath": "p[1]",
+      "xhtml_fragment": "<p>이곳에서 QueryPie의 사용자가 어떻게 QueryPie Web에 접속하여 리소스(DB, System, Cluster)에 대한 접근 권한을 받고, 원하는 리소스에 안전하게 접속할 수 있는지에 대한 가이드를 제공합니다. </p>",
+      "mdx_content_hash": "253483cd7cb7ecf82eb0d2d61fb602aaf56ad5fba9e25419f1798fb9f82a5104",
+      "mdx_line_range": [
+        8,
+        8
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 2,
+      "xhtml_xpath": "p[2]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "dd058e11696749fd3a8cf088a5d7c9c5c9d5dec172d92716d469cfd9189954a6",
+      "mdx_line_range": [
+        10,
+        10
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 3,
+      "xhtml_xpath": "h2[2]",
+      "xhtml_fragment": "<h2>QueryPie가 처음이신가요?</h2>",
+      "mdx_content_hash": "d69b8364954004bca84f4ea843d7fd1d77ef518da1dcf56609a46182bf848a4e",
+      "mdx_line_range": [
+        13,
+        13
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 4,
+      "xhtml_xpath": "p[3]",
+      "xhtml_fragment": "<p>아래 순서를 따라 사용해 보세요. 각 항목을 클릭하면 자세한 사용 방법을 확인하실 수 있습니다.</p>",
+      "mdx_content_hash": "eebb4a0a46b94fb82c61df0d5cfb660ce3bef562fda10536e489c7bc48262d4f",
+      "mdx_line_range": [
+        15,
+        16
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 5,
+      "xhtml_xpath": "table[1]",
+      "xhtml_fragment": "<table data-table-width=\"760\" data-layout=\"default\" ac:local-id=\"c53b8e8a-3f68-476f-aa0a-03f2f0eb700f\"><colgroup><col /><col style=\"width: 247.0px;\" /><col style=\"width: 512.0px;\" /></colgroup><tbody><tr><th class=\"numberingColumn\" /><th data-highlight-colour=\"var(--ds-background-accent-gray-subtlest, #F4F5F7)\"><p style=\"text-align: center;\"><strong>사용 순서</strong></p></th><th data-highlight-colour=\"var(--ds-background-accent-gray-subtlest, #F4F5F7)\"><p style=\"text-align: center;\"><strong>기능</strong></p></th></tr><tr><td class=\"numberingColumn\">1</td><th data-highlight-colour=\"var(--ds-background-accent-gray-subtlest, #F4F5F7)\"><p><strong>로그인</strong></p></th><td><ul><li><p><ac:link ac:card-appearance=\"inline\" ac:anchor=\"QueryPie-Web%EC%97%90-%EB%A1%9C%EA%B7%B8%EC%9D%B8%ED%95%98%EA%B8%B0\"><ri:page ri:content-title=\"My Dashboard\" ri:version-at-save=\"12\" /><ac:link-body>My Dashboard</ac:link-body></ac:link> </p></li></ul></td></tr><tr><td class=\"numberingColumn\">2</td><th data-highlight-colour=\"var(--ds-background-accent-gray-subtlest, #F4F5F7)\"><p><strong>대시보드 둘러보기</strong></p></th><td><ul><li><p><ac:link ac:card-appearance=\"inline\" ac:anchor=\"%EC%82%AC%EC%9A%A9%EC%9E%90-%EB%8C%80%EC%8B%9C%EB%B3%B4%EB%93%9C\"><ri:page ri:content-title=\"My Dashboard\" ri:version-at-save=\"12\" /><ac:link-body>My Dashboard</ac:link-body></ac:link> </p></li></ul></td></tr><tr><td class=\"numberingColumn\">3</td><th data-highlight-colour=\"var(--ds-background-accent-gray-subtlest, #F4F5F7)\"><p><strong>Workflow로 권한 받기 </strong></p></th><td><ul><li><p><ac:link ac:card-appearance=\"inline\"><ri:page ri:content-title=\"DB Access Request 요청하기\" ri:version-at-save=\"25\" /><ac:link-body>DB Access Request 요청하기</ac:link-body></ac:link></p></li><li><p><ac:link ac:card-appearance=\"inline\"><ri:page ri:content-title=\"SQL Request 요청하기\" ri:version-at-save=\"26\" /><ac:link-body>SQL Request 요청하기</ac:link-body></ac:link></p></li><li><p><ac:link><ri:page ri:content-title=\"SQL Export Request 요청하기\" ri:version-at-save=\"19\" /><ac:link-body>SQL Export Request 요청하기</ac:link-body></ac:link></p></li><li><p><ac:link><ri:page ri:content-title=\"Unmasking Request 요청하기 (마스킹 해제 요청)\" ri:version-at-save=\"2\" /><ac:link-body>Unmasking Request 요청하기</ac:link-body></ac:link></p></li><li><p><ac:link><ri:page ri:content-title=\"Restricted Data Access 요청하기 (제한된 데이터 접근 요청)\" ri:version-at-save=\"1\" /><ac:link-body>Restricted Data Access 요청하기</ac:link-body></ac:link></p></li><li><p><ac:link><ri:page ri:content-title=\"Access Role Request 요청하기\" ri:version-at-save=\"19\" /><ac:link-body>Server Access Request 요청하기</ac:link-body></ac:link></p></li><li><p><ac:link><ri:page ri:content-title=\"Server Privilege Request 요청하기\" ri:version-at-save=\"5\" /><ac:link-body>Server Privilege Request 요청하기</ac:link-body></ac:link></p></li><li><p><ac:link><ri:page ri:content-title=\"Access Role Request 요청하기\" ri:version-at-save=\"19\" /><ac:link-body>Access Role Request 요청하기</ac:link-body></ac:link></p></li><li><p><ac:link><ri:page ri:content-title=\"IP Registration Request 요청하기\" ri:version-at-save=\"5\" /><ac:link-body>IP Registration Request 요청하기</ac:link-body></ac:link></p></li><li><p><ac:link><ri:page ri:content-title=\"DB 정책 예외 요청하기 (DB Policy Exception Request)\" ri:version-at-save=\"2\" /><ac:link-body>DB Policy Exception Request 요청하기</ac:link-body></ac:link></p></li></ul></td></tr><tr><td class=\"numberingColumn\">4</td><th data-highlight-colour=\"var(--ds-background-accent-gray-subtlest, #F4F5F7)\"><p><strong>QueryPie Web에서 접속하기 </strong></p></th><td><ul><li><p>Database Access Control </p><ul><li><p><ac:link><ri:page ri:content-title=\"웹 SQL 에디터로 접속하기\" ri:version-at-save=\"19\" /><ac:link-body>웹 SQL 에디터로 접속하기</ac:link-body></ac:link></p></li><li><p><ac:link><ri:page ri:content-title=\"Default Privilege 설정하기\" ri:version-at-save=\"10\" /><ac:link-body>Default Privilege 설정하기 </ac:link-body></ac:link></p></li><li><p><ac:link><ri:page ri:content-title=\"에이전트 없이 프록시 접속하기\" ri:version-at-save=\"9\" /><ac:link-body>에이전트 없이 프록시 접속하기 </ac:link-body></ac:link></p></li></ul></li><li><p>Server Access Control</p><ul><li><p><ac:link><ri:page ri:content-title=\"권한이 있는 서버에 접속하기\" ri:version-at-save=\"12\" /><ac:link-body>접근 권한이 있는 서버에 접속하기</ac:link-body></ac:link> </p></li><li><p><ac:link><ri:page ri:content-title=\"웹 터미널 사용하기\" ri:version-at-save=\"8\" /><ac:link-body>웹 터미널 사용하기</ac:link-body></ac:link></p></li><li><p><ac:link><ri:page ri:content-title=\"웹 SFTP 사용하기\" ri:version-at-save=\"6\" /><ac:link-body>웹 SFTP 사용하기 </ac:link-body></ac:link></p></li></ul></li><li><p>Kubernetes Access Control</p><ul><li><p><ac:link><ri:page ri:content-title=\"접근 권한 목록 확인하기\" ri:version-at-save=\"13\" /><ac:link-body>접근 권한 목록 확인하기</ac:link-body></ac:link></p></li></ul></li><li><p>Web Access Control</p><ul><li><p><ac:link><ri:page ri:content-title=\"Root CA 인증서 및 Extension 설치하기\" ri:version-at-save=\"1\" /><ac:link-body>Root CA 인증 서 및 Extension 설치하기</ac:link-body></ac:link></p></li><li><p><ac:link><ri:page ri:content-title=\"웹 어플리케이션 (웹 사이트) 접속하기\" ri:version-at-save=\"2\" /><ac:link-body>웹 어플리케이션 (웹 사이트) 접속하기</ac:link-body></ac:link></p></li></ul></li></ul></td></tr><tr><td class=\"numberingColumn\">5</td><th data-highlight-colour=\"var(--ds-background-accent-gray-subtlest, #F4F5F7)\"><p><strong>QueryPie Agent로 접속하기</strong></p></th><td><ul><li><p><ac:link><ri:page ri:content-title=\"Multi Agent\" ri:version-at-save=\"14\" /><ac:link-body>Agent</ac:link-body></ac:link></p></li></ul></td></tr><tr><td class=\"numberingColumn\">6</td><th data-highlight-colour=\"var(--ds-background-accent-gray-subtlest, #F4F5F7)\"><p><strong>개인 설정 둘러보기</strong></p></th><td><ul><li><p><ac:link><ri:page ri:content-title=\"Preferences\" ri:version-at-save=\"18\" /><ac:link-body>Preferences</ac:link-body></ac:link></p></li></ul></td></tr></tbody></table>",
+      "mdx_content_hash": "21afe08ce34fba728c065bb12cefcc393d2af078b375211f5ef72229ce0623cf",
+      "mdx_line_range": [
+        18,
+        123
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 6,
+      "xhtml_xpath": "p[4]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "",
+      "mdx_line_range": [
+        0,
+        0
+      ],
+      "lost_info": {}
+    }
+  ],
+  "separators": [
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ],
+  "document_envelope": {
+    "prefix": "",
+    "suffix": ""
+  }
+}

--- a/confluence-mdx/tests/testcases/544375741/expected.roundtrip.json
+++ b/confluence-mdx/tests/testcases/544375741/expected.roundtrip.json
@@ -1,0 +1,469 @@
+{
+  "schema_version": "2",
+  "page_id": "544375741",
+  "mdx_sha256": "c58aa7c5f524dd5e9cbf1f011b720865dda5e1456318a046a741ba996fd41f38",
+  "source_xhtml_sha256": "89b833aa5c960cf06b8c5f9a803f3d30b076dad7dc82ec8ac2eb709abb67f3e9",
+  "blocks": [
+    {
+      "block_index": 0,
+      "xhtml_xpath": "macro-toc[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"toc\" ac:schema-version=\"1\" data-layout=\"default\" ac:local-id=\"d20a7b68-bbd3-4415-bd42-1c3d42bab812\" ac:macro-id=\"b1b7a13a598cededc74e26d40052217d\"><ac:parameter ac:name=\"minLevel\">1</ac:parameter><ac:parameter ac:name=\"maxLevel\">1</ac:parameter><ac:parameter ac:name=\"exclude\">External API 변경사항 바로가기</ac:parameter></ac:structured-macro>",
+      "mdx_content_hash": "94f335e8d5059c966555ffaffea5fbee14835f3a8382fa944e0c7e0757482152",
+      "mdx_line_range": [
+        6,
+        6
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 1,
+      "xhtml_xpath": "hr[1]",
+      "xhtml_fragment": "<hr />",
+      "mdx_content_hash": "a70304d3a44c0068e572cc94e850c8c6fe5b885326e1eef4abc25f79ca87aba9",
+      "mdx_line_range": [
+        8,
+        8
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 2,
+      "xhtml_xpath": "h1[1]",
+      "xhtml_fragment": "<h1>API Docs Json File</h1>",
+      "mdx_content_hash": "2debcb002cd59881fca3eae704f4a38ad92908efff0097eb913cd0e0ce696fdf",
+      "mdx_line_range": [
+        10,
+        10
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 3,
+      "xhtml_xpath": "p[1]",
+      "xhtml_fragment": "<p class=\"media-group\"><ac:structured-macro ac:name=\"view-file\" ac:schema-version=\"1\" ac:macro-id=\"bb52972a-ed8f-4020-a27f-c84b50eb1e0c\"><ac:parameter ac:name=\"name\"><ri:attachment ri:filename=\"994_external.json\" ri:version-at-save=\"1\" /></ac:parameter></ac:structured-macro><ac:structured-macro ac:name=\"view-file\" ac:schema-version=\"1\" ac:macro-id=\"7bd5e77e-1eef-4fea-b41d-c4305e195959\"><ac:parameter ac:name=\"name\"><ri:attachment ri:filename=\"995_external.json\" ri:version-at-save=\"1\" /></ac:parameter></ac:structured-macro></p>",
+      "mdx_content_hash": "45548d360f130d2d014eefd5e943039fd45819bb4ee8945a809d1a51306e44aa",
+      "mdx_line_range": [
+        12,
+        14
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 4,
+      "xhtml_xpath": "hr[2]",
+      "xhtml_fragment": "<hr />",
+      "mdx_content_hash": "fca53f4bb3f98c21c7b84a1ad9154ba545432c5326faf1b71599fcab6c173541",
+      "mdx_line_range": [
+        16,
+        16
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 5,
+      "xhtml_xpath": "h1[2]",
+      "xhtml_fragment": "<h1>1. Access Approval API</h1>",
+      "mdx_content_hash": "6814c2809676e539c450c3489978526093f76a42f685679f6aa54dfa0767ed22",
+      "mdx_line_range": [
+        18,
+        18
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 6,
+      "xhtml_xpath": "h3[1]",
+      "xhtml_fragment": "<h3><strong>(GET) List</strong></h3>",
+      "mdx_content_hash": "7efa6238ff76d523a311c131a96ed7edbbcc6b1c6d8555cdb33f115832fa654a",
+      "mdx_line_range": [
+        20,
+        20
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 7,
+      "xhtml_xpath": "h4[1]",
+      "xhtml_fragment": "<h4>Request</h4>",
+      "mdx_content_hash": "92474269f5b72b10897cc8a0b4844539de4caf1806750f5af74c160ea590cd75",
+      "mdx_line_range": [
+        22,
+        22
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 8,
+      "xhtml_xpath": "ul[1]",
+      "xhtml_fragment": "<ul><li><p>변경점 없음</p></li></ul>",
+      "mdx_content_hash": "56a19afc05098f858bbf0e761bd7b2484b2c4f1cd6298db380ba8705974481fa",
+      "mdx_line_range": [
+        24,
+        24
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 9,
+      "xhtml_xpath": "h4[2]",
+      "xhtml_fragment": "<h4>Response</h4>",
+      "mdx_content_hash": "852fc820480d95438176efc03eeeddf6bea553ff6d15fb7eba51e7b1c5d7f663",
+      "mdx_line_range": [
+        26,
+        41
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 10,
+      "xhtml_xpath": "table[1]",
+      "xhtml_fragment": "<table data-table-width=\"760\" data-layout=\"default\" ac:local-id=\"729f4860-908e-453e-a2ce-586ef92bde21\"><colgroup><col style=\"width: 316.0px;\" /><col style=\"width: 364.0px;\" /></colgroup><tbody><tr><th><p><strong>변경 전</strong></p></th><th><p><strong>변경 후</strong></p></th></tr><tr><td><p /></td><td><ul><li><p>id</p></li></ul></td></tr></tbody></table>",
+      "mdx_content_hash": "293957f1e6e179d7da9ec795acfdddb8972a6769902417fabbf29508d3113be1",
+      "mdx_line_range": [
+        43,
+        49
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 11,
+      "xhtml_xpath": "ul[2]",
+      "xhtml_fragment": "<ul><li><p><strong>id</strong> 가 <strong>추가</strong>되었습니다.</p></li></ul>",
+      "mdx_content_hash": "075f1331e2fe466f1a7304074f4130c8c2cab432cbdc128336b9ec712aedb76d",
+      "mdx_line_range": [
+        51,
+        51
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 12,
+      "xhtml_xpath": "hr[3]",
+      "xhtml_fragment": "<hr />",
+      "mdx_content_hash": "a70304d3a44c0068e572cc94e850c8c6fe5b885326e1eef4abc25f79ca87aba9",
+      "mdx_line_range": [
+        52,
+        52
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 13,
+      "xhtml_xpath": "h1[3]",
+      "xhtml_fragment": "<h1>2. Approval API</h1>",
+      "mdx_content_hash": "3e18f046cfad164ebbf451b777dd80b35469c2bc278f928cfd6c30587ab6790b",
+      "mdx_line_range": [
+        54,
+        54
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 14,
+      "xhtml_xpath": "h3[2]",
+      "xhtml_fragment": "<h3><strong>(GET) List</strong></h3>",
+      "mdx_content_hash": "6814c2809676e539c450c3489978526093f76a42f685679f6aa54dfa0767ed22",
+      "mdx_line_range": [
+        56,
+        56
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 15,
+      "xhtml_xpath": "h4[3]",
+      "xhtml_fragment": "<h4>Request</h4>",
+      "mdx_content_hash": "7efa6238ff76d523a311c131a96ed7edbbcc6b1c6d8555cdb33f115832fa654a",
+      "mdx_line_range": [
+        58,
+        58
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 16,
+      "xhtml_xpath": "ul[3]",
+      "xhtml_fragment": "<ul><li><p>변경점 없음</p></li></ul>",
+      "mdx_content_hash": "92474269f5b72b10897cc8a0b4844539de4caf1806750f5af74c160ea590cd75",
+      "mdx_line_range": [
+        60,
+        60
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 17,
+      "xhtml_xpath": "h4[4]",
+      "xhtml_fragment": "<h4>Response</h4>",
+      "mdx_content_hash": "56a19afc05098f858bbf0e761bd7b2484b2c4f1cd6298db380ba8705974481fa",
+      "mdx_line_range": [
+        62,
+        62
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 18,
+      "xhtml_xpath": "table[2]",
+      "xhtml_fragment": "<table data-table-width=\"760\" data-layout=\"default\" ac:local-id=\"d1aedf57-9c7c-4ffd-abf3-d1381144dd7d\"><colgroup><col style=\"width: 316.0px;\" /><col style=\"width: 364.0px;\" /></colgroup><tbody><tr><th><p><strong>변경 전</strong></p></th><th><p><strong>변경 후</strong></p></th></tr><tr><td><p /></td><td><ul><li><p>id</p></li></ul></td></tr></tbody></table>",
+      "mdx_content_hash": "852fc820480d95438176efc03eeeddf6bea553ff6d15fb7eba51e7b1c5d7f663",
+      "mdx_line_range": [
+        64,
+        79
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 19,
+      "xhtml_xpath": "ul[4]",
+      "xhtml_fragment": "<ul><li><p><strong>id</strong> 가 <strong>추가</strong>되었습니다.</p></li></ul>",
+      "mdx_content_hash": "293957f1e6e179d7da9ec795acfdddb8972a6769902417fabbf29508d3113be1",
+      "mdx_line_range": [
+        81,
+        87
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 20,
+      "xhtml_xpath": "hr[4]",
+      "xhtml_fragment": "<hr />",
+      "mdx_content_hash": "075f1331e2fe466f1a7304074f4130c8c2cab432cbdc128336b9ec712aedb76d",
+      "mdx_line_range": [
+        89,
+        89
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 21,
+      "xhtml_xpath": "h1[4]",
+      "xhtml_fragment": "<h1>3. Audit Log API</h1>",
+      "mdx_content_hash": "a70304d3a44c0068e572cc94e850c8c6fe5b885326e1eef4abc25f79ca87aba9",
+      "mdx_line_range": [
+        90,
+        90
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 22,
+      "xhtml_xpath": "h3[3]",
+      "xhtml_fragment": "<h3><strong>(GET) List of Approval</strong></h3>",
+      "mdx_content_hash": "4a2bf07bd9503f19dc1cfcd588ec1b01fd9f7ae1b8abaa6e9dc9b7b24fd55e63",
+      "mdx_line_range": [
+        92,
+        92
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 23,
+      "xhtml_xpath": "p[2]",
+      "xhtml_fragment": "<p><code>/api/external/audit-logs</code></p>",
+      "mdx_content_hash": "eba06966480eeb813b9057708569ea0aa929eac292d9239d6e139b698b8c1a77",
+      "mdx_line_range": [
+        94,
+        94
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 24,
+      "xhtml_xpath": "h4[5]",
+      "xhtml_fragment": "<h4>Request</h4>",
+      "mdx_content_hash": "7edfaa914a83c184ce18289ea1d71063ca5f86c26c2fde755bb36ec4771b656c",
+      "mdx_line_range": [
+        96,
+        96
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 25,
+      "xhtml_xpath": "ul[5]",
+      "xhtml_fragment": "<ul><li><p>Query Parameter</p></li><li><p>/api/docs 에 잘못 표기 되어 있던 <strong>cursor</strong> 에 대한 내용이 수정되었습니다.</p></li></ul>",
+      "mdx_content_hash": "7efa6238ff76d523a311c131a96ed7edbbcc6b1c6d8555cdb33f115832fa654a",
+      "mdx_line_range": [
+        98,
+        98
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 26,
+      "xhtml_xpath": "h4[6]",
+      "xhtml_fragment": "<h4>Response</h4>",
+      "mdx_content_hash": "bff053b97c3f0fda4799b8f0239134166d38cd360cac02202bbc38f606786ca3",
+      "mdx_line_range": [
+        100,
+        101
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 27,
+      "xhtml_xpath": "ul[6]",
+      "xhtml_fragment": "<ul><li><p>/api/docs 에 잘못 표기 되어 있던 <strong>nextCursor</strong> 에 대한 내용이 수정되었습니다.</p></li></ul>",
+      "mdx_content_hash": "56a19afc05098f858bbf0e761bd7b2484b2c4f1cd6298db380ba8705974481fa",
+      "mdx_line_range": [
+        103,
+        103
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 28,
+      "xhtml_xpath": "hr[5]",
+      "xhtml_fragment": "<hr />",
+      "mdx_content_hash": "4e5ee88d78d154cdca6dcf2af4c89e407b07ebef5a515b6959e105813795d98a",
+      "mdx_line_range": [
+        105,
+        105
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 29,
+      "xhtml_xpath": "h1[5]",
+      "xhtml_fragment": "<h1>4. Notification Channels API</h1>",
+      "mdx_content_hash": "a70304d3a44c0068e572cc94e850c8c6fe5b885326e1eef4abc25f79ca87aba9",
+      "mdx_line_range": [
+        106,
+        106
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 30,
+      "xhtml_xpath": "h3[4]",
+      "xhtml_fragment": "<h3><strong>(GET) List</strong></h3>",
+      "mdx_content_hash": "c2dbd1e6731d83c9cce7fb70c246ec4f4255e57e239e2c06f5b317dd9b8e5b2e",
+      "mdx_line_range": [
+        108,
+        108
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 31,
+      "xhtml_xpath": "p[3]",
+      "xhtml_fragment": "<p><code>/api/external/notification-channels</code></p>",
+      "mdx_content_hash": "6814c2809676e539c450c3489978526093f76a42f685679f6aa54dfa0767ed22",
+      "mdx_line_range": [
+        110,
+        110
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 32,
+      "xhtml_xpath": "h4[7]",
+      "xhtml_fragment": "<h4>Request</h4>",
+      "mdx_content_hash": "b31108c4f6e999c5592c8a2c73fd0245ebc6fd4cc9cd1cd4cc50783ba2b9c10c",
+      "mdx_line_range": [
+        112,
+        112
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 33,
+      "xhtml_xpath": "ul[7]",
+      "xhtml_fragment": "<ul><li><p>Query Parameter</p></li></ul>",
+      "mdx_content_hash": "7efa6238ff76d523a311c131a96ed7edbbcc6b1c6d8555cdb33f115832fa654a",
+      "mdx_line_range": [
+        114,
+        114
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 34,
+      "xhtml_xpath": "table[3]",
+      "xhtml_fragment": "<table data-table-width=\"760\" data-layout=\"default\" ac:local-id=\"a8579e9b-bf3a-44ef-8dbe-bef487c68840\"><colgroup><col style=\"width: 316.0px;\" /><col style=\"width: 364.0px;\" /></colgroup><tbody><tr><th><p><strong>변경 전</strong></p></th><th><p><strong>변경 후</strong></p></th></tr><tr><td><ul><li><p>dataFlowRequest.filterKey</p></li><li><p>dataFlowRequest.filterValue</p></li><li><p>dataFlowRequest.sortKey</p></li><li><p>dataFlowRequest.sortType</p></li></ul></td><td><ul><li><p>filterKey</p></li><li><p>filterValue</p></li><li><p>sortKey</p></li><li><p>sortType</p></li></ul></td></tr></tbody></table>",
+      "mdx_content_hash": "d5f90f565f347a4ce0e9e55b4763a3af9e78f1ad2d8804e3c5138053c338b33d",
+      "mdx_line_range": [
+        116,
+        116
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 35,
+      "xhtml_xpath": "ul[8]",
+      "xhtml_fragment": "<ul><li><p><strong>이름</strong>이 <strong>변경</strong>되었습니다.</p></li></ul>",
+      "mdx_content_hash": "217b9da8ce659743139aa82ba19d4442d914503c52c9528ca13748f0bfc2559b",
+      "mdx_line_range": [
+        118,
+        147
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 36,
+      "xhtml_xpath": "h4[8]",
+      "xhtml_fragment": "<h4>Response</h4>",
+      "mdx_content_hash": "71549591868435b48c983a29e75841bca775889a5efe1069660bb4e333a622e2",
+      "mdx_line_range": [
+        149,
+        149
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 37,
+      "xhtml_xpath": "ul[9]",
+      "xhtml_fragment": "<ul><li><p>변경점 없음</p></li></ul>",
+      "mdx_content_hash": "56a19afc05098f858bbf0e761bd7b2484b2c4f1cd6298db380ba8705974481fa",
+      "mdx_line_range": [
+        151,
+        151
+      ],
+      "lost_info": {}
+    }
+  ],
+  "separators": [
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ],
+  "document_envelope": {
+    "prefix": "",
+    "suffix": ""
+  }
+}

--- a/confluence-mdx/tests/testcases/544377869/expected.roundtrip.json
+++ b/confluence-mdx/tests/testcases/544377869/expected.roundtrip.json
@@ -1,0 +1,181 @@
+{
+  "schema_version": "2",
+  "page_id": "544377869",
+  "mdx_sha256": "b5d36fcc6516463e5a76f1d4e7be81011e053e5d7cc00354d8982b1c3fe99a66",
+  "source_xhtml_sha256": "a74628f8a53d804ffd124b133efc5d9fbf3b623262f07cf2e824b9d7e0f69946",
+  "blocks": [
+    {
+      "block_index": 0,
+      "xhtml_xpath": "h2[1]",
+      "xhtml_fragment": "<h2>Overview</h2>",
+      "mdx_content_hash": "819484f4643cfb87be34a01b9f3e4c1be106494bd94f607ad922908c4e593b1c",
+      "mdx_line_range": [
+        8,
+        8
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 1,
+      "xhtml_xpath": "p[1]",
+      "xhtml_fragment": "<p>데이터베이스 커넥션 접속시 Proxy 연결을 지원합니다. 기본적으로 QueryPie 에서 제공하는 웹 SQL 에디터를 통해 커넥션에 접속할 수 있고, QueryPie 에서 생성한 Proxy Credential 정보 또는 Agent 를 통한 기존의 DB username/password로 쓰시던 툴에서 커넥션에 접속할 수 있습니다. 웹 SQL 에디터와 함께 Proxy 연결을 지원하여 다양한 사용자 환경에서도 문제없이 커넥션 접근을 제어하고, 정책을 적용할 수 있으며, 로그를 남길 수 있습니다. 현재 Proxy 연결은 MySQL, MariaDB, Oracle, PostgreSQL, Redshift, Trino, SQLServer, MongoDB 를 지원합니다.</p>",
+      "mdx_content_hash": "570f2c848432064a0ee7873e13333c111c0aeb41d4a26775907e952b18104d92",
+      "mdx_line_range": [
+        10,
+        10
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 2,
+      "xhtml_xpath": "p[2]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "596d5d59e2f68610e1aa2e1864c7fbca797517a56d65e76a563af8052be4d218",
+      "mdx_line_range": [
+        12,
+        15
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 3,
+      "xhtml_xpath": "h2[2]",
+      "xhtml_fragment": "<h2>Proxy 사용 옵션 활성화</h2>",
+      "mdx_content_hash": "7b2136d15680b9f3fffe88521e47b482bf51e0717bd6f3214dc9cf549dcf64da",
+      "mdx_line_range": [
+        18,
+        18
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 4,
+      "xhtml_xpath": "p[3]",
+      "xhtml_fragment": "<p>기본적으로는 Proxy 사용 옵션이 비활성화되어 있습니다. 접속을 허용할 커넥션에서 Proxy 사용 여부를 활성화합니다.</p>",
+      "mdx_content_hash": "ea7adbff000bcfb756c95e9a719a65c97e161a4c226e0ef04a86028ab97e9f49",
+      "mdx_line_range": [
+        20,
+        21
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 5,
+      "xhtml_xpath": "ac:image[1]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"1902\" ac:original-width=\"3450\" ac:custom-width=\"true\" ac:alt=\"image-20240725-070857.png\" ac:width=\"760\"><ri:attachment ri:filename=\"image-20240725-070857.png\" ri:version-at-save=\"1\" /><ac:caption><p>Administrator &gt; Databases &gt; Connection Management &gt; DB Connections &gt; Connection Details &gt; Proxy Usage</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "e63c89b9f5129c1199f6aa2331401448285e10836935ce52585e50000c3de8e5",
+      "mdx_line_range": [
+        23,
+        28
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 6,
+      "xhtml_xpath": "ol[1]",
+      "xhtml_fragment": "<ol start=\"1\"><li><p>Database 설정 메뉴에서 DB Connections 메뉴로 이동합니다.</p></li><li><p>등록한 커넥션을 하나 클릭합니다.</p></li><li><p>하단의 Additional Information 항목으로 이동합니다.</p></li><li><p><code>Proxy Usage</code> 옵션을 체크하여 활성화합니다.</p></li><li><p>두 가지 Proxy 인증 방식 중 하나를 선택합니다.</p><ol start=\"1\"><li><p><strong>Use QueryPie registered account </strong>: 관리자가 커넥션 정보 페이지 내에 저장한 DB username / password 기준으로 Proxy 접속 정보를 생성하는 방식입니다. 사용자는 Agent 또는 별도로 생성된 Proxy Credential 정보를 이용해 Proxy 로 접속할 수 있습니다.</p></li><li><p><strong>Use existing database account with Agent</strong> : 사용자가 기존에 사용하던 DB username / password 를 사용할 수 있는 방식으로 Proxy 접속 정보가 생성됩니다. 사용자는 Agent 에서 실행 후 localhost 와 port 정보를 이용해 Proxy 로 접속할 수 있습니다.</p><p>※ 사용자의 DB username / password 인증을 사용할 경우, Agent 를 통해서만 접속 가능합니다.</p></li></ol></li><li><p><strong>Network ID</strong> : Reverse SSH 기능을 사용하는 경우에 필요한 설정 값입니다.</p></li></ol>",
+      "mdx_content_hash": "49b32b99b7555dbb564774a16d9dd6d808375e8b9113d4288cc365da9b0cee9a",
+      "mdx_line_range": [
+        30,
+        37
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 7,
+      "xhtml_xpath": "p[4]",
+      "xhtml_fragment": "<p>Proxy Usage 옵션을 활성화하면 Proxy 로 접속할 수 있는 Port 가 해당 커넥션에 할당됩니다. 사용자는 해당 옵션이 활성화되면 Proxy 접속 정보를 확인할 수 있고, 관리자만 해당 Proxy 옵션을 설정할 수 있습니다.</p>",
+      "mdx_content_hash": "1687022f2eb679fa26d144722f8b23081b7be7a99b6ec4d16121bfedd25566c9",
+      "mdx_line_range": [
+        39,
+        40
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 8,
+      "xhtml_xpath": "p[5]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "1308b8e338c7c5e53725ea900f477bd3ad76411a075a7c411531948e0caf417f",
+      "mdx_line_range": [
+        43,
+        43
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 9,
+      "xhtml_xpath": "h2[3]",
+      "xhtml_fragment": "<h2>Proxy 사용 활성화된 커넥션 확인하기</h2>",
+      "mdx_content_hash": "a5ee98a09881b3653e9fe8a6ecf7abef456920aa576130dd018bd4c888519dc9",
+      "mdx_line_range": [
+        45,
+        47
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 10,
+      "xhtml_xpath": "macro-info[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\" ac:macro-id=\"e4a06898-7369-49ac-9d89-0ecfc1dacab8\"><ac:rich-text-body><p>10.3.0 부터 Databases &gt; Connection Management &gt; Proxy Management 는 Databases &gt; Monitoring &gt; Proxy Management 로 이동되었습니다. 10.3.0 이후 버전 사용자는 <ac:link ac:card-appearance=\"inline\"><ri:page ri:content-title=\"Proxy Management​\" ri:version-at-save=\"4\" /><ac:link-body>Proxy Management​</ac:link-body></ac:link> 를 참고하시기 바랍니다.</p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "b2da7f53a98160f9a467e89f4f04afbd6efa6caff1e00b4a072e5fd65d238800",
+      "mdx_line_range": [
+        48,
+        48
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 11,
+      "xhtml_xpath": "ac:image[2]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"1912\" ac:original-width=\"3448\" ac:custom-width=\"true\" ac:alt=\"image-20240725-071030.png\" ac:width=\"760\"><ri:attachment ri:filename=\"image-20240725-071030.png\" ri:version-at-save=\"1\" /><ac:caption><p>Administrator &gt; Databases &gt; Connection Management &gt; DB Connections &gt; Proxy Management</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "d77f2485cb317c48daf74afb4415b1a72bd38181962c82f37e8ba79c644c3304",
+      "mdx_line_range": [
+        50,
+        55
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 12,
+      "xhtml_xpath": "ol[2]",
+      "xhtml_fragment": "<ol start=\"1\"><li><p>Database 설정 메뉴에서 Proxy Manangement 메뉴로 이동합니다.</p></li><li><p>클러스터 기준으로 Proxy 사용이 활성화된 커넥션과 Port 정보를 확인할 수 있습니다.</p></li><li><p>Proxy 접속을 통해 커넥션에 연결 중인 사용자를 확인할 수 있고, 필요한 경우 해당 세션을 <code>Kill</code>할 수 있습니다.</p></li></ol>",
+      "mdx_content_hash": "48479025f558b60fdea436f1ef982a7b88f644ee5a207af2f04597f5e02becfd",
+      "mdx_line_range": [
+        57,
+        59
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 13,
+      "xhtml_xpath": "p[6]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "",
+      "mdx_line_range": [
+        0,
+        0
+      ],
+      "lost_info": {}
+    }
+  ],
+  "separators": [
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ],
+  "document_envelope": {
+    "prefix": "",
+    "suffix": ""
+  }
+}

--- a/confluence-mdx/tests/testcases/544379140/expected.roundtrip.json
+++ b/confluence-mdx/tests/testcases/544379140/expected.roundtrip.json
@@ -1,0 +1,325 @@
+{
+  "schema_version": "2",
+  "page_id": "544379140",
+  "mdx_sha256": "581f5bc5a0c8fd9da970bc2007a079c8c7f5ae48c972cb0a6ea483fa3433e70a",
+  "source_xhtml_sha256": "4afc192738be9e19c9b78f324aab5800dd7bad4490d49520f6ff2c0e964840c5",
+  "blocks": [
+    {
+      "block_index": 0,
+      "xhtml_xpath": "h2[1]",
+      "xhtml_fragment": "<h2>Overview</h2>",
+      "mdx_content_hash": "f6a82505fca5c8442d478f9f435e80d3f7715e406852be21f95a6b803b8f4e25",
+      "mdx_line_range": [
+        8,
+        8
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 1,
+      "xhtml_xpath": "p[1]",
+      "xhtml_fragment": "<p>QueryPie에서 생성된 각종 감사 로그를 추출하고 csv 파일로 내려받을 수 있는 기능입니다. 장기간에 걸친 로그 등 대용량 파일인 경우에도 안정적인 추출 및 다운로드가 가능합니다. 한 번 생성된 로그 추출 파일은 30일 동안 다운로드가 가능합니다. 추출 지원 로그는 Query Audit, Workflow SQL Request 등 21종입니다. </p>",
+      "mdx_content_hash": "570f2c848432064a0ee7873e13333c111c0aeb41d4a26775907e952b18104d92",
+      "mdx_line_range": [
+        10,
+        10
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 2,
+      "xhtml_xpath": "macro-note[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"note\" ac:schema-version=\"1\" ac:macro-id=\"d584e29c-8e4f-4028-96d5-3483b1f27c54\"><ac:rich-text-body><p>Audit Log Export 기능 추가에 따라, 각 로그 화면에서 제공되던 &lsquo;Excel File Download&rsquo; 버튼은 QueryPie v9.15.0부터 지원이 중단되었습니다.</p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "abfac661485eda50b3bd8ea2e527309a21cf661376e724c9e24b84535e6a86b0",
+      "mdx_line_range": [
+        12,
+        15
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 3,
+      "xhtml_xpath": "p[2]",
+      "xhtml_fragment": "<p><strong>추출 지원 로그 종류 (QueryPie v11.0.0 기준)</strong></p>",
+      "mdx_content_hash": "1bbb5d77eba61bc39acc2e92b97eadc6aad8e1f6340142c4eb402c7bde433f1c",
+      "mdx_line_range": [
+        17,
+        18
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 4,
+      "xhtml_xpath": "table[1]",
+      "xhtml_fragment": "<table data-layout=\"default\" ac:local-id=\"2947c127-97e1-4b3d-82ff-fcecae88fdc1\"><colgroup><col style=\"width: 498.0px;\" /><col style=\"width: 160.0px;\" /><col style=\"width: 99.0px;\" /></colgroup><tbody><tr><th data-highlight-colour=\"#d9d9d9\"><p style=\"text-align: center;\"><strong>Log Type</strong></p></th><th data-highlight-colour=\"#d9d9d9\"><p style=\"text-align: center;\"><strong>Release Version</strong></p></th><th data-highlight-colour=\"#d9d9d9\"><p style=\"text-align: center;\"><strong>Format</strong></p></th></tr><tr><td><p>Workflow DB Access Request</p></td><td><p /></td><td><p>CSV</p></td></tr><tr><td><p>Workflow SQL Request</p></td><td><p /></td><td><p>CSV</p></td></tr><tr><td><p>Workflow SQL Request for Query Details</p></td><td><p /></td><td><p>CSV</p></td></tr><tr><td><p>Workflow SQL Export Request</p></td><td><p /></td><td><p>CSV</p></td></tr><tr><td><p>Workflow Restricted Data Access Request</p></td><td><p>11.0.0</p></td><td><p>JSON</p></td></tr><tr><td><p>Workflow DB Policy Exception Request</p></td><td><p>11.0.0</p></td><td><p>JSON</p></td></tr><tr><td><p>Workflow Unmasking Request</p></td><td><p>11.0.0</p></td><td><p>JSON</p></td></tr><tr><td><p>Workflow Decryption Request</p></td><td><p>10.3.0</p></td><td><p>JSON</p></td></tr><tr><td><p>Workflow Server Access Request</p></td><td><p /></td><td><p>JSON</p></td></tr><tr><td><p>Workflow Server Privilege Request</p></td><td><p>11.3.0</p></td><td><p>JSON</p></td></tr><tr><td><p>Workflow Access Role Request</p></td><td><p>10.0.0</p></td><td><p>CSV</p></td></tr><tr><td><p>IP Registration Request</p></td><td><p>11.0.0</p></td><td><p>JSON</p></td></tr><tr><td><p>User Access History</p></td><td><p /></td><td><p>CSV</p></td></tr><tr><td><p>Admin Role History</p></td><td><p /></td><td><p>CSV</p></td></tr><tr><td><p>Activity Logs</p></td><td><p /></td><td><p>JSON</p></td></tr><tr><td><p>Alert Logs</p></td><td><p>10.3.0</p></td><td><p>JSON</p></td></tr><tr><td><p>Query Audit</p></td><td><p /></td><td><p>CSV</p></td></tr><tr><td><p>DB Access History</p></td><td><p /></td><td><p>CSV</p></td></tr><tr><td><p>DB Account Lock History</p></td><td><p /></td><td><p>CSV</p></td></tr><tr><td><p>DB Access Control Logs</p></td><td><p /></td><td><p>CSV</p></td></tr><tr><td><p>DML Snapshot</p></td><td><p /></td><td><p>JSON</p></td></tr><tr><td><p>Restricted Data Access Logs (Legacy)</p></td><td><p>10.3.0</p></td><td><p>JSON</p></td></tr><tr><td><p>Masked Data Access Logs (Legacy)</p></td><td><p>10.3.0</p></td><td><p>JSON</p></td></tr><tr><td><p>Sensitive Data Access Logs (Legacy)</p></td><td><p>10.3.0</p></td><td><p>JSON</p></td></tr><tr><td><p>DAC Policy Audit Log</p></td><td><p>11.3.0</p></td><td><p>JSON</p></td></tr><tr><td><p>Server Access History</p></td><td><p /></td><td><p>JSON</p></td></tr><tr><td><p>Command Audit</p></td><td><p /></td><td><p>JSON</p></td></tr><tr><td><p>Session Logs</p></td><td><p /></td><td><p>JSON</p></td></tr><tr><td><p>Server Access Control Logs</p></td><td><p /></td><td><p>JSON</p></td></tr><tr><td><p>Server Role History</p></td><td><p /></td><td><p>JSON</p></td></tr><tr><td><p>Server Account Lock History</p></td><td><p /></td><td><p>JSON</p></td></tr><tr><td><p>Request Audit</p></td><td><p /></td><td><p>JSON</p></td></tr><tr><td><p>Kubernetes Role History</p></td><td><p /></td><td><p>JSON</p></td></tr><tr><td><p>Web App Access History</p></td><td><p>11.0.0</p></td><td><p>CSV</p></td></tr><tr><td><p>Web App Role History</p></td><td><p>11.0.0</p></td><td><p>CSV</p></td></tr><tr><td><p>Web App JIT Access Control Log</p></td><td><p>11.0.0</p></td><td><p>CSV</p></td></tr><tr><td><p>Web App Event Audit</p></td><td><p>11.0.0</p></td><td><p>CSV</p></td></tr></tbody></table>",
+      "mdx_content_hash": "b2da7f53a98160f9a467e89f4f04afbd6efa6caff1e00b4a072e5fd65d238800",
+      "mdx_line_range": [
+        19,
+        19
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 5,
+      "xhtml_xpath": "h2[2]",
+      "xhtml_fragment": "<h2>Audit Log Export 목록 조회하기</h2>",
+      "mdx_content_hash": "3dd9cdd65a79e9018e73aef5457369a235bd48dd09456b48f1528d66685211bc",
+      "mdx_line_range": [
+        21,
+        21
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 6,
+      "xhtml_xpath": "ac:image[1]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"864\" ac:original-width=\"1566\" ac:custom-width=\"true\" ac:alt=\"image-20240714-063656.png\" ac:width=\"760\"><ri:attachment ri:filename=\"image-20240714-063656.png\" ri:version-at-save=\"1\" /><ac:caption><p>Administrator &gt; Audit &gt; General &gt; Audit Log Export</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "690814957cee9b62cd93a916cf03e84cb5b8442b4da3972a92c7f06ff04179a6",
+      "mdx_line_range": [
+        23,
+        61
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 7,
+      "xhtml_xpath": "ol[1]",
+      "xhtml_fragment": "<ol start=\"1\"><li><p>Administrator &gt; Audit &gt; General &gt; Audit Log Export 메뉴로 이동합니다.</p></li><li><p>현재까지 생성된 Audit Log Export 태스크 목록을 확인할 수 있습니다.</p></li><li><p>Status 에서는 태스크의 진행 상태를 확인할 수 있습니다.</p><ul><li><p><strong>Processing</strong> : 감사 로그 추출이 진행 중입니다.</p></li><li><p><strong>Completed</strong> : 감사 로그 추출이 완료되었으며, 파일 다운로드가 가능합니다. (추출 완료 후 30일이 경과하였다면, 파일이 만료되어 다운로드가 불가능합니다.)</p></li><li><p><strong>Failed</strong> : 감사 로그 추출이 실패하였습니다. QueryPie Customer Support 를 통해 문의 바랍니다.</p></li></ul></li></ol>",
+      "mdx_content_hash": "92a4412305da61ff249e365f3c575321e011406ad3050016b549b8c7aa1ca21b",
+      "mdx_line_range": [
+        63,
+        63
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 8,
+      "xhtml_xpath": "h2[3]",
+      "xhtml_fragment": "<h2>로그 추출 작업 생성하기</h2>",
+      "mdx_content_hash": "b004526982d66613661e36ce8917c5503ca1b0de6939e7ea3e985e0cea5d4d0f",
+      "mdx_line_range": [
+        65,
+        70
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 9,
+      "xhtml_xpath": "p[3]",
+      "xhtml_fragment": "<p>감사 로그 추출 및 다운로드는 크게 다음과 같은 단계로 진행됩니다. (1) 관련 메뉴 진입 &rarr; (2) 로그 추출 작업 생성 &rarr; (3) 로그 추출 완료까지 대기 &rarr; (4) 추출 완료시 파일 다운로드</p>",
+      "mdx_content_hash": "86f69fc68b0492bc03b0933f8d1a9484a0695500d29d5e0cc7170d19a98c8444",
+      "mdx_line_range": [
+        72,
+        77
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 10,
+      "xhtml_xpath": "p[4]",
+      "xhtml_fragment": "<p>감사 로그 추출을 시작하기 위해서는 &lsquo;Audit &gt; General &gt; Audit Log Export&rsquo; 메뉴 접근 후, 우측 상단의 <code>Create Task</code> 버튼을 클릭해야 합니다. 해당 버튼 클릭시 아래와 같은 화면이 나타납니다. </p>",
+      "mdx_content_hash": "cff74747e1be560a1163770f1ece6854e7aab54976c00a61e93312f5627937b2",
+      "mdx_line_range": [
+        79,
+        79
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 11,
+      "xhtml_xpath": "ac:image[2]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"1005\" ac:original-width=\"1494\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2025-01-16 오후 1.18.05.png\" ac:width=\"612\"><ri:attachment ri:filename=\"스크린샷 2025-01-16 오후 1.18.05.png\" ri:version-at-save=\"1\" /><ac:caption><p>Administrator &gt; Audit &gt; General &gt; Audit Log Export &gt; Create New Task</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "fbe092b4bbc89046f9da19abd713290ecfee9e887e84687c85c3f3e0b9af5640",
+      "mdx_line_range": [
+        81,
+        82
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 12,
+      "xhtml_xpath": "ol[2]",
+      "xhtml_fragment": "<ol start=\"1\"><li><p><strong>Task Name </strong>: 로그 추출 작업의 이름을 입력합니다.</p></li><li><p><strong>Log Type </strong>: 추출 대상 로그의 종류를 선택합니다. </p><ol start=\"1\"><li><p>Query Audit 등 추출하기 원하는 로그 타입을 선택합니다.</p></li><li><p>로그 종류 선택 후 <span style=\"color: rgb(76,154,255);\">See Log Template and Description</span>을 클릭하시면 각 로그의 key 등 상세 정보를 조회할 수 있습니다.</p></li></ol></li><li><p><strong>Download File Format </strong>: 로그 출력 파일 형식을 지정합니다. (9.17.0 기준, 각 로그마다 다운로드 가능한 형식이 단일로 제한됩니다. 상단의 <strong>&lsquo;추출 지원 로그 종류&rsquo;</strong>을 참고해주시기 바랍니다.) </p></li><li><p><strong>For Text Exceeding 32,000 Characters</strong> : CSV 파일의 경우 32,000자를 초과하는 글자를 잘라낼지 여부를 선택할 수 있습니다.</p><ol start=\"1\"><li><p>Trim Overflowing Text - 32,000자를 초과하는 글자를 잘라냅니다. Excel로 파일을 직접 열어야 하는 경우에 셀 당 최대 글자수 초과로 표가 깨지는 현상을 방지합니다.</p></li><li><p>No Action - 32,000자를 초과하는 글자를 그대로 포함시킵니다.</p></li></ol></li><li><p><strong>From</strong> : 추출 시작 날짜를 지정합니다.</p></li><li><p><strong>To </strong>: 추출 대상 마지막 날짜를 지정합니다. 11.2.0부터 당일 날짜를 선택할 수 있도록 개선되었습니다. </p></li><li><p><strong>Filter Expression</strong> : 필터 표현식을 지정합니다. </p><ol start=\"1\"><li><p>조건 입력 방법 및 예시는 하단의 &lsquo;<strong>필터 표현식</strong>&rsquo;을 참고해주시기 바랍니다.</p></li></ol></li><li><p><strong>Generate Preview </strong>: 미리보기를 생성합니다. </p><ol start=\"1\"><li><p>미리보기는 필수 단계입니다.</p></li><li><p>미리보기 결과를 확인해야 다음 단계인 &lsquo;Create&rsquo;가 가능합니다.</p></li></ol></li><li><p><code>Create</code> 버튼 : 로그 추출 작업을 생성합니다. </p></li></ol>",
+      "mdx_content_hash": "367c62d080581c6e51369e7ac668a64eb7e95c365e4f7e1b7856261962bda019",
+      "mdx_line_range": [
+        84,
+        85
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 13,
+      "xhtml_xpath": "macro-info[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\" ac:macro-id=\"f453d3e9-c88d-4457-a68f-cb81ce0c1b6b\"><ac:rich-text-body><p><strong>유의 사항</strong></p><p>당일 날짜를 선택하여 로그를 추출하는 경우, 실시간으로 데이터가 쌓이기 때문에 Preview 시점의 결과와 실제 Create를 통해 생성된 파일의 내용이 다를 수 있습니다.</p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "32aa38ecc924c948612470763c69adfcd61e3481ef30dd0cd200649f1886819e",
+      "mdx_line_range": [
+        87,
+        92
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 14,
+      "xhtml_xpath": "ac:adf-extension[1]",
+      "xhtml_fragment": "<ac:adf-extension><ac:adf-node type=\"panel\"><ac:adf-attribute key=\"panel-type\">note</ac:adf-attribute><ac:adf-content><p><strong>필터 표현식</strong></p><p>(1) 필터 표현식을 사용하시기 위해 '<span style=\"color: rgb(76,154,255);\">See Log Template and Description</span>'을 통해 로그별 key와 각각의 type 및 포함하는 value를 참고해주시기 바랍니다.<br /></p><p>(2) 사용 가능한 필터 표현식은 데이터의 종류에 따라 아래와 같이 나뉩니다.  </p><p>- Number Type</p><p>지원하는 표현식 : <code>&gt;</code>, <code>&lt;</code>, <code>&lt;=</code>, <code>&gt;=</code>, <code>==</code>, <code>!=</code><br />예 : <code>x &gt; `10`</code>, <code>x == `10`</code></p><p>- String Type</p><p>지원하는 표현식 :  <code>== (equals)</code>, <code>!= (not equals)</code>, <code>contains</code><br />예 : <code>x == 'abc'</code>, <code>x != 'abc'</code>, <code>contains(x, 'ab')</code></p><p>- Boolean Type </p><p>지원하는 표현식 : <code>== (equals)</code>, <code>!= (not equals)</code>, <code>&amp;&amp; (and)</code>, <code>|| (or)</code><br />예 : <code>x == `true`</code>,<code> x &amp;&amp; y</code>, <code>(x &gt; `0`) &amp;&amp; (y == `0`)</code></p><p>- Array Type</p><p>예 : <code>x[? @ == 'value']</code>, <code>list[? @ &gt; `10`]</code></p><p /><p>(3) 여러 조건을 함께 사용하기 위해 아래의 문자를 활용할 수 있습니다.</p><p>- AND 조건 : <code>&amp;&amp;</code> 연산자를 활용합니다.</p><p>- OR 조건 : <code>||</code> 연산자를 활용합니다.</p><p>- 복합 조건 : 함께 처리해야하는 조건은 괄호(<code>( )</code>)로 묶어서 활용합니다.</p><p /><p>(4) 예시</p><p>- Query Audit 중 쿼리 실행 로그만 추출하려는 경우 필요한 표현식 : <code>actionType == 'SQL_EXECUTION'</code></p><p>- Query Audit 중 웹에디터에 수행한 쿼리 실행 로그만 추출하려는 경우 필요한 표현식 : <code>actionType == 'SQL_EXECUTION' &amp;&amp; executedFrom == 'WEB_EDITOR'</code></p><p>- DB Access History 중 특정 데이터베이스 2종류 대해서만 추출하려는 경우 필요한 표현식 : <code>connectionName == 'database1' || connectionName == 'database2'</code></p><p>- DB Access History 중 특정 데이터베이스 2종류이면서 Replication Type이 SINGLE인 경우에 대해서만 추출하려는 경우 필요한 표현식 : <code>(connectionName == 'database1' || connectionName == 'database2') &amp;&amp; replicationType == 'SINGLE'</code></p></ac:adf-content></ac:adf-node><ac:adf-fallback><div class=\"panel conf-macro output-block\" style=\"background-color: rgb(234,230,255);border-color: rgb(153,141,217);border-width: 1.0px;\"><div class=\"panelContent\" style=\"background-color: rgb(234,230,255);\">\n<p><strong>필터 표현식</strong></p><p>(1) 필터 표현식을 사용하시기 위해 '<span style=\"color: rgb(76,154,255);\">See Log Template and Description</span>'을 통해 로그별 key와 각각의 type 및 포함하는 value를 참고해주시기 바랍니다.<br /></p><p>(2) 사용 가능한 필터 표현식은 데이터의 종류에 따라 아래와 같이 나뉩니다.  </p><p>- Number Type</p><p>지원하는 표현식 : <code>&gt;</code>, <code>&lt;</code>, <code>&lt;=</code>, <code>&gt;=</code>, <code>==</code>, <code>!=</code><br />예 : <code>x &gt; `10`</code>, <code>x == `10`</code></p><p>- String Type</p><p>지원하는 표현식 :  <code>== (equals)</code>, <code>!= (not equals)</code>, <code>contains</code><br />예 : <code>x == 'abc'</code>, <code>x != 'abc'</code>, <code>contains(x, 'ab')</code></p><p>- Boolean Type </p><p>지원하는 표현식 : <code>== (equals)</code>, <code>!= (not equals)</code>, <code>&amp;&amp; (and)</code>, <code>|| (or)</code><br />예 : <code>x == `true`</code>,<code> x &amp;&amp; y</code>, <code>(x &gt; `0`) &amp;&amp; (y == `0`)</code></p><p>- Array Type</p><p>예 : <code>x[? @ == 'value']</code>, <code>list[? @ &gt; `10`]</code></p><p> </p><p>(3) 여러 조건을 함께 사용하기 위해 아래의 문자를 활용할 수 있습니다.</p><p>- AND 조건 : <code>&amp;&amp;</code> 연산자를 활용합니다.</p><p>- OR 조건 : <code>||</code> 연산자를 활용합니다.</p><p>- 복합 조건 : 함께 처리해야하는 조건은 괄호(<code>( )</code>)로 묶어서 활용합니다.</p><p> </p><p>(4) 예시</p><p>- Query Audit 중 쿼리 실행 로그만 추출하려는 경우 필요한 표현식 : <code>actionType == 'SQL_EXECUTION'</code></p><p>- Query Audit 중 웹에디터에 수행한 쿼리 실행 로그만 추출하려는 경우 필요한 표현식 : <code>actionType == 'SQL_EXECUTION' &amp;&amp; executedFrom == 'WEB_EDITOR'</code></p><p>- DB Access History 중 특정 데이터베이스 2종류 대해서만 추출하려는 경우 필요한 표현식 : <code>connectionName == 'database1' || connectionName == 'database2'</code></p><p>- DB Access History 중 특정 데이터베이스 2종류이면서 Replication Type이 SINGLE인 경우에 대해서만 추출하려는 경우 필요한 표현식 : <code>(connectionName == 'database1' || connectionName == 'database2') &amp;&amp; replicationType == 'SINGLE'</code></p>\n</div></div></ac:adf-fallback></ac:adf-extension>",
+      "mdx_content_hash": "f9e178b73cdbf15682943b7c79473e2ed32835c757eb241a144d82ae71a9f5c1",
+      "mdx_line_range": [
+        94,
+        109
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 15,
+      "xhtml_xpath": "p[5]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "440a04c18681393f3c1be3fca0166a4491993ff1f22016cb47cd50bef7b30f18",
+      "mdx_line_range": [
+        111,
+        113
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 16,
+      "xhtml_xpath": "ac:adf-extension[2]",
+      "xhtml_fragment": "<ac:adf-extension><ac:adf-node type=\"panel\"><ac:adf-attribute key=\"panel-type\">note</ac:adf-attribute><ac:adf-content><p><strong>Query Audit의 내보내기 파일의 Privilege Type 명시 기준</strong></p><p>내보내기 파일의 &lsquo;Privilege Type&rsquo; 컬럼에는 실행시점에는 어느 권한이 필요했는지가 기록됩니다. 아래와 같이 작동합니다. </p><ol start=\"1\"><li><p>기본 권한으로 실행되는 명령어(SET, SHOW 등)는 해당 컬럼의 값이 공백입니다.</p></li><li><p>INSERT 등 권한에 따라 수행된 로그에는 SQL Type이 명시됩니다. </p></li><li><p>Redis의 경우에는 커맨드명이 명시됩니다.</p></li></ol></ac:adf-content></ac:adf-node><ac:adf-fallback><div class=\"panel conf-macro output-block\" style=\"background-color: rgb(234,230,255);border-color: rgb(153,141,217);border-width: 1.0px;\"><div class=\"panelContent\" style=\"background-color: rgb(234,230,255);\">\n<p><strong>Query Audit의 내보내기 파일의 Privilege Type 명시 기준</strong></p><p>내보내기 파일의 &lsquo;Privilege Type&rsquo; 컬럼에는 실행시점에는 어느 권한이 필요했는지가 기록됩니다. 아래와 같이 작동합니다. </p><ol start=\"1\"><li><p>기본 권한으로 실행되는 명령어(SET, SHOW 등)는 해당 컬럼의 값이 공백입니다.</p></li><li><p>INSERT 등 권한에 따라 수행된 로그에는 SQL Type이 명시됩니다. </p></li><li><p>Redis의 경우에는 커맨드명이 명시됩니다.</p></li></ol>\n</div></div></ac:adf-fallback></ac:adf-extension>",
+      "mdx_content_hash": "b2da7f53a98160f9a467e89f4f04afbd6efa6caff1e00b4a072e5fd65d238800",
+      "mdx_line_range": [
+        114,
+        114
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 17,
+      "xhtml_xpath": "p[6]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "410377ccbfae6b265333a0c77cbcbdb002fd75799ecdd041ee1efda01eb70777",
+      "mdx_line_range": [
+        116,
+        117
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 18,
+      "xhtml_xpath": "h2[4]",
+      "xhtml_fragment": "<h2>추출 작업 완료시 파일 내려받기</h2>",
+      "mdx_content_hash": "c95e4312640d4ee6fc55890f7f42fa527153ee03d691b521e50d8dc17106dd97",
+      "mdx_line_range": [
+        119,
+        119
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 19,
+      "xhtml_xpath": "p[7]",
+      "xhtml_fragment": "<p>별도의 필터링 조건이 없는 단기간 조회의 경우에는 로그 추출이 몇 분 이내에 완료됩니다. 장기간에 걸친 로그이거나 필터링 조건의 복잡도가 높은 경우 등에서는 로그 추출까지 다소 시간이 소요될 수 있습니다.</p>",
+      "mdx_content_hash": "1d0d207a0483d3a61fea332377eb9c87ac34d9a60627b4b20c54d6ee1bbef963",
+      "mdx_line_range": [
+        121,
+        121
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 20,
+      "xhtml_xpath": "p[8]",
+      "xhtml_fragment": "<p>추출 작업이 완료된 이후에는 두 가지 방법으로 로그 파일을 내려받을 수 있습니다. </p>",
+      "mdx_content_hash": "42b05fca06d793f0a26efaf578152ee6a53e54ec5d3f7dc4858934116b7cf543",
+      "mdx_line_range": [
+        123,
+        123
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 21,
+      "xhtml_xpath": "ol[3]",
+      "xhtml_fragment": "<ol start=\"1\"><li><p>목록 페이지에서 다운로드: 목록 페이지에서 Download 버튼을 클릭합니다.</p></li><li><p>상세 페이지에서 다운로드: 목록 페이지에서 태스크를 클릭하여 상세 페이지로 진입, 우측 상단 Download 버튼을 클릭합니다.</p></li></ol>",
+      "mdx_content_hash": "cc2c96dceb54bea55ca5ef3ef0df15048d17a84625e1941af39652206174945b",
+      "mdx_line_range": [
+        125,
+        125
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 22,
+      "xhtml_xpath": "ac:adf-extension[3]",
+      "xhtml_fragment": "<ac:adf-extension><ac:adf-node type=\"panel\"><ac:adf-attribute key=\"panel-type\">note</ac:adf-attribute><ac:adf-content><p><strong>다운로드 파일에 암호 포함하기</strong></p><p>다운로드 대상 파일은 &lsquo;*.csv 또는 *.json 파일을 압축한 *.zip 파일&rsquo;입니다. </p><p>해당 압축 파일에 대한 암호를 지정하기 위해서는 &lsquo;General Setting &gt; Security&rsquo; 메뉴에서 <code>Export a file with Encryption</code> 옵션을 &lsquo;Required&rsquo;로 지정해야 합니다.  </p></ac:adf-content></ac:adf-node><ac:adf-fallback><div class=\"panel conf-macro output-block\" style=\"background-color: rgb(234,230,255);border-color: rgb(153,141,217);border-width: 1.0px;\"><div class=\"panelContent\" style=\"background-color: rgb(234,230,255);\">\n<p><strong>다운로드 파일에 암호 포함하기</strong></p><p>다운로드 대상 파일은 &lsquo;*.csv 또는 *.json 파일을 압축한 *.zip 파일&rsquo;입니다. </p><p>해당 압축 파일에 대한 암호를 지정하기 위해서는 &lsquo;General Setting &gt; Security&rsquo; 메뉴에서 <code>Export a file with Encryption</code> 옵션을 &lsquo;Required&rsquo;로 지정해야 합니다.  </p>\n</div></div></ac:adf-fallback></ac:adf-extension>",
+      "mdx_content_hash": "1f01b97fa54fc6299d5a3b1d75982b25e6025e460fa1e361a538ea7dcd611a2b",
+      "mdx_line_range": [
+        127,
+        127
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 23,
+      "xhtml_xpath": "p[9]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "30523b998cdefda268de05d1c7b57e80fd4783347664acace49d54ff2d2ce334",
+      "mdx_line_range": [
+        129,
+        129
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 24,
+      "xhtml_xpath": "h2[5]",
+      "xhtml_fragment": "<h2>로그 추출 파일 보관 기간 정책 안내</h2>",
+      "mdx_content_hash": "0cdca73215ed61b39584ff2a3682ef94d7206f17871a97166952ddd87513bcf5",
+      "mdx_line_range": [
+        131,
+        131
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 25,
+      "xhtml_xpath": "p[10]",
+      "xhtml_fragment": "<p>추출이 완료된 로그 파일은 작업 생성일로부터 30일간 보관되며, 해당 기간 이내에는 횟수 제한 없이 내려받기가 가능합니다. 하지만 30일이 경과하면 파일이 만료됩니다. 만료된 로그 파일이 필요해진 경우, 로그 추출 태스크를 다시 생성해주시기 바랍니다.</p>",
+      "mdx_content_hash": "00608a7b459c7a397a53ea2985a98e7123957a1c939f0aa3b68ca0425214bd1c",
+      "mdx_line_range": [
+        133,
+        133
+      ],
+      "lost_info": {}
+    }
+  ],
+  "separators": [
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ],
+  "document_envelope": {
+    "prefix": "",
+    "suffix": ""
+  }
+}

--- a/confluence-mdx/tests/testcases/544381877/expected.roundtrip.json
+++ b/confluence-mdx/tests/testcases/544381877/expected.roundtrip.json
@@ -1,0 +1,169 @@
+{
+  "schema_version": "2",
+  "page_id": "544381877",
+  "mdx_sha256": "907335b639c974473775f7ce0cc7bcf9cc97a26f6052506a6f3e5b7bd2989ba2",
+  "source_xhtml_sha256": "cc44184af8a58c67adea622946171a262d266f7a8371352323a96d047b79e3e4",
+  "blocks": [
+    {
+      "block_index": 0,
+      "xhtml_xpath": "h2[1]",
+      "xhtml_fragment": "<h2>Overview</h2>",
+      "mdx_content_hash": "d1b470880b98dedfb4d3c3aa26b8e00887f624f9782740cf85944e978a712e6a",
+      "mdx_line_range": [
+        6,
+        6
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 1,
+      "xhtml_xpath": "p[1]",
+      "xhtml_fragment": "<p>QueryPie에서는 접근 제어를 적용할 온프레미스 등에 위치한 쿠버네티스 클러스터를 수동으로 등록할 수 있습니다. </p>",
+      "mdx_content_hash": "570f2c848432064a0ee7873e13333c111c0aeb41d4a26775907e952b18104d92",
+      "mdx_line_range": [
+        8,
+        8
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 2,
+      "xhtml_xpath": "p[2]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "72ed6a9e3b20d5ee24ae8bc3fe866dea2fb08abf891dcb67935ddd65ab2fdaad",
+      "mdx_line_range": [
+        10,
+        10
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 3,
+      "xhtml_xpath": "h2[2]",
+      "xhtml_fragment": "<h2>수동으로 클러스터 등록하기</h2>",
+      "mdx_content_hash": "c4d4ad659fd3881e66b4b066ca33666ef936712d382f0d59a350ab98f84c3841",
+      "mdx_line_range": [
+        13,
+        13
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 4,
+      "xhtml_xpath": "p[3]",
+      "xhtml_fragment": "<p>개별 서버를 수동으로 등록하기 위해서는 서버의 기본적인 정보 입력이 필요합니다. </p>",
+      "mdx_content_hash": "a17283551678d1d4048d169a3b1a5b03a7c18a42f1849de9ffc7a3a5a267d694",
+      "mdx_line_range": [
+        15,
+        15
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 5,
+      "xhtml_xpath": "ac:image[1]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"1800\" ac:original-width=\"2880\" ac:custom-width=\"true\" ac:alt=\"image-20240721-054859.png\" ac:width=\"760\"><ri:attachment ri:filename=\"image-20240721-054859.png\" ri:version-at-save=\"2\" /><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "6f5c71055a1df82fa1be4e0973b0cbcf34131d9e80108ace308900fcebced1fd",
+      "mdx_line_range": [
+        17,
+        19
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 6,
+      "xhtml_xpath": "ol[1]",
+      "xhtml_fragment": "<ol start=\"1\"><li><p>Administrator &gt; Kubernetes &gt; Connection Management &gt; Clusters 메뉴로 이동합니다.</p></li><li><p>우측 상단의 <code>+ Create Cluster</code> 버튼을 클릭합니다.</p></li><li><p><strong>Information</strong> : 클러스터 수동 등록을 위한 다음의 정보들을 입력합니다</p><ol start=\"1\"><li><p><strong>Name</strong> : 해당 클러스터를 식별할 수 있는 이름을 입력합니다. (필수) </p><ul><li><p>해당 정보는 향후 수정이 불가한 항목입니다. </p></li></ul></li><li><p><strong>Version</strong> : 클러스터의 버전을 기입합니다. (선택) </p><ul><li><p>이후 크리덴셜 인증 테스트 절차를 통해 자동 기입 예정인 항목입니다. </p></li></ul></li><li><p><strong>API URL</strong> : Kubernetes API를 수신할 클러스터의 API URL을 기입합니다. </p></li><li><p /></li><li><p><strong>Credential</strong> : 해당 클러스터의 Kubernetes API 서버에 액세스 권한을 부여하려면 서비스 계정 토큰 및 CA인증서를 해당 클러스터에서 가져와야 합니다. 자세한 내용은 파란색 정보 박스 안 내용을 확인해 주세요.</p><ol start=\"1\"><li><p><strong>Service Account Token</strong> : QueryPie Proxy에서 사용자 Kubernetes API 호출 시 사용할 쿠버네티스 클러스터의 서버스 계정 토큰 값을 기입합니다. </p></li><li><p><strong>Certificate Authority</strong> : QueryPie에서 Kubernetes API 서버 인증서를 검증할 CA 인증서를 기입합니다.</p></li><li><p><strong>Verify Credential</strong> : 서비스 계정 토큰 및 CA인증서를 모두 기입 시 해당 버튼이 활성화됩니다. 버튼을 클릭하면 정상 연결이 가능한지 여부를 체크할 수 있습니다. 수행 결과에 따라 다음과 같이 결과가 표시됩니다.</p><ul><li><p><ac:emoticon ac:name=\"tick\" ac:emoji-shortname=\":check_mark:\" ac:emoji-id=\"atlassian-check_mark\" ac:emoji-fallback=\":check_mark:\" /> <strong>Verified</strong> : 클러스터 연결 성공으로 서비스 계정 토큰 및 CA 인증서가 정상 기입되었음을 의미합니다. </p></li><li><p><ac:emoticon ac:name=\"cross\" ac:emoji-shortname=\":cross_mark:\" ac:emoji-id=\"atlassian-cross_mark\" ac:emoji-fallback=\":cross_mark:\" /> <strong>Verification Failed</strong> : 클러스터 연결 실패로 서비스 계정 토큰 및 CA인증서 중 값의 오류가 있거나, 네트워크 연결에 실패하였을 가능성이 있음을 의미합니다. </p></li></ul></li></ol></li><li><p><strong>Logging Options</strong>  : 해당 클러스터에 대한 로깅 옵션을 선택합니다. </p><ol start=\"1\"><li><p><strong>Request Audit</strong> : 해당 클러스터에 대한 Kubernetes API 호출 이력에 대한 로깅 활성화 옵션으로, Default는 <code>On</code>입니다. 해당 기능을 <code>Off</code>로 전환 시, </p><ol start=\"1\"><li><p>해당 클러스터를 대상으로 호출되는 Kubernetes API 이력이 남지 않습니다. </p></li><li><p>하위의 Request Audit Types 및 Pod Session Recording 모두 일괄 비활성화 처리됩니다.   </p></li></ol></li><li><p><strong>Request Audit Types</strong> : 해당 클러스터의 감사할 대상 Verb를 관리자가 선택할 수 있습니다. Default는 이하의 기본 verb 전부를 선택하고 있습니다. </p><ol start=\"1\"><li><p>Verb 종류: </p><ol start=\"1\"><li><p><code>get</code> </p></li><li><p><code>list</code> </p></li><li><p><code>watch</code> </p></li><li><p><code>create</code></p></li><li><p><code>update </code></p></li><li><p><code>patch</code></p></li><li><p><code>delete</code></p></li><li><p><code>deletecollection </code></p></li></ol></li><li><p><ac:emoticon ac:name=\"blue-star\" ac:emoji-shortname=\":white_check_mark:\" ac:emoji-id=\"2705\" ac:emoji-fallback=\"✅\" /> Select All : 모든 API 호출에 대해 감사를 진행합니다.  </p></li></ol></li><li><p><strong>Pod Session Recording</strong> : 해당 클러스터 내 Pod exec 명령에 의해 오픈된 세션에 대한 레코딩 활성화 옵션으로, Default는 <code>On</code>입니다. 해당 기능은 이하의 조건을 충족하지 못하면 <code>Off</code>로 전환됩니다: </p><ol start=\"1\"><li><p>Request Audit이 <code>On</code>으로 활성화되어야 합니다. </p></li><li><p>Request Audit Types에 이하의 verb가 선택되어 있어야 합니다:</p><ol start=\"1\"><li><p><code>create</code></p></li><li><p><code>get </code></p></li></ol></li></ol></li></ol></li></ol></li><li><p><strong>Tags</strong> : 필요 시 개별 클러스터에 Tag를 수동으로 입력할 수 있으며 Cloud Provider를 통해 동기화된 클러스터의 경우 동기화해 온 태그도 함께 표시됩니다. (단, 동기화를 통해 불러온 태그는 삭제 및 수정 불가합니다.) <code>+ Add Tag</code> 버튼을 클릭하여 새 행을 추가하고 원하는 태그 값을 기입할 수 있으며 태그는 key-value 형태로 기입해야 합니다. </p><ol start=\"1\"><li><p><strong>Key</strong> : 태그를 구분할 수 있는 Key 값을 512자 이내로 입력합니다. </p><ol start=\"1\"><li><p>Key 값을 필수로 입력해야 하며, 이미 등록된 키는 중복 입력이 불가합니다. </p></li><li><p>중복은 대소문자를 구분하여 체크합니다. </p></li></ol></li><li><p><strong>Value</strong> : 필터링에 사용할 Value 값을 256자 이내로 입력합니다.</p></li></ol></li><li><p>위 과정을 거친 후 최종 <code>Save</code> 버튼을 클릭하면 클러스터가 성공적으로 등록됩니다. </p></li></ol>",
+      "mdx_content_hash": "3133b576a8a11a87d76c36a525e76c21414c77c1401df4cfd80a6074c3709b76",
+      "mdx_line_range": [
+        21,
+        61
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 7,
+      "xhtml_xpath": "p[4]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "6d98e1645813cb06e052dff2d8f64119031abfe0bfff4510f61e4f9075b77a3c",
+      "mdx_line_range": [
+        64,
+        64
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 8,
+      "xhtml_xpath": "h2[3]",
+      "xhtml_fragment": "<h2>쿠버네티스 클러스터 연동용 스크립트 이용 안내  </h2>",
+      "mdx_content_hash": "ac3fd57576b743ae6276b65937d94f2235f3e0873121b2a58793aaf6629720b3",
+      "mdx_line_range": [
+        66,
+        68
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 9,
+      "xhtml_xpath": "ac:image[2]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"1980\" ac:original-width=\"1796\" ac:custom-width=\"true\" ac:alt=\"image-20240511-033842.png\" ac:width=\"760\"><ri:attachment ri:filename=\"image-20240511-033842.png\" ri:version-at-save=\"2\" /><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "9fbec23dc905456abc3086af843afd25fc482543479e7fb7d713625f6c93dd3c",
+      "mdx_line_range": [
+        70,
+        71
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 10,
+      "xhtml_xpath": "ul[1]",
+      "xhtml_fragment": "<ul><li><p>관리자는 사전에 해당 대상 쿠버네티스 클러스터에 접속이 가능하여야 합니다.</p></li><li><p>관리자는 Administrator &gt; Kubernetes &gt; Connection Management &gt; Clusters &gt; Create Cluster &gt; Credential 안내 박스 내 &ldquo;download and run this script&rdquo;의 링크를 클릭하여 스크립트를 다운로드할 수 있습니다. </p></li></ul>",
+      "mdx_content_hash": "0b8d395caca2f74223e718e5d40f9c26379f8d8c993368258546b2f88e5cb143",
+      "mdx_line_range": [
+        72,
+        75
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 11,
+      "xhtml_xpath": "macro-expand[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"expand\" ac:schema-version=\"1\" ac:macro-id=\"1df48224-102c-464b-931c-e5e53abcb781\"><ac:parameter ac:name=\"title\">generate_kubepie_sa.sh 스크립트 컨텐츠 </ac:parameter><ac:rich-text-body><ac:structured-macro ac:name=\"code\" ac:schema-version=\"1\" ac:macro-id=\"af7dde18-30fb-46b2-9cab-d4ff1b0e1607\"><ac:plain-text-body><![CDATA[#!/bin/bash\n\nset -o nounset -o errexit -o pipefail\n\nRESOURCE_PREFIX=querypie\nNAMESPACE=querypie\n\nSERVICE_ACCOUNT_NAME=${RESOURCE_PREFIX}-sa\nCLUSTER_ROLE_NAME=${RESOURCE_PREFIX}-role\nCLUSTER_ROLE_BINDING_NAME=${RESOURCE_PREFIX}-crb\nSERVICE_ACCOUNT_SECRET_NAME=${SERVICE_ACCOUNT_NAME}-secret\n\necho \"Creating the Queypie Service Account and grant permission\"\nkubectl apply -f - <<EOF\napiVersion: v1\nkind: Namespace\nmetadata:\n  name: ${NAMESPACE}\n---\napiVersion: v1\nkind: ServiceAccount\nmetadata:\n  name: ${SERVICE_ACCOUNT_NAME}\n  namespace: ${NAMESPACE}\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRole\nmetadata:\n  name: ${CLUSTER_ROLE_NAME}\nrules:\n- apiGroups:\n  - \"\"\n  resources:\n  - users\n  - groups\n  - serviceaccounts\n  verbs:\n  - impersonate\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRoleBinding\nmetadata:\n  name: ${CLUSTER_ROLE_BINDING_NAME}\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n  kind: ClusterRole\n  name: ${CLUSTER_ROLE_NAME}\nsubjects:\n- kind: ServiceAccount\n  name: ${SERVICE_ACCOUNT_NAME}\n  namespace: ${NAMESPACE}\nEOF\n\n\nSA_SECRET_NAME=$(kubectl get -n ${NAMESPACE} sa/${SERVICE_ACCOUNT_NAME} -o \"jsonpath={.secrets[0]..name}\")\nif [ -z $SA_SECRET_NAME ]\nthen\nkubectl apply -f - <<EOF\napiVersion: v1\nkind: Secret\ntype: kubernetes.io/service-account-token\nmetadata:\n  name: ${SERVICE_ACCOUNT_SECRET_NAME}\n  namespace: ${NAMESPACE}\n  annotations:\n    kubernetes.io/service-account.name: \"${SERVICE_ACCOUNT_NAME}\"\nEOF\nSA_SECRET_NAME=${SERVICE_ACCOUNT_SECRET_NAME}\nfi\n\nif [[ \"$OSTYPE\" == \"linux-gnu\" ]]; then\n    BASE64_DECODE_FLAG=\"-d\"\nelif [[ \"$OSTYPE\" == \"darwin\"* ]]; then\n    BASE64_DECODE_FLAG=\"-D\"\nelif [[ \"$OSTYPE\" == \"linux-musl\" ]]; then\n    BASE64_DECODE_FLAG=\"-d\"\nelse\n    echo \"Unknown OS ${OSTYPE}\"\n    exit 1\nfi\n\nSA_TOKEN=$(kubectl get -n ${NAMESPACE} secrets/${SA_SECRET_NAME} -o \"jsonpath={.data['token']}\" | base64 ${BASE64_DECODE_FLAG})\nCA_CERT=$(kubectl get -n ${NAMESPACE} secrets/${SA_SECRET_NAME} -o \"jsonpath={.data['ca\\.crt']}\" | base64 ${BASE64_DECODE_FLAG})\n\necho \"\nFinished successfully.\nPlease copy the token and ca cert below and paste them into the credential input box on the querypie clusters page.\n\n>>> Service Account token\n${SA_TOKEN}\n\n--------------\n\n>>> CA Cert\n${CA_CERT}\"]]></ac:plain-text-body></ac:structured-macro></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "017a8d7a60f28905264cf009688045d2773ff32c65c65e4d558f134c7f6cf5b2",
+      "mdx_line_range": [
+        77,
+        77
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 12,
+      "xhtml_xpath": "ul[2]",
+      "xhtml_fragment": "<ul><li><p>스크립트 다운로드 이후 해당 경로에서 이하의 명령어를 수행하여 실행 권한을 부여한 뒤 사용합니다. </p><ac:structured-macro ac:name=\"code\" ac:schema-version=\"1\" ac:macro-id=\"0a1a2ec5-0106-4f75-8c06-79da67839e78\"><ac:plain-text-body><![CDATA[chmod +x generate_kubepie_sa.sh\n./generate_kubepie_sa.sh]]></ac:plain-text-body></ac:structured-macro></li></ul>",
+      "mdx_content_hash": "f9e52b21499b16e8e74201a3dceecdf68345f6e2cdb45ab520a0d22821de6ae6",
+      "mdx_line_range": [
+        79,
+        80
+      ],
+      "lost_info": {}
+    }
+  ],
+  "separators": [
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ],
+  "document_envelope": {
+    "prefix": "",
+    "suffix": ""
+  }
+}

--- a/confluence-mdx/tests/testcases/544382364/expected.roundtrip.json
+++ b/confluence-mdx/tests/testcases/544382364/expected.roundtrip.json
@@ -1,0 +1,373 @@
+{
+  "schema_version": "2",
+  "page_id": "544382364",
+  "mdx_sha256": "19255cc1d069b92945d2376526b645a34c88de690ebddb5487d50180cf4cc951",
+  "source_xhtml_sha256": "672aae0060c85c2dff3cc80ef243fe69dcb915a52e2117a181acfef5733be0c7",
+  "blocks": [
+    {
+      "block_index": 0,
+      "xhtml_xpath": "macro-info[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\" ac:macro-id=\"a03a3802-d35d-4956-8454-ab544398e5ba\"><ac:rich-text-body><p>해당 문서는 <strong>QueryPie Enterprise 9.20.0 기준</strong>으로 작성되었습니다.</p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "caf1613a2bce6452ba9fbd53ea7cc2939c0e47c12624d2d2ea9677d1e5fd8cfc",
+      "mdx_line_range": [
+        8,
+        8
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 1,
+      "xhtml_xpath": "macro-toc[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"toc\" ac:schema-version=\"1\" data-layout=\"default\" ac:local-id=\"7044a520-d23f-4ce1-9d21-1ec2df329420\" ac:macro-id=\"908303f4-956c-42f6-934c-e029e57519ad\"><ac:parameter ac:name=\"minLevel\">1</ac:parameter><ac:parameter ac:name=\"maxLevel\">6</ac:parameter><ac:parameter ac:name=\"outline\">false</ac:parameter><ac:parameter ac:name=\"style\">disc</ac:parameter><ac:parameter ac:name=\"exclude\">토픽</ac:parameter><ac:parameter ac:name=\"type\">list</ac:parameter><ac:parameter ac:name=\"printable\">true</ac:parameter></ac:structured-macro>",
+      "mdx_content_hash": "5fc41aae621e16ca10436ada6d43f79c30016082a632ba062b753af244873187",
+      "mdx_line_range": [
+        10,
+        11
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 2,
+      "xhtml_xpath": "p[1]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "b2da7f53a98160f9a467e89f4f04afbd6efa6caff1e00b4a072e5fd65d238800",
+      "mdx_line_range": [
+        12,
+        12
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 3,
+      "xhtml_xpath": "h2[1]",
+      "xhtml_fragment": "<h2>쿼리파이 접근 제어 정책 개요  </h2>",
+      "mdx_content_hash": "167c7a92a70914c9993379e0c57fecfb41b51e50775c34cce3dc44fe230c6d72",
+      "mdx_line_range": [
+        15,
+        15
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 4,
+      "xhtml_xpath": "p[2]",
+      "xhtml_fragment": "<p>쿼리파이에서 정의하는 접근 제어 정책은 EABAC(Enhanced Attribute Based Access Control)을 기반으로 동작합니다. EABAC은 쿼리파이 사용자의 역할(Role)과 속성(Attribute)을 기반으로 쿼리파이에 등록된 리소스에 대한 접근을 제어하고 권한 관리를 수행할 수 있는 정책의 통제 방식을 의미합니다. RBAC(Role-Based Access Control) 및 ABAC(Attribute-Based Access Control)의 기능을 결합하여 더욱 유연하고 정교한 접근 제어를 제공합니다. 모든 정책은 All Deny를 전제로 동작합니다. </p>",
+      "mdx_content_hash": "909ae9c815fa780e0f679865ccf121a9c63d046d2c41ae76992e82649b3eefc8",
+      "mdx_line_range": [
+        17,
+        20
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 5,
+      "xhtml_xpath": "p[3]",
+      "xhtml_fragment": "<p>EABAC 은 Role, Policy 두 가지로 동작합니다. Role 설정은 GUI 로 하며, Policy 정의는 코드(YAML)로 관리합니다.</p>",
+      "mdx_content_hash": "2d986d4711b186357e67205f1d0856df6dafc55aea181d9ab1591bf06175a4b0",
+      "mdx_line_range": [
+        22,
+        23
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 6,
+      "xhtml_xpath": "p[4]",
+      "xhtml_fragment": "<p>쿠버네티스 정책의 경우, 실제 쿠버네티스에 존재하는 네임스페이스에 국한되는 Role과 네임스페이스 범위 외 리소스를 지원하는 ClusterRole 양측 모두를 수용할 수 있는 종합적 모델로 스펙이 제작되었습니다. </p>",
+      "mdx_content_hash": "4c1df5d3953be3dbb101c7954aea3e5e63d1ade1d71c7b61d584226795d9073e",
+      "mdx_line_range": [
+        25,
+        25
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 7,
+      "xhtml_xpath": "p[5]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "0e74d42837dc8cea04c85a1160ee59bfaf539ea8a7c9e708fe23445eed457bb0",
+      "mdx_line_range": [
+        28,
+        28
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 8,
+      "xhtml_xpath": "h2[2]",
+      "xhtml_fragment": "<h2>쿠버네티스 정책 YAML 기본 구조</h2>",
+      "mdx_content_hash": "9a823c9a6277619e31865ac21af5347cd11a04b3a5ae7dc1b0ebb59cf847256d",
+      "mdx_line_range": [
+        30,
+        30
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 9,
+      "xhtml_xpath": "p[6]",
+      "xhtml_fragment": "<p>일부 항목을 제외한 전반 정책 코드에서 와일드카드(&ldquo;*&rdquo;) 및 정규표현식(<a href=\"https://github.com/girishji/re2/wiki/Syntax\">RE2 형식</a>: <code>^$</code> 명시 필수) 패턴을 지원합니다.</p>",
+      "mdx_content_hash": "4e011d8c218e33280f8f87afd316bdb31cf2279f51fd3ecc215fe363321483a1",
+      "mdx_line_range": [
+        32,
+        117
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 10,
+      "xhtml_xpath": "table[1]",
+      "xhtml_fragment": "<table data-table-width=\"760\" data-layout=\"default\" ac:local-id=\"35831a4b-16f9-461f-96a1-0af983cbf59e\"><colgroup><col style=\"width: 111.0px;\" /><col style=\"width: 110.0px;\" /><col style=\"width: 87.0px;\" /><col style=\"width: 255.0px;\" /><col style=\"width: 197.0px;\" /></colgroup><tbody><tr><th data-highlight-colour=\"var(--ds-background-accent-gray-subtlest, #F4F5F7)\"><p><strong>Category</strong></p></th><th data-highlight-colour=\"var(--ds-background-accent-gray-subtlest, #F4F5F7)\"><p><strong>Property</strong></p></th><th data-highlight-colour=\"var(--ds-background-accent-gray-subtlest, #F4F5F7)\"><p><strong>Required</strong></p></th><th data-highlight-colour=\"var(--ds-background-accent-gray-subtlest, #F4F5F7)\"><p><strong>Description</strong></p></th><th data-highlight-colour=\"var(--ds-background-accent-gray-subtlest, #F4F5F7)\"><p><strong>Valid Values</strong></p></th></tr><tr><td><p><code>apiVersion</code></p></td><td><p>-</p></td><td><p>O</p></td><td><p>작성된 YAML Code의 버전입니다. 시스템에서 관리하는 값으로, 수정이 불필요합니다.</p></td><td><p><code>kubernetes.rbac.querypie.com/v1</code></p></td></tr><tr><td><p><code>kind</code></p></td><td><p>-</p></td><td><p>O</p></td><td><p>작성된 YAML Code의 종류입니다. 시스템에서 관리하는 값으로, 수정이 불필요합니다.</p></td><td><p><code>KacPolicy</code></p></td></tr><tr><td><p><code>spec:</code><br />  <code>&lt;effect&gt;</code></p></td><td><p>-</p></td><td><p>O</p></td><td><p>정책의 구체적인 규칙의 허용 또는 거부 여부 지정합니다. </p><ul><li><p>각 정책은 이하의 스펙만 허용합니다: </p><ul><li><p>단일 Allow </p></li><li><p>단일 Deny</p></li><li><p>단일 Allow &amp; 단일 Deny</p></li></ul></li><li><p>Deny가 Allow보다 우선순위가 높습니다.</p></li></ul></td><td><p><code>allow</code>, <code>deny</code></p></td></tr><tr><td><p>&nbsp;</p></td><td><p><code>resources</code></p></td><td><p>O</p></td><td><p>접근을 허용/거부할 리소스를 지정합니다. <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"2cc8eb02-be82-493c-9696-cb2a8aaf9c0d\"><ac:parameter ac:name=\"title\">와일드카드 및 정규표현식 허용</ac:parameter><ac:parameter ac:name=\"colour\">Blue</ac:parameter></ac:structured-macro> </p></td><td><p><code>- &quot;cluster:*&quot;</code></p><p><code>- &quot;cluster:^eks-.*$&quot;</code></p></td></tr><tr><td><p>&nbsp;</p></td><td><p><code>subjects</code></p></td><td><p>O</p></td><td><p>쿠버네티스 명령을 impersonate할 쿠버네티스 사용자/그룹을 지정합니다.</p><ul><li><p><code>kubernetesGroups</code> : 쿼리파이 Proxy가 이용할 kubernetes group을 지정합니다.</p></li><li><p><code>impersonation</code> : 클라이언트 단에서 impersonation을 허용할 대상 사용자/그룹을 지정합니다. <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"fa4575b4-d73e-4bda-9c0c-7bcadd159131\"><ac:parameter ac:name=\"title\">와일드카드 허용</ac:parameter><ac:parameter ac:name=\"colour\">Green</ac:parameter></ac:structured-macro></p></li></ul></td><td><p><code>kubernetesGroups:</code><br />    <code>- &quot;system:masters&quot;</code><br />    <code>- $user.groups</code></p><p><code>impersonation:</code><br /><code>  users:</code><br /><code>    - &quot;system:user&quot;</code><br /><code>  groups:</code><br /><code>    - &quot;system:admin&quot;</code></p></td></tr><tr><td><p>&nbsp;</p></td><td><p><code>actions</code></p></td><td><p>O</p></td><td><p>쿠버네티스 클러스터 API 서버 내 허용/거부할 Resource API를 명시합니다. <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"e912d28f-47c8-430a-8eb3-451106ee642d\"><ac:parameter ac:name=\"title\">와일드카드 및 정규표현식 허용</ac:parameter><ac:parameter ac:name=\"colour\">Blue</ac:parameter></ac:structured-macro></p><ul><li><p><code>apiGroups</code> : 쿠버네티스 API 그룹 리스트를 정의합니다. <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"3a892c80-dd2d-4d0d-86e8-40d71489ca7c\"><ac:parameter ac:name=\"title\">와일드카드 허용</ac:parameter><ac:parameter ac:name=\"colour\">Green</ac:parameter></ac:structured-macro></p></li><li><p><code>resources</code> : 쿠버네티스 리소스를 정의합니다. <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"9d067dba-4481-407e-b2a0-0d2974eb3e4b\"><ac:parameter ac:name=\"title\">와일드카드 허용</ac:parameter><ac:parameter ac:name=\"colour\">Green</ac:parameter></ac:structured-macro></p></li><li><p><code>namespace</code> : 대상 네임스페이스를 정의합니다. <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"ee658e14-29a8-455b-a0ea-d7ac57a33b1f\"><ac:parameter ac:name=\"title\">와일드카드 및 정규표현식 허용</ac:parameter><ac:parameter ac:name=\"colour\">Blue</ac:parameter></ac:structured-macro></p></li><li><p><code>name</code> : 대상 리소스명을 정의합니다. <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"15a65f3b-eb3d-4190-831e-5540f6188524\"><ac:parameter ac:name=\"title\">와일드카드 및 정규표현식 허용</ac:parameter><ac:parameter ac:name=\"colour\">Blue</ac:parameter></ac:structured-macro></p></li><li><p><code>verbs</code> : 작업을 허용하거나 거부할 kubernetes 내의 권한을 명시합니다. <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"9cfda9ca-fc7f-4de2-8ec0-c101880b7527\"><ac:parameter ac:name=\"title\">와일드카드 허용</ac:parameter><ac:parameter ac:name=\"colour\">Green</ac:parameter></ac:structured-macro></p></li></ul></td><td><p><code>- apiGroups: [&quot;*&quot;]</code><br /><code>  resources:</code><br /><code>    - &quot;*&quot;</code><br /><code>  namespace: &quot;*&quot;</code><br /><code>  name: &quot;*&quot;</code><br /><code>  verbs: [&quot;*&quot;]</code></p></td></tr><tr><td><p>&nbsp;</p></td><td><p><code>conditions</code></p></td><td><p /></td><td><p>리소스 접근 정책 적용 여부를 조건으로 적용 대상을 세부 제어합니다.</p><ul><li><p><code>resourceTags</code> : 리소스 태그의 키와 값으로 필터링할 수 있습니다. <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"cdd97253-608a-45c6-97f3-2030124d3737\"><ac:parameter ac:name=\"title\">Value 와일드카드 및 정규표현식 허용</ac:parameter><ac:parameter ac:name=\"colour\">Purple</ac:parameter></ac:structured-macro> </p></li><li><p><code>userAttributes</code> : 사용자의 attribute을 조건으로 권한 사용을 제한합니다. <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"95292a1e-204c-4424-ba9c-5d18a066b680\"><ac:parameter ac:name=\"title\">Value 와일드카드 및 정규표현식 허용</ac:parameter><ac:parameter ac:name=\"colour\">Purple</ac:parameter></ac:structured-macro></p></li><li><p><code>ipAddresses</code> : 리소스에 대한 IP 접근 통제 조건 리스트를 단일IP, CIDR 형태으로 정의합니다. <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"e9384081-7c4a-47ac-b325-981b4c04f5cb\"><ac:parameter ac:name=\"title\">와일드카드 허용</ac:parameter><ac:parameter ac:name=\"colour\">Green</ac:parameter></ac:structured-macro></p></li></ul></td><td><p><code>resourceTags:      </code><br /><code>  - &quot;Owner&quot;: &quot;Daniel&quot;</code><br /><code>userAttributes:    </code><br /><code>  - &quot;department&quot;: &quot;DevOps&quot;   ipAddresses: </code><br /><code>  - &quot;10.10.10.0/24&quot;</code></p></td></tr></tbody></table>",
+      "mdx_content_hash": "040911f47d567e2990b2cb5fd4f0e61dbe54927e340154686df662eceaa0bd2d",
+      "mdx_line_range": [
+        119,
+        135
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 11,
+      "xhtml_xpath": "p[7]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "6c5f6c3fb12781508bd5a76c8c79bcc55599be80b23defe373823fa2da0bf9c2",
+      "mdx_line_range": [
+        137,
+        155
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 12,
+      "xhtml_xpath": "h2[3]",
+      "xhtml_fragment": "<h2>Resources 명시 방법</h2>",
+      "mdx_content_hash": "241da3627c11e86e45d276fe334d8c74b36a1dfd09c00082f945875a50813831",
+      "mdx_line_range": [
+        157,
+        177
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 13,
+      "xhtml_xpath": "p[8]",
+      "xhtml_fragment": "<p><code>resources</code>는 <u>쿠버네티스의 리소스가 아닌</u> 쿼리파이에 등록된 쿠버네티스 클러스터에 대한 리소스를 정의합니다.</p>",
+      "mdx_content_hash": "8e4dfe54396a65ff9b9f08f00984cb77c0b70005578f9b728d77c9fef635aeda",
+      "mdx_line_range": [
+        179,
+        183
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 14,
+      "xhtml_xpath": "ol[1]",
+      "xhtml_fragment": "<ol start=\"1\"><li><p>해당 <code>resources</code> 필드에 대한 정의는 필수입니다. <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"b54b33dd-77c5-47b4-9c5c-1e103ead3ed1\"><ac:parameter ac:name=\"title\">required</ac:parameter><ac:parameter ac:name=\"colour\">Red</ac:parameter></ac:structured-macro> </p></li><li><p>쿠버네티스 클러스터명을 바탕으로 입력합니다.</p><ul><li><p><code>&quot;cluster:{Kubernetes Cluster Name in QueryPie}&quot;</code></p></li></ul></li><li><p>쿠버네티스 클러스터명은 이하의 기준으로 정립됩니다. </p><ul><li><p>문자 길이 100자 제한</p></li><li><p>알파벳 대소문자 (case-sensitive), 숫자 및 이하 특수기호만 허용</p><ul><li><p>underscore (_)</p></li><li><p>hyphen (-)</p></li></ul></li><li><p>이름 시작과 끝은 알파벳 대소문자 또는 숫자로 제한</p></li><li><p>클러스터명은 중복을 제한</p></li></ul></li><li><p>쿠버네티스 클러스터는 단일 정책에서 다중으로 지정이 가능합니다. </p><ul><li><p><code>- &quot;cluster:kubepie-dev-1&quot;</code><br /><code>- &quot;cluster:kubepie-dev-2&quot;</code></p></li><li><p><code>[&quot;cluster:kubepie-dev-1&quot;, &quot;cluster:kubepie-dev-2&quot;]</code></p></li></ul></li><li><p>경로는 와일드카드를 허용합니다.</p><ul><li><p><code>&quot;cluster:kubepie-dev-*&quot;</code></p></li></ul></li><li><p>경로는 정규표현식을 허용합니다.</p><ul><li><p><code>&quot;cluster:^kubepie-dev-.*$&quot;</code></p></li></ul></li></ol>",
+      "mdx_content_hash": "76daff9f69d3b0d28222d1fbe092d664131fead78d9941b5a3568abfaeac648d",
+      "mdx_line_range": [
+        185,
+        197
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 15,
+      "xhtml_xpath": "p[9]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "ebb83515c1e6c6691667d72695536a6c428e1bd4a6002a43748d3bacdc166884",
+      "mdx_line_range": [
+        200,
+        200
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 16,
+      "xhtml_xpath": "h2[4]",
+      "xhtml_fragment": "<h2>Subjects 명시 방법</h2>",
+      "mdx_content_hash": "922951084ff09b3590886c2ac611a71b50972a9f97d621ce8f0ce1f121da16c5",
+      "mdx_line_range": [
+        202,
+        202
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 17,
+      "xhtml_xpath": "p[10]",
+      "xhtml_fragment": "<p><code>subjects</code>는 쿠버네티스 명령을 impersonate할 쿠버네티스 내 사용자/그룹을 정의합니다. <code>subjects</code>는 spec:allow에 한해 적용이 필요한 필드로, spec:deny에서는 문법적으로 허용되지 않습니다. </p>",
+      "mdx_content_hash": "53101071b7dd7ae1b8c09b400539c8115fedb383313a750c6e60f01c736495bb",
+      "mdx_line_range": [
+        204,
+        220
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 18,
+      "xhtml_xpath": "ol[2]",
+      "xhtml_fragment": "<ol start=\"1\"><li><p><code>kubernetesGroups</code>: <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"4bb074c1-fb2a-4db5-a5dd-02e5c33463aa\"><ac:parameter ac:name=\"title\">required</ac:parameter><ac:parameter ac:name=\"colour\">Red</ac:parameter></ac:structured-macro></p><ul><li><p>리소스에 대한 API 수행을 위해 쿼리파이 Proxy가 impersonate할 kubernetes 그룹 계정을 정의합니다.</p><ul><li><p>해당 subjects는 Policy-wide 레벨에서 정의할 수 있어야 하며, 최소 하나가 배정되도록 정의되어야 합니다.</p><ul><li><p>Impersonation을 위한 해당 subjects는 다른 Policy들과 하나의 Role 내에서 중첩이 가능합니다.</p></li></ul></li><li><p>Resources에 명시된 리소스에 대한 권한 수행이 가능한 kubernetes 측 그룹(단일 또는 복수)을 정의합니다.</p><ac:structured-macro ac:name=\"code\" ac:schema-version=\"1\" ac:macro-id=\"01f0f4a3-7e24-4ea8-9e5b-817a3c4ad756\"><ac:plain-text-body><![CDATA[kubernetesGroups: \n  - system:masters\n  - default-group-account]]></ac:plain-text-body></ac:structured-macro></li><li><p>kubernetesGroups에는 Querypie User의 Group을 예약어 형태로 입력할 수 있습니다. 이 때, User의 Group은 쌍따옴표(&ldquo;) 없이 입력 입력되어야 하며, 사용자가 Policy를 볼 땐 실제 user Group의 값이 표시됩니다.</p><ac:structured-macro ac:name=\"code\" ac:schema-version=\"1\" ac:macro-id=\"dad5f979-5d57-4803-9000-64e1be392bd5\"><ac:plain-text-body><![CDATA[kubernetesGroups: \n  - $user.groups]]></ac:plain-text-body></ac:structured-macro></li></ul></li></ul></li><li><p><code>impersonation</code>: <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"65bc7992-ce51-469e-971f-a2d21fcb204c\"><ac:parameter ac:name=\"title\">OPTIONAL</ac:parameter><ac:parameter ac:name=\"colour\">Yellow</ac:parameter></ac:structured-macro></p><ul><li><p>사용자가 클라이언트 단에서 kubernetes 내 특정 serviceaccount 등의 권한으로 kubectl 명령에 impersonation(--as, --as-group)을 시도하는 경우, 이에 대한 호출 허용 목록을 정의합니다.</p><ul><li><p><code>users</code>: 쿠버네티스 내 존재하는 사용자/서비스 계정으로 &quot;--as&quot; 파라미터에 허용 가능한 값을 나열합니다.</p></li><li><p><code>groups</code>: 쿠버네티스 내 존재하는 그룹 계정으로 &quot;--as-group&quot; 파라미터에 허용 가능한 값을 나열합니다.</p><ac:structured-macro ac:name=\"code\" ac:schema-version=\"1\" ac:macro-id=\"68ebe426-b925-4db3-9c85-e214f6c05a1b\"><ac:plain-text-body><![CDATA[impersonation: \n  users: \n    - \"system:serviceaccount:argocd\"\n  groups: \n    - \"system:admin\"]]></ac:plain-text-body></ac:structured-macro></li><li><p>와일드카드를 허용합니다. (<code>&quot;*&quot;</code>)</p></li></ul></li></ul></li></ol>",
+      "mdx_content_hash": "b74f2aad67fcebc8d89cf08003e8af296150ec30bb7afafb18ae866edd341f66",
+      "mdx_line_range": [
+        223,
+        223
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 19,
+      "xhtml_xpath": "p[11]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "ba4a98b5933e2a18861e525bb22fedb0654232ec2075e1a564ffb4bc0d2dbd1b",
+      "mdx_line_range": [
+        225,
+        225
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 20,
+      "xhtml_xpath": "h2[5]",
+      "xhtml_fragment": "<h2>Actions 명시 방법</h2>",
+      "mdx_content_hash": "5c577cb3bb862c9c5d90f3faa821a18ea98d7ead3882026de03b2c9ac9dc5d97",
+      "mdx_line_range": [
+        227,
+        253
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 21,
+      "xhtml_xpath": "p[12]",
+      "xhtml_fragment": "<p>클러스터 API 서버 내 허용할 Resource API 리스트를 명시합니다. 각 action에는 <code>apiGroups</code>, <code>resources</code>, <code>namespace</code>, <code>name</code>, <code>verbs</code> 기입이 필요합니다. </p>",
+      "mdx_content_hash": "c070f5384250fb3c25367a457fa0d1e94bf7fb7e143c05355ed3f808c3e7ef65",
+      "mdx_line_range": [
+        256,
+        256
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 22,
+      "xhtml_xpath": "ol[3]",
+      "xhtml_fragment": "<ol start=\"1\"><li><p><code>apiGroups</code> : 쿠버네티스 API 그룹 리스트를 정의합니다. </p><ol start=\"1\"><li><p>API 그룹을 정의함으로써 더욱 세부적인 권한 통제가 API 그룹별로 가능합니다. </p></li><li><p>커스텀 리소스에 대한 통제가 필요 시, apiGroups에 명시하여 커스텀 리소스에 한하여 통제도 가능합니다. </p></li><li><p>참고: </p><ol start=\"1\"><li><p><a href=\"https://kubernetes.io/docs/reference/using-api/#api-groups\">API Groups 안내 </a></p></li><li><p><a href=\"https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#api-groups\">API Group 목록</a> </p></li></ol></li><li><p>와일드카드를 허용하여 API 그룹 전체를 포괄적으로 지정하는 것이 가능합니다.</p><ul><li><p><code>apiGroups: [&quot;*&quot;]</code></p></li></ul></li></ol></li><li><p><code>resources</code> : 쿠버네티스 리소스 리스트를 정의합니다.</p><ol start=\"1\"><li><p>일반적으로 많이 쓰이는 리소스는 이하와 같습니다:</p><ul><li><p><code>pods</code>, <code>pods/exec</code>, <code>pods/log</code>, <code>pods/portforward</code>, <code>services</code>, <code>ingresses</code>, <code>deployments</code>, <code>replicasets</code>, <code>statefulsets</code>, <code>daemonsets</code>, <code>configmaps</code>, <code>secrets</code>, <code>namespaces</code>, <code>nodes</code>, <code>persistentvolumes</code>, <code>persistentvolumeclaims</code>, <code>jobs</code>, <code>cronjobs</code>, <code>serviceaccounts</code>, <code>endpoints</code>, <code>roles</code>, <code>rolebindings</code>, <code>clusterroles</code>, <code>clusterrolebindings</code></p></li></ul></li><li><p>위에 표기되지 않은 리소스 또한 정책에서 수용이 가능합니다. </p></li><li><p>네임스페이스 하위 리소스만 지정하여 권한을 부여하더라도, Namespace에 대한 ReadOnly 권한이 함께 부여됩니다. 따라서, 리소스 호출 시 매번 네임스페이스 명시해주어야 하는 사례가 발생되지 않습니다. 특정 네임스페이스에 대한 권한 부여를 방지하고자 하는 경우, <code>spec:deny</code> 에서 네임스페이스 리소스에 대한 접근 거부를 설정할 수 있습니다. </p></li><li><p>단일 정책 액션에서 다중으로 리소스 지정이 가능합니다. </p><ac:structured-macro ac:name=\"code\" ac:schema-version=\"1\" ac:macro-id=\"598f0299-fb6f-4fcb-bcef-888f8b3d7865\"><ac:plain-text-body><![CDATA[ resources:\n   - \"pods\"\n   - \"deployments\"\n   - \"configmaps\"]]></ac:plain-text-body></ac:structured-macro></li><li><p>와일드카드를 허용합니다. (<code>&quot;*&quot;</code>)</p></li></ol></li><li><p><code>namespace</code> : 대상 네임스페이스를 정의합니다. </p><ol start=\"1\"><li><p>네임스페이스를 액션에서 정의하여 클러스터 내 허용 대상 네임스페이스를 리소스별로 제어할 수 있습니다. </p></li><li><p>와일드카드와 정규표현식 모두 허용합니다.</p><ul><li><p><code>namespace: &quot;*&quot;</code></p></li></ul></li><li><p>namespaces 외 네임스페이스에 존속되지 않는 리소스의 경우, 해당 namespace를 작성하지 않아도 됩니다.</p><ol start=\"1\"><li><p>대상 예) <code>persistentvolumes</code>, <code>persistentvolumeclaims</code>, <code>serviceaccounts</code>, <code>customresourcedefinitions</code>, <code>endpoints</code>, <code>nodes</code>, <code>clusterroles</code>, <code>clusterrolebindings</code> 등</p></li></ol></li></ol></li><li><p><code>name</code> : 대상 리소스명을 정의하여 클러스터 내 허용 리소스 중 네이밍을 바탕으로 제어가 가능합니다. </p><ol start=\"1\"><li><p>와일드카드와 정규표현식 모두 허용합니다.</p><ul><li><p><code>name: &quot;pods-*&quot;</code></p></li></ul></li></ol></li><li><p><code>verbs</code> : 작업을 허용하거나 거부할 kubernetes 내의 API 권한을 명시합니다.</p><ul><li><p>일반적으로 호출되는 verb는 아래와 같습니다: </p><ul><li><p><code>get</code>: 리소스 정보 검색</p></li><li><p><code>list</code>: 리소스 목록 나열</p></li><li><p><code>watch</code>: 리소스 변경사항 주시 </p></li><li><p><code>create</code>: 새로운 리소스 생성</p></li><li><p><code>update</code>: 기존 리소스 업데이트</p></li><li><p><code>patch</code>: 리소스 부분 수정</p></li><li><p><code>delete</code>: 리소스 삭제 </p></li><li><p><code>deletecollection</code>: 단일 작업에서 여러 자원 삭제</p></li></ul></li><li><p>위에 표기되지 않은 특수한 verb가 있더라도 정책에 명시하여 적용 가능합니다. </p></li><li><p>3rd-Party 클라이언트 지원 시 이하의 verb가 필수로 요구되며 안내합니다: </p><ul><li><p>View 권한 : <code>get</code>, <code>list</code>, <code>watch</code></p></li><li><p>Edit 권한 : <code>get</code>, <code>list</code>, <code>watch</code> + <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>deletecollection</code></p></li></ul></li><li><p>pod exec명령을 통한 컨테이너 쉘 접속 세션 생성을 위해서는 일반적으로 <code>create</code> verb 명시가 필요합니다. </p></li><li><p>와일드카드를 허용합니다. </p><ul><li><p><code>verbs: [&quot;*&quot;]</code></p></li></ul></li></ul></li></ol>",
+      "mdx_content_hash": "39de666a1bd5cb23a13ebb77b31ee732f6e19ded55af2c31e515c550f16fdc73",
+      "mdx_line_range": [
+        258,
+        259
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 23,
+      "xhtml_xpath": "p[13]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "60f9b1fb488c60c38ddf6a97c218cf083b9e0a81bab8c17e5ddc9c18f73d0647",
+      "mdx_line_range": [
+        261,
+        307
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 24,
+      "xhtml_xpath": "h2[6]",
+      "xhtml_fragment": "<h2>Conditions 명시 방법</h2>",
+      "mdx_content_hash": "2cb6e60011df10e285a95addae13e029d0d70097032cb26814839f2464451c83",
+      "mdx_line_range": [
+        310,
+        310
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 25,
+      "xhtml_xpath": "p[14]",
+      "xhtml_fragment": "<p><code>conditions</code> 항목에는 <code>resourceTags</code>, <code>userAttributes</code>, <code>ipAddresses</code>를 조건으로 정의할 수 있습니다. <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"9b7635d3-7de5-4c02-8b71-751ce3f4a1d9\"><ac:parameter ac:name=\"title\">OPTIONAL</ac:parameter><ac:parameter ac:name=\"colour\">Yellow</ac:parameter></ac:structured-macro></p>",
+      "mdx_content_hash": "3c77e8d4aacee4da2c6dfaf5ffebeccdb74d047c93326485931387202e9d406a",
+      "mdx_line_range": [
+        312,
+        312
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 26,
+      "xhtml_xpath": "ul[1]",
+      "xhtml_fragment": "<ul><li><p><code>resourceTags</code> : 태그 항목에서는 리소스 태그의 키와 값으로 필터링할 수 있습니다. </p><ac:structured-macro ac:name=\"code\" ac:schema-version=\"1\" ac:macro-id=\"9b9de014-2f9d-43e5-b3e3-4e46c2d19fdf\"><ac:plain-text-body><![CDATA[resourceTags: \n  \"region\": \"ap-northeast-1\"\n  \"Owner\": \"Brant\"]]></ac:plain-text-body></ac:structured-macro></li><li><p><code>userAttributes</code> : 사용자의 속성(attribute)을 조건으로 지정하고 값이 매칭되는 사용자에 한해서만 해당 정책에서 정의된 권한의 사용을 제한합니다. </p><ac:structured-macro ac:name=\"code\" ac:schema-version=\"1\" ac:macro-id=\"bd92697f-d6eb-4c40-99aa-b9c6bad7973d\"><ac:plain-text-body><![CDATA[userAttributes: \n  \"countryCode\": \"KR\"\n  \"department\": \"Infra\"]]></ac:plain-text-body></ac:structured-macro></li><li><p><code>ipAddresses</code> : 리소스에 대한 IP 접근 통제 조건 리스트를 단일IP, CIDR 형태으로 정의합니다. </p><ac:structured-macro ac:name=\"code\" ac:schema-version=\"1\" ac:macro-id=\"f47b9722-b2b5-4d60-931d-dd5abf4ee359\"><ac:plain-text-body><![CDATA[ipAddresses: [\"10.10.0.0/24\", \"10.11.10.1\"]]]></ac:plain-text-body></ac:structured-macro></li></ul>",
+      "mdx_content_hash": "e0db78d0d74f14fc1094538cee4220d4a55b6c25a8a26b6199e8b88b3029c1d7",
+      "mdx_line_range": [
+        314,
+        329
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 27,
+      "xhtml_xpath": "p[15]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "da909d31fe958c56375e515d5b6342f325d9cc46441a9dcee337a52ed1daa43d",
+      "mdx_line_range": [
+        332,
+        332
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 28,
+      "xhtml_xpath": "h2[7]",
+      "xhtml_fragment": "<h2>KAC Policy 예시</h2>",
+      "mdx_content_hash": "cd2aa3931f04d6d3bef7f7da3740cb4e6a413f7bd888a66e2ac3e6c5656dbfb0",
+      "mdx_line_range": [
+        334,
+        376
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 29,
+      "xhtml_xpath": "macro-code[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"code\" ac:schema-version=\"1\" ac:macro-id=\"c993ff80-b384-4cb8-ae37-12a0744b1b2f\"><ac:plain-text-body><![CDATA[apiVersion: kubernetes.rbac.querypie.com/v1 \nkind: KacPolicy\n\nspec:\n  allow: \n    resources: \n      - \"cluster:*\"\n    subjects: \n      kubernetesGroups: \n        - \"system:masters\"\n      impersonation: \n        users: [\"system:serviceaccount:argocd\"] \n        groups: [\"system:admin\"]  \n    actions: \n      - apiGroups: [\"*\"] \n        resources: \n          - \"pods\"\n        namespace: \"*\" \n        name: \"*\" \n        verbs: [\"get\", \"list\", \"watch\"]\n    conditions: \n      resourceTags: \n        \"Owner\": [\"Kenny\", \"Brant\"]\n        \"Team\": \"DevSecOps\" \n      userAttributes: \n        \"countryCode\": \"KR\"\n        \"department\": \"Infra\"\n      ipAddresses: [\"10.10.0.0/24\", \"10.11.10.1\"] \n  deny: \n    resources: \n      - \"cluster:kubepie-*\"\n    actions: \n      - apiGroups: [\"*\"]\n        resources: \n          - \"*\"\n        namespace: \"production\"\n        name: \"*\"\n        verbs: [\"*\"]\n    conditions: \n      resourceTags: \n        \"Owner\": \"Brant\"]]></ac:plain-text-body></ac:structured-macro>",
+      "mdx_content_hash": "",
+      "mdx_line_range": [
+        0,
+        0
+      ],
+      "lost_info": {}
+    }
+  ],
+  "separators": [
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ],
+  "document_envelope": {
+    "prefix": "",
+    "suffix": ""
+  }
+}

--- a/confluence-mdx/tests/testcases/544384417/expected.roundtrip.json
+++ b/confluence-mdx/tests/testcases/544384417/expected.roundtrip.json
@@ -1,0 +1,457 @@
+{
+  "schema_version": "2",
+  "page_id": "544384417",
+  "mdx_sha256": "fac11d53fc8dbf48322f4f8cab2ff7d712af4d8b51e82a76e08299bbacabe85c",
+  "source_xhtml_sha256": "a4e2f99d4cec940a78d4fec41ca182195bcca8a70edd3085f72d5e778c47d4c0",
+  "blocks": [
+    {
+      "block_index": 0,
+      "xhtml_xpath": "macro-note[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"note\" ac:schema-version=\"1\" ac:macro-id=\"b98c114e-83b6-4ba3-8830-5a3ef3102272\"><ac:rich-text-body><p>11.2.0 현재 Reports 기능은 Beta 버전으로 제공 중입니다.</p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "c07641296dfa329cf4fc59b0c5aca8afa3faf2f5e6fa7af2457ed8c4e056796c",
+      "mdx_line_range": [
+        8,
+        8
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 1,
+      "xhtml_xpath": "h2[1]",
+      "xhtml_fragment": "<h2>Overview</h2>",
+      "mdx_content_hash": "2cf3e8d0312d307488ce43fd312a295d160966d1a0662270d9d9bf5204b740be",
+      "mdx_line_range": [
+        10,
+        11
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 2,
+      "xhtml_xpath": "p[1]",
+      "xhtml_fragment": "<p>QueryPie 보고서는 감사 대응에 필요한 데이터를 보고서 형태로 출력하는 기능입니다. </p>",
+      "mdx_content_hash": "b2da7f53a98160f9a467e89f4f04afbd6efa6caff1e00b4a072e5fd65d238800",
+      "mdx_line_range": [
+        12,
+        12
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 3,
+      "xhtml_xpath": "p[2]",
+      "xhtml_fragment": "<p>사용자 및 관리자 현황 및 내역, 보안 설정 내역, DB/서버에 주어진 사용자별 권한 현황 및 이력, DB/서버 접속 및 쿼리/명령어 사용 내역 등을 출력할 수 있습니다.</p>",
+      "mdx_content_hash": "570f2c848432064a0ee7873e13333c111c0aeb41d4a26775907e952b18104d92",
+      "mdx_line_range": [
+        14,
+        14
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 4,
+      "xhtml_xpath": "macro-info[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\" ac:macro-id=\"2b63aaca-78d8-42e2-ab82-18c8577d5a9c\"><ac:rich-text-body><p>11.2.0 버전 현재 보고서는 영어로만 출력 가능합니다.</p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "ba28091440b67b203fb70b9cb31d9973c8b139a33c5dea02bd934095c00755ff",
+      "mdx_line_range": [
+        16,
+        16
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 5,
+      "xhtml_xpath": "macro-toc[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"toc\" ac:schema-version=\"1\" data-layout=\"default\" ac:local-id=\"6b02762b-bf17-4c99-a9d4-3cf779b8c8be\" ac:macro-id=\"6c6873d4-65ad-4b7e-880d-586444365d6e\"><ac:parameter ac:name=\"maxLevel\">3</ac:parameter><ac:parameter ac:name=\"minLevel\">2</ac:parameter><ac:parameter ac:name=\"include\" /><ac:parameter ac:name=\"outline\">false</ac:parameter><ac:parameter ac:name=\"indent\" /><ac:parameter ac:name=\"exclude\">Overview</ac:parameter><ac:parameter ac:name=\"style\">disc</ac:parameter><ac:parameter ac:name=\"type\">list</ac:parameter><ac:parameter ac:name=\"printable\">true</ac:parameter><ac:parameter ac:name=\"class\" /><ac:adf-fragment-mark><ac:adf-fragment-mark-detail name=\"Extension 1\" local-id=\"5ca0ac0e-77cc-4291-8759-f2e6aca2c10d\" /></ac:adf-fragment-mark></ac:structured-macro>",
+      "mdx_content_hash": "a3616dfdfed5ef9bb53b2cee3d00d0cc9e81e3aeef77123bc57be8f6bb61f773",
+      "mdx_line_range": [
+        18,
+        18
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 6,
+      "xhtml_xpath": "h2[2]",
+      "xhtml_fragment": "<h2>보고서 출력 항목 및 필터 지원 사항</h2>",
+      "mdx_content_hash": "563224b2b03599b1d86317599598ecca1ffb8c5bba84a888541e666717edfbcb",
+      "mdx_line_range": [
+        20,
+        21
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 7,
+      "xhtml_xpath": "p[3]",
+      "xhtml_fragment": "<p>11.2.0 버전 현재 지원하는 보고서 항목 및 필터는 아래의 표를 참고하시기 바랍니다.</p>",
+      "mdx_content_hash": "b2da7f53a98160f9a467e89f4f04afbd6efa6caff1e00b4a072e5fd65d238800",
+      "mdx_line_range": [
+        22,
+        22
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 8,
+      "xhtml_xpath": "table[1]",
+      "xhtml_fragment": "<table data-table-width=\"958\" data-layout=\"center\" ac:local-id=\"cfcbf091-3775-4454-bff4-924bf43e88f4\"><ac:adf-fragment-mark><ac:adf-fragment-mark-detail name=\"Table 1\" local-id=\"42cfbf5f-5c57-44da-8f07-e1ea866a985a\" /></ac:adf-fragment-mark><colgroup><col style=\"width: 118.0px;\" /><col style=\"width: 160.0px;\" /><col style=\"width: 349.0px;\" /><col style=\"width: 93.0px;\" /><col style=\"width: 93.0px;\" /><col style=\"width: 141.0px;\" /></colgroup><tbody><tr><th><p><strong>보고서 유형</strong></p></th><th><p><strong>대분류</strong></p></th><th><p><strong>소분류</strong></p></th><th><p style=\"text-align: center;\"><strong>User / Group</strong></p></th><th><p style=\"text-align: center;\"><strong>Resource</strong></p></th><th><p style=\"text-align: center;\"><strong>기타 필터</strong></p></th></tr><tr><td rowspan=\"12\"><p>QueryPie System</p></td><td rowspan=\"5\"><p>Users</p></td><td><p>User Account Status <br />사용자 계정 현황</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">X</p></td><td><ul><li><p>User Status</p></li></ul></td></tr><tr><td><p>User Account Management History <br />사용자 계정 관리 이력</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td><p>User Account Activation History <br />사용자 계정 활성화/비활성화 이력</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td><p>Group Status <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"e0e13438-7b7e-4321-ba4b-de74193644d0\"><ac:parameter ac:name=\"title\">added-10.2.2</ac:parameter><ac:parameter ac:name=\"colour\">Green</ac:parameter></ac:structured-macro><br />그룹 현황</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td><p>Group Membership History <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"3303b13c-e1b9-4959-87be-2661d98e9007\"><ac:parameter ac:name=\"title\">added-10.2.2</ac:parameter><ac:parameter ac:name=\"colour\">Green</ac:parameter></ac:structured-macro><br />그룹 멤버 추가/삭제 이력</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td rowspan=\"3\"><p>Administrator</p></td><td><p>Administrator Status <br />관리자 현황</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td><p>Admin Role History <br />관리자 권한 부여/회수 이력</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td><p>Admin Activity History <br />관리자 행위 이력</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td rowspan=\"2\"><p>Login</p></td><td><p>User Login History <br />사용자 로그인 이력</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td><p>Login IPs by User <br />사용자 별 로그인 IP 이력</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td rowspan=\"2\"><p>Security Settings</p></td><td><p>Authentication Method <br />사용자 인증 방식</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td><p>Security Configuration Stauts <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"c9623961-7ad3-40c8-9359-4094a2c3cd1a\"><ac:parameter ac:name=\"title\">updated-10.2.2</ac:parameter><ac:parameter ac:name=\"colour\">Blue</ac:parameter></ac:structured-macro><br />보안 설정 현황</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td rowspan=\"8\"><p>QueryPie DAC</p></td><td rowspan=\"2\"><p>Databases <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"6a7e4ed7-259d-44d7-a78b-58d862477909\"><ac:parameter ac:name=\"title\">added-10.2.2</ac:parameter><ac:parameter ac:name=\"colour\">Green</ac:parameter></ac:structured-macro> </p></td><td><p>DB Connection Status<br />DB 커넥션 현황</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td><p>DB Connection Management History<br />DB 커넥션 추가/삭제 이력</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td rowspan=\"2\"><p>DB Access Control</p></td><td><p>DB Access Control - Assigned Status <br />DB 접근 권한 부여 현황</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td><p>DB Access Control Logs <br />DB 접근 권한 부여/회수 이력</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td rowspan=\"2\"><p>DB Access &amp; Queries</p></td><td><p>DB Access History <br />DB 접근 이력</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">O</p></td><td><ul><li><p>Time Range</p></li></ul></td></tr><tr><td><p>Query Execution History <br />쿼리 실행 이력</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td rowspan=\"2\"><p>Workflow Logs - DB <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"55400ce3-ae6a-49df-a209-eb117723afef\"><ac:parameter ac:name=\"title\">added-10.2.2</ac:parameter><ac:parameter ac:name=\"colour\">Green</ac:parameter></ac:structured-macro></p></td><td><p>DAC Type Requests<br />Workflow를 통해 진행된 DAC 유형 요청</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td><p>DAC Unmasking Requests <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"16fcb74a-3d4f-4bd6-a9e4-9b8bddfe58d2\"><ac:parameter ac:name=\"title\">added-11.2.0</ac:parameter><ac:parameter ac:name=\"colour\">Green</ac:parameter></ac:structured-macro></p><p>Workflow를 통해 진행된 Unmasking 요청</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td rowspan=\"20\"><p>QueryPie SAC</p></td><td rowspan=\"2\"><p>Servers <br /><ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"36a4db16-02c7-4ada-9e63-fb5a4e24e771\"><ac:parameter ac:name=\"title\">added-10.2.2</ac:parameter><ac:parameter ac:name=\"colour\">Green</ac:parameter></ac:structured-macro></p></td><td><p>Server Status<br />서버 현황</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td><p>Server Management History<br />서버 추가/삭제/변경 이력</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td rowspan=\"2\"><p>Server Groups <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"6d47ebe6-7320-4a30-8849-5e429e1481e7\"><ac:parameter ac:name=\"title\">added-10.2.2</ac:parameter><ac:parameter ac:name=\"colour\">Green</ac:parameter></ac:structured-macro></p></td><td><p>Server Group Status<br />서버 그룹 현황</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td><p>Server Group Management History<br />서버 그룹 추가/삭제/변경 이력</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td rowspan=\"2\"><p>Server Account &amp; Password <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"65826446-4ec6-4777-bd48-7d3216b418d6\"><ac:parameter ac:name=\"title\">added-10.2.2</ac:parameter><ac:parameter ac:name=\"colour\">Green</ac:parameter></ac:structured-macro></p></td><td><p>Provisioned Server Account Status<br />프로비저닝된 서버 계정 현황</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td><p>Server Account Provisioning History<br />서버 계정 프로비저닝 이력</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td rowspan=\"7\"><p>Server Access Control</p></td><td><p>Direct Permission Status by User/Group <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"4edb7a9b-f55b-4f87-8bb2-dccdfa14b892\"><ac:parameter ac:name=\"title\">updated-10.2.2</ac:parameter><ac:parameter ac:name=\"colour\">Blue</ac:parameter></ac:structured-macro><br />사용자/그룹별 Direct Permission 현황</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td><p>Direct Permission Change History <br />Direct Permission 변경 이력</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td><p><em><span style=\"color: rgb(151,160,175);\">Server Role Status by User </span></em><ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"3cdc8c07-9c01-4dd8-9456-288a2153bb30\"><ac:parameter ac:name=\"title\">deprecated-10.2.2</ac:parameter><ac:parameter ac:name=\"colour\">Red</ac:parameter></ac:structured-macro><br /><em><span style=\"color: rgb(151,160,175);\">사용자별 서버 역할 현황</span></em></p></td><td><p style=\"text-align: center;\"><em><span style=\"color: rgb(151,160,175);\">O</span></em></p></td><td><p style=\"text-align: center;\"><em><span style=\"color: rgb(151,160,175);\">O</span></em></p></td><td><p style=\"text-align: center;\"><em><span style=\"color: rgb(151,160,175);\">-</span></em></p></td></tr><tr><td><p>Role-Granted Users by Role <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"8532647f-91fc-4ac4-94ec-daa935c5ec39\"><ac:parameter ac:name=\"title\">added-10.2.2</ac:parameter><ac:parameter ac:name=\"colour\">Green</ac:parameter></ac:structured-macro><br />역할별 역할 부여 사용자 현황</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td><p>Accessible Servers by Role <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"c688a4b5-f072-4046-b865-e287ec097126\"><ac:parameter ac:name=\"title\">added-10.2.2</ac:parameter><ac:parameter ac:name=\"colour\">Green</ac:parameter></ac:structured-macro><br />역할별 접근 가능 서버 현황</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td><p>Server Role &amp; Policy Management History <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"8d4ac478-4a1a-4a5a-8b33-3f2c6da4b43b\"><ac:parameter ac:name=\"title\">added-10.2.2</ac:parameter><ac:parameter ac:name=\"colour\">Green</ac:parameter></ac:structured-macro><br />서버 역할 및 정책 변경 이력</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td><p>Server Role Grant/Revocation History <br />서버 역할 부여/회수 이력</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td rowspan=\"6\"><p>Server Sessions and Commands</p></td><td><p>Server Access History <br />서버 접근 이력</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">O</p></td><td><ul><li><p>Time Range</p></li><li><p>Result</p></li><li><p>Action Type</p></li><li><p>Role</p></li></ul><p style=\"text-align: center;\" /></td></tr><tr><td><p>Command History <br />명령어 이력</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">O</p></td><td><ul><li><p>Keyword</p></li></ul></td></tr><tr><td><p>Command Template Status <br />명령어 템플릿 현황</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td><p>Command Template Management History <br />명령어 템플릿 관리 이력</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td><p>Command Whitelist Grant/Revocation History <br />명령어 일시 허용 권한 부여/회수 이력</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">-</p></td></tr><tr><td><p>Restricted Commands <br />차단 명령어 이력</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">O</p></td><td><ul><li><p>Keyword</p></li></ul><p style=\"text-align: center;\" /></td></tr><tr><td><p>Workflow Logs - Servers <br /><ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"51cf78de-24c9-4373-a581-12bc50194cd1\"><ac:parameter ac:name=\"title\">added-10.2.2</ac:parameter><ac:parameter ac:name=\"colour\">Green</ac:parameter></ac:structured-macro></p></td><td><p>SAC Type Requests<br />SAC 유형 요청</p></td><td><p style=\"text-align: center;\">X</p></td><td><p style=\"text-align: center;\">O</p></td><td><p style=\"text-align: center;\">-</p></td></tr></tbody></table>",
+      "mdx_content_hash": "88a3fed7b33569f8ab625bcbafff997ad7db74eac0e5837789ba36286973f020",
+      "mdx_line_range": [
+        24,
+        24
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 9,
+      "xhtml_xpath": "h2[3]",
+      "xhtml_fragment": "<h2>보고서 목록 조회</h2>",
+      "mdx_content_hash": "2f666ca944c072c7c10a4e141c19a0e057d0dae907b659ede6002b26dc0042cb",
+      "mdx_line_range": [
+        26,
+        26
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 10,
+      "xhtml_xpath": "p[4]",
+      "xhtml_fragment": "<p>Audit 메뉴에서 Reports &gt; Reports 메뉴로 진입하면 보고서 생성 태스크 목록을 확인할 수 있습니다.</p>",
+      "mdx_content_hash": "46c1ecbc8aa81de48b6d0c76193b212ffeed563fec59c17cd861ca0d67780ca9",
+      "mdx_line_range": [
+        28,
+        584
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 11,
+      "xhtml_xpath": "macro-info[2]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\" ac:macro-id=\"6242e2a3-3012-4ea2-8fe9-8902d67e8d64\"><ac:rich-text-body><p>리포트 메뉴에 접근하기 위해서는 계정에 Report Audit Full Access 관리자 권한이 부여되어야 합니다.</p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "b8a4178efb1e54db9d2a25e73e2afbb41de3597bb6cf471675063e42695b1236",
+      "mdx_line_range": [
+        586,
+        655
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 12,
+      "xhtml_xpath": "p[5]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "4582021f82645ff457f10a05c69c28c0240c9e358d57cc4d21f9ed037de20ec9",
+      "mdx_line_range": [
+        657,
+        677
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 13,
+      "xhtml_xpath": "ac:image[1]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"1005\" ac:original-width=\"1627\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-12-23 오전 11.22.38.png\" ac:width=\"760\"><ri:attachment ri:filename=\"스크린샷 2024-12-23 오전 11.22.38.png\" ri:version-at-save=\"1\" /><ac:caption><p>Administrator &gt; Audit &gt; Reports &gt; Reports</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "147cc44ad5934bd51a02861a5295f24d5b34cee794bbaf429bc65f795a046f85",
+      "mdx_line_range": [
+        679,
+        679
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 14,
+      "xhtml_xpath": "p[6]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "638f53a823d899ee1793192d6dac377062d07da25fc784889c02ea338c6de9fd",
+      "mdx_line_range": [
+        681,
+        681
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 15,
+      "xhtml_xpath": "ol[1]",
+      "xhtml_fragment": "<ol start=\"1\"><li><p><strong>검색</strong> : Task Name으로 검색이 가능합니다.</p></li><li><p><strong>Create Task</strong> : 리포트 생성 페이지로 진입합니다.</p></li><li><p><strong>새로고침</strong> : 목록을 다시 불러옵니다.</p></li><li><p><strong>Type</strong> : 보고서 생성시 지정한 유형 정보로, 다음의 세 가지가 있습니다.</p><ol start=\"1\"><li><p>QueryPie System</p></li><li><p>QueryPie DAC</p></li><li><p>QueryPie SAC</p></li></ol></li><li><p><strong>Task Name</strong> : 보고서 생성 시 입력한 태스크의 이름입니다.</p></li><li><p><strong>Scheduling</strong> : 보고서 생성 시 입력한 태스크의 반복 주기 정보로, 다음과 같은 값을 가질 수 있습니다.</p><ol start=\"1\"><li><p>None : 반복 없음 (일회성으로 생성)</p></li><li><p>Daily : 매일 반복</p></li><li><p>Weekly : 매주 반복</p></li><li><p>Monthly : 매 월 반복</p></li><li><p>Quarterly : 매 분기 반복</p></li></ol></li><li><p><strong>Created By</strong> : 보고서 생성 태스크를 만든 사람의 정보입니다.</p></li><li><p><strong>Created At</strong> : 보고서 생성 태스크를 만든 시점입니다.</p></li><li><p><strong>Last Task At</strong> : 마지막으로 보고서가 생성된 시점입니다. (생성된 적이 없을 경우 비어 있음)</p></li><li><p><strong>Last Task Status</strong> : 마지막 보고서 생성 태스크의 상태입니다. 다음과 같은 값을 가집니다.</p><ol start=\"1\"><li><p>Succeeded : 성공</p></li><li><p>In Progress : 진행 중</p></li><li><p>Failed : 실패</p></li></ol></li><li><p><strong>Last Report File</strong> : 버튼을 클릭하면, 마지막으로 생성된 보고서 파일을 다운로드 받을 수 있습니다.</p><ol start=\"1\"><li><p>생성된 파일이 없거나, 이미 만료된 경우 비활성화 처리됩니다.</p></li><li><p>파일 다운로드 시 비밀번호 지정 여부는 Security 설정에서 지정할 수 있습니다.</p></li><li><p>비밀번호 지정 활성화 시, 파일을 다운로드 할 때 비밀번호를 설정합니다. 이후 파일의 압축을 해제할 때 설정한 비밀번호를 입력해야 합니다.</p></li></ol></li></ol>",
+      "mdx_content_hash": "d2fa217ac6ea363ef20ca3626b7ed344c6e21155e753c4bdda0e997c4d3a55cc",
+      "mdx_line_range": [
+        683,
+        684
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 16,
+      "xhtml_xpath": "h2[4]",
+      "xhtml_fragment": "<h2>보고서 상세 조회하기</h2>",
+      "mdx_content_hash": "b2da7f53a98160f9a467e89f4f04afbd6efa6caff1e00b4a072e5fd65d238800",
+      "mdx_line_range": [
+        685,
+        685
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 17,
+      "xhtml_xpath": "p[7]",
+      "xhtml_fragment": "<p>보고서 목록에서 상세 내용을 조회하고자 하는 항목을 선택하면 Drawer가 열리고, 상세 정보를 확인할 수 있습니다.</p>",
+      "mdx_content_hash": "e2dccdc61d726d13c4e4f99fe4b3a4187b5dc7b0a2777e14e0a2d7c89b8a819f",
+      "mdx_line_range": [
+        688,
+        693
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 18,
+      "xhtml_xpath": "p[8]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "046bb91b7d5f5ebc572b1c3600cc7d73b2e30705b1fb59e95d2c590de1690e77",
+      "mdx_line_range": [
+        696,
+        720
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 19,
+      "xhtml_xpath": "ac:image[2]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"1005\" ac:original-width=\"1627\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-12-23 오전 11.25.24.png\" ac:width=\"760\"><ri:attachment ri:filename=\"스크린샷 2024-12-23 오전 11.25.24.png\" ri:version-at-save=\"1\" /><ac:caption><p>Administrator &gt; Audit &gt; Reports &gt; Reports &gt; Report Detail</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "5ec0f7302eac8f80991a4aec694b30be61efa5925d341dee08d5e35ed4ae1c5f",
+      "mdx_line_range": [
+        722,
+        722
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 20,
+      "xhtml_xpath": "p[9]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "156734d8fd2bd8a238a33bf5ed74d7cc1f2b6582e1d3c546dff51d12f0013b7f",
+      "mdx_line_range": [
+        724,
+        724
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 21,
+      "xhtml_xpath": "ol[2]",
+      "xhtml_fragment": "<ol start=\"1\"><li><p><strong>Unschedule Task</strong> : 반복 생성하는 보고서의 경우, 스케줄링 해제가 가능합니다.</p><ol start=\"1\"><li><p>스케줄이 없거나 이미 해제된 태스크의 버튼은 비활성화되어 있으며, Task Unscheduled로 표시됩니다.</p></li></ol></li><li><p><strong>Type</strong> : 보고서 유형 정보를 표시합니다. (QueryPie General, DAC, SAC) </p><ol start=\"1\"><li><p>돋보기 버튼을 클릭하면 선택된 출력 항목 및 필터 정보를 확인할 수 있습니다.</p></li></ol></li><li><p><strong>Scheduling</strong> : 설정된 반복 주기 정보를 표시합니다. (None, Daily, Weekly, Quarterly)</p></li><li><p><strong>Date Range</strong> : 일회성으로 생성하는 보고서의 경우 기간 범위를 표시합니다.</p></li><li><p><strong>Start Date</strong> : 반복 생성하는 보고서의 경우 태스크 시작일을 표시합니다.</p></li><li><p><strong>Next Task At</strong> : 다음으로 예정된 태스크의 일시를 표시합니다. (반복하지 않는 경우 비워둡니다)</p></li><li><p><strong>User Scope</strong> : 사용자 Scope 정보를 표시합니다.</p></li><li><p><strong>Resource Scope</strong> : 리소스 Scope 정보를 표시합니다.</p></li><li><p><strong>Report List 탭</strong> : 생성된 보고서의 목록을 표시합니다. </p><ol start=\"1\"><li><p>Report No. : 보고서 태스크 내 보고서 일련번호</p></li><li><p>Created At : 보고서의 생성일시</p></li><li><p>Expired At : 보고서 파일의 만료(예정)일시</p></li><li><p>Status : 보고서 태스크의 상태 (Succeeded, Failed 중 하나)</p></li><li><p>Report File : 파일 다운로드 링크 </p><ul><li><p>생성된 파일이 없거나, 이미 만료된 경우 비활성화 처리됩니다.</p></li><li><p>파일 다운로드 시 비밀번호 지정 여부는 Security 설정에서 지정할 수 있습니다.</p></li><li><p>비밀번호 지정 활성화 시, 파일을 다운로드 할 때 비밀번호를 설정합니다. 이후 파일의 압축을 해제할 때 설정한 비밀번호를 입력해야 합니다.</p></li></ul></li></ol></li><li><p><strong>Action History 탭</strong> : 보고서에 대한 사용자의 작업 내역을 표시합니다.</p><ol start=\"1\"><li><p>Action At : 작업 수행 일시</p></li><li><p>Action Type : 작업 유형 (Report Download, Report Unschedule 중 하나)</p></li><li><p>Target Report No. : 대상 리포트 일련번호 (없을 경우 비워져 있음)</p></li><li><p>Action By : 작업자</p></li></ol></li></ol>",
+      "mdx_content_hash": "0926a61ff72d71f3a7a427eb2fbb9c55778632474c4ca148871ef6346e1d40e3",
+      "mdx_line_range": [
+        727,
+        732
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 22,
+      "xhtml_xpath": "h2[5]",
+      "xhtml_fragment": "<h2>보고서 생성하기</h2>",
+      "mdx_content_hash": "0abbcb9c840f84919e1cfa01b176299317e532e1efe78514076550520f23a1ba",
+      "mdx_line_range": [
+        735,
+        758
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 23,
+      "xhtml_xpath": "p[10]",
+      "xhtml_fragment": "<p>보고서 목록 화면에서 <code>+ Create Task</code> 버튼을 클릭하여 보고서 생성 페이지로 진입합니다.</p>",
+      "mdx_content_hash": "c9fb15fa99806137f2ac358cbc7a9cc6323de039f381042ed174117f4d247afa",
+      "mdx_line_range": [
+        760,
+        760
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 24,
+      "xhtml_xpath": "p[11]",
+      "xhtml_fragment": "<p>태스크 이름, 보고서 유형, 스케줄링 관련 내용을 입력하고, 섹션 단위로 보고서 출력 항목 및 적용할 필터를 지정할 수 있습니다. <code>+ Add Section</code> 버튼을 클릭하여 섹션을 추가할 수 있습니다.</p>",
+      "mdx_content_hash": "e30c554b8d4a193ea12eb8b4b5410debf2b83e9634db422dc119d6ba8a55f4a0",
+      "mdx_line_range": [
+        762,
+        762
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 25,
+      "xhtml_xpath": "ac:image[3]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"972\" ac:original-width=\"1635\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-12-09 오전 10.43.37.png\" ac:width=\"760\"><ri:attachment ri:filename=\"스크린샷 2024-12-09 오전 10.43.37.png\" ri:version-at-save=\"1\" /><ac:caption><p>Administrator &gt; Audit &gt; Reports &gt; Reports &gt; Create</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "2959acd44a5b77246414cc54bdd102c04312c91a88d6617f33fbb53e69683721",
+      "mdx_line_range": [
+        764,
+        764
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 26,
+      "xhtml_xpath": "ol[3]",
+      "xhtml_fragment": "<ol start=\"1\"><li><p><strong>Task Name</strong> : 보고서 생성 태스크를 식별할 수 있는 이름을 입력합니다.</p></li><li><p><strong>Type</strong> : 보고서 유형을 선택합니다. (QueryPie General, DAC, SAC)</p></li><li><p><strong>Scheduling</strong> : 보고서 생성 태스크의 반복 주기를 입력합니다.</p><ol start=\"1\"><li><p>None : 태스크의 반복 없이 일회성으로 생성할 때 선택합니다.</p></li><li><p>Daily : 매일 반복 생성하고자 할 때 선택합니다.</p></li><li><p>Weekly : 매주 반복 생성하고자 할 때 선택합니다.</p></li><li><p>Monthly : 매 월 반복 생성하고자 할 때 선택합니다.</p></li><li><p>Quarterly : 매 분기 반복 생성하고자 할 때 선택합니다.</p></li></ol></li><li><p><strong>Date Range</strong> : 이력 데이터의 기간 범위</p><ol start=\"1\"><li><p><code>Scheduling</code>을 <code>None</code> 으로 지정한 경우, 이력 데이터의 출력 범위를 지정합니다.</p></li><li><p>현황 데이터는 Date Range 입력 값과 무관하게 태스크 실행 시점을 기준으로 출력됩니다.</p></li><li><p>제약사항: Date Range는 최대 3개월치의 데이터만 선택할 수 있습니다.</p><ol start=\"1\"><li><p> <code>10.2.8</code> 버전 현재, 오늘로부터 최대 3개월 전의 데이터만 선택할 수 있습니다. 이는 <code>10.2.9</code> 버전에서 수정될 예정입니다.</p></li></ol></li></ol></li><li><p><strong>Start Date</strong> : 반복 태스크의 시작일</p><ol start=\"1\"><li><p><code>Scheduling</code>을 <code>Daily</code>, <code>Weekly</code>, <code>Monthly</code>, 또는 <code>Quarterly</code> 로 지정한 경우, 태스크 시작일을 지정합니다.</p></li></ol></li><li><p><strong>Data</strong> : 보고서 출력 항목</p><ol start=\"1\"><li><p>항목 선택 시 하단에서 데이터 기간 범위 정보를 확인할 수 있으며, Scheduling 지정 시 최초로 출력되는 보고서에 적용될 내용을 표시해줍니다.</p></li><li><p>Reference Time : 현황 데이터에 적용되는 기준 시점 안내</p></li><li><p>Date Range : 이력 데이터에 적용되는 기간 범위 안내</p></li></ol></li><li><p><strong>Filter</strong> : 섹션에 적용할 필터 입력</p><ol start=\"1\"><li><p>보고서 출력 항목 선택에 따라 적용 가능한 필터가 표시됩니다.</p></li><li><p>하단 필터 항목 참고</p></li></ol></li></ol>",
+      "mdx_content_hash": "9deabe035ca00b864cf8e85d5297b31254fd78c4186e9349ad41c0084d319da4",
+      "mdx_line_range": [
+        766,
+        771
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 27,
+      "xhtml_xpath": "p[12]",
+      "xhtml_fragment": "<p>원하는 정보를 모두 입력 후 <code>Preview</code> 버튼을 클릭 시 출력될 보고서를 미리보기할 수 있습니다.</p>",
+      "mdx_content_hash": "6ded3b61dac8ed6a7c59776ed2191dd9a7a5704e95895f117ed0afdfdffcfe47",
+      "mdx_line_range": [
+        773,
+        794
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 28,
+      "xhtml_xpath": "p[13]",
+      "xhtml_fragment": "<p><code>Save</code> 버튼을 클릭하여 보고서 태스크를 저장하고 목록으로 돌아갑니다.</p>",
+      "mdx_content_hash": "a09a58b7d2e422e040ef2c7acffd6640eafbadb77f739837003335cb3b9b66ce",
+      "mdx_line_range": [
+        796,
+        796
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 29,
+      "xhtml_xpath": "h2[6]",
+      "xhtml_fragment": "<h2>보고서 복제하기 <ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"4eae14de-2fe8-43cd-b5ad-685522149976\"><ac:parameter ac:name=\"title\">10.2.2</ac:parameter></ac:structured-macro> </h2>",
+      "mdx_content_hash": "2d609ac9bd0e3b50629a943d54f8b83fc97f7e19b2475e17714b13cdeb985806",
+      "mdx_line_range": [
+        798,
+        798
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 30,
+      "xhtml_xpath": "ac:image[4]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"1005\" ac:original-width=\"1627\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-12-23 오전 10.45.29.png\" ac:width=\"589\"><ri:attachment ri:filename=\"스크린샷 2024-12-23 오전 10.45.29.png\" ri:version-at-save=\"1\" /><ac:caption><p>Administrator &gt; Audit &gt; Reports &gt; Reports - Duplicate Task</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "ab1da70db6eada1e421ce73dba7703c6e331ce9c30412c1f17ae8addf08af6c8",
+      "mdx_line_range": [
+        800,
+        800
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 31,
+      "xhtml_xpath": "p[14]",
+      "xhtml_fragment": "<p>복제하려는 보고서를 목록에서 선택한 뒤  <ac:emoticon ac:name=\"blue-star\" ac:emoji-shortname=\":copy:\" ac:emoji-id=\"8131cbc6-728f-4eb5-abed-e3e9204f76a4\" ac:emoji-fallback=\":copy:\" /> <code>Duplicate Task</code> 버튼을 클릭하면, 기존에 생성했던 보고서를 복제하여 새로운 보고서 태스크를 생성할 수 있습니다. </p>",
+      "mdx_content_hash": "11f42f8599a2a41462f611bb12b620c20e9bb765189bf994ad633bc0e22dfad3",
+      "mdx_line_range": [
+        802,
+        807
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 32,
+      "xhtml_xpath": "p[15]",
+      "xhtml_fragment": "<p>태스크 복제 시에 복제되는 정보는 다음과 같습니다.</p>",
+      "mdx_content_hash": "77c0760018499f08b7b45089e7faddf97e8637e87b41b01a231065be0a43ac5e",
+      "mdx_line_range": [
+        809,
+        809
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 33,
+      "xhtml_xpath": "ul[1]",
+      "xhtml_fragment": "<ul><li><p><strong>Task Name</strong> - 기존 태스크 이름 뒤에 Copy가 추가됨</p></li><li><p><strong>Type</strong> - 기존 태스크에서 선택한 보고서 유형이 유지됨</p></li><li><p><strong>Scheduling</strong> - 기존 태스크에서 선택한 반복 주기가 유지됨</p><ul><li><p>단, Date Range 및 Start Date 는 초기화되며, 재입력이 필요함</p></li></ul></li><li><p><strong>Data</strong> - 기존 태스크에서 선택한 출력 항목이 보존됨</p></li><li><p><strong>Filter</strong> - Data별로 입력한 필터가 보존됨</p><ul><li><p>단, 기존에 선택한 Role, User, Group이 더 이상 존재하지 않는 경우에는 필터값에서 제거됨</p></li></ul></li></ul>",
+      "mdx_content_hash": "a5349eb03819b4c74062eefb7138bc02f20724a2c35ecace39acfc82969090e4",
+      "mdx_line_range": [
+        811,
+        811
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 34,
+      "xhtml_xpath": "h2[7]",
+      "xhtml_fragment": "<h2>필터</h2>",
+      "mdx_content_hash": "048157edc38f60e1ab18080c0dfaf09ab63afe78f29e0eb5dcd71dbca12cd9ad",
+      "mdx_line_range": [
+        813,
+        819
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 35,
+      "xhtml_xpath": "p[16]",
+      "xhtml_fragment": "<p>보고서에서 지원하는 필터의 상세 스펙을 안내합니다.</p>",
+      "mdx_content_hash": "e949e80ccb2279de0999bd4e4e89722e1a2ea72f9b517a8f4983f4c222d84185",
+      "mdx_line_range": [
+        821,
+        821
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 36,
+      "xhtml_xpath": "ol[4]",
+      "xhtml_fragment": "<ol start=\"1\"><li><p><strong>User/Group</strong> : 보고서 출력 데이터를 사용자 또는 그룹으로 필터링합니다.</p><ol start=\"1\"><li><p>예: PM팀에 대해서 부여된 DB 접근 권한 보고서 출력을 원하는 경우 다음과 같이 선택</p><ul><li><p>Type: QueryPie DAC</p></li><li><p>Data: DB Access Control - Assigned Status</p></li><li><p>Filter &gt; User/Group: PM (그룹)</p></li></ul></li></ol></li><li><p><strong>Resource</strong> : 보고서 출력 데이터를 리소스에 부여된 태그로 필터링합니다.</p><ol start=\"1\"><li><p>예: <code>Service:Homepage</code> 태그가 달린 DB에 대한 접근 권한 보고서 출력을 원하는 경우</p><ul><li><p>Type: QueryPie DAC</p></li><li><p>Data: DB Access Control - Assigned Status</p></li><li><p>Filter &gt; Resource: <code>Service:Homepage</code></p></li></ul></li><li><p>태그 연산 로직은 다른 QueryPie 기능과 동일하며, 다음과 같습니다.</p><ul><li><p>Key가 동일한 태그 필터를 여러 개 입력하는 경우 OR 조건으로 합쳐집니다.</p></li><li><p>Key가 다른 태그 필터를 여러 개 입력하는 경우 AND 조건으로 합쳐집니다.</p></li></ul></li><li><p>Workflow의 경우 한 번에 여러 개의 리소스에 대해 요청이 가능합니다. 이 때 요청 내에 조건을 만족하는 리소스가 한 개 이상 포함되었다면 검색결과에 포함됩니다.</p></li></ol></li><li><p><strong>User Status : </strong>User Account Status 출력 시 User Account의 상태로 필터링합니다.</p><ol start=\"1\"><li><p>필터값: Active, Locked, Expired, Locked Manually</p></li></ol></li><li><p><strong>Time Range</strong> : DB Access History 또는 Server Access History 선택 시 시간 범위로 필터링합니다.</p><ol start=\"1\"><li><p>시작 시간 및 종료 시간을 입력합니다.</p></li><li><p>입력된 시간 범위 내의 결과를 제외할 지 여부를 선택합니다. 선택 시, 입력된 시간 범위 외의 로그만 출력됩니다.</p></li></ol></li><li><p><strong>Result</strong> : Server Access History 선택 시 결과를 기준으로 필터링합니다.</p><ol start=\"1\"><li><p>필터값: Success, Failure</p></li></ol></li><li><p><strong>Action Type</strong> : Server Access History 선택 시 행위 유형(Action Type)을 기준으로 필터링합니다.</p><ol start=\"1\"><li><p>필터값: Connect, Disconnect</p></li></ol></li><li><p><strong>Role</strong> : Server Access History 선택 시 사용한 서버 역할을 기준으로 필터링합니다.</p><ol start=\"1\"><li><p>복수 개의 Role을 입력하는 경우 OR 조건으로 합쳐집니다.</p></li></ol></li><li><p><strong>Keyword</strong> : Command History 또는 Restricted Commands 선택 시 입력한 커맨드 기준으로 필터링합니다.</p><ol start=\"1\"><li><p>키워드 입력 후 키보드에서 Enter 키를 입력하여 검색 조건을 적용합니다.</p></li><li><p>입력한 키워드가 포함된 커맨드 이력만 추출됩니다. (like 검색)</p></li><li><p>대소문자를 구분하지 않습니다.</p></li><li><p>복수의 키워드를 입력하는 경우 OR 조건으로 합쳐집니다.</p></li></ol></li></ol>",
+      "mdx_content_hash": "ba219a62b7090cf6461561c174545a107f68c134be4fce86560add2acae11923",
+      "mdx_line_range": [
+        823,
+        823
+      ],
+      "lost_info": {}
+    }
+  ],
+  "separators": [
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ],
+  "document_envelope": {
+    "prefix": "",
+    "suffix": ""
+  }
+}

--- a/confluence-mdx/tests/testcases/568918170/expected.roundtrip.json
+++ b/confluence-mdx/tests/testcases/568918170/expected.roundtrip.json
@@ -1,0 +1,469 @@
+{
+  "schema_version": "2",
+  "page_id": "568918170",
+  "mdx_sha256": "d42bf9174ddbc1d9e63fabbea2bb4c14659267352859b7d1de8f598a1333588a",
+  "source_xhtml_sha256": "dc295c914735b806617a4d44cec180f0db014894623a9e43cbb178d334c1ea16",
+  "blocks": [
+    {
+      "block_index": 0,
+      "xhtml_xpath": "h2[1]",
+      "xhtml_fragment": "<h2>Overview</h2>",
+      "mdx_content_hash": "55bbd1b46dc155b04f7c083e4f0b61b636d42e8c294b8d29b44a5a03a34b9558",
+      "mdx_line_range": [
+        8,
+        8
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 1,
+      "xhtml_xpath": "p[1]",
+      "xhtml_fragment": "<p>Workflow 사용 시 편리함을 더해주는 부가 기능을 소개합니다. </p>",
+      "mdx_content_hash": "570f2c848432064a0ee7873e13333c111c0aeb41d4a26775907e952b18104d92",
+      "mdx_line_range": [
+        10,
+        10
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 2,
+      "xhtml_xpath": "macro-toc[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"toc\" ac:schema-version=\"1\" data-layout=\"default\" ac:local-id=\"fffae0b9-84f6-42d8-b6f2-b38fd4a694ce\" ac:macro-id=\"334477e7-dc7b-494d-9513-c21c2ccabe57\"><ac:parameter ac:name=\"maxLevel\">2</ac:parameter><ac:parameter ac:name=\"minLevel\">1</ac:parameter><ac:parameter ac:name=\"include\" /><ac:parameter ac:name=\"outline\">false</ac:parameter><ac:parameter ac:name=\"indent\" /><ac:parameter ac:name=\"exclude\">Overview</ac:parameter><ac:parameter ac:name=\"style\">default</ac:parameter><ac:parameter ac:name=\"type\">list</ac:parameter><ac:parameter ac:name=\"printable\">true</ac:parameter><ac:parameter ac:name=\"class\" /></ac:structured-macro>",
+      "mdx_content_hash": "814340096f09ab74bcec2969caae0d3d071141400d6d37e5c131626f610e7ad1",
+      "mdx_line_range": [
+        12,
+        12
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 3,
+      "xhtml_xpath": "p[2]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "3c2001ba27f25a2eb468de78355544d4f8cdb0c4ee223749466009ecc505401d",
+      "mdx_line_range": [
+        15,
+        15
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 4,
+      "xhtml_xpath": "h2[2]",
+      "xhtml_fragment": "<h2>참조된 요청 확인 처리하기</h2>",
+      "mdx_content_hash": "05c632cb4a060d4169e3500ed9613291acf5a418d10a5a4dd70ed0b1de788d83",
+      "mdx_line_range": [
+        17,
+        22
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 5,
+      "xhtml_xpath": "ac:image[1]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"1291\" ac:original-width=\"1990\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-08-02 오전 11.41.29.png\" ac:width=\"760\"><ri:attachment ri:filename=\"스크린샷 2024-08-02 오전 11.41.29.png\" ri:version-at-save=\"1\" /><ac:caption><p>Workflow &gt; Reviews &gt; All Reviews &gt; Review Details</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "7dd45c9581da81183e2a7aedbee38489c17d61634328b7bc847717cb194891a4",
+      "mdx_line_range": [
+        24,
+        29
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 6,
+      "xhtml_xpath": "ol[1]",
+      "xhtml_fragment": "<ol start=\"1\"><li><p>Reviews &gt; All Reviews 목록에서 참조 완료 처리하려는 요청을 클릭하여 상세 페이지로 진입합니다. </p><ol start=\"1\"><li><p>참조 문서는 결재 승인 상태와 관계없이(승인 전/후) 모두 열람할 수 있습니다. </p></li><li><p>Review Status 가 <strong>Unread</strong> 인 요청들에 대해서만 <code>Confirm</code>이 가능합니다. </p></li></ol></li><li><p>요청 상세 페이지 우측 상단의 <code>Confirm</code> 버튼을 클릭하여 Comment 입력할 수 있는 팝업창을 띄웁니다. </p></li><li><p>검토 의견을 입력 후 <code>OK</code> 버튼을 눌러 확인을 완료합니다. </p></li><li><p>All Reviews 목록으로 돌아가면 Review Status 값이 <strong>Confirmed</strong>로 변경된 것을 확인할 수 있습니다.</p></li></ol>",
+      "mdx_content_hash": "f15812a00692fb55935f388763291a48a60998609604c9c727859f56751ed528",
+      "mdx_line_range": [
+        33,
+        33
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 7,
+      "xhtml_xpath": "p[3]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "65a8bee698cd501d19e228f4cf35927880bd9dd6c5b1a994425369c571d487b0",
+      "mdx_line_range": [
+        35,
+        36
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 8,
+      "xhtml_xpath": "p[4]",
+      "xhtml_fragment": "<p> </p>",
+      "mdx_content_hash": "873a7b2810dcd7dfb2279ab68e42a771aadcf8df0ac974fa295e25042bfdfee4",
+      "mdx_line_range": [
+        38,
+        38
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 9,
+      "xhtml_xpath": "h2[3]",
+      "xhtml_fragment": "<h2>대리 결재 사용하기</h2>",
+      "mdx_content_hash": "105bb55e1c7ca215b374b43c862f8893a15f30148e07c11cd4d3aef0a93478b2",
+      "mdx_line_range": [
+        40,
+        45
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 10,
+      "xhtml_xpath": "p[5]",
+      "xhtml_fragment": "<p>대리 결재란 승인자 역할을 일정 기간 동안 다른 사용자에게 위임하는 기능입니다. 사용 방법은 다음과 같습니다.</p>",
+      "mdx_content_hash": "03d7bc1d8d7dcdfd662b75476e6831914fbc7b178c98309a36f55a174f193d11",
+      "mdx_line_range": [
+        47,
+        51
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 11,
+      "xhtml_xpath": "h3[1]",
+      "xhtml_fragment": "<h3>1. 대리 결재 사용 설정하기</h3>",
+      "mdx_content_hash": "8d5e1043869660f271bce247072254506e6313dd080a0210485d7043ac95411e",
+      "mdx_line_range": [
+        53,
+        53
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 12,
+      "xhtml_xpath": "ac:image[2]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"557\" ac:original-width=\"897\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-08-02 오후 12.04.01.png\" ac:width=\"760\"><ri:attachment ri:filename=\"스크린샷 2024-08-02 오후 12.04.01.png\" ri:version-at-save=\"1\" /><ac:caption><p>User &gt; 상단 메뉴바에서 프로필 클릭 &gt; Preferences</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "a9214550a39a7493db60ceb894a459d5d84e86f204c75ac123134209b14134bf",
+      "mdx_line_range": [
+        55,
+        55
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 13,
+      "xhtml_xpath": "ul[1]",
+      "xhtml_fragment": "<ul><li><p><strong>Delegate Approval to</strong> : 대리 결재자 입력 </p></li><li><p><strong>Start Date</strong> : 대리 결재 시작일자</p></li><li><p><strong>End Date</strong> : 대리 결재 종료일자</p></li><li><p><strong>Delegation Reason</strong> : 대리 결재 설정 사유 입력 </p></li><li><p><strong>Save</strong> : <code>Save</code> 버튼을 입력하면 대리 결재 설정이 저장됩니다. 설정 시작이 당일인 경우 <code>Save</code> 즉시 적용됩니다.</p></li></ul>",
+      "mdx_content_hash": "68ac0320d622ce48e000af71e29b9562ffec2dcf6f3735c662e563d88ce52832",
+      "mdx_line_range": [
+        56,
+        71
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 14,
+      "xhtml_xpath": "h3[2]",
+      "xhtml_fragment": "<h3>2. 대리 결재 설정 상태 확인하기</h3>",
+      "mdx_content_hash": "f3f0eae6fa6f6fccdceea3f7ca0148bb657bf4982ecc8e5c60819a031c4dbf61",
+      "mdx_line_range": [
+        73,
+        73
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 15,
+      "xhtml_xpath": "p[6]",
+      "xhtml_fragment": "<p>대리 결재 설정 기간에는 원 결재자와 대리 결재자의 접속 시 상단 메뉴바에 다음과 같이 표시됩니다.</p>",
+      "mdx_content_hash": "67cecc9181391d80a39483639fcaf58de2b5552e87a5dccaf2055e1d9365dc2e",
+      "mdx_line_range": [
+        75,
+        78
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 16,
+      "xhtml_xpath": "ac:image[3]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"174\" ac:original-width=\"594\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-08-02 오후 12.07.41.png\" ac:width=\"594\"><ri:attachment ri:filename=\"스크린샷 2024-08-02 오후 12.07.41.png\" ri:version-at-save=\"1\" /><ac:caption><p>원 결재자 기준 표시 내용</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "0b6a2cc3c95fa56988047c1b161ad8fd178f419d2f29f7c21acd08e555541410",
+      "mdx_line_range": [
+        80,
+        82
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 17,
+      "xhtml_xpath": "ac:image[4]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"174\" ac:original-width=\"594\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-08-02 오후 12.08.54.png\" ac:width=\"594\"><ri:attachment ri:filename=\"스크린샷 2024-08-02 오후 12.08.54.png\" ri:version-at-save=\"1\" /><ac:caption><p>대리 결재자 기준 표시 내용</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "a0929542da27e2e6d65f501bf72b0d9fad8aefaeec1624504b1c2db6d375db92",
+      "mdx_line_range": [
+        84,
+        84
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 18,
+      "xhtml_xpath": "macro-info[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\" ac:macro-id=\"0e393d17-632f-4483-91ba-6fc07e3650b3\"><ac:rich-text-body><p>대리 결재 설정 기간 중 기안 요청자에게는 별도의 안내가 나타나지 않습니다. 요청자는 평소와 마찬가지로 Approval Rule 및 Approver를 선택하면 됩니다.</p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "174749322ab40899a5710e83bfc11404a1e0b3ee5540de7939b0073b9fac8762",
+      "mdx_line_range": [
+        86,
+        86
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 19,
+      "xhtml_xpath": "h3[3]",
+      "xhtml_fragment": "<h3>3. 위임받은 대리 결재 요청 처리하기</h3>",
+      "mdx_content_hash": "aacd5b713ffc49c66c3e78efc7c64afda4ba3f417d717d4a5bbfbc2e53008489",
+      "mdx_line_range": [
+        87,
+        87
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 20,
+      "xhtml_xpath": "ul[2]",
+      "xhtml_fragment": "<ul><li><p>대리 결재 설정 기간 동안, 대리 결재자가 확인할 수 있는 요청은 다음과 같습니다. </p><ul><li><p><strong>Received Requests &gt; To Do</strong> : 원 결재자가 수신한 미처리 요청 목록 (설정 기간 이전에 수신한 요청 포함</p></li><li><p><strong>Received Requests &gt; Done</strong> : 대리 결재 설정 기간 내 대리 결재자가 처리한 요청을 볼 수 있습니다.</p></li></ul></li><li><p>상세 페이지에서 승인 또는 반려할 수 있으며, Comment 입력 시에는 대리 결재 중임을 알리는 문구가 표시됩니다. </p></li></ul>",
+      "mdx_content_hash": "2c96dc5680d39864877e98b7883e47d485d22e6ab4f82743ed486e86637c64a5",
+      "mdx_line_range": [
+        88,
+        104
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 21,
+      "xhtml_xpath": "ac:image[5]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"928\" ac:original-width=\"1433\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-08-02 오후 12.46.38.png\" ac:width=\"760\"><ri:attachment ri:filename=\"스크린샷 2024-08-02 오후 12.46.38.png\" ri:version-at-save=\"1\" /><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "2b7dec7c0abef06dba47caa13acf5c8d680a928d002e6943023d300de7ed4ea2",
+      "mdx_line_range": [
+        106,
+        106
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 22,
+      "xhtml_xpath": "h3[4]",
+      "xhtml_fragment": "<h3>4. 대리 결재 처리된 요청 건 확인하기 </h3>",
+      "mdx_content_hash": "af212b23acfb69422788ca289df11bc968fc25522810471a148a228a9ee0a93b",
+      "mdx_line_range": [
+        108,
+        108
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 23,
+      "xhtml_xpath": "ul[3]",
+      "xhtml_fragment": "<ul><li><p>다음과 같이 요청 상세페이지 내 승인 현황에서 원 결재자 또는 대리 결재자가 처리한 것인지를 확인할 수 있습니다.  </p></li></ul>",
+      "mdx_content_hash": "03c74eff84434baa96d39e6069b606b448315e246415bd71e4c8e096c367f6fc",
+      "mdx_line_range": [
+        111,
+        111
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 24,
+      "xhtml_xpath": "p[7]",
+      "xhtml_fragment": "<p style=\"text-align: center;\"><strong>원 결재자가 처리한 경우</strong></p>",
+      "mdx_content_hash": "b6cf9d4dbfc73bba4984d4b699e386afb5fbe1f3a427f42219086acde8f6e640",
+      "mdx_line_range": [
+        113,
+        113
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 25,
+      "xhtml_xpath": "ac:image[6]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"576\" ac:original-width=\"676\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-07-25 오후 3.35.33.png\" ac:width=\"363\"><ri:attachment ri:filename=\"스크린샷 2024-07-25 오후 3.35.33.png\" ri:version-at-save=\"1\" /><ac:caption><p>대리 결재 관련 문구 없음</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "3d67ed978b93cc3926e130a14af3ce9dd21f20d4097daef7999298b1a8b553c0",
+      "mdx_line_range": [
+        115,
+        120
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 26,
+      "xhtml_xpath": "p[8]",
+      "xhtml_fragment": "<p style=\"text-align: center;\"><strong>대리 결재자가 처리한 경우</strong></p>",
+      "mdx_content_hash": "57a5eb27cc749091edfc3cbb231daa8eb4c98d1a568a91570db6b592d4c8a849",
+      "mdx_line_range": [
+        122,
+        122
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 27,
+      "xhtml_xpath": "ac:image[7]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"571\" ac:original-width=\"662\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2024-07-25 오후 3.21.41.png\" ac:width=\"363\"><ri:attachment ri:filename=\"스크린샷 2024-07-25 오후 3.21.41.png\" ri:version-at-save=\"1\" /><ac:caption><p>대리 결재자가 Done by the delegate와 함께 표기됨</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "c04cb8a6ccb237d6ad2651e8879c74da85677132af2480f9a3cd81a1dd71ce69",
+      "mdx_line_range": [
+        124,
+        125
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 28,
+      "xhtml_xpath": "macro-info[2]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\" ac:macro-id=\"0d492211-666c-4cf5-b197-36ab604842b9\"><ac:rich-text-body><p>Slack DM을 통한 요청 알림을 사용 중이라면, 대리 결재자에게도 Workflow 단계별 알림이 발송됩니다. Slack DM 알림 관련 자세한 내용은 <ac:link><ri:page ri:content-title=\"Slack DM - Workflow 알림 유형\" ri:version-at-save=\"14\" /><ac:link-body>Slack DM 개인 알림 사용하기</ac:link-body></ac:link> 문서를 참고해주세요. </p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "b2da7f53a98160f9a467e89f4f04afbd6efa6caff1e00b4a072e5fd65d238800",
+      "mdx_line_range": [
+        126,
+        126
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 29,
+      "xhtml_xpath": "h3[5]",
+      "xhtml_fragment": "<h3>5. 대리 결재 설정 종료 이후의 기안 조회 방법</h3>",
+      "mdx_content_hash": "8a8252fe0a9a8f0817c1430a59714f0fe5259bad8ded5da6e085692d9d8c3035",
+      "mdx_line_range": [
+        128,
+        131
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 30,
+      "xhtml_xpath": "ul[4]",
+      "xhtml_fragment": "<ul><li><p>대리 결재 설정 기간이 종료되었다 하더라도 Received Requests &gt; Done 목록에서, 대리 결재 설정 기간 내 대리 결재자가 처리한 요청을 확인할 수 있습니다. 그 이외의 요청들은 더 이상 조회하거나 처리할 수 없습니다. </p></li></ul>",
+      "mdx_content_hash": "",
+      "mdx_line_range": [
+        0,
+        0
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 31,
+      "xhtml_xpath": "p[9]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "",
+      "mdx_line_range": [
+        0,
+        0
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 32,
+      "xhtml_xpath": "h2[4]",
+      "xhtml_fragment": "<h2>기존 요청 건 재상신하기 </h2>",
+      "mdx_content_hash": "",
+      "mdx_line_range": [
+        0,
+        0
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 33,
+      "xhtml_xpath": "p[10]",
+      "xhtml_fragment": "<p>동일한 내용으로 반복적인 결재 요청을 하거나 반려 처리된 결재 건에 대해 다음과 같이 재상신할 수 있습니다. </p>",
+      "mdx_content_hash": "",
+      "mdx_line_range": [
+        0,
+        0
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 34,
+      "xhtml_xpath": "ac:image[8]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"wide\" ac:original-height=\"235\" ac:original-width=\"575\" ac:custom-width=\"true\" ac:width=\"768\"><ri:attachment ri:filename=\"image-20230824-110815.png\" ri:version-at-save=\"1\" /><ac:caption><p>Workflow &gt; Sent Requests &gt; Done &gt; List Details</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "",
+      "mdx_line_range": [
+        0,
+        0
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 35,
+      "xhtml_xpath": "ol[2]",
+      "xhtml_fragment": "<ol start=\"1\"><li><p>Sent Requests &gt; Done 목록에서 재상신을 원하는 요청 건을 클릭하여 상세 페이지로 진입합니다. </p></li></ol>",
+      "mdx_content_hash": "",
+      "mdx_line_range": [
+        0,
+        0
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 36,
+      "xhtml_xpath": "macro-info[3]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\" ac:macro-id=\"131be646-3aa7-492b-902a-32bf694b89af\"><ac:rich-text-body><p>이때 이미 삭제된 데이터(결재 규칙, 승인자, 서버, 계정 등)는 <em><span style=\"color: rgb(255,86,48);\">Deleted</span></em>로 표시되는 것을 확인할 수 있으며, 삭제된 값은 재상신 시 제외하고 수정된 값은 현재 기준으로 불러오게 됩니다. </p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "",
+      "mdx_line_range": [
+        0,
+        0
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 37,
+      "xhtml_xpath": "ol[3]",
+      "xhtml_fragment": "<ol start=\"2\"><li><p>우측 상단에 있는 <code>Resubmit</code> 버튼을 클릭하여 재상신 페이지로 진입합니다. </p></li><li><p>재상신 페이지 내에서 수정을 원하는 값이 있을 경우 수정을 합니다. </p></li><li><p><code>Save</code> 버튼을 통해 저장합니다.</p></li><li><p>Workflow &gt; Sent Request &gt; In Progress 메뉴에서 본인의 요청 내역과 승인 현황을 확인할 수 있습니다.</p></li></ol>",
+      "mdx_content_hash": "",
+      "mdx_line_range": [
+        0,
+        0
+      ],
+      "lost_info": {}
+    }
+  ],
+  "separators": [
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "</ac:layout-cell></ac:layout-section><ac:layout-section ac:type=\"two_equal\" ac:breakout-mode=\"default\"><ac:layout-cell>",
+    "</ac:layout-cell><ac:layout-cell>",
+    "</ac:layout-cell></ac:layout-section><ac:layout-section ac:type=\"fixed-width\" ac:breakout-mode=\"default\"><ac:layout-cell>",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "</ac:layout-cell></ac:layout-section><ac:layout-section ac:type=\"two_equal\" ac:breakout-mode=\"default\"><ac:layout-cell>",
+    "",
+    "</ac:layout-cell><ac:layout-cell>",
+    "",
+    "</ac:layout-cell></ac:layout-section><ac:layout-section ac:type=\"fixed-width\" ac:breakout-mode=\"default\"><ac:layout-cell>",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ],
+  "document_envelope": {
+    "prefix": "<ac:layout><ac:layout-section ac:type=\"fixed-width\" ac:breakout-mode=\"default\"><ac:layout-cell>",
+    "suffix": "</ac:layout-cell></ac:layout-section></ac:layout>"
+  }
+}

--- a/confluence-mdx/tests/testcases/692355151/expected.roundtrip.json
+++ b/confluence-mdx/tests/testcases/692355151/expected.roundtrip.json
@@ -1,0 +1,241 @@
+{
+  "schema_version": "2",
+  "page_id": "692355151",
+  "mdx_sha256": "05b9bdc273a0d560eea19481486060237076f83b656bfeecbcfa6ad5d71578fe",
+  "source_xhtml_sha256": "b9e0646039c7414bbc75057fcec55a2d80783ca2b6767f0fb6147dde5920d6dd",
+  "blocks": [
+    {
+      "block_index": 0,
+      "xhtml_xpath": "macro-info[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\" ac:macro-id=\"d17430fb-9447-470e-83ac-d17ab23b1c3b\"><ac:rich-text-body><p>10.2.0 부터 추가된 기능입니다. (10.2.0 기준 MySQL만 지원합니다.)</p><p>11.2.0 부터 관리자가 이 기능을 비활성화 할 수 있도록 변경되었습니다. 사용자가 이 기능을 사용할 수 없는 경우 관리자가 정책적으로 비활성화한 것입니다.</p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "13827d542696285443a68e5919f9324d9a34adc37774580799cdd591866319c5",
+      "mdx_line_range": [
+        8,
+        8
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 1,
+      "xhtml_xpath": "h2[1]",
+      "xhtml_fragment": "<h2>Overview</h2>",
+      "mdx_content_hash": "e0ba182a853acb19236b7a78865e3cbaff6e098f8dc30ca635ec06d6be177027",
+      "mdx_line_range": [
+        10,
+        14
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 2,
+      "xhtml_xpath": "p[1]",
+      "xhtml_fragment": "<p>사용자가 Workflow를 통해 SQL Request를 요청할 때 해당 쿼리에 대해 DBMS에서 제공하는 실행 계획(Explain 구문)을 사용하여 쿼리에 대한 제한적인 절차 정보를 확인할 수 있습니다.  이 기능은 DBMS에 종속된 기능이므로 Workflow의 SQL Request 작성할 때 커넥션에 해당하는 DBMS 마다 차이가 있을 수 있습니다. </p>",
+      "mdx_content_hash": "b2da7f53a98160f9a467e89f4f04afbd6efa6caff1e00b4a072e5fd65d238800",
+      "mdx_line_range": [
+        15,
+        15
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 3,
+      "xhtml_xpath": "macro-info[2]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\" ac:macro-id=\"4352403e-dc94-4062-93c6-154a747a602f\"><ac:rich-text-body><p>실행계획이란?<br />데이터베이스의 옵티마이저가 가장 최적의 쿼리를 수행하기 위해 생성하는 일련의 작업세트 또는 작업 절차입니다. 단계적으로 수행 단계를 볼 수 있고 단계별 비용을 볼 수 있습니다. </p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "570f2c848432064a0ee7873e13333c111c0aeb41d4a26775907e952b18104d92",
+      "mdx_line_range": [
+        17,
+        17
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 4,
+      "xhtml_xpath": "h2[2]",
+      "xhtml_fragment": "<h2>SQL Request 작성 및 실행계획(Explain) 수행하기</h2>",
+      "mdx_content_hash": "421b9b5db209fa83425ddaf1e289e9f82536295d978cc29cd6c4d87c4a1eb9a4",
+      "mdx_line_range": [
+        19,
+        20
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 5,
+      "xhtml_xpath": "p[2]",
+      "xhtml_fragment": "<p>QueryPie Workflow에서 SQL Request를 작성하는 기본 방법은 동일합니다. (참고 : <ac:link ac:card-appearance=\"inline\"><ri:page ri:content-title=\"SQL Request 요청하기\" ri:version-at-save=\"26\" /><ac:link-body>SQL Request 요청하기</ac:link-body></ac:link>)</p>",
+      "mdx_content_hash": "c26b4966637d6328398cd5a1d9bec76a2ff4af651a3ff384201305874535f06f",
+      "mdx_line_range": [
+        22,
+        24
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 6,
+      "xhtml_xpath": "ol[1]",
+      "xhtml_fragment": "<ol start=\"1\"><li><p> MySQL Connection 및 Database 선택 <br />쿼리를 실행할 MySQL Connection 과 Database를 선택하고 쿼리를 입력합니다. </p></li></ol>",
+      "mdx_content_hash": "b2da7f53a98160f9a467e89f4f04afbd6efa6caff1e00b4a072e5fd65d238800",
+      "mdx_line_range": [
+        25,
+        25
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 7,
+      "xhtml_xpath": "macro-note[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"note\" ac:schema-version=\"1\" ac:macro-id=\"426a0df6-e9e8-4f8e-95c2-7e96de40ba61\"><ac:rich-text-body><p>Content Type은 &ldquo;Text&rdquo;만 지원합니다. &ldquo;File&rdquo;을 선택하면 실행 계획(Explain)기능을 사용할 수 없습니다.</p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "095561f1a17316c1d89cbbff7883a79baccf1c425176ffbf81f177988d4a66b9",
+      "mdx_line_range": [
+        27,
+        27
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 8,
+      "xhtml_xpath": "ac:image[1]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"531\" ac:original-width=\"776\" ac:custom-width=\"true\" ac:alt=\"image-20241029-234721.png\" ac:width=\"760\"><ri:attachment ri:filename=\"image-20241029-234721.png\" ri:version-at-save=\"1\" /></ac:image>",
+      "mdx_content_hash": "785e0279b6307f702e1f56e490e83ee13c0bfdf89091b79604da569d9091b40b",
+      "mdx_line_range": [
+        29,
+        30
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 9,
+      "xhtml_xpath": "ol[2]",
+      "xhtml_fragment": "<ol start=\"2\"><li><p>실행계획(Explain) 옵션 및 실행계획 수행<br />쿼리 에디터 하단에 있는 옵션을 선택하고 <code>Explain</code> 버튼을 누릅니다.</p><ol start=\"1\"><li><p><strong>Attach Explain Results</strong> : 실행계획의 결과를 SQL Request 에 첨부 여부를 선택하는 스위치입니다. (기본값은 OFF 입니다. 필요한 경우 스위치를 ON으로 전환하여 실행 계획 결과를 첨부해야 합니다.) </p></li><li><p>결과 표시 방식 선택</p><ol start=\"1\"><li><p><strong>Table</strong> : 테이블 형태로 결과가 표시됩니다.</p></li><li><p><strong>JSON</strong> : JSON 형태로 결과가 표시됩니다. </p></li></ol></li></ol></li></ol>",
+      "mdx_content_hash": "c07c868d115723b146eb04a46d7525181978546473024c59215340e2d82886e2",
+      "mdx_line_range": [
+        32,
+        32
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 10,
+      "xhtml_xpath": "ac:image[2]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"537\" ac:original-width=\"682\" ac:custom-width=\"true\" ac:alt=\"image-20241029-235845.png\" ac:width=\"682\"><ri:attachment ri:filename=\"image-20241029-235845.png\" ri:version-at-save=\"1\" /></ac:image>",
+      "mdx_content_hash": "82370c8e50590a997f0e7bf8b346a073dce364c1b55c5e96d504959256340a02",
+      "mdx_line_range": [
+        34,
+        36
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 11,
+      "xhtml_xpath": "macro-note[2]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"note\" ac:schema-version=\"1\" ac:macro-id=\"f0d417a3-d230-473c-ad86-b389329dc1c2\"><ac:rich-text-body><ul><li><p>실행계획 대상이 되는 쿼리(세미콜론으로 끝나는 구문)는 100개로 제한됩니다. </p></li><li><p>MySQL은 5.6 이후 부터 Explain의 결과를 JSON 포맷으로 출력할 수 있습니다. 따라서 5.6 이전 버전을 대상으로 Explain을 수행시 JSON으로 출력할 수 없습니다.</p></li></ul><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"392\" ac:original-width=\"719\" ac:custom-width=\"true\" ac:alt=\"image-20241030-001252.png\" ac:width=\"682\"><ri:attachment ri:filename=\"image-20241030-001252.png\" ri:version-at-save=\"1\" /></ac:image></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "b2da7f53a98160f9a467e89f4f04afbd6efa6caff1e00b4a072e5fd65d238800",
+      "mdx_line_range": [
+        37,
+        37
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 12,
+      "xhtml_xpath": "ol[3]",
+      "xhtml_fragment": "<ol start=\"3\"><li><p>실행계획(Explain) 결과 확인</p><ol start=\"1\"><li><p>Table 형태의 결과 확인<br />아래 그림과 같은 결과가 표시됩니다. 각 필드의 의미는 MySQL reference 문서를 참고 바랍니다.<br /></p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"271\" ac:original-width=\"1080\" ac:custom-width=\"true\" ac:alt=\"image-20241030-002325.png\" ac:width=\"712\"><ri:attachment ri:filename=\"image-20241030-002325.png\" ri:version-at-save=\"1\" /></ac:image><p> </p></li><li><p>JSON 형태의 결과 확인<br />JSON 을 선택하고 Explain 버튼을 누르면 아래 그림과 같은 결과가 표시됩니다. {JSON} 을 클릭하면 전체 JSON 내용을 확인 할 수 있습니다.<br /></p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"270\" ac:original-width=\"1078\" ac:custom-width=\"true\" ac:alt=\"image-20241030-003040.png\" ac:width=\"712\"><ri:attachment ri:filename=\"image-20241030-003040.png\" ri:version-at-save=\"1\" /><ac:caption><p>{JSON}을 클릭하면 전체 내용을 볼수 있습니다.</p></ac:caption></ac:image><p> <br /></p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"680\" ac:original-width=\"760\" ac:custom-width=\"true\" ac:alt=\"image-20241030-003129.png\" ac:width=\"560\"><ri:attachment ri:filename=\"image-20241030-003129.png\" ri:version-at-save=\"1\" /><ac:caption><p>JSON 결과의 복사와 내보내기가 가능합니다.</p></ac:caption></ac:image><p> <br />내보내기(Export)를 할 때 관리자 설정에 따라 암호 입력을 요구하는 팝업이 출력될 수 있습니다.</p></li></ol></li></ol>",
+      "mdx_content_hash": "c29278939dc19c6402035382fc9333f5564c93ac7a5d91d7f80cb3231618fc1d",
+      "mdx_line_range": [
+        39,
+        41
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 13,
+      "xhtml_xpath": "h2[3]",
+      "xhtml_fragment": "<h2>기타 참고사항 </h2>",
+      "mdx_content_hash": "b0a3d590fcd224f0fc621d92608e06fb9c0f2d138186493b7dc816ab0174b148",
+      "mdx_line_range": [
+        43,
+        47
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 14,
+      "xhtml_xpath": "ol[4]",
+      "xhtml_fragment": "<ol start=\"1\"><li><p>결재자(Approver)의 실행계획(Explain)결과 확인<br />결재자는 Explain Results 탭에서 첨부된 실행계획(Explain)결과를 확인하고 승인의 참고자료로 활용할 수 있습니다.</p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"249\" ac:original-width=\"1139\" ac:custom-width=\"true\" ac:alt=\"image-20241030-004258.png\" ac:width=\"736\"><ri:attachment ri:filename=\"image-20241030-004258.png\" ri:version-at-save=\"1\" /></ac:image></li></ol>",
+      "mdx_content_hash": "554f7fd968824d94c22e01e062ad0066ee86779f7d999eb965f6ff49e1ec96ab",
+      "mdx_line_range": [
+        49,
+        51
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 15,
+      "xhtml_xpath": "macro-note[3]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"note\" ac:schema-version=\"1\" ac:macro-id=\"2b5b3cc5-8cdf-4782-b102-7fb0d83a152f\"><ac:rich-text-body><p>결재자가 볼 수 있는 실행계획(Explain) 결과는 상신자가 실행계획을 수행할 때 선택한 포맷으로만 볼 수 있습니다. 즉, 상신자가 실행계획을 JSON 형태로 출력하도록 하고 첨부하여 상신했다면 결재자는 JSON 형태의 결과만 볼 수 있고 출력 형태를 테이블로 바꿀 수 없습니다. </p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "79aeeff57c0fe45aa52f6417a670588985a460d28f50e800c28a4a17f294d4ee",
+      "mdx_line_range": [
+        53,
+        53
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 16,
+      "xhtml_xpath": "ol[5]",
+      "xhtml_fragment": "<ol start=\"2\"><li><p>MySQL에서 실행계획(Explain)을 통해 검토 가능한 구문<br />MySQL은 버전별로 실행계획을 통해 분석하는 지원 구문이 다릅니다. </p></li></ol>",
+      "mdx_content_hash": "1c774171964dac4c1d5a89b65ea436117ff2095dc3ae4e57274c68421b11a394",
+      "mdx_line_range": [
+        54,
+        55
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 17,
+      "xhtml_xpath": "table[1]",
+      "xhtml_fragment": "<table data-table-width=\"760\" data-layout=\"default\" ac:local-id=\"2ff2c2d5-c31c-463e-b8d8-2e44a15a51c5\"><colgroup><col style=\"width: 381.0px;\" /><col style=\"width: 379.0px;\" /></colgroup><tbody><tr><th data-highlight-colour=\"var(--ds-background-accent-gray-subtlest, var(--ds-background-accent-gray-subtlest, #F1F2F4))\"><p><strong>MySQL 5.6.3 이전</strong></p></th><th data-highlight-colour=\"var(--ds-background-accent-gray-subtlest, var(--ds-background-accent-gray-subtlest, #F1F2F4))\"><p><strong>MySQL 5.6.3 이후</strong></p></th></tr><tr><td><p>SELECT</p></td><td><p>SELECT , DELETE , INSERT , REPLACE , UPDATE</p></td></tr></tbody></table>",
+      "mdx_content_hash": "9e56a0212218375b58ad1e1161da9e5b942c693fef011370f4831d98ed4e26b8",
+      "mdx_line_range": [
+        56,
+        59
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 18,
+      "xhtml_xpath": "macro-note[4]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"note\" ac:schema-version=\"1\" ac:macro-id=\"8ef7997a-646b-4e96-97a5-42d91c92abe8\"><ac:rich-text-body><p>optimizer_trace, analyze 는 SQL Request 에서 제공하는 실행계획(Explain) 수행 기능에서 지원하지 않습니다. </p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "658bc016384f450117872ca59c04248ede215078cb5844c66d52600c822b9846",
+      "mdx_line_range": [
+        61,
+        78
+      ],
+      "lost_info": {}
+    }
+  ],
+  "separators": [
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ],
+  "document_envelope": {
+    "prefix": "",
+    "suffix": ""
+  }
+}

--- a/confluence-mdx/tests/testcases/793608206/expected.roundtrip.json
+++ b/confluence-mdx/tests/testcases/793608206/expected.roundtrip.json
@@ -1,0 +1,337 @@
+{
+  "schema_version": "2",
+  "page_id": "793608206",
+  "mdx_sha256": "8942355bb84f715a00bb8a651af9c1edf0ced7ecab66ffce07b72c30e435c1b2",
+  "source_xhtml_sha256": "1fe717056eda284c8e41946fa98b25a00dae0e421798cccd34abcd2c0ae80c3c",
+  "blocks": [
+    {
+      "block_index": 0,
+      "xhtml_xpath": "p[1]",
+      "xhtml_fragment": "<p>Alert Type을 New Request로 선택한 경우, Request Type에 따른 템플릿 변수 지원 내용은 다음과 같습니다.</p>",
+      "mdx_content_hash": "1e7963a07852e6c7287e8136dafeecf1d6bf5a4351cf8a65baa97dfd8ca4f2dc",
+      "mdx_line_range": [
+        6,
+        6
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 1,
+      "xhtml_xpath": "h2[1]",
+      "xhtml_fragment": "<h2>공통 변수</h2>",
+      "mdx_content_hash": "c540152e7b6044e0b0f50f622bf2df0ab9f9ce24ae86b69f044425caf8c94661",
+      "mdx_line_range": [
+        8,
+        8
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 2,
+      "xhtml_xpath": "p[2]",
+      "xhtml_fragment": "<p>모든 요청 타입에서 지원하는 변수 목록입니다.</p>",
+      "mdx_content_hash": "4f6c666a12be336b23a1058b74341e8bb60f5b8e480dab0d1d938c919c808c73",
+      "mdx_line_range": [
+        10,
+        10
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 3,
+      "xhtml_xpath": "p[3]",
+      "xhtml_fragment": "<p>Request Type을 전체 선택한 경우에도 공통 변수는 사용 가능합니다.</p>",
+      "mdx_content_hash": "8fe1babdfc5074ed44a4575c07d81cd57ad059528d605479776b46ded7236416",
+      "mdx_line_range": [
+        12,
+        12
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 4,
+      "xhtml_xpath": "table[1]",
+      "xhtml_fragment": "<table data-table-width=\"811\" data-layout=\"center\" ac:local-id=\"c749b9ca-9033-4c2b-b8fa-3880ad5a8736\"><colgroup><col style=\"width: 178.0px;\" /><col style=\"width: 178.0px;\" /><col style=\"width: 315.0px;\" /><col style=\"width: 140.0px;\" /></colgroup><tbody><tr><th><p><strong>변수명</strong></p></th><th><p><strong>변수</strong></p></th><th><p><strong>설명</strong></p></th><th><p><strong>추가 시점</strong></p></th></tr><tr><td><p>Request Title             </p></td><td><p>{{requestTitle}}    </p></td><td><p>요청 제목</p><ul><li><p>예: 서비스 DB 접근 요청</p></li></ul></td><td><p>-</p></td></tr><tr><td><p>Assignees                 </p></td><td><p>{{assignees}}       </p></td><td><p>요청 승인 담당자</p><ul><li><p>예: STEP 1(Katie Wells), STEP 2(Kenny Park), STEP 3(Brant Hwang)</p></li></ul></td><td><p>-</p></td></tr><tr><td><p>Comment                   </p></td><td><p>{{comment}}         </p></td><td><p>요청 코멘트</p><ul><li><p>예: 서비스 운영 목적으로 DB 접근 권한 요청드립니다.</p></li></ul></td><td><p>-</p></td></tr><tr><td><p>User Name                 </p></td><td><p>{{userName}}        </p></td><td><p>요청자 이름  </p><ul><li><p>예: Keira Yoon</p></li></ul></td><td><p>-</p></td></tr><tr><td><p>Email                     </p></td><td><p>{{email}}           </p></td><td><p>요청자 이메일</p><ul><li><p>예: <a href=\"mailto:keira@email.com\">keira@email.com</a></p></li></ul></td><td><p>-</p></td></tr><tr><td><p>Access Type               </p></td><td><p>{{accessType}}      </p></td><td><p>요청 유형</p><ul><li><p>DB Access Request</p></li><li><p>SQL Request</p></li><li><p>SQL Export Request</p></li><li><p>Unmasking Request</p></li><li><p>Server Access Request</p></li><li><p>Access Role Request</p></li></ul></td><td><p>-</p></td></tr><tr><td><p>Link                      </p></td><td><p>{{link}}            </p></td><td><p>요청 상세 페이지 링크</p><ul><li><p>예: https://{querypie_domain}/workflow/received-requests/to-do/detail/{workflow_uuid}</p></li></ul></td><td><p>-</p></td></tr><tr><td><p>Workflow Uuid             </p></td><td><p>{{workflowUuid}}    </p></td><td><p>요청 UUID </p><ul><li><p>예: b63f9f94-11e5-4095-a399-be7d96e9ce06</p></li></ul></td><td><p>-</p></td></tr><tr><td><p>Workflow Id               </p></td><td><p>{{id}}              </p></td><td><p>요청 ID</p><ul><li><p>예: 12</p></li></ul></td><td><p>-</p></td></tr><tr><td><p>Urgent                    </p></td><td><p>{{urgent}}          </p></td><td><p>긴급 요청 여부</p><ul><li><p>true 또는 false</p></li></ul></td><td><p>10.2.0</p></td></tr></tbody></table>",
+      "mdx_content_hash": "859461fa7f061bcd40faf8245ef0afa6ab84b87d37be33b4e8dec97cdddf0fa8",
+      "mdx_line_range": [
+        14,
+        14
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 5,
+      "xhtml_xpath": "h2[2]",
+      "xhtml_fragment": "<h2><strong>DB Access Request</strong></h2>",
+      "mdx_content_hash": "2d8ce5012b539286d78a489a7731188b8729ab20f1956d49f8255d741031fdab",
+      "mdx_line_range": [
+        16,
+        194
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 6,
+      "xhtml_xpath": "table[2]",
+      "xhtml_fragment": "<table data-table-width=\"808\" data-layout=\"center\" ac:local-id=\"ee62ec7d-c9f6-4e28-b56e-747b6443c26d\"><colgroup><col style=\"width: 174.0px;\" /><col style=\"width: 174.0px;\" /><col style=\"width: 319.0px;\" /><col style=\"width: 137.0px;\" /></colgroup><tbody><tr><th><p><strong>변수명</strong></p></th><th><p><strong>변수</strong></p></th><th><p><strong>설명</strong></p></th><th><p><strong>추가 시점</strong></p></th></tr><tr><td><p>Expiration Date                  </p></td><td><p>{{expirationDate}}            </p></td><td><p>만료 일자</p></td><td><p>10.2.2</p><p>11.2.0 - Deprecated</p></td></tr><tr><td><p>Approval Expiration Date</p></td><td><p>{{approvalExpirationDate}}</p></td><td><p>승인 만료일자</p></td><td><p>11.2.0</p></td></tr><tr><td><p>Access Expiration Date</p></td><td><p>{{accessExpirationDate}}</p></td><td><p>권한 만료일자</p></td><td><p>11.2.0</p></td></tr><tr><td><p>Requested Privilege per Connection </p></td><td><p>{{connectionPrivilegeNames}}  </p></td><td><p>커넥션 별 요청된 Privilege를 목록으로 표시</p><ul><li><p>예:</p><ul><li><p>Connection A : Read/Write</p></li><li><p>Connection B : Read-Only</p></li></ul></li></ul></td><td><p>10.2.2</p></td></tr></tbody></table>",
+      "mdx_content_hash": "39fb89e782c7e0d5df9e520f270b1ee87a13467a52b955978374e1658bad4136",
+      "mdx_line_range": [
+        196,
+        196
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 7,
+      "xhtml_xpath": "h2[3]",
+      "xhtml_fragment": "<h2><strong>SQL Request</strong></h2>",
+      "mdx_content_hash": "aedbeb5ed742fbd5c0c254bae238e14495b7854705e00da5d40b4c7707e397d6",
+      "mdx_line_range": [
+        198,
+        281
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 8,
+      "xhtml_xpath": "table[3]",
+      "xhtml_fragment": "<table data-table-width=\"814\" data-layout=\"center\" ac:local-id=\"65178aed-8861-4dee-943a-42d33ce617bf\"><colgroup><col style=\"width: 176.0px;\" /><col style=\"width: 174.0px;\" /><col style=\"width: 316.0px;\" /><col style=\"width: 140.0px;\" /></colgroup><tbody><tr><th><p><strong>변수명</strong></p></th><th><p><strong>변수</strong></p></th><th><p><strong>설명</strong></p></th><th><p><strong>추가 시점</strong></p></th></tr><tr><td><p>SQL Text                  </p></td><td><p>{{sqlText}}              </p></td><td><p>SQL 구문</p><ul><li><p>최대 100자 (TEXT, FILE 동일)</p></li></ul></td><td><p>10.2.2</p></td></tr><tr><td><p>Content Type              </p></td><td><p>{{contentType}}          </p></td><td><p>SQL 구문 입력 방식</p><ul><li><p>TEXT 또는 FILE</p></li></ul></td><td><p>10.2.2</p></td></tr><tr><td><p>Cluster Group Uuid        </p></td><td><p>{{clusterGroupUuid}}     </p></td><td><p>DB 커넥션 UUID</p></td><td><p>10.2.2</p></td></tr><tr><td><p>Cluster Group Name        </p></td><td><p>{{clusterGroupName}}     </p></td><td><p>DB 커넥션 이름</p></td><td><p>10.2.2</p></td></tr><tr><td><p>Cluster Id                </p></td><td><p>{{clusterId}}            </p></td><td><p>DB 커넥션 ID</p></td><td><p>10.2.2</p></td></tr><tr><td><p>Database Type             </p></td><td><p>{{databaseType}}         </p></td><td><p>데이터베이스 유형</p></td><td><p>10.2.2</p></td></tr><tr><td><p>Database Name             </p></td><td><p>{{databaseName}}         </p></td><td><p>데이터베이스 이름</p></td><td><p>10.2.2</p></td></tr><tr><td><p>Use Ledger Approval Rule  </p></td><td><p>{{useLedgerApprovalRule}}</p></td><td><p>원장 승인 규칙 사용 여부</p></td><td><p>10.2.2</p></td></tr><tr><td><p>Target Date               </p></td><td><p>{{targetDate}}           </p></td><td><p>실행 목표 일자</p></td><td><p>10.2.2</p><p>11.2.0 - Deprecated</p></td></tr><tr><td><p>Preferred Execution Date</p></td><td><p>{{preferredExecutionDate}}</p></td><td><p>실행 목표 일자</p></td><td><p>11.2.0</p></td></tr><tr><td><p>Due Date                  </p></td><td><p>{{dueDate}}              </p></td><td><p>승인/실행 만료 일자</p></td><td><p>10.2.2</p><p>11.2.0 - Deprecated</p></td></tr><tr><td><p>Approval Expiration Date</p></td><td><p>{{approvalExpirationDate}}</p></td><td><p>승인 만료 일자</p></td><td><p>11.2.0</p></td></tr><tr><td><p>Execution Expiration Date</p></td><td><p>{{executionExpirationDate}}</p></td><td><p>실행 만료 일자</p></td><td><p>11.2.0</p></td></tr></tbody></table>",
+      "mdx_content_hash": "822a87df69e26952f9a5e0852156626be8b8d921a4da0dd32e7adf422a2be1c2",
+      "mdx_line_range": [
+        283,
+        283
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 9,
+      "xhtml_xpath": "h2[4]",
+      "xhtml_fragment": "<h2><strong>SQL Export Request</strong></h2>",
+      "mdx_content_hash": "554d8130320574b8de10b42f1b6c07413867c5d24fa39e314d6f755bc8198a5c",
+      "mdx_line_range": [
+        285,
+        494
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 10,
+      "xhtml_xpath": "table[4]",
+      "xhtml_fragment": "<table data-table-width=\"816\" data-layout=\"center\" ac:local-id=\"a7dabd97-8ea6-4502-b876-197d927dd1dc\"><colgroup><col style=\"width: 166.0px;\" /><col style=\"width: 166.0px;\" /><col style=\"width: 344.0px;\" /><col style=\"width: 137.0px;\" /></colgroup><tbody><tr><th><p><strong>변수명</strong></p></th><th><p><strong>변수</strong></p></th><th><p><strong>설명</strong></p></th><th><p><strong>추가 시점</strong></p></th></tr><tr><td><p>Cluster Group Uuid        </p></td><td><p>{{clusterGroupUuid}}     </p></td><td><p>DB 커넥션 UUID</p></td><td><p>10.2.2</p></td></tr><tr><td><p>Cluster Group Name        </p></td><td><p>{{clusterGroupName}}     </p></td><td><p>DB 커넥션 이름</p></td><td><p>10.2.2</p></td></tr><tr><td><p>Cluster Id                </p></td><td><p>{{clusterId}}            </p></td><td><p>DB 커넥션 ID</p></td><td><p>10.2.2</p></td></tr><tr><td><p>Database Type             </p></td><td><p>{{databaseType}}         </p></td><td><p>데이터베이스 유형</p></td><td><p>10.2.2</p></td></tr><tr><td><p>Database Name             </p></td><td><p>{{databaseName}}         </p></td><td><p>데이터베이스 이름</p></td><td><p>10.2.2</p></td></tr><tr><td><p>Export Type               </p></td><td><p>{{exportType}}           </p></td><td><p>내보내기 유형</p><ul><li><p>QUERY 또는 TABLE</p></li></ul></td><td><p>10.2.2</p></td></tr><tr><td><p>Export Detail             </p></td><td><p>{{exportDetail}}         </p></td><td><p>내보내기 세부 정보</p><ul><li><p>Query인 경우, 최대 100자의 쿼리</p></li><li><p>Table인 경우, 테이블 이름</p></li></ul></td><td><p>10.2.2</p></td></tr><tr><td><p>Target Date               </p></td><td><p>{{targetDate}}           </p></td><td><p>실행 목표 일자</p></td><td><p>10.2.2</p></td></tr><tr><td><p>Preferred Execution Date</p></td><td><p>{{preferredExecutionDate}}</p></td><td><p>실행 목표 일자</p></td><td><p>11.2.0</p></td></tr><tr><td><p>Due Date                  </p></td><td><p>{{dueDate}}              </p></td><td><p>승인/실행 만료 일자</p></td><td><p>10.2.2</p></td></tr><tr><td><p>Approval Expiration Date</p></td><td><p>{{approvalExpirationDate}}</p></td><td><p>승인 만료 일자</p></td><td><p>11.2.0</p></td></tr><tr><td><p>Execution Expiration Date</p></td><td><p>{{executionExpirationDate}}</p></td><td><p>실행 만료 일자</p></td><td><p>11.2.0</p></td></tr></tbody></table>",
+      "mdx_content_hash": "0d51c3faf0abee8e6e9ff9bd4bb0e2c1b5dbdfd207b37c5ecf6a5f18139b137d",
+      "mdx_line_range": [
+        496,
+        496
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 11,
+      "xhtml_xpath": "h2[5]",
+      "xhtml_fragment": "<h2><strong>Unmasking Request</strong></h2>",
+      "mdx_content_hash": "42a7928edb72f6fea7e0e40fd74a8b7d9fc072f90dcb979ea303652a1d25da0e",
+      "mdx_line_range": [
+        498,
+        692
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 12,
+      "xhtml_xpath": "table[5]",
+      "xhtml_fragment": "<table data-table-width=\"816\" data-layout=\"center\" ac:local-id=\"212dceed-34bd-42c0-9cab-7b11a24950af\"><colgroup><col style=\"width: 168.0px;\" /><col style=\"width: 168.0px;\" /><col style=\"width: 341.0px;\" /><col style=\"width: 135.0px;\" /></colgroup><tbody><tr><th><p><strong>변수명</strong></p></th><th><p><strong>변수</strong></p></th><th><p><strong>설명</strong></p></th><th><p><strong>추가 시점</strong></p></th></tr><tr><td><p>Cluster Group Uuid        </p></td><td><p>{{clusterGroupUuid}}     </p></td><td><p>DB 커넥션 UUID</p></td><td><p>10.2.2</p></td></tr><tr><td><p>Cluster Group Name        </p></td><td><p>{{clusterGroupName}}     </p></td><td><p>DB 커넥션 이름</p></td><td><p>10.2.2</p></td></tr><tr><td><p>Database Type             </p></td><td><p>{{databaseType}}         </p></td><td><p>데이터베이스 유형</p></td><td><p>10.2.2</p></td></tr><tr><td><p>Database Name             </p></td><td><p>{{databaseName}}         </p></td><td><p>데이터베이스 이름</p></td><td><p>10.2.2</p></td></tr><tr><td><p>Table Name                </p></td><td><p>{{tableName}}            </p></td><td><p>테이블 이름</p></td><td><p>10.2.2</p></td></tr><tr><td><p>Column Names              </p></td><td><p>{{columnNames}}          </p></td><td><p>컬럼 이름을 목록으로 표시</p><ul><li><p>예: [actor_id, first_name, last_name, last_update]</p></li></ul></td><td><p>10.2.2</p></td></tr><tr><td><p>Unmasking Expiration      </p></td><td><p>{{unmaskingExpiration}}  </p></td><td><p>마스킹 해제 만료 시점 </p><ul><li><p>예: </p><ul><li><p>10 Minutes</p></li><li><p>2024-12-03T14:59:00 </p></li></ul></li></ul></td><td><p>10.2.2</p></td></tr><tr><td><p>Approval Expiration Date</p></td><td><p>{{approvalExpirationDate}}</p></td><td><p>승인 만료 일자</p></td><td><p>11.2.0</p></td></tr></tbody></table>",
+      "mdx_content_hash": "4bd7a3e21f19bc7577cc9c40cbfaf0007987334f0186e588a9a99d98646dc4bd",
+      "mdx_line_range": [
+        694,
+        694
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 13,
+      "xhtml_xpath": "h2[6]",
+      "xhtml_fragment": "<h2><strong>Restricted Data Access Request</strong></h2>",
+      "mdx_content_hash": "f9fc5faac034f7afcf301ecbcd9c48baeff6f4c3f32cd822ad2288ab79536e07",
+      "mdx_line_range": [
+        696,
+        835
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 14,
+      "xhtml_xpath": "table[6]",
+      "xhtml_fragment": "<table data-table-width=\"816\" data-layout=\"center\" ac:local-id=\"8d66df32-3ad9-473e-9876-a4c7fe8775e1\"><colgroup><col style=\"width: 168.0px;\" /><col style=\"width: 168.0px;\" /><col style=\"width: 341.0px;\" /><col style=\"width: 135.0px;\" /></colgroup><tbody><tr><th><p><strong>변수명</strong></p></th><th><p><strong>변수</strong></p></th><th><p><strong>설명</strong></p></th><th><p><strong>추가 시점</strong></p></th></tr><tr><td><p>Cluster Group Uuid        </p></td><td><p>{{clusterGroupUuid}}     </p></td><td><p>DB 커넥션 UUID</p></td><td><p>11.0.0</p></td></tr><tr><td><p>Cluster Group Name        </p></td><td><p>{{clusterGroupName}}     </p></td><td><p>DB 커넥션 이름</p></td><td><p>11.0.0</p></td></tr><tr><td><p>Database Type             </p></td><td><p>{{databaseType}}         </p></td><td><p>데이터베이스 유형</p></td><td><p>11.0.0</p></td></tr><tr><td><p>Database Name             </p></td><td><p>{{databaseName}}         </p></td><td><p>데이터베이스 이름</p></td><td><p>11.0.0</p></td></tr><tr><td><p>Table Name                </p></td><td><p>{{tableName}}            </p></td><td><p>테이블 이름</p></td><td><p>11.0.0</p></td></tr><tr><td><p>Column Names              </p></td><td><p>{{columnNames}}          </p></td><td><p>컬럼 이름을 목록으로 표시</p><ul><li><p>예: [actor_id, first_name, last_name, last_update]</p></li></ul></td><td><p>11.0.0</p></td></tr><tr><td><p>Restricted Data Access Expiration</p></td><td><p>{{restrictedDataAccessExpiration}}  </p></td><td><p>접근 허용 만료 시점 </p><ul><li><p>예: </p><ul><li><p>10 Minutes</p></li><li><p>2024-12-03T14:59:00 </p></li></ul></li></ul></td><td><p>11.0.0</p></td></tr><tr><td><p>Approval Expiration Date</p></td><td><p>{{approvalExpirationDate}}</p></td><td><p>승인 만료 일자</p></td><td><p>11.2.0</p></td></tr></tbody></table>",
+      "mdx_content_hash": "79512c7f0563478ddc7192d828d8705c2a6b52dff249c54705d8d138ee21732f",
+      "mdx_line_range": [
+        837,
+        837
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 15,
+      "xhtml_xpath": "h2[7]",
+      "xhtml_fragment": "<h2><strong>DB Policy Exception Request</strong></h2>",
+      "mdx_content_hash": "719f9880c79c243ab7dca5f6c08f259fdfaf19509914a4b767cc4b4e7a1b8b21",
+      "mdx_line_range": [
+        839,
+        978
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 16,
+      "xhtml_xpath": "table[7]",
+      "xhtml_fragment": "<table data-table-width=\"816\" data-layout=\"center\" ac:local-id=\"8fdf1d5c-786c-4147-8e56-bfd6d8dcdb0f\"><colgroup><col style=\"width: 168.0px;\" /><col style=\"width: 168.0px;\" /><col style=\"width: 341.0px;\" /><col style=\"width: 135.0px;\" /></colgroup><tbody><tr><th><p><strong>변수명</strong></p></th><th><p><strong>변수</strong></p></th><th><p><strong>설명</strong></p></th><th><p><strong>추가 시점</strong></p></th></tr><tr><td><p>Cluster Group Uuid        </p></td><td><p>{{clusterGroupUuid}}     </p></td><td><p>DB 커넥션 UUID</p></td><td><p>11.0.0</p></td></tr><tr><td><p>Cluster Group Name        </p></td><td><p>{{clusterGroupName}}     </p></td><td><p>DB 커넥션 이름</p></td><td><p>11.0.0</p></td></tr><tr><td><p>Data Scope Type</p></td><td><p>{{dataScopeType}}</p></td><td><p>Data Path와 Tag중 하나를 선택</p></td><td><p>11.0.0</p></td></tr><tr><td><p>Database Type             </p></td><td><p>{{databaseType}}         </p></td><td><p>데이터베이스 유형</p></td><td><p>11.0.0</p></td></tr><tr><td><p>Database Name             </p></td><td><p>{{databaseName}}         </p></td><td><p>데이터베이스 이름</p></td><td><p>11.0.0</p></td></tr><tr><td><p>Table Name                </p></td><td><p>{{tableName}}            </p></td><td><p>테이블 이름</p></td><td><p>11.0.0</p></td></tr><tr><td><p>Column Names              </p></td><td><p>{{columnNames}}          </p></td><td><p>컬럼 이름을 목록으로 표시</p><ul><li><p>예: [actor_id, first_name, last_name, last_update]</p></li></ul></td><td><p>11.0.0</p></td></tr><tr><td><p>Expiration</p></td><td><p>{{expiration}}  </p></td><td><p>예외 허용 만료 시점 </p><ul><li><p>예: </p><ul><li><p>10 Minutes</p></li><li><p>2024-12-03T14:59:00 </p></li></ul></li></ul></td><td><p>11.0.0</p></td></tr><tr><td><p>Approval Expiration Date</p></td><td><p>{{approvalExpirationDate}}</p></td><td><p>승인 만료 일자</p></td><td><p>11.2.0</p></td></tr></tbody></table>",
+      "mdx_content_hash": "008e26d8ba8f953f43397f9d9bf35bce75ae0a080e69e3df617fa08f29d0a106",
+      "mdx_line_range": [
+        980,
+        980
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 17,
+      "xhtml_xpath": "h2[8]",
+      "xhtml_fragment": "<h2><strong>Server Access Request</strong></h2>",
+      "mdx_content_hash": "2989b4f4f7b3af4c6eeccd031094af2cdd120efc2fa91e88aa3a81e018355bc1",
+      "mdx_line_range": [
+        982,
+        1135
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 18,
+      "xhtml_xpath": "table[8]",
+      "xhtml_fragment": "<table data-table-width=\"820\" data-layout=\"center\" ac:local-id=\"a4480e83-0193-4c46-ba7c-53a665a6ad03\"><colgroup><col style=\"width: 170.0px;\" /><col style=\"width: 170.0px;\" /><col style=\"width: 345.0px;\" /><col style=\"width: 132.0px;\" /></colgroup><tbody><tr><th><p><strong>변수명</strong></p></th><th><p><strong>변수</strong></p></th><th><p><strong>설명</strong></p></th><th><p><strong>추가 시점</strong></p></th></tr><tr><td><p>Server Group Name         </p></td><td><p>{{serverGroupName}}      </p></td><td><p>서버 그룹 이름</p></td><td><p>10.2.2</p></td></tr><tr><td><p>Server Names              </p></td><td><p>{{serverNames}}          </p></td><td><p>서버 이름을 목록으로 표시</p><ul><li><p>예: </p><ul><li><p>Server A</p></li><li><p>Server B</p></li></ul></li></ul></td><td><p>10.2.2</p></td></tr><tr><td><p>Server Accounts           </p></td><td><p>{{serverAccounts}}       </p></td><td><p>서버 계정을 목록으로 표시</p><ul><li><p>예: </p><ul><li><p>dev</p></li><li><p>ec2-user</p></li></ul></li></ul></td><td><p>10.2.2</p></td></tr><tr><td><p>Expiration Date           </p></td><td><p>{{expirationDate}}       </p></td><td><p>만료 일자</p></td><td><p>10.2.2</p><p>11.2.0 - Deprecated</p></td></tr><tr><td><p>Approval Expiration Date</p></td><td><p>{{approvalExpirationDate}}</p></td><td><p>승인 만료 일자</p></td><td><p>11.2.0</p></td></tr><tr><td><p>Access Expiration Date</p></td><td><p>{{accessExpirationDate}}</p></td><td><p>권한 만료일자</p></td><td><p>11.2.0</p></td></tr><tr><td><p>Trigger Condition</p></td><td><p>{{triggerCondition}}</p></td><td><p>권한 부여 시작 조건</p></td><td><p>11.2.0</p></td></tr><tr><td><p>Duration</p></td><td><p>{{duration}}</p></td><td><p>분(Minutes) 단위 서버 접근 권한이 유효한 시간</p></td><td><p>11.2.0</p></td></tr></tbody></table>",
+      "mdx_content_hash": "9223b8b11c645c3d2e023bdbb4d6d30e013223586674bb9af2a4d1d190757280",
+      "mdx_line_range": [
+        1137,
+        1137
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 19,
+      "xhtml_xpath": "h2[9]",
+      "xhtml_fragment": "<h2><strong>Server Privilege Request</strong></h2>",
+      "mdx_content_hash": "c4dc12d79c0ddd66d2364ed4d3ea6b144456a6ed18261761ad170f0965d76fae",
+      "mdx_line_range": [
+        1139,
+        1281
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 20,
+      "xhtml_xpath": "table[9]",
+      "xhtml_fragment": "<table data-table-width=\"820\" data-layout=\"center\" ac:local-id=\"1ac8db57-f53b-4306-9a63-eabe504365d4\"><colgroup><col style=\"width: 170.0px;\" /><col style=\"width: 170.0px;\" /><col style=\"width: 345.0px;\" /><col style=\"width: 132.0px;\" /></colgroup><tbody><tr><th><p><strong>변수명</strong></p></th><th><p><strong>변수</strong></p></th><th><p><strong>설명</strong></p></th><th><p><strong>추가 시점</strong></p></th></tr><tr><td><p>Server Group Name         </p></td><td><p>{{serverGroupName}}      </p></td><td><p>서버 그룹 이름</p></td><td><p>10.2.2</p></td></tr><tr><td><p>Server Names              </p></td><td><p>{{serverNames}}          </p></td><td><p>서버 이름을 목록으로 표시</p><ul><li><p>예: </p><ul><li><p>Server A</p></li><li><p>Server B</p></li></ul></li></ul></td><td><p>10.2.2</p></td></tr><tr><td><p>Server Accounts           </p></td><td><p>{{serverAccounts}}       </p></td><td><p>서버 계정을 목록으로 표시</p><ul><li><p>예: </p><ul><li><p>dev</p></li><li><p>ec2-user</p></li></ul></li></ul></td><td><p>10.2.2</p></td></tr><tr><td><p>Expiration Date           </p></td><td><p>{{expirationDate}}       </p></td><td><p>만료 일자</p></td><td><p>10.2.2</p><p>11.2.0 - Deprecated</p></td></tr><tr><td><p>Approval Expiration Date</p></td><td><p>{{approvalExpirationDate}}</p></td><td><p>승인 만료 일자</p></td><td><p>11.2.0</p></td></tr><tr><td><p>Privilege Expiration Date</p></td><td><p>{{accessExpirationDate}}</p></td><td><p>권한 만료일자</p></td><td><p>11.2.0</p></td></tr><tr><td><p>Trigger Condition</p></td><td><p>{{triggerCondition}}</p></td><td><p>권한 부여 시작 조건</p></td><td><p>11.2.0</p></td></tr><tr><td><p>Duration</p></td><td><p>{{duration}}</p></td><td><p>분(Minutes) 단위 서버 특권이 유효한 시간</p></td><td><p>11.2.0</p></td></tr></tbody></table>",
+      "mdx_content_hash": "e84b3a050a806a123424bafda88ad81bc1d626ffa78f482e5db2110758e2116b",
+      "mdx_line_range": [
+        1283,
+        1283
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 21,
+      "xhtml_xpath": "h2[10]",
+      "xhtml_fragment": "<h2><strong>Access Role Request</strong></h2>",
+      "mdx_content_hash": "3c06e38484b00372160d5d417b36eda23818fc3b699e34ce8d16e4b1a4287372",
+      "mdx_line_range": [
+        1285,
+        1427
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 22,
+      "xhtml_xpath": "table[10]",
+      "xhtml_fragment": "<table data-table-width=\"816\" data-layout=\"center\" ac:local-id=\"e44f2beb-29c0-417c-b961-8a1b7946b510\"><colgroup><col style=\"width: 172.0px;\" /><col style=\"width: 172.0px;\" /><col style=\"width: 339.0px;\" /><col style=\"width: 130.0px;\" /></colgroup><tbody><tr><th><p><strong>변수명</strong></p></th><th><p><strong>변수</strong></p></th><th><p><strong>설명</strong></p></th><th><p><strong>추가 시점</strong></p></th></tr><tr><td><p>Service                   </p></td><td><p>{{service}}              </p></td><td><p>역할 요청 대상 서비스</p><ul><li><p>SAC, KAC, WAC</p></li></ul></td><td><p>10.2.2</p></td></tr><tr><td><p>Role Name                 </p></td><td><p>{{roleName}}             </p></td><td><p>역할 이름</p></td><td><p>10.2.2</p></td></tr><tr><td><p>Expiration Date           </p></td><td><p>{{expirationDate}}       </p></td><td><p>만료 일자</p></td><td><p>10.2.2</p><p>11.2.0 - Deprecated</p></td></tr><tr><td><p>Approval Expiration Date</p></td><td><p>{{approvalExpirationDate}}</p></td><td><p>승인 만료 일자</p></td><td><p>11.2.0</p></td></tr><tr><td><p>Role Expiration Date</p></td><td><p>{{roleExpirationDate}}</p></td><td><p>권한 만료 일자 </p></td><td><p>11.2.0</p></td></tr></tbody></table>",
+      "mdx_content_hash": "fb7a93d1634daa70e83a71ef207f912660cb2973cb1a8e61391374971b4ed95f",
+      "mdx_line_range": [
+        1429,
+        1429
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 23,
+      "xhtml_xpath": "h2[11]",
+      "xhtml_fragment": "<h2><strong>Web APP Just-In-Time Access Request</strong></h2>",
+      "mdx_content_hash": "66231157c145364b87a22e4d98b8e8a2342b6bca3801afec9dc3aa72dc038f3d",
+      "mdx_line_range": [
+        1431,
+        1526
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 24,
+      "xhtml_xpath": "table[11]",
+      "xhtml_fragment": "<table data-table-width=\"816\" data-layout=\"center\" ac:local-id=\"f2f9b44d-eaa3-4c0d-9471-fed198990f83\"><colgroup><col style=\"width: 172.0px;\" /><col style=\"width: 172.0px;\" /><col style=\"width: 339.0px;\" /><col style=\"width: 130.0px;\" /></colgroup><tbody><tr><th><p><strong>변수명</strong></p></th><th><p><strong>변수</strong></p></th><th><p><strong>설명</strong></p></th><th><p><strong>추가 시점</strong></p></th></tr><tr><td><p>Approval Expiration Date</p></td><td><p>{{approvalExpirationDate}}</p></td><td><p>승인 만료 일자</p></td><td><p>11.2.0</p></td></tr><tr><td><p>Web App Name</p></td><td><p>{{webAppName}}</p></td><td><p>요청 대상 웹앱</p></td><td><p>11.0.0</p></td></tr><tr><td><p>Access Duration</p></td><td><p>{{accessDuration}}             </p></td><td><p>분(Minutes) 단위 웹앱 접근 권한이 유효한 시간</p></td><td><p>11.0.0</p></td></tr></tbody></table>",
+      "mdx_content_hash": "755fd23d35642c65459c213f492413cdd9e79f4b300799bc4d1b58cbd1b7af96",
+      "mdx_line_range": [
+        1528,
+        1528
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 25,
+      "xhtml_xpath": "h2[12]",
+      "xhtml_fragment": "<h2><strong>IP Registration Request</strong></h2>",
+      "mdx_content_hash": "3f3bcc63e221688c10791b381444ca454c57f6509e10ad54cc0e3cce4854abb8",
+      "mdx_line_range": [
+        1530,
+        1534
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 26,
+      "xhtml_xpath": "table[12]",
+      "xhtml_fragment": "<table data-table-width=\"816\" data-layout=\"center\" ac:local-id=\"c1a404fa-905f-4b0c-9613-f8439a2e702e\"><colgroup><col style=\"width: 172.0px;\" /><col style=\"width: 172.0px;\" /><col style=\"width: 339.0px;\" /><col style=\"width: 130.0px;\" /></colgroup><tbody><tr><th><p><strong>변수명</strong></p></th><th><p><strong>변수</strong></p></th><th><p><strong>설명</strong></p></th><th><p><strong>추가 시점</strong></p></th></tr><tr><td><p>Approval Expiration Date</p></td><td><p>{{approvalExpirationDate}}</p></td><td><p>승인 만료 일자</p></td><td><p>11.2.0</p></td></tr><tr><td><p>IP Addresses                </p></td><td><p>{{ipAddresses}}             </p></td><td><p>IP 주소 </p></td><td><p>11.0.0</p></td></tr></tbody></table>",
+      "mdx_content_hash": "98556346fcd2d5d3e9f5f0300b27fa970927f06506ad7b2fcd2c837f008d3c66",
+      "mdx_line_range": [
+        1536,
+        1536
+      ],
+      "lost_info": {}
+    }
+  ],
+  "separators": [
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ],
+  "document_envelope": {
+    "prefix": "",
+    "suffix": ""
+  }
+}

--- a/confluence-mdx/tests/testcases/880181257/expected.roundtrip.json
+++ b/confluence-mdx/tests/testcases/880181257/expected.roundtrip.json
@@ -1,0 +1,121 @@
+{
+  "schema_version": "2",
+  "page_id": "880181257",
+  "mdx_sha256": "f59e03cb11065fd22f8bda66c4b12e950d4dc08799c5f2911609a865a0fec448",
+  "source_xhtml_sha256": "dd6df6dbfae4e50c7b53823a9bbfbc3d1bc4119240c4155d9c4b3a276a28e3b9",
+  "blocks": [
+    {
+      "block_index": 0,
+      "xhtml_xpath": "macro-toc[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"toc\" ac:schema-version=\"1\" data-layout=\"default\" ac:local-id=\"c35fc44e-3eda-46fb-9e57-b7b45c4a80ce\" ac:macro-id=\"5f9d6351-54a9-4524-86ca-acd73b79bfad\"><ac:parameter ac:name=\"minLevel\">2</ac:parameter><ac:parameter ac:name=\"maxLevel\">6</ac:parameter><ac:parameter ac:name=\"outline\">false</ac:parameter><ac:parameter ac:name=\"style\">none</ac:parameter><ac:parameter ac:name=\"type\">list</ac:parameter><ac:parameter ac:name=\"printable\">true</ac:parameter></ac:structured-macro>",
+      "mdx_content_hash": "04a48ffb03fc28e39a3bd3e970233c73282a315f96d74465ef81a43644e9bd03",
+      "mdx_line_range": [
+        8,
+        8
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 1,
+      "xhtml_xpath": "h3[1]",
+      "xhtml_fragment": "<h3>Custom Data Source 접근 요청</h3>",
+      "mdx_content_hash": "fb6d83cb72873c4f92680266e53e2e80a2c0d5af77b8cd8d944416976386bd88",
+      "mdx_line_range": [
+        10,
+        10
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 2,
+      "xhtml_xpath": "ol[1]",
+      "xhtml_fragment": "<ol start=\"1\"><li><p>사용자 화면 상단 Workflow 메뉴로 이동합니다.</p></li><li><p>좌측 상단 <code>Submit Request</code> 버튼 클릭후 DB Access Request 항목을 선택합니다.</p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"766\" ac:original-width=\"1512\" ac:custom-width=\"true\" ac:width=\"712\"><ri:attachment ri:filename=\"Screenshot 2025-03-06 at 1.19.24 PM.png\" ri:version-at-save=\"1\" /></ac:image><p /></li><li><p>Approval Rule을 상황에 맞게 설정하고 Title도 작성합니다.</p></li><li><p>DB Connection 목록에서 Type이 'Custom Data Source'인 항목을 선택합니다.</p></li><li><p>다른 벤더들과 다르게 Privilege를 선택할 수 없기 때문에 &ldquo;-&rdquo;로 표기됩니다. </p></li><li><p>Expiration Date과 Reason for Request 항목도 상황에 맞게 설정 및 작성합니다.</p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"763\" ac:original-width=\"1512\" ac:custom-width=\"true\" ac:width=\"712\"><ri:attachment ri:filename=\"Screenshot 2025-03-06 at 1.22.28 PM.png\" ri:version-at-save=\"1\" /></ac:image><p /></li><li><p>작성을 완료했다면 하단 <code>Submit</code>버튼을 클릭하여 신청을 완료합니다.  </p></li><li><p>관리자의 승인을 받았다면 좌측 Workflow &gt; Sent Request &gt; Done 메뉴에서 확인할 수 있습니다.</p></li></ol>",
+      "mdx_content_hash": "fbd76f993e38760f942cbe410a4785a89f728cb052b51852e4aab75389e024e2",
+      "mdx_line_range": [
+        12,
+        25
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 3,
+      "xhtml_xpath": "macro-note[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"note\" ac:schema-version=\"1\" ac:macro-id=\"49e266fd-3fe8-41c2-a65b-1892fa504004\"><ac:rich-text-body><p><strong>Custom Data Source Type 외 다중 요청 시 주의사항</strong></p><ul><li><p>Custom Data Source와 다른 벤더를 함께 선택하는 경우 권한 타입이 다르기 때문에 일괄적으로 선택할 수 없습니다. </p></li><li><p>이 경우 다음 메시지가 표시됩니다: &quot;Privileges cannot be applied across different types at once (e.g., General, Redis, Custom Data Source). Please assign privileges separately for each connection.&quot;</p></li><li><p>같은 권한 타입의 커넥션끼리는 일괄 적용이 가능합니다.</p></li></ul></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "1ba8ee5f4cf5845eb083224457553015eeaa0363d016960afb5beeda6114d42b",
+      "mdx_line_range": [
+        27,
+        28
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 4,
+      "xhtml_xpath": "h3[2]",
+      "xhtml_fragment": "<h3><br />Agent를 통한 접속</h3>",
+      "mdx_content_hash": "c029179610d1846a928e83c22234b3b97c066757d72f7c4c5df9d8f0d09c0092",
+      "mdx_line_range": [
+        29,
+        31
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 5,
+      "xhtml_xpath": "ol[2]",
+      "xhtml_fragment": "<ol start=\"1\"><li><p><strong>QueryPie Agent 실행</strong></p><ul><li><p>QueryPie Agent를 실행합니다.</p></li><li><p>Database 항목에서 Custom Data Source를 확인할 수 있습니다.</p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"550\" ac:original-width=\"400\" ac:custom-width=\"true\" ac:width=\"400\"><ri:attachment ri:filename=\"Screenshot 2025-03-06 at 2.05.26 PM.png\" ri:version-at-save=\"1\" /></ac:image><p /></li></ul></li><li><p><strong>Connection Guide 확인</strong></p><ul><li><p>Agent에서 Custom Data Source 커넥션 행을 클릭하면 Port 정보를 담은 행이 보입니다.</p></li><li><p>위 행을 우클릭을 한뒤 Connection Guide를 클릭하면 접속 정보를 확인할 수 있습니다.</p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"453\" ac:original-width=\"903\" ac:custom-width=\"true\" ac:width=\"712\"><ri:attachment ri:filename=\"Screenshot 2025-03-06 at 2.08.11 PM.png\" ri:version-at-save=\"1\" /></ac:image><p /></li><li><p>UID/PW는 수정할 수 없는 db username, db password로 표시됩니다.</p></li><li><p>Privileges는 &quot;-&quot;로 표시됩니다.</p></li></ul></li><li><p><strong>SQL Tool에서 접속</strong></p><ul><li><p>DataGrip이나 기타 SQL Tool을 실행합니다.</p></li><li><p><strong>Host와 Port는 Connection Guide에 명시되어있는 정보를 입력해야합니다.</strong> </p></li><li><p>벤더에 따라 추가 정보를 입력합니다.</p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"680\" ac:original-width=\"800\" ac:custom-width=\"true\" ac:width=\"712\"><ri:attachment ri:filename=\"Screenshot 2025-03-06 at 2.18.26 PM.png\" ri:version-at-save=\"1\" /></ac:image></li></ul></li></ol>",
+      "mdx_content_hash": "b2da7f53a98160f9a467e89f4f04afbd6efa6caff1e00b4a072e5fd65d238800",
+      "mdx_line_range": [
+        32,
+        32
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 6,
+      "xhtml_xpath": "macro-note[2]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"note\" ac:schema-version=\"1\" ac:macro-id=\"4de93d75-70f3-4361-aa97-fca387cd343e\"><ac:rich-text-body><p><strong>주의사항</strong></p><ul><li><p>관리자가 설정한 접근 가능 시간 외에 접속 시도 시 에러 메시지가 표시됩니다.</p></li></ul></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "d779405b6eb61234155c19fbab3df9bca589fa616876275efc3cb635621dda94",
+      "mdx_line_range": [
+        34,
+        34
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 7,
+      "xhtml_xpath": "h3[3]",
+      "xhtml_fragment": "<h3>웹으로 접속 시도하는 경우</h3>",
+      "mdx_content_hash": "f398294a4e0071259a143393f74841734947758f62a817cd00f41cbefc5fb3cd",
+      "mdx_line_range": [
+        36,
+        56
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 8,
+      "xhtml_xpath": "ol[3]",
+      "xhtml_fragment": "<ol start=\"1\"><li><p><strong>웹 커넥션 목록 확인</strong></p><ul><li><p>사용자 화면 상단 Databases를 클릭합니다. </p></li><li><p>좌측 커넥션 목록에서 QueryPie Connections를 클릭하면 접근 권한이 있는 Custom Data Source가 표시됩니다.</p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"768\" ac:original-width=\"1512\" ac:custom-width=\"true\" ac:width=\"712\"><ri:attachment ri:filename=\"Screenshot 2025-03-06 at 2.22.22 PM.png\" ri:version-at-save=\"1\" /></ac:image><p /></li></ul></li><li><p><strong>접속 불가 안내</strong></p><ul><li><p>Custom Data Source 선택 시 Connect 버튼이 비활성화됩니다.</p></li><li><p>아래와 같은 툴팁이 표시되며 웹으로는 접속이 불가합니다. </p><p>&quot;Access is only possible through a proxy and cannot be accessed through the web. Please open the QueryPie Agent to connect to the Custom Data Source.&quot;</p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"763\" ac:original-width=\"1512\" ac:custom-width=\"true\" ac:width=\"712\"><ri:attachment ri:filename=\"Screenshot 2025-03-06 at 2.23.37 PM.png\" ri:version-at-save=\"1\" /></ac:image></li></ul></li></ol>",
+      "mdx_content_hash": "b963f89c94977df2c1ab1002bd67b98b739c61d0248249943a13253d21653ccc",
+      "mdx_line_range": [
+        58,
+        59
+      ],
+      "lost_info": {}
+    }
+  ],
+  "separators": [
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ],
+  "document_envelope": {
+    "prefix": "",
+    "suffix": ""
+  }
+}

--- a/confluence-mdx/tests/testcases/883654669/expected.roundtrip.json
+++ b/confluence-mdx/tests/testcases/883654669/expected.roundtrip.json
@@ -1,0 +1,349 @@
+{
+  "schema_version": "2",
+  "page_id": "883654669",
+  "mdx_sha256": "b6cd1b24182d0e47cb829ea9f47bfa91318d61481fdaa363cf5d749afb8877ad",
+  "source_xhtml_sha256": "4c79226b0a847e7cc4faf0b39127a7b02510347c4653b0e18129de8c59e7e1f7",
+  "blocks": [
+    {
+      "block_index": 0,
+      "xhtml_xpath": "h2[1]",
+      "xhtml_fragment": "<h2>Overview</h2>",
+      "mdx_content_hash": "7f00734464afa1e733ede2700ec8ab989d1ab1ef25ea9405efcc994af75c5563",
+      "mdx_line_range": [
+        8,
+        8
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 1,
+      "xhtml_xpath": "p[1]",
+      "xhtml_fragment": "<p>Slack App을 QueryPie에 연동하고, QueryPie로부터 Direct Message 알림을 수신할 수 있습니다.</p>",
+      "mdx_content_hash": "570f2c848432064a0ee7873e13333c111c0aeb41d4a26775907e952b18104d92",
+      "mdx_line_range": [
+        10,
+        10
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 2,
+      "xhtml_xpath": "macro-info[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\" ac:macro-id=\"44cc9f0c-9c85-4681-b6ed-75010e6450ce\"><ac:rich-text-body><p>본 문서는 <strong>10.2.6 또는 그 이상의 버전</strong>에 적용됩니다.</p><p>10.2.5 또는 그 이하 버전의 Slack 연동 방법은 <a href=\"https://docs.querypie.com/ko/querypie-manual/10.1.0/workflow-configurations\">10.1.0 버전 매뉴얼 문서</a>를 참고해주세요.</p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "ae656c620004a1e8c13e41042eb55264edf1b3f08ca6b244046b575a5f33c803",
+      "mdx_line_range": [
+        12,
+        12
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 3,
+      "xhtml_xpath": "macro-toc[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"toc\" ac:schema-version=\"1\" data-layout=\"default\" ac:local-id=\"c3d00c63-12a9-4498-b3e2-1f6e7e91066f\" ac:macro-id=\"20a50dd1-17d2-461f-b2d3-cf8e141d0c23\"><ac:parameter ac:name=\"minLevel\">1</ac:parameter><ac:parameter ac:name=\"maxLevel\">2</ac:parameter><ac:parameter ac:name=\"outline\">false</ac:parameter><ac:parameter ac:name=\"style\">disc</ac:parameter><ac:parameter ac:name=\"exclude\">Overview</ac:parameter><ac:parameter ac:name=\"type\">list</ac:parameter><ac:parameter ac:name=\"printable\">true</ac:parameter></ac:structured-macro>",
+      "mdx_content_hash": "c031e1e61730bc9eef8cc10ddffd7ae163717590484ef20f12047c2bb015186c",
+      "mdx_line_range": [
+        14,
+        16
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 4,
+      "xhtml_xpath": "h3[1]",
+      "xhtml_fragment": "<h3>구성 시 사전에 필요한 권한</h3>",
+      "mdx_content_hash": "b2da7f53a98160f9a467e89f4f04afbd6efa6caff1e00b4a072e5fd65d238800",
+      "mdx_line_range": [
+        17,
+        17
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 5,
+      "xhtml_xpath": "ul[1]",
+      "xhtml_fragment": "<ul><li><p>Slack Workspace 관리자 권한 계정 (Slack Workspace에 App을 설치하기 위해 필요)</p></li><li><p>QueryPie Owner 및 Approval Admin 권한 계정</p></li></ul>",
+      "mdx_content_hash": "58afb7d68f8b0be96b6ae3663a0d6dae16de164e3a44c8b0c748cf562ddcd785",
+      "mdx_line_range": [
+        19,
+        19
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 6,
+      "xhtml_xpath": "h2[2]",
+      "xhtml_fragment": "<h2>Slack API 에서 DM App 생성 (via Manifest Files)</h2>",
+      "mdx_content_hash": "5fa1fc290e267a09309aad5d7a5dcd1dbc5add6703b1213e1f533eb076865c30",
+      "mdx_line_range": [
+        21,
+        22
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 7,
+      "xhtml_xpath": "p[2]",
+      "xhtml_fragment": "<p>App Manifest를 이용하여 QueryPie DM 연동 전용 Slack App을 생성합니다.</p>",
+      "mdx_content_hash": "4805854df9c692d254d293348a05c1adf05688142363ec9b920e2f9d340b99d2",
+      "mdx_line_range": [
+        24,
+        24
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 8,
+      "xhtml_xpath": "p[3]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "66cda2d5d8e09408bed3c6086a6b12699e2ff671b129ddbf34823a2d93a9e62c",
+      "mdx_line_range": [
+        26,
+        26
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 9,
+      "xhtml_xpath": "ol[1]",
+      "xhtml_fragment": "<ol start=\"1\"><li><p><a href=\"https://api.slack.com/apps\">https://api.slack.com/apps</a> 으로 이동하여 <code>Create an App</code> 을 클릭합니다.<br /></p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"1203\" ac:original-width=\"2317\" ac:custom-width=\"true\" ac:width=\"760\"><ri:attachment ri:filename=\"image-20231227-065658.png\" ri:version-at-save=\"1\" /><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image><p /></li><li><p>Create an app 모달에서, App 생성 방식을 선택합니다. <code>From a manifest</code> 를 클릭합니다.<br /></p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"507\" ac:original-width=\"712\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2025-02-18 오후 1.17.25.png\" ac:width=\"712\"><ri:attachment ri:filename=\"스크린샷 2025-02-18 오후 1.17.25.png\" ri:version-at-save=\"1\" /><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image><p /></li><li><p>Pick a workspace 모달에서 QueryPie와 연동할 Slack Workspace를 선택한 뒤 다음 단계로 진행합니다.<br /></p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"443\" ac:original-width=\"707\" ac:custom-width=\"true\" ac:width=\"710\"><ri:attachment ri:filename=\"image-20231227-065951.png\" ri:version-at-save=\"1\" /></ac:image><p /></li><li><p>Create app from manifest 모달에서 JSON 형식의 App Manifest를 입력합니다. <br />미리 채워져 있는 내용들을 삭제하고 아래의 App Manifest를 붙여넣은 뒤 다음 단계로 진행합니다.<br /><ac:emoticon ac:name=\"light-on\" ac:emoji-shortname=\":light_bulb_on:\" ac:emoji-id=\"atlassian-light_bulb_on\" ac:emoji-fallback=\":light_bulb_on:\" /><span style=\"background-color: rgb(254,222,200);\"> </span><code>{{..}}</code><span style=\"background-color: rgb(254,222,200);\">  안의 값은 원하는 값으로 변경해 주세요.</span></p><ac:structured-macro ac:name=\"code\" ac:schema-version=\"1\" ac:macro-id=\"7431661e-8f16-40dd-8edf-84e7b117492f\"><ac:plain-text-body><![CDATA[{\n    \"display_information\": {\n        \"name\": \"{{name}}\"\n    },\n    \"features\": {\n        \"bot_user\": {\n            \"display_name\": \"{{display_name}}\",\n            \"always_online\": false\n        }\n    },\n    \"oauth_config\": {\n        \"scopes\": {\n            \"bot\": [\n                \"chat:write\",\n                \"users:read.email\",\n                \"users:read\"\n            ]\n        }\n    },\n    \"settings\": {\n        \"interactivity\": {\n            \"is_enabled\": true\n        },\n        \"org_deploy_enabled\": false,\n        \"socket_mode_enabled\": true,\n        \"token_rotation_enabled\": false\n    }\n}]]></ac:plain-text-body></ac:structured-macro><p /></li><li><p>설정 내용을 검토하고 <code>Create</code> 버튼을 클릭하여 App 생성을 완료합니다.<br /></p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"375\" ac:original-width=\"574\" ac:custom-width=\"true\" ac:alt=\"image-20240115-220447.png\" ac:width=\"763\"><ri:attachment ri:filename=\"image-20240115-220447.png\" ri:version-at-save=\"1\" /></ac:image><p /></li></ol>",
+      "mdx_content_hash": "df85b7a07457310df66d00923a0b2b5a14898023f7f4db36b14cc072b320ad3c",
+      "mdx_line_range": [
+        29,
+        75
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 10,
+      "xhtml_xpath": "h2[3]",
+      "xhtml_fragment": "<h2>Slack Workspace에 Slack App 설치</h2>",
+      "mdx_content_hash": "553573c9b38cc87e9063c541b880b98aa79d1d31ab2adc4fc3547dbc7f29dcfa",
+      "mdx_line_range": [
+        77,
+        77
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 11,
+      "xhtml_xpath": "ol[2]",
+      "xhtml_fragment": "<ol start=\"1\"><li><p>Settings &gt; Install App에서 <code>Install to Workspace</code> 버튼을 클릭하여 생성된 앱을 Slack Workspace에 설치합니다. </p></li><li><p>권한 요청 페이지에서, <code>허용</code>을 클릭합니다.</p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"1203\" ac:original-width=\"1720\" ac:custom-width=\"true\" ac:alt=\"image-20240115-221520.png\" ac:width=\"760\"><ri:attachment ri:filename=\"image-20240115-221520.png\" ri:version-at-save=\"1\" /><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image><p /></li><li><p>설정한 Slack Workspace에서 Slack DM 전용 App이 생성된 것을 확인할 수 있습니다.</p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"991\" ac:original-width=\"1624\" ac:custom-width=\"true\" ac:alt=\"image-20240115-221618.png\" ac:width=\"760\"><ri:attachment ri:filename=\"image-20240115-221618.png\" ri:version-at-save=\"1\" /></ac:image></li></ol>",
+      "mdx_content_hash": "aee0222a26c15ef8ba487c8548b5c25387c5c59a006e7b46dacfc5fb9010ff8e",
+      "mdx_line_range": [
+        79,
+        87
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 12,
+      "xhtml_xpath": "h2[4]",
+      "xhtml_fragment": "<h2>Bot User OAuth Token 획득</h2>",
+      "mdx_content_hash": "dbef7ac3abe33621575a92e5b13bde7b81f17c985e8f3201942007450cd3a5d6",
+      "mdx_line_range": [
+        89,
+        89
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 13,
+      "xhtml_xpath": "p[4]",
+      "xhtml_fragment": "<p>Features &gt; OAuth &amp; Permissions 메뉴 내 OAuth Tokens for Your Workspace 섹션에서, <strong>Bot User OAuth Token</strong> 을 복사하여 기록해 둡니다.</p>",
+      "mdx_content_hash": "e98671894b7a9062db86c358a801f31d675f46a691727a7810e1a24f8c2a0761",
+      "mdx_line_range": [
+        91,
+        91
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 14,
+      "xhtml_xpath": "ac:image[1]",
+      "xhtml_fragment": "<ac:image ac:align=\"center\" ac:layout=\"wide\" ac:original-height=\"1526\" ac:original-width=\"3024\" ac:custom-width=\"true\" ac:alt=\"image-20240418-022640.png\" ac:width=\"764\"><ri:attachment ri:filename=\"image-20240418-022640.png\" ri:version-at-save=\"1\" /><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image>",
+      "mdx_content_hash": "f4b8d4196ae15037c802a4c261f0af27a8fe82d8f20e622568036a27c2d23764",
+      "mdx_line_range": [
+        93,
+        95
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 15,
+      "xhtml_xpath": "p[5]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "33ac8ae13d0e19f13da556b9e70141f072d66fe9d6245c1a84bfe0e1eccfca8c",
+      "mdx_line_range": [
+        98,
+        98
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 16,
+      "xhtml_xpath": "h2[5]",
+      "xhtml_fragment": "<h2>App-Level Token 생성</h2>",
+      "mdx_content_hash": "51a0e2d2b566b71152c7fa3039fe872b697df5692b39dc15a91f80f8171f0df9",
+      "mdx_line_range": [
+        100,
+        101
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 17,
+      "xhtml_xpath": "macro-info[2]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\" ac:macro-id=\"63581712-0376-4c4c-96cb-846de5153704\"><ac:rich-text-body><p>App manifest로 Slack app을 생성할 때 Socket Mode와 관련 권한들을 활성화할 수는 있지만, App Level Token(xapp-)은 자동으로 생성되지 않습니다.</p><ul><li><p>App Level Token은 보안 자격 증명(security credential)이기 때문에 manifest로 자동 생성/노출되면 보안상 위험</p></li><li><p>App manifest는 앱의 구성(configuration)만 정의하고, 실제 인증 토큰들은 별도로 생성/관리됨</p></li></ul></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "8695548e368da16917ff6881b8a8ec4df3247f6f32568633832b36526b191f13",
+      "mdx_line_range": [
+        102,
+        103
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 18,
+      "xhtml_xpath": "p[6]",
+      "xhtml_fragment": "<p>다음 단계를 수행하여 App-Level Token을 수동으로 생성합니다.</p>",
+      "mdx_content_hash": "b2da7f53a98160f9a467e89f4f04afbd6efa6caff1e00b4a072e5fd65d238800",
+      "mdx_line_range": [
+        104,
+        104
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 19,
+      "xhtml_xpath": "ol[3]",
+      "xhtml_fragment": "<ol start=\"1\"><li><p>앱 설정 페이지의 Settings &gt; Basic Information 메뉴의 App-Level Tokens 섹션으로 이동하고, <code>Generate Token and Scope</code> 버튼을 클릭합니다.<br /></p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"794\" ac:original-width=\"1169\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2025-02-18 오후 2.09.51.png\" ac:width=\"736\"><ri:attachment ri:filename=\"스크린샷 2025-02-18 오후 2.09.51.png\" ri:version-at-save=\"1\" /><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image><p /></li><li><p>Generate an app-level token 모달에서, Add Scope 버튼을 클릭한 뒤 <code>connections:write</code> 를 추가합니다.<br /></p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"756\" ac:original-width=\"804\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2025-02-18 오후 2.15.55.png\" ac:width=\"736\"><ri:attachment ri:filename=\"스크린샷 2025-02-18 오후 2.15.55.png\" ri:version-at-save=\"1\" /><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image><p /></li><li><p>생성된 App-Level Token 모달에서, 앱 토큰을 복사하여 따로 기록해 둡니다. App-Level Token은 <code>xapp-</code> 으로 시작합니다.</p></li></ol>",
+      "mdx_content_hash": "7cc27a38eb55cb685676a3308bf7afdc8da2ef1c03f6f1bcc22e7908658030d1",
+      "mdx_line_range": [
+        106,
+        106
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 20,
+      "xhtml_xpath": "h2[6]",
+      "xhtml_fragment": "<h2>QueryPie에서 Slack DM 설정하기</h2>",
+      "mdx_content_hash": "2b883f1409fd769ef5156146f04bb8b30abee0971e1e77f569b7f895a5563d7c",
+      "mdx_line_range": [
+        108,
+        116
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 21,
+      "xhtml_xpath": "ol[4]",
+      "xhtml_fragment": "<ol start=\"1\"><li><p>Admin &gt; General &gt; System &gt; Integrations &gt; Slack 메뉴로 진입한 뒤, <code>Configure</code> 버튼을 클릭하여 설정 모달을 엽니다.<br /></p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"822\" ac:original-width=\"1272\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2025-03-10 오전 11.35.09.png\" ac:width=\"736\"><ri:attachment ri:filename=\"스크린샷 2025-03-10 오전 11.35.09.png\" ri:version-at-save=\"1\" /><ac:caption><p>Administrator &gt; General &gt; System &gt; Integrations &gt; Slack &gt; Create a New Slack Configuration</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image><p /></li><li><p>설정 모달에 아까 기록해둔 App Token과 Bot User OAuth Token을 입력합니다.</p></li><li><p>추가 설정 값은 다음과 같습니다. DM으로 Workflow 알림을 받고 메시지 안에서 승인/거절을 수행하려면 모든 설정 토글을 활성화 합니다.</p><ul><li><p><strong>Send Workflow Notification via Slack DM</strong> : 워크플로우 요청에 대한 Slack DM 전송 활성화</p></li><li><p><strong>Allow Users to approve or reject on Slack DM</strong> : Slack DM 내에서 승인 또는 거절 기능 활성화<br /></p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"300\" ac:original-width=\"480\" ac:custom-width=\"true\" ac:width=\"760\"><ri:attachment ri:filename=\"image-20231003-054240.png\" ri:version-at-save=\"1\" /><ac:caption><p>액션 허용타입 예시 (좌) / 액션 비허용 타입 예시 (우)</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image><p /></li></ul></li><li><p><code>Save</code> 버튼을 누르고 설정을 완료합니다.</p></li></ol>",
+      "mdx_content_hash": "4e48187bbc477a4a3b715bcdc7efe66b1ca5f870ce4d7f9cb8cfd8b2cfbb0531",
+      "mdx_line_range": [
+        118,
+        118
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 22,
+      "xhtml_xpath": "h2[7]",
+      "xhtml_fragment": "<h2>Slack DM 설정 관리하기</h2>",
+      "mdx_content_hash": "587d3030da4fb8d35621e4b14221a4b6409b646157cb221c6396d125fe4ddfd9",
+      "mdx_line_range": [
+        120,
+        137
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 23,
+      "xhtml_xpath": "ol[5]",
+      "xhtml_fragment": "<ol start=\"1\"><li><p>Slack Configuration을 등록한 뒤, 현재 설정 상태를 화면에서 확인할 수 있습니다.<br /></p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"822\" ac:original-width=\"1272\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2025-03-10 오전 11.39.50.png\" ac:width=\"736\"><ri:attachment ri:filename=\"스크린샷 2025-03-10 오전 11.39.50.png\" ri:version-at-save=\"1\" /><ac:caption><p>Administrator &gt; General &gt; System &gt; Integrations &gt; Slack</p></ac:caption><ac:adf-mark key=\"border\" size=\"1\" color=\"#091e4224\" /></ac:image><p /></li><li><p><code>Edit</code> 버튼을 클릭하여 입력한 설정을 변경할 수 있습니다.<br /></p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"817\" ac:original-width=\"1260\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2025-02-18 오후 3.28.40.png\" ac:width=\"736\"><ri:attachment ri:filename=\"스크린샷 2025-02-18 오후 3.28.40.png\" ri:version-at-save=\"1\" /><ac:caption><p>Administrator &gt; General &gt; System &gt; Integrations &gt; Slack &gt; Edit the Slack Configuration</p></ac:caption><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image></li></ol>",
+      "mdx_content_hash": "e659d0fda999a5f1b1bff133e6467d6b66c12424663eeceb33003cd0769cb3a8",
+      "mdx_line_range": [
+        139,
+        139
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 24,
+      "xhtml_xpath": "p[7]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "fa1cda765441760f45e67802ad87eb2e6ce5d363a23e4f899a7b24d90f02ca25",
+      "mdx_line_range": [
+        141,
+        154
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 25,
+      "xhtml_xpath": "h2[8]",
+      "xhtml_fragment": "<h2>Workflow 요청 시 Slack DM 테스트</h2>",
+      "mdx_content_hash": "b2ea56a763a96abb99985fa79dcc28626a18c28734a35beb3560f5e697a9fc84",
+      "mdx_line_range": [
+        157,
+        157
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 26,
+      "xhtml_xpath": "p[8]",
+      "xhtml_fragment": "<p>DB Access Request를 예시로, Slack DM 기능이 정상적으로 작동하는지 테스트를 수행합니다.</p>",
+      "mdx_content_hash": "34bf7b6e75e07c47de7c2333948e227cf6f757e43389d4f113896ce7dd5bb35b",
+      "mdx_line_range": [
+        159,
+        159
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 27,
+      "xhtml_xpath": "ol[6]",
+      "xhtml_fragment": "<ol start=\"1\"><li><p>QueryPie User &gt; Workflow 페이지에서 Submit Request 버튼을 클릭한 뒤, DB Access Request를 선택하여 요청 작성 화면으로 진입합니다. 요청 작성 화면에서 필요한 정보를 입력하고, 요청을 상신합니다.</p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"817\" ac:original-width=\"1260\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2025-02-18 오후 3.15.04.png\" ac:width=\"736\"><ri:attachment ri:filename=\"스크린샷 2025-02-18 오후 3.15.04.png\" ri:version-at-save=\"1\" /><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image><p /></li><li><p>승인자는 앞에서 추가한 Slack App과의 DM으로 승인해야 할 요청 알림을 수신할 수 있습니다.<br /><strong>Allow Users to approve or reject on Slack DM</strong> 설정이 켜져 있으므로, DM에서 직접 사유를 입력하고 요청을 승인 또는 거절할 수 있습니다.<br /></p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"354\" ac:original-width=\"701\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2025-02-18 오후 3.22.38.png\" ac:width=\"701\"><ri:attachment ri:filename=\"스크린샷 2025-02-18 오후 3.22.38.png\" ri:version-at-save=\"1\" /></ac:image><p /></li><li><p>DM에서 <code>Details</code> 버튼을 클릭 시, QueryPie Admin에서 결재 요청에 대한 상세 내용을 확인하고 승인 또는 거절할 수 있습니다.<br /></p><ac:image ac:align=\"center\" ac:layout=\"center\" ac:original-height=\"817\" ac:original-width=\"1260\" ac:custom-width=\"true\" ac:alt=\"스크린샷 2025-02-18 오후 3.25.27.png\" ac:width=\"736\"><ri:attachment ri:filename=\"스크린샷 2025-02-18 오후 3.25.27.png\" ri:version-at-save=\"1\" /><ac:adf-mark key=\"border\" size=\"2\" color=\"#091e4224\" /></ac:image></li></ol>",
+      "mdx_content_hash": "0a5a2afafb2a36c2f91d2dcd7ff20ff8712db138757681019637fc27d8f822b5",
+      "mdx_line_range": [
+        161,
+        172
+      ],
+      "lost_info": {}
+    }
+  ],
+  "separators": [
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ],
+  "document_envelope": {
+    "prefix": "",
+    "suffix": ""
+  }
+}

--- a/confluence-mdx/tests/testcases/lists/expected.roundtrip.json
+++ b/confluence-mdx/tests/testcases/lists/expected.roundtrip.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": "2",
+  "page_id": "lists",
+  "mdx_sha256": "67e914c155a6e962cae05eb72f50df55353bade9ea51740c5f4c15a260a0d33e",
+  "source_xhtml_sha256": "9d0d9a133f46555437bd107ea630d34d06edff8520f0c8cb5af825cfb42d1233",
+  "blocks": [
+    {
+      "block_index": 0,
+      "xhtml_xpath": "h3[1]",
+      "xhtml_fragment": "<h3>Unordered List</h3>",
+      "mdx_content_hash": "cce52217739ff6d320fc2ead58dc31ec2183d5aecb2a5bee951ca0084150d14b",
+      "mdx_line_range": [
+        1,
+        1
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 1,
+      "xhtml_xpath": "ul[1]",
+      "xhtml_fragment": "<ul>\n<li>\n    <p>one</p>\n    <ul>\n        <li>\n            <p>eleven</p></li>\n        <li>\n            <p>twelve</p>\n            <ul>\n                <li>\n                    <p>one twenty one</p></li>\n                <li>\n                    <p>one twenty two</p></li>\n                <li>\n                    <p>one twenty three</p></li></ul></li></ul></li>\n<li>\n    <p>two</p>\n    <ul>\n        <li>\n            <p>twenty one</p>\n            <ul>\n                <li>\n                    <p>two eleven</p></li>\n                <li>\n                    <p>two twelve</p></li></ul></li>\n        <li>\n            <p>twenty two</p></li></ul></li>\n<li>\n    <p>three</p>\n    <ul>\n        <li>\n            <p>thirty one</p></li>\n        <li>\n            <p>thirty two</p></li></ul></li>\n<li>\n    <p>four</p></li></ul>",
+      "mdx_content_hash": "f767a79a55eaf4020d6be426a0ef37b6111d78cb91d541903c46b25d0293961f",
+      "mdx_line_range": [
+        3,
+        17
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 2,
+      "xhtml_xpath": "h3[2]",
+      "xhtml_fragment": "<h3>Ordered List</h3>",
+      "mdx_content_hash": "07c8c21a9f59361a706c23bcb832aea835134a74aa6924cf236e6b0398d1dc33",
+      "mdx_line_range": [
+        19,
+        19
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 3,
+      "xhtml_xpath": "ol[1]",
+      "xhtml_fragment": "<ol start=\"1\">\n<li>\n    <p>hello 1</p>\n    <ol start=\"1\">\n        <li>\n            <p>world 1</p></li>\n        <li>\n            <p>world 2</p>\n            <ol start=\"1\">\n                <li>\n                    <p>love 1</p></li>\n                <li>\n                    <p>love 2</p>\n                    <ol start=\"1\">\n                        <li>\n                            <p>peace 1</p></li>\n                        <li>\n                            <p>peace 2</p></li></ol></li>\n                <li>\n                    <p>love 3</p></li></ol></li>\n        <li>\n            <p>world 3</p></li></ol></li>\n<li>\n    <p>hello 2</p></li>\n<li>\n    <p>hello 3</p></li></ol>",
+      "mdx_content_hash": "b103757fb3695720b6161ec82601e1c6e756343921b5b586c9df70f9b485c75b",
+      "mdx_line_range": [
+        21,
+        31
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 4,
+      "xhtml_xpath": "h3[3]",
+      "xhtml_fragment": "<h3>Mixed List</h3>",
+      "mdx_content_hash": "58a45d8859c30bb1cd5f86acbfcd97c9e95e98829e5d64b71018a2ef4fe5e8b8",
+      "mdx_line_range": [
+        33,
+        33
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 5,
+      "xhtml_xpath": "ol[2]",
+      "xhtml_fragment": "<ol start=\"1\">\n<li>\n    <p>hello 1</p></li>\n<li>\n    <p>hello 2</p>\n    <ul>\n        <li>\n            <p>one</p>\n            <ol start=\"1\">\n                <li>\n                    <p>world 1</p></li>\n                <li>\n                    <p>world 2</p>\n                    <ul>\n                        <li>\n                            <p>eleven</p></li>\n                        <li>\n                            <p>twelve</p></li>\n                        <li>\n                            <p>thirteen</p></li></ul></li>\n                <li>\n                    <p>world 3</p></li></ol></li>\n        <li>\n            <p>two</p></li>\n        <li>\n            <p>three</p></li></ul></li>\n<li>\n    <p>hello 3</p></li>\n<li>\n    <p>hello 4</p></li></ol>",
+      "mdx_content_hash": "4ed7b816eebf901231bca9a02273ff0e336c150cb27ae95660e394b587a5fcac",
+      "mdx_line_range": [
+        35,
+        47
+      ],
+      "lost_info": {}
+    }
+  ],
+  "separators": [
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n"
+  ],
+  "document_envelope": {
+    "prefix": "",
+    "suffix": ""
+  }
+}

--- a/confluence-mdx/tests/testcases/panels/expected.roundtrip.json
+++ b/confluence-mdx/tests/testcases/panels/expected.roundtrip.json
@@ -1,0 +1,181 @@
+{
+  "schema_version": "2",
+  "page_id": "panels",
+  "mdx_sha256": "8cb5fa670c0281558c58e532c58d33ef4b90440a4623b85cfbe85a6e7e45d875",
+  "source_xhtml_sha256": "ac1ec9ed15afad6a00c3a4337fc7393cd4bb7a899662a6ddc71f293b84465c0e",
+  "blocks": [
+    {
+      "block_index": 0,
+      "xhtml_xpath": "macro-info[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\" ac:macro-id=\"52a351ab-604c-4a22-9f9d-9f0941d2d112\"><ac:rich-text-body><p>This is an info panel.</p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "87375bc9ffdf1dd1c579e6210bf38aba0b74aab2da0292155122ae11459def95",
+      "mdx_line_range": [
+        3,
+        4
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 1,
+      "xhtml_xpath": "hr[1]",
+      "xhtml_fragment": "<hr />",
+      "mdx_content_hash": "a404d4598b98a22d68c11b21c85a209c1c93160823c8b860bd228d62ccfb2743",
+      "mdx_line_range": [
+        5,
+        6
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 2,
+      "xhtml_xpath": "ac:adf-extension[1]",
+      "xhtml_fragment": "<ac:adf-extension><ac:adf-node type=\"panel\"><ac:adf-attribute key=\"panel-type\">note</ac:adf-attribute><ac:adf-content><p>This is a note panel.</p></ac:adf-content></ac:adf-node><ac:adf-fallback><div class=\"panel conf-macro output-block\" style=\"background-color: rgb(234,230,255);border-color: rgb(153,141,217);border-width: 1.0px;\"><div class=\"panelContent\" style=\"background-color: rgb(234,230,255);\"><p>This is a note panel.</p></div></div></ac:adf-fallback></ac:adf-extension>",
+      "mdx_content_hash": "84c4c43c26f39794dfb1a13fc09df95f4871bbd51b6d055d57b73a5098883200",
+      "mdx_line_range": [
+        8,
+        9
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 3,
+      "xhtml_xpath": "hr[2]",
+      "xhtml_fragment": "<hr />",
+      "mdx_content_hash": "a404d4598b98a22d68c11b21c85a209c1c93160823c8b860bd228d62ccfb2743",
+      "mdx_line_range": [
+        10,
+        11
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 4,
+      "xhtml_xpath": "macro-warning[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"warning\" ac:schema-version=\"1\" ac:macro-id=\"8864c519-cc60-4195-ab7d-9702130cff97\"><ac:rich-text-body><p>This is an error panel.</p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "abab02d611dc9d04beb7ab9ab1c219c305f58013ef4eed70869c88381367c85c",
+      "mdx_line_range": [
+        13,
+        14
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 5,
+      "xhtml_xpath": "hr[3]",
+      "xhtml_fragment": "<hr />",
+      "mdx_content_hash": "a404d4598b98a22d68c11b21c85a209c1c93160823c8b860bd228d62ccfb2743",
+      "mdx_line_range": [
+        15,
+        16
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 6,
+      "xhtml_xpath": "macro-tip[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"tip\" ac:schema-version=\"1\" ac:macro-id=\"509924cb-99b1-4299-adfe-263357395cca\"><ac:rich-text-body><p>This is a success panel.</p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "4f39ea50ede2d12e171063a4d7d6cbf60aa4d1117bcdd98e8935671882b84455",
+      "mdx_line_range": [
+        18,
+        19
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 7,
+      "xhtml_xpath": "hr[4]",
+      "xhtml_fragment": "<hr />",
+      "mdx_content_hash": "a404d4598b98a22d68c11b21c85a209c1c93160823c8b860bd228d62ccfb2743",
+      "mdx_line_range": [
+        20,
+        21
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 8,
+      "xhtml_xpath": "macro-note[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"note\" ac:schema-version=\"1\" ac:macro-id=\"6611ad2b-a3f8-4dbe-b7f4-79758adece17\"><ac:rich-text-body><p>This is a warning panel.</p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "21aa6f6928fd3848caeb7b53923b6f5f66708cbdba15f869dd3fd959f647f4be",
+      "mdx_line_range": [
+        23,
+        24
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 9,
+      "xhtml_xpath": "hr[5]",
+      "xhtml_fragment": "<hr />",
+      "mdx_content_hash": "a404d4598b98a22d68c11b21c85a209c1c93160823c8b860bd228d62ccfb2743",
+      "mdx_line_range": [
+        25,
+        26
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 10,
+      "xhtml_xpath": "macro-panel[1]",
+      "xhtml_fragment": "<ac:structured-macro ac:name=\"panel\" ac:schema-version=\"1\" ac:macro-id=\"67d1ae85-a2a2-45c7-8a71-0098b7752a3d\"><ac:parameter ac:name=\"panelIcon\">:rainbow:</ac:parameter><ac:parameter ac:name=\"panelIconId\">1f308</ac:parameter><ac:parameter ac:name=\"panelIconText\">🌈</ac:parameter><ac:parameter ac:name=\"bgColor\">#E6FCFF</ac:parameter><ac:rich-text-body><p>This is a custom panel.</p></ac:rich-text-body></ac:structured-macro>",
+      "mdx_content_hash": "bf4b2b9419aa6d416285c3a9c79a020ed33cb69ff9d9253dc13721f1290d5486",
+      "mdx_line_range": [
+        28,
+        29
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 11,
+      "xhtml_xpath": "hr[6]",
+      "xhtml_fragment": "<hr />",
+      "mdx_content_hash": "a404d4598b98a22d68c11b21c85a209c1c93160823c8b860bd228d62ccfb2743",
+      "mdx_line_range": [
+        30,
+        31
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 12,
+      "xhtml_xpath": "p[1]",
+      "xhtml_fragment": "<p>Done.</p>",
+      "mdx_content_hash": "16fceed19d3f55f9da618f9b89fe69d717d6015113a0d8312af96ea0eabee312",
+      "mdx_line_range": [
+        33,
+        33
+      ],
+      "lost_info": {}
+    },
+    {
+      "block_index": 13,
+      "xhtml_xpath": "p[2]",
+      "xhtml_fragment": "<p />",
+      "mdx_content_hash": "",
+      "mdx_line_range": [
+        0,
+        0
+      ],
+      "lost_info": {}
+    }
+  ],
+  "separators": [
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ],
+  "document_envelope": {
+    "prefix": "",
+    "suffix": ""
+  }
+}


### PR DESCRIPTION
## Summary
- `rehydrator.py`에 `splice_rehydrate_xhtml()` 함수를 추가하여 블록 단위 splice 경로를 구현합니다
- Sidecar 블록 기준으로 순회하면서 MDX 해시 매칭 → 원본 fragment 사용, 불일치 시 emitter 폴백
- `byte_verify.py`에 `verify_case_dir_splice()` forced-splice 검증 함수를 추가합니다
- 21개 testcase의 `expected.roundtrip.json` sidecar 파일을 생성합니다
- **21/21 forced-splice byte-equal 검증 통과** (625 전체 테스트 통과)

## 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `bin/reverse_sync/rehydrator.py` | `splice_rehydrate_xhtml()`, `SpliceResult` 추가 |
| `bin/reverse_sync/byte_verify.py` | `verify_case_dir_splice()`, `SpliceVerificationResult` 추가 |
| `tests/test_reverse_sync_rehydrator.py` | splice 유닛 테스트 + 21/21 통합 테스트 |
| `tests/test_reverse_sync_byte_verify.py` | forced-splice 유닛 테스트 + 21/21 통합 테스트 |
| `tests/testcases/*/expected.roundtrip.json` | 21개 sidecar v2 파일 생성 |

## Splice 알고리즘
1. MDX → `parse_mdx_blocks()` → content 블록 추출
2. Sidecar 블록을 순서대로 순회 (XHTML fragment 기준)
3. `mdx_content_hash` 없는 블록 (이미지 등) → 원본 fragment 보존
4. 해시 일치 → 원본 `xhtml_fragment` 사용
5. 해시 불일치 → `emit_block()` emitter 폴백
6. `separators` + `document_envelope`로 조립

## Test plan
- [x] 기존 616 테스트 전체 통과 확인
- [x] 새 splice 유닛 테스트 5건 통과 (매칭, emitter 폴백, envelope 보존)
- [x] 21/21 실제 testcase forced-splice byte-equal 통과 (rehydrator 테스트)
- [x] 21/21 실제 testcase forced-splice byte-equal 통과 (byte_verify 테스트)

🤖 Generated with [Claude Code](https://claude.com/claude-code)