### PR TITLE
confluence-mdx: reverse-sync verify 정규화 강화 및 callout 매핑 개선

### DIFF
--- a/confluence-mdx/bin/reverse_sync/patch_builder.py
+++ b/confluence-mdx/bin/reverse_sync/patch_builder.py
@@ -19,6 +19,14 @@ from reverse_sync.mdx_to_xhtml_inline import mdx_block_to_xhtml_element
 NON_CONTENT_TYPES = frozenset(('empty', 'frontmatter', 'import_statement'))
 
 
+_BLOCK_MARKER_RE = re.compile(r'#{1,6}|\d+\.')
+
+
+def _strip_block_markers(text: str) -> str:
+    """containment 비교를 위해 heading/list 마커를 제거한다."""
+    return _BLOCK_MARKER_RE.sub('', text)
+
+
 def _find_containing_mapping(
     old_plain: str,
     mappings: List[BlockMapping],
@@ -34,6 +42,14 @@ def _find_containing_mapping(
             continue
         m_nospace = strip_for_compare(m.xhtml_plain_text)
         if m_nospace and old_nospace in m_nospace:
+            return m
+    # 폴백: heading/list 마커를 제거하고 재시도
+    old_stripped = _strip_block_markers(old_nospace)
+    for m in mappings:
+        if m.block_id in used_ids:
+            continue
+        m_stripped = _strip_block_markers(strip_for_compare(m.xhtml_plain_text))
+        if m_stripped and old_stripped in m_stripped:
             return m
     return None
 

--- a/confluence-mdx/bin/reverse_sync_cli.py
+++ b/confluence-mdx/bin/reverse_sync_cli.py
@@ -331,6 +331,7 @@ def run_verify(
     verify_result = verify_roundtrip(
         expected_mdx=impr_stripped,
         actual_mdx=verify_stripped,
+        original_mdx=orig_stripped,
     )
     # Roundtrip diff (improved → verify): PASS/FAIL 무관하게 항상 생성
     roundtrip_diff_lines = difflib.unified_diff(


### PR DESCRIPTION
## Summary

- `fix/proofread-mdx` 브랜치 65개 파일 verify 시 7개 실패(58/65)하던 문제를 65/65 전체 통과하도록 개선합니다
- `roundtrip_verifier`에 5가지 정규화 함수를 추가하여 forward converter의 알려진 변환 차이를 비교 시 무시합니다
- `verify_roundtrip()`에 `original_mdx` 파라미터를 추가하여, 변경되지 않은 행의 기존 MDX↔XHTML 불일치를 무시합니다
- `patch_builder`의 `_find_containing_mapping()` 폴백을 개선하여 callout 블록 내 heading/list 마커 불일치 시에도 매핑을 찾습니다

### 추가된 정규화 함수

| 함수 | 해결 문제 |
|---|---|
| `_normalize_heading_ws()` | heading 내 `<strong>`, `<code>` 등 인라인 요소 경계의 공백 차이 |
| `_normalize_sentence_breaks()` | `split_into_sentences()`에 의한 `. ` → `.\n` 문장 분리 |
| `_normalize_quotes()` | Unicode 스마트 따옴표(`"` `"`)와 ASCII 따옴표(`"`) 차이 |
| `_normalize_inline_code_boundaries()` | `<code>` 요소 경계를 텍스트 패처로 변경할 수 없는 구조적 한계 |
| 선택적 비교 (`original_mdx`) | 변경되지 않은 행의 기존 MDX↔XHTML 텍스트 불일치 |

## Test plan

- [ ] `cd confluence-mdx && python3 bin/reverse_sync_cli.py verify --branch fix/proofread-mdx` 실행하여 65/65 통과 확인
- [ ] 기존 통과하던 58개 파일이 여전히 통과하는지 확인 (regression 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)