### PR TITLE
confluence-mdx: verify 기본 동작을 엄격 모드로 변경하고 --lenient 옵션 추가

### DIFF
--- a/confluence-mdx/bin/reverse_sync_cli.py
+++ b/confluence-mdx/bin/reverse_sync_cli.py
@@ -225,10 +225,13 @@ def run_verify(
     original_src: MdxSource,
     improved_src: MdxSource,
     xhtml_path: str = None,
+    lenient: bool = False,
 ) -> Dict[str, Any]:
     """로컬 검증 파이프라인을 실행한다.
 
     모든 중간 파일을 var/<page_id>/ 에 reverse-sync. prefix로 저장한다.
+
+    lenient=True면 변경된 행만 검사하는 관대 모드로 검증한다.
     """
     now = datetime.now(timezone.utc).isoformat()
     var_dir = _clean_reverse_sync_artifacts(page_id)
@@ -331,7 +334,7 @@ def run_verify(
     verify_result = verify_roundtrip(
         expected_mdx=impr_stripped,
         actual_mdx=verify_stripped,
-        original_mdx=orig_stripped,
+        lenient=lenient,
     )
     # Roundtrip diff (improved → verify): PASS/FAIL 무관하게 항상 생성
     roundtrip_diff_lines = difflib.unified_diff(
@@ -472,12 +475,12 @@ _USAGE_SUMMARY = """\
 reverse-sync — MDX 변경사항을 Confluence XHTML에 역반영
 
 Usage:
-  reverse-sync verify <mdx> [--original-mdx <mdx>]
-  reverse-sync verify --branch <branch>
-  reverse-sync debug  <mdx> [--original-mdx <mdx>]
-  reverse-sync debug  --branch <branch>
-  reverse-sync push   <mdx> [--original-mdx <mdx>] [--dry-run]
-  reverse-sync push   --branch <branch> [--dry-run]
+  reverse-sync verify <mdx> [--original-mdx <mdx>] [--lenient]
+  reverse-sync verify --branch <branch> [--lenient]
+  reverse-sync debug  <mdx> [--original-mdx <mdx>] [--lenient]
+  reverse-sync debug  --branch <branch> [--lenient]
+  reverse-sync push   <mdx> [--original-mdx <mdx>] [--dry-run] [--lenient]
+  reverse-sync push   --branch <branch> [--dry-run] [--lenient]
   reverse-sync -h | --help
 
 Commands:
@@ -505,6 +508,11 @@ Options:
   --branch <branch>
     브랜치의 모든 변경 ko MDX 파일을 자동 발견하여 배치 처리한다.
     <mdx>와 동시에 사용할 수 없다.
+
+  --lenient
+    관대 모드: trailing whitespace, 날짜 형식 등 XHTML↔MDX 변환기 한계에
+    의한 차이를 정규화한 후 비교한다. 기본 동작은 정규화 없이 문자 그대로
+    비교하는 엄격 모드이다.
 
 Examples:
   # 단일 파일 검증
@@ -589,6 +597,8 @@ def _add_common_args(parser: argparse.ArgumentParser):
                         help='배치 모드에서 최대 처리 파일 수 (기본: 0=전체)')
     parser.add_argument('--failures-only', action='store_true',
                         help='실패한 결과만 출력 (--limit와 함께 사용 시 실패 건수 기준으로 제한)')
+    parser.add_argument('--lenient', action='store_true',
+                        help='관대 모드: 정규화 후 비교 (기본은 문자 그대로 비교하는 엄격 모드)')
 
 
 def _do_verify(args) -> dict:
@@ -608,14 +618,16 @@ def _do_verify(args) -> dict:
         original_src=original_src,
         improved_src=improved_src,
         xhtml_path=args.xhtml,
+        lenient=getattr(args, 'lenient', False),
     )
 
 
 def _do_verify_batch(branch: str, limit: int = 0, failures_only: bool = False,
-                     push: bool = False) -> List[dict]:
+                     push: bool = False, lenient: bool = False) -> List[dict]:
     """브랜치의 변경 ko MDX 파일을 배치 처리한다.
 
     push=True이면 개별 문서마다 verify 성공 시 즉시 Confluence에 push한다.
+    lenient=True이면 변경된 행만 검사하는 관대 모드로 검증한다.
     """
     files = _get_changed_ko_mdx_files(branch)
     if not files:
@@ -633,6 +645,7 @@ def _do_verify_batch(branch: str, limit: int = 0, failures_only: bool = False,
             args = argparse.Namespace(
                 improved_mdx=f"{branch}:{ko_path}",
                 original_mdx=None, xhtml=None,
+                lenient=lenient,
             )
             result = _do_verify(args)
             result['file'] = ko_path
@@ -749,7 +762,8 @@ def main():
             if getattr(args, 'branch', None):
                 # 배치 모드
                 results = _do_verify_batch(args.branch, limit=getattr(args, 'limit', 0),
-                                           failures_only=failures_only, push=not dry_run)
+                                           failures_only=failures_only, push=not dry_run,
+                                           lenient=getattr(args, 'lenient', False))
                 if use_json:
                     output = results
                     if failures_only:

--- a/confluence-mdx/tests/test_reverse_sync_cli.py
+++ b/confluence-mdx/tests/test_reverse_sync_cli.py
@@ -376,7 +376,7 @@ def test_main_verify_branch(monkeypatch):
          patch('builtins.print'):
         main()
 
-    mock_batch.assert_called_once_with('proofread/fix-typo', limit=0, failures_only=False, push=False)
+    mock_batch.assert_called_once_with('proofread/fix-typo', limit=0, failures_only=False, push=False, lenient=False)
     mock_push.assert_not_called()
 
 
@@ -396,7 +396,7 @@ def test_main_push_branch(tmp_path, monkeypatch):
          patch('builtins.print'):
         main()
 
-    mock_batch.assert_called_once_with('proofread/fix-typo', limit=0, failures_only=False, push=True)
+    mock_batch.assert_called_once_with('proofread/fix-typo', limit=0, failures_only=False, push=True, lenient=False)
 
 
 def test_main_push_branch_with_failure(monkeypatch):
@@ -414,7 +414,7 @@ def test_main_push_branch_with_failure(monkeypatch):
             main()
 
     assert exc_info.value.code == 1
-    mock_batch.assert_called_once_with('proofread/fix-typo', limit=0, failures_only=False, push=True)
+    mock_batch.assert_called_once_with('proofread/fix-typo', limit=0, failures_only=False, push=True, lenient=False)
 
 
 def test_main_branch_mutual_exclusive(monkeypatch):
@@ -457,7 +457,22 @@ def test_main_verify_branch_with_failure_exits(monkeypatch):
             main()
 
     assert exc_info.value.code == 1
-    mock_batch.assert_called_once_with('proofread/fix-typo', limit=0, failures_only=False, push=False)
+    mock_batch.assert_called_once_with('proofread/fix-typo', limit=0, failures_only=False, push=False, lenient=False)
+
+
+def test_main_verify_branch_lenient(monkeypatch):
+    """--lenient 플래그가 _do_verify_batch에 전달된다."""
+    monkeypatch.setattr('sys.argv', [
+        'reverse_sync_cli.py', 'verify', '--branch', 'proofread/fix-typo', '--lenient'])
+    batch_results = [
+        {'status': 'pass', 'page_id': 'p1', 'changes_count': 1},
+    ]
+
+    with patch('reverse_sync_cli._do_verify_batch', return_value=batch_results) as mock_batch, \
+         patch('builtins.print'):
+        main()
+
+    mock_batch.assert_called_once_with('proofread/fix-typo', limit=0, failures_only=False, push=False, lenient=True)
 
 
 # --- normalize_mdx_to_plain tests ---

--- a/confluence-mdx/tests/test_reverse_sync_roundtrip_verifier.py
+++ b/confluence-mdx/tests/test_reverse_sync_roundtrip_verifier.py
@@ -20,11 +20,21 @@ def test_different_mdx_fails():
     assert result.diff_report != ""
 
 
-def test_trailing_whitespace_normalized():
-    """trailing whitespace 차이는 정규화되어 통과해야 한다."""
+def test_strict_mode_fails_on_trailing_whitespace():
+    """엄격 모드(기본): trailing whitespace 차이도 실패한다."""
     result = verify_roundtrip(
         expected_mdx="# Title\n\nParagraph. \n",  # trailing space
         actual_mdx="# Title\n\nParagraph.\n",
+    )
+    assert result.passed is False
+
+
+def test_lenient_mode_normalizes_trailing_whitespace():
+    """관대 모드: trailing whitespace 차이는 정규화되어 통과한다."""
+    result = verify_roundtrip(
+        expected_mdx="# Title\n\nParagraph. \n",  # trailing space
+        actual_mdx="# Title\n\nParagraph.\n",
+        lenient=True,
     )
     assert result.passed is True
 
@@ -36,3 +46,44 @@ def test_diff_report_shows_line_numbers():
     )
     assert result.passed is False
     assert "2" in result.diff_report  # 2번째 줄
+
+
+def test_strict_mode_fails_on_any_diff():
+    """엄격 모드(기본): 정규화 없이 모든 차이를 실패로 처리한다."""
+    expected = "line1\nline2 changed\nline3\n"
+    actual = "line1 differs\nline2 changed\nline3\n"
+    result = verify_roundtrip(
+        expected_mdx=expected,
+        actual_mdx=actual,
+    )
+    assert result.passed is False
+
+
+def test_lenient_mode_normalizes_then_compares_all_lines():
+    """관대 모드: 정규화 후 전체 행에서 exact match를 수행한다."""
+    # 정규화로 해소되지 않는 차이는 관대 모드에서도 실패
+    result = verify_roundtrip(
+        expected_mdx="line1\nline2\n",
+        actual_mdx="line1 differs\nline2\n",
+        lenient=True,
+    )
+    assert result.passed is False
+
+
+def test_lenient_mode_normalizes_dates():
+    """관대 모드: 한국어 날짜 형식 차이는 정규화되어 통과한다."""
+    result = verify_roundtrip(
+        expected_mdx="2024년 01월 15일\n",
+        actual_mdx="Jan 15, 2024\n",
+        lenient=True,
+    )
+    assert result.passed is True
+
+
+def test_strict_mode_fails_on_date_format():
+    """엄격 모드: 한국어 날짜 형식 차이도 실패한다."""
+    result = verify_roundtrip(
+        expected_mdx="2024년 01월 15일\n",
+        actual_mdx="Jan 15, 2024\n",
+    )
+    assert result.passed is False


### PR DESCRIPTION
## Summary
- `verify_roundtrip()` 기본 동작을 정규화 없이 문자 그대로 비교하는 **엄격 모드**로 변경합니다.
- 기존의 정규화 후 비교 동작은 `--lenient` 옵션으로 분리합니다.
- 기존의 smart-pass 로직(변경된 행만 검사, `original_mdx` 기반)을 완전히 제거합니다.

### 변경 전후 비교

| | 변경 전 (기본) | 변경 후 (기본=엄격) | 변경 후 (`--lenient`) |
|---|---|---|---|
| 정규화 | 항상 적용 | 적용 안 함 | 적용 |
| 비교 범위 | 변경된 행만 (smart-pass) | 전체 행 | 전체 행 |
| whitespace 차이 | 무시될 수 있음 | FAIL | 정규화 대상이면 무시 |

### Background
기존 verify는 `original_mdx` 기반 smart-pass 로직과 9개 정규화를 기본 적용하여, whitespace 변경이 있어도 PASS로 간주하는 경우가 있었습니다. 이를 개선하여 기본 동작을 엄격하게 변경하고, 관대한 검증은 명시적 옵션으로 분리합니다.

### 사용 예시
```bash
# 엄격 검증 (기본) — 문자 그대로 비교
bin/reverse_sync_cli.py verify --branch=split/ko-proofread-20260221-installation

# 관대 검증 — 정규화 후 비교
bin/reverse_sync_cli.py verify --lenient --branch=split/ko-proofread-20260221-installation
```

## Test plan
- [x] `test_reverse_sync_roundtrip_verifier.py` — 엄격/관대 모드 동작 검증 (9개 테스트)
- [x] `test_reverse_sync_cli.py` — `--lenient` 플래그 전달 검증 포함 (60개 테스트)
- [x] 전체 69개 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)