### PR TITLE
confluence-mdx: reverse_sync 리스트 항목 수 불일치 시 전체 inner XHTML 재생성

### DIFF
--- a/confluence-mdx/bin/reverse_sync/patch_builder.py
+++ b/confluence-mdx/bin/reverse_sync/patch_builder.py
@@ -525,6 +525,19 @@ def build_list_item_patches(
     old_items = split_list_items(change.old_block.content)
     new_items = split_list_items(change.new_block.content)
     if len(old_items) != len(new_items):
+        # 항목 수가 다르면 (삭제/추가) 전체 리스트 inner XHTML 재생성
+        parent = None
+        if mdx_to_sidecar is not None and xpath_to_mapping is not None:
+            parent = find_mapping_by_sidecar(
+                change.index, mdx_to_sidecar, xpath_to_mapping)
+        if parent is not None:
+            new_inner = mdx_block_to_inner_xhtml(
+                change.new_block.content, change.new_block.type)
+            return [{
+                'xhtml_xpath': parent.xhtml_xpath,
+                'old_plain_text': parent.xhtml_plain_text,
+                'new_inner_xhtml': new_inner,
+            }]
         return []
 
     # sidecar에서 parent mapping 획득


### PR DESCRIPTION
## Summary
- `build_list_item_patches`에서 리스트 항목 수가 달라질 때(삭제/추가) 빈 패치를 반환하여 XHTML에 반영되지 않는 버그 수정
- parent mapping이 존재하면 전체 리스트를 `new_inner_xhtml`로 재생성하도록 변경
- release-notes/10.3.0-10.3.4.mdx의 중복 리스트 항목 삭제 시 verify 실패 해결

## Test plan
- [x] 새 테스트 `test_item_count_mismatch_with_parent_generates_inner_xhtml` 추가 및 통과
- [x] 기존 테스트 `test_path2_sidecar_match_child_fail_list_split` 새 동작에 맞게 업데이트
- [x] Python 단위 테스트 전체 통과
- [x] 셸 기반 테스트 (convert, skeleton, reverse-sync, image-copy) 전체 통과
- [x] `bin/reverse_sync_cli.py verify` 로 10.3.0-10.3.4.mdx PASS 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)