### PR TITLE
confluence-mdx: reverse-sync 연속 inline 마커 사이 텍스트 변경 감지 수정

### DIFF
--- a/confluence-mdx/bin/reverse_sync/mdx_to_xhtml_inline.py
+++ b/confluence-mdx/bin/reverse_sync/mdx_to_xhtml_inline.py
@@ -24,6 +24,8 @@ def mdx_block_to_inner_xhtml(content: str, block_type: str) -> str:
         return _convert_heading(text)
     elif block_type == 'paragraph':
         return _convert_paragraph(text)
+    elif block_type == 'callout':
+        return _convert_callout_inner(text)
     elif block_type == 'list':
         return _convert_list_content(text)
     elif block_type == 'code_block':
@@ -56,6 +58,17 @@ def _convert_paragraph(text: str) -> str:
             continue
         converted.append(convert_inline(line))
     return ' '.join(converted)
+
+
+def _convert_callout_inner(text: str) -> str:
+    """callout: <Callout> 래퍼 태그를 제거하고 내부 텍스트를 paragraph로 변환."""
+    lines = text.splitlines()
+    if lines and lines[0].strip().startswith('<Callout'):
+        lines = lines[1:]
+    if lines and lines[-1].strip().startswith('</Callout'):
+        lines = lines[:-1]
+    inner = '\n'.join(lines).strip()
+    return _convert_paragraph(inner)
 
 
 def _convert_code_block(text: str) -> str:

--- a/confluence-mdx/tests/test_reverse_sync_patch_builder.py
+++ b/confluence-mdx/tests/test_reverse_sync_patch_builder.py
@@ -1021,3 +1021,24 @@ class TestHasInlineFormatChange:
             '앞문장 `code` 뒷문장',
             '변경된 앞문장 `code` 변경된 뒷문장',
         ) is False
+
+    def test_comma_added_between_consecutive_code_spans(self):
+        """연속된 code 마커 사이에 쉼표 추가 → inline 변경."""
+        assert has_inline_format_change(
+            '해당 주소는 `http`  `https` 와 같은 Scheme 을 붙여서는 안 됩니다.',
+            '해당 주소는 `http`, `https`와 같은 Scheme을 붙여서는 안 됩니다.',
+        ) is True
+
+    def test_punctuation_added_between_markers(self):
+        """연속된 마커 사이에 구두점 추가 → inline 변경."""
+        assert has_inline_format_change(
+            '`a` `b` end',
+            '`a`, `b` end',
+        ) is True
+
+    def test_whitespace_only_change_between_markers(self):
+        """연속된 마커 사이 공백만 변경 → inline 변경 아님."""
+        assert has_inline_format_change(
+            '`http`  `https` text',
+            '`http` `https` text',
+        ) is False


### PR DESCRIPTION
## Summary
- `has_inline_format_change()`가 연속된 inline 마커 사이의 텍스트 변경(쉼표 추가 등)을 감지하도록 확장합니다.
- `mdx_block_to_inner_xhtml()`에 callout 블록 핸들러를 추가하여 `<Callout>` 래퍼 태그 중첩 문제를 해결합니다.
- `` `http`  `https` `` → `` `http`, `https` `` 같은 변경이 text-only 패치로 잘못 처리되어 쉼표가 소실되거나 `<code>` 내부로 이동하는 버그를 수정합니다.

## Test plan
- [x] `test_comma_added_between_consecutive_code_spans` — 연속 code 마커 사이 쉼표 추가 감지
- [x] `test_punctuation_added_between_markers` — 일반 마커 사이 구두점 감지
- [x] `test_whitespace_only_change_between_markers` — 공백만 변경 시 false negative 확인
- [x] `bin/reverse_sync_cli.py verify split/ko-proofread-20260221-installation:src/content/ko/installation/post-installation-setup.mdx` PASS 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)