### PR TITLE
confluence-mdx: Phase L6 byte-equal CI gate 추가

### DIFF
--- a/.github/workflows/test-confluence-mdx.yml
+++ b/.github/workflows/test-confluence-mdx.yml
@@ -65,6 +65,10 @@ jobs:
         working-directory: ./confluence-mdx/tests
         run: make test-xhtml-diff
 
+      - name: Run Byte-equal verify
+        working-directory: ./confluence-mdx/tests
+        run: make test-byte-verify
+
       - name: Run MDX Render tests
         working-directory: ./confluence-mdx/tests
         run: make test-render

--- a/confluence-mdx/tests/Makefile
+++ b/confluence-mdx/tests/Makefile
@@ -97,6 +97,11 @@ test-image-copy-one:
 	fi
 	@$(TEST_SCRIPT) --type image-copy --test-id $(TEST_ID) $(VERBOSE_FLAG)
 
+# Run byte-equal verify (fast-path + forced-splice)
+.PHONY: test-byte-verify
+test-byte-verify:
+	@$(TEST_SCRIPT) --type byte-verify $(VERBOSE_FLAG)
+
 # Run xhtml-diff tests
 .PHONY: test-xhtml-diff
 test-xhtml-diff:
@@ -166,6 +171,10 @@ help:
 	@echo "  test-xhtml-diff / test-xhtml-diff-one"
 	@echo "    page.xhtml ↔ patched.xhtml beautify-diff."
 	@echo "    serializer 부산물 무시, 실제 변경만 검증"
+	@echo ""
+	@echo "  test-byte-verify"
+	@echo "    Byte-equal 라운드트립 검증 (fast-path + forced-splice)."
+	@echo "    expected.roundtrip.json sidecar 기반 XHTML 복원 → page.xhtml 과 byte 비교"
 	@echo ""
 	@echo "  test-render / test-render-one"
 	@echo "    MDX → HTML 렌더링(vitest). expected.html 과 비교"

--- a/confluence-mdx/tests/run-tests.sh
+++ b/confluence-mdx/tests/run-tests.sh
@@ -7,7 +7,7 @@
 #
 # Options:
 #   --type TYPE       Test type: convert (default), skeleton, reverse-sync,
-#                     reverse-sync-verify, image-copy, xhtml-diff
+#                     reverse-sync-verify, image-copy, xhtml-diff, byte-verify
 #   --log-level LEVEL Log level: warning (default), debug, info
 #   --test-id ID      Run specific test case only
 #   --test-dir DIR    Test case directory (default: testcases)
@@ -486,6 +486,14 @@ main() {
             else
                 run_all_tests run_xhtml_diff_test "XHTML-Diff" has_xhtml_diff_input
             fi
+            ;;
+        byte-verify)
+            local byte_verify_cli="${BIN_DIR}/mdx_to_storage_xhtml_byte_verify_cli.py"
+            echo "Running byte-equal verify (fast-path)..."
+            run_cmd python3 "${byte_verify_cli}" --testcases-dir "${TEST_DIR}"
+            echo ""
+            echo "Running byte-equal verify (forced-splice)..."
+            run_cmd python3 "${byte_verify_cli}" --testcases-dir "${TEST_DIR}" --splice
             ;;
         *)
             echo "Unknown test type: ${TEST_TYPE}"

--- a/confluence-mdx/tests/test_mdx_to_storage_xhtml_byte_verify_cli.py
+++ b/confluence-mdx/tests/test_mdx_to_storage_xhtml_byte_verify_cli.py
@@ -15,6 +15,7 @@ def test_main_returns_2_when_testcases_dir_missing(monkeypatch, capsys):
             case_id=None,
             sidecar_name="expected.roundtrip.json",
             show_fail_limit=10,
+            splice=False,
         ),
     )
     rc = cli.main()
@@ -34,6 +35,7 @@ def test_main_returns_0_when_all_pass(monkeypatch, tmp_path, capsys):
             case_id=None,
             sidecar_name="expected.roundtrip.json",
             show_fail_limit=10,
+            splice=False,
         ),
     )
     monkeypatch.setattr(cli, "iter_testcase_dirs", lambda _: [case])
@@ -67,6 +69,7 @@ def test_main_returns_1_when_failures(monkeypatch, tmp_path, capsys):
             case_id=None,
             sidecar_name="expected.roundtrip.json",
             show_fail_limit=1,
+            splice=False,
         ),
     )
     monkeypatch.setattr(cli, "iter_testcase_dirs", lambda _: [case1, case2])


### PR DESCRIPTION
## Summary
- byte_verify CLI에 `--splice` 플래그를 추가하여 forced-splice 경로 검증을 지원합니다.
- `run-tests.sh`에 `byte-verify` 테스트 타입을 추가합니다 (기존 컨벤션 준수).
- Makefile에 `test-byte-verify` 타겟을 추가합니다 (`$(TEST_SCRIPT)` 패턴).
- GitHub Actions CI workflow에 `Byte-equal verify` 단계를 추가합니다.
- byte mismatch 발생 시 CI가 즉시 fail 처리합니다 (exit code 1).

## 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `bin/mdx_to_storage_xhtml_byte_verify_cli.py` | `--splice` 플래그 추가, 라벨 분기 |
| `tests/run-tests.sh` | `byte-verify` 테스트 타입 추가 (venv 활성화 후 CLI 호출) |
| `tests/Makefile` | `test-byte-verify` 타겟 추가 (`$(TEST_SCRIPT)` 패턴) |
| `.github/workflows/test-confluence-mdx.yml` | `Run Byte-equal verify` 단계 추가 |
| `tests/test_mdx_to_storage_xhtml_byte_verify_cli.py` | 기존 테스트에 `splice=False` 호환성 추가 |

## 검증 결과
```
[mdx->xhtml-byte-verify] total=21 passed=21 failed=0
[mdx->xhtml-byte-verify-splice] total=21 passed=21 failed=0
```
- 627 pytest 전체 통과

## Test plan
- [x] `make test-byte-verify` — fast-path 21/21 pass
- [x] `make test-byte-verify` — forced-splice 21/21 pass
- [x] pytest 627 전체 통과
- [ ] CI workflow 실행 확인 (PR 머지 후 자동)

🤖 Generated with [Claude Code](https://claude.com/claude-code)