### PR TITLE
confluence-mdx: xhtml_patcher에서 <strong> 뒤 조사 앞 공백 제거 처리

### DIFF
--- a/confluence-mdx/tests/test_reverse_sync_xhtml_patcher.py
+++ b/confluence-mdx/tests/test_reverse_sync_xhtml_patcher.py
@@ -237,3 +237,27 @@ class TestPatchOrdering:
                      'new_plain_text': 'New text'}]
         result = patch_xhtml(xhtml, patches)
         assert 'New text' in result
+
+
+def test_remove_space_before_korean_particle_after_strong():
+    """<strong> 뒤 조사 앞 공백 제거를 올바르게 패치한다.
+
+    XHTML: <h3>... <strong>AGENT_SECRET</strong> 를 변경해도 괜찮은가요?</h3>
+    교정: 'AGENT_SECRET 를' → 'AGENT_SECRET를' (공백 제거)
+
+    old_plain_text는 xhtml_plain_text(element.get_text())에서 오므로 double-space를 포함.
+    <strong> 다음 text node의 leading whitespace가 diff에서 삭제된 경우,
+    xhtml_patcher가 해당 공백도 제거해야 한다.
+    """
+    xhtml = '<h3>Q: 운영 도중  <strong>AGENT_SECRET</strong> 를 변경해도 괜찮은가요?</h3>'
+    patches = [
+        {
+            'xhtml_xpath': 'h3[1]',
+            # old_plain_text는 element.get_text()에서 오므로 XHTML 그대로의 공백 포함
+            'old_plain_text': 'Q: 운영 도중  AGENT_SECRET 를 변경해도 괜찮은가요?',
+            'new_plain_text': 'Q: 운영 도중  AGENT_SECRET를 변경해도 괜찮은가요?',
+        }
+    ]
+    result = patch_xhtml(xhtml, patches)
+    assert '<strong>AGENT_SECRET</strong>를 변경해도' in result
+    assert '<strong>AGENT_SECRET</strong> 를 변경해도' not in result


### PR DESCRIPTION
## Summary

- `_apply_text_changes()`에서 `<strong>IDENTIFIER</strong> 를` 패턴의 공백 제거 버그를 수정합니다.
- 직전 텍스트 노드 범위와 현재 텍스트 노드 범위 사이의 gap이 diff로 삭제된 경우, leading whitespace를 제거하도록 수정합니다.
- 회귀 방지를 위한 단위 테스트를 추가합니다.

## 배경

Confluence XHTML에서 `<h3>Q: 운영 도중 <strong>AGENT_SECRET</strong> 를 변경해도...</h3>` 형태의 구조를 패치할 때, `<strong>` 다음 텍스트 노드(` 를`)의 leading whitespace가 diff에서 삭제 대상이더라도 기존 코드는 이 공백을 항상 보존했습니다.

## 원인 분석

`_apply_text_changes()`의 텍스트 노드 처리에서:
- `old_stripped`에서 텍스트 노드 간 gap(`AGENT_SECRET`와 `를` 사이 공백)은 별도 인덱스 위치에 존재
- 해당 gap은 어느 텍스트 노드의 `node_start~node_end` 범위에도 포함되지 않아 opcode가 처리되지 않음
- 결과적으로 diff가 공백을 삭제해도 leading whitespace는 그대로 복원됨

## 수정 내용

현재 노드 처리 시 직전 노드 범위와 현재 노드 범위 사이의 gap을 `_map_text_range()`로 검사합니다. gap이 diff로 완전히 삭제된 경우(`gap_new == ''`), leading whitespace를 제거합니다.

## Test plan

- [x] `test_remove_space_before_korean_particle_after_strong` 신규 테스트 통과
- [x] 기존 19개 테스트 전체 통과 (`pytest tests/test_reverse_sync_xhtml_patcher.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)