### PR TITLE
mdx: 한국어 MDX 문서 스마트 따옴표 정규화 및 문구 교정

### DIFF
--- a/src/content/ko/administrator-manual/databases/ledger-management/ledger-approval-rules.mdx
+++ b/src/content/ko/administrator-manual/databases/ledger-management/ledger-approval-rules.mdx
@@ -7,7 +7,7 @@ confluenceUrl: 'https://querypie.atlassian.net/wiki/spaces/QM/pages/571277650/Le
 
 ### Overview
 
-관리자는 원장 테이블에 맵핑할 ‘원장 전용 승인 규칙(Ledger Approval Rule)’을 정의할 수 있습니다.
+관리자는 원장 테이블에 맵핑할 '원장 전용 승인 규칙(Ledger Approval Rule)'을 정의할 수 있습니다.
 
 ### 원장 테이블에 승인 규칙 생성하기
 

--- a/src/content/ko/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-azure.mdx
+++ b/src/content/ko/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-azure.mdx
@@ -30,7 +30,7 @@ Administrator &gt; Servers &gt; Connection Management &gt; Cloud Providers &gt; 
 6. 특정  **Region** 의 리소스를 동기화하고자 할 경우 Use Region 항목에 체크 후 Region을 선택해 주세요.
 7.  **Subscription**   **ID** 를 입력합니다.
 8. 리소스를 동기화하기 위해 필요한  **Credential**  정보를 입력합니다. 현재는 Client Secret 방식만 지원되고 있습니다.
-    1. `Synchronize` 버튼 클릭 시 Azure의 Client Secret을 입력하는 수동 동기화 방식을 기본 제공합니다. <br/>QueryPie 10.2.2 부터 “Save Credential for Synchronization” 옵션을 제공하여 Credential type으로 Client Secret을 사용할 때도 스케줄을 통한 동기화가 가능하도록 개선되었습니다.
+    1. `Synchronize` 버튼 클릭 시 Azure의 Client Secret을 입력하는 수동 동기화 방식을 기본 제공합니다. <br/>QueryPie 10.2.2 부터 "Save Credential for Synchronization" 옵션을 제공하여 Credential type으로 Client Secret을 사용할 때도 스케줄을 통한 동기화가 가능하도록 개선되었습니다.
 9.  **Search**   **Filter** 를 사용하여 동기화하고자 하는 일부 유형의 리소스 목록을 가져올 수 있습니다.
     1. Search Filter는 AWS의 검색 방식과 동일하게 작동합니다. 이름, 호스트, OS, 태그 등의 값을 필터로 사용할 수 있으며 아래 순서대로 Enter 키를 활용하여 검색 조건 및 필터를 편리하게 입력할 수 있습니다.
         1. Key 값 입력 후 Enter → 검색 조건 선택 후 Enter → Value 값 입력 후 Enter
@@ -38,7 +38,7 @@ Administrator &gt; Servers &gt; Connection Management &gt; Cloud Providers &gt; 
 10.  **Replication**   **Frequency**  항목에서 동기화 방식을 선택합니다.
     1. Manual : 동기화를 하고자 하는 시점에만 수동으로 동기화하는 방식입니다.
     2. Scheduling : 주기적인 스케줄링을 통해 리소스를 동기화하는 방식입니다. Cron Expressions를 제공합니다.
-11.  **Auto Configuration Upon Initial Synchronization** Cloud Provider에서 처음 동기화하는 서버의 일부 값을 사용자가 지정할 수 있습니다. 초기값 설정은 Cloud Provider 저장 후 수정할 수 없습니다. 이 설정의 변경이 필요한 경우, Cloud Provider 삭제 후 다시 등록을 해야 합니다.
+11.  **Auto Configuration Upon Initial Synchronization** Cloud Provider에서 처음 동기화하는 서버의 일부 값을 사용자가 지정할 수 있습니다. 초기값 설정은 Cloud Provider 저장 후 수정할 수 없습니다. 이 설정의 변경이 필요한 경우, Cloud Provider 삭제 후 다시 등록해야 합니다.
     * port **:**  동기화된 서버의 접속 포트를 지정할 수 있습니다. 현재는 SSH/SFTP 포트만 지정이 가능합니다.
     * Tag : 동기화된 서버에 자동으로 태그를 추가할 수 있습니다.
         * 태그 값에 `{vpcid}`를 입력하면, 해당 서버가 속한 Cloud의 VPC ID가 자동으로 채워집니다.

--- a/src/content/ko/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-gcp.mdx
+++ b/src/content/ko/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-gcp.mdx
@@ -29,7 +29,7 @@ Administrator &gt; Servers &gt; Connection Management &gt; Cloud Providers &gt; 
 5. 동기화하고자 하는 리소스의  **Project ID** 를 입력합니다.
 6. 특정 Region 및 Zone의 리소스를 동기화하고자 할 경우  **Use Region and Zone**  항목에 체크 후 Region 과 Zone을 각각 선택해 주세요.
 7. 리소스를 동기화하기 위해 필요한  **Credential** 을 선택하세요. 현재는 Service Account 방식만 지원되고 있습니다.
-    1. `Synchronize` 버튼 클릭 시 GCP의 Service Account JSON을 입력하는 수동 동기화 방식을 기본 제공합니다. <br/>QueryPie 10.2.2 부터 “Save Credential for Synchronization” 옵션을 제공하여 Credential type으로 Service Account를 사용할 때도 스케줄을 통한 동기화가 가능하도록 개선되었습니다.
+    1. `Synchronize` 버튼 클릭 시 GCP의 Service Account JSON을 입력하는 수동 동기화 방식을 기본 제공합니다. <br/>QueryPie 10.2.2 부터 "Save Credential for Synchronization" 옵션을 제공하여 Credential type으로 Service Account를 사용할 때도 스케줄을 통한 동기화가 가능하도록 개선되었습니다.
 8.  **Search**   **Filter** 를 사용하여 동기화하고자 하는 일부 유형의 리소스 목록을 가져올 수 있습니다.
     1. Search Filter는 AWS의 검색 방식과 동일하게 작동합니다. 이름, 호스트, OS, 태그 등의 값을 필터로 사용할 수 있으며 아래 순서대로 Enter 키를 활용하여 검색 조건 및 필터를 편리하게 입력할 수 있습니다.
         1. Key 값 입력 후 Enter → 검색 조건 선택 후 Enter → Value 값 입력 후 Enter
@@ -37,7 +37,7 @@ Administrator &gt; Servers &gt; Connection Management &gt; Cloud Providers &gt; 
 9.  **Replication**   **Frequency**  항목에서 동기화 방식을 선택합니다.
     1. Manual : 동기화를 하고자 하는 시점에만 수동으로 동기화하는 방식입니다.
     2. Scheduling : 주기적인 스케줄링을 통해 리소스를 동기화하는 방식입니다. Cron Expressions를 제공합니다.
-10.  **Auto Configuration Upon Initial Synchronization** Cloud Provider에서 처음 동기화하는 서버의 일부 값을 사용자가 지정할 수 있습니다. 초기값 설정은 Cloud Provider 저장 후 수정할 수 없습니다. 이 설정의 변경이 필요한 경우, Cloud Provider 삭제 후 다시 등록을 해야 합니다.
+10.  **Auto Configuration Upon Initial Synchronization** Cloud Provider에서 처음 동기화하는 서버의 일부 값을 사용자가 지정할 수 있습니다. 초기값 설정은 Cloud Provider 저장 후 수정할 수 없습니다. 이 설정의 변경이 필요한 경우, Cloud Provider 삭제 후 다시 등록해야 합니다.
     * port **:**  동기화된 서버의 접속 포트를 지정할 수 있습니다. 현재는 SSH/SFTP 포트만 지정이 가능합니다.
     * Tag : 동기화된 서버에 자동으로 태그를 추가할 수 있습니다.
         * 태그 값에 `{vpcid}`를 입력하면, 해당 서버가 속한 Cloud의 VPC ID가 자동으로 채워집니다.


### PR DESCRIPTION
## Summary
- 유니코드 스마트 따옴표(U+2018/2019, U+201C/201D)를 ASCII 직선 따옴표로 정규화합니다. (3건)
- Azure/GCP Cloud Provider 동기화 문서에서 "다시 등록을 해야 합니다" → "다시 등록해야 합니다"로 문법을 교정합니다. (2건)

## 변경 파일
| 파일 | 변경 내용 |
|------|-----------|
| `ko/.../ledger-approval-rules.mdx` | `'...'` → `'...'` 스마트 따옴표 정규화 |
| `ko/.../synchronizing-server-resources-from-azure.mdx` | `"..."` → `"..."` 스마트 따옴표 정규화 + "등록을 해야" → "등록해야" 문법 교정 |
| `ko/.../synchronizing-server-resources-from-gcp.mdx` | `"..."` → `"..."` 스마트 따옴표 정규화 + "등록을 해야" → "등록해야" 문법 교정 |

## 비고
- 영어/일본어 대응 파일에는 스마트 따옴표가 사용되지 않아 변경이 불필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)