### PR TITLE
confluence-mdx: reverse_sync callout 매크로 패치 누락 수정

### DIFF
--- a/confluence-mdx/bin/reverse_sync/list_patcher.py
+++ b/confluence-mdx/bin/reverse_sync/list_patcher.py
@@ -55,6 +55,23 @@ def _resolve_child_mapping(
                 if old_unmarked == child_nospace:
                     return child
 
+    # 5차: 앞부분 prefix 일치 (emoticon/lost_info 차이 허용)
+    # XHTML에서 ac:emoticon이 텍스트로 치환되지 않는 경우,
+    # 전체 문자열 비교가 실패할 수 있으므로 앞부분 20자로 비교한다.
+    # 단, old_nospace가 child보다 2배 이상 긴 경우는 잘못된 매칭으로 판단한다
+    # (callout 전체 텍스트가 내부 paragraph 첫 줄과 prefix를 공유하는 경우 방지).
+    _PREFIX_LEN = 20
+    if len(old_nospace) >= _PREFIX_LEN:
+        old_prefix = old_nospace[:_PREFIX_LEN]
+        for child_id in parent_mapping.children:
+            child = id_to_mapping.get(child_id)
+            if child:
+                child_nospace = re.sub(r'\s+', '', child.xhtml_plain_text)
+                if (len(child_nospace) >= _PREFIX_LEN
+                        and child_nospace[:_PREFIX_LEN] == old_prefix
+                        and len(old_nospace) <= len(child_nospace) * 2):
+                    return child
+
     return None
 
 

--- a/confluence-mdx/bin/reverse_sync/sidecar.py
+++ b/confluence-mdx/bin/reverse_sync/sidecar.py
@@ -549,6 +549,20 @@ def _find_text_match(
             if prefix in mdx_sig or mdx_sig[:50] in xhtml_sig:
                 return ptr
 
+    # 4차: 짧은 prefix 포함 매칭 (emoticon/lost_info 차이 허용)
+    # XHTML ac:emoticon 태그가 텍스트로 치환되지 않는 경우,
+    # 전체 문자열의 substring 비교가 실패할 수 있으므로
+    # 앞부분 20자만으로 포함 관계를 검사한다.
+    _SHORT_PREFIX = 20
+    for ptr in range(start_ptr, end_ptr):
+        mdx_idx = mdx_content_indices[ptr]
+        mdx_sig = _strip_all_ws(mdx_plains[mdx_idx])
+        if len(mdx_sig) < _SHORT_PREFIX:
+            continue
+        mdx_prefix = mdx_sig[:_SHORT_PREFIX]
+        if mdx_prefix in xhtml_sig:
+            return ptr
+
     return None
 
 

--- a/confluence-mdx/bin/reverse_sync/xhtml_patcher.py
+++ b/confluence-mdx/bin/reverse_sync/xhtml_patcher.py
@@ -5,6 +5,8 @@ import difflib
 import re
 from reverse_sync.mapping_recorder import _iter_block_children
 
+from reverse_sync.mapping_recorder import _get_text_with_emoticons
+
 
 def patch_xhtml(xhtml: str, patches: List[Dict[str, str]]) -> str:
     """XHTML에 패치를 적용한다.
@@ -63,14 +65,16 @@ def patch_xhtml(xhtml: str, patches: List[Dict[str, str]]) -> str:
     for element, patch in resolved_modifies:
         if 'new_inner_xhtml' in patch:
             old_text = patch.get('old_plain_text', '')
-            current_plain = element.get_text()
+            # ac:emoticon의 fallback 텍스트를 포함하여 비교
+            current_plain = _get_text_with_emoticons(element)
             if old_text and current_plain.strip() != old_text.strip():
                 continue
             _replace_inner_html(element, patch['new_inner_xhtml'])
         else:
             old_text = patch['old_plain_text']
             new_text = patch['new_plain_text']
-            current_plain = element.get_text()
+            # ac:emoticon의 fallback 텍스트를 포함하여 비교
+            current_plain = _get_text_with_emoticons(element)
             if current_plain.strip() != old_text.strip():
                 continue
             _apply_text_changes(element, old_text, new_text)

--- a/confluence-mdx/tests/test_reverse_sync_mapping_recorder.py
+++ b/confluence-mdx/tests/test_reverse_sync_mapping_recorder.py
@@ -158,6 +158,52 @@ def test_adf_extension_non_callout_no_children():
     assert mappings[0].children == []
 
 
+def test_callout_panel_excludes_parameter_metadata():
+    """panel callout의 xhtml_plain_text가 파라미터 메타데이터를 포함하지 않는다."""
+    xhtml = (
+        '<ac:structured-macro ac:name="panel">'
+        '<ac:parameter ac:name="panelIcon">:purple_circle:</ac:parameter>'
+        '<ac:parameter ac:name="panelIconId">1f7e3</ac:parameter>'
+        '<ac:parameter ac:name="panelIconText">🟣</ac:parameter>'
+        '<ac:parameter ac:name="bgColor">#F4F5F7</ac:parameter>'
+        '<ac:rich-text-body>'
+        '<p><strong>본문 텍스트입니다.</strong></p>'
+        '</ac:rich-text-body>'
+        '</ac:structured-macro>'
+    )
+    mappings = record_mapping(xhtml)
+    parent = mappings[0]
+    assert parent.xhtml_xpath == 'macro-panel[1]'
+    # 파라미터 메타데이터가 제외되고 body 텍스트만 포함
+    assert ':purple_circle:' not in parent.xhtml_plain_text
+    assert '#F4F5F7' not in parent.xhtml_plain_text
+    assert '본문 텍스트입니다.' in parent.xhtml_plain_text
+
+
+def test_callout_includes_emoticon_fallback_text():
+    """ac:emoticon의 fallback 텍스트가 xhtml_plain_text에 포함된다."""
+    xhtml = (
+        '<ac:structured-macro ac:name="panel">'
+        '<ac:parameter ac:name="panelIcon">:purple_circle:</ac:parameter>'
+        '<ac:rich-text-body>'
+        '<p><strong>클릭해서 확대해서 보세요. </strong>'
+        '<ac:emoticon ac:emoji-fallback="🔎" ac:emoji-id="1f50e" '
+        'ac:emoji-shortname=":mag_right:" ac:name="blue-star"></ac:emoticon>'
+        ' )</p>'
+        '</ac:rich-text-body>'
+        '</ac:structured-macro>'
+    )
+    mappings = record_mapping(xhtml)
+
+    parent = mappings[0]
+    assert '🔎' in parent.xhtml_plain_text
+
+    # child paragraph에도 emoticon fallback이 포함
+    child = mappings[1]
+    assert child.xhtml_xpath.endswith('/p[1]')
+    assert '🔎' in child.xhtml_plain_text
+
+
 from pathlib import Path
 
 def test_mapping_real_testcase():

--- a/confluence-mdx/tests/test_reverse_sync_patch_builder.py
+++ b/confluence-mdx/tests/test_reverse_sync_patch_builder.py
@@ -194,6 +194,17 @@ class TestResolveChildMapping:
         result = _resolve_child_mapping('some text here', parent, id_map)
         assert result is None
 
+    def test_prefix_match_rejects_long_text(self):
+        # 5차 prefix: old_plain이 child보다 훨씬 길 때 잘못된 매칭 방지
+        # callout 전체 텍스트가 내부 paragraph와 같은 prefix를 공유하는 경우
+        child_text = '11.4.0부터 속성 기반 승인자 지정시 여러개의 속성을 지정할 수 있도록 개선되었습니다.'
+        long_old = child_text + ' ' + '기존 Attribute 기반 승인자 지정시 하나의 Attribute만 지정할 수 있었으나...' * 3
+        child = _make_mapping('c1', child_text)
+        parent = _make_mapping('p1', 'parent', children=['c1'])
+        id_map = {'c1': child, 'p1': parent}
+        result = _resolve_child_mapping(long_old, parent, id_map)
+        assert result is None
+
 
 # ── Helper 함수 테스트 ──
 


### PR DESCRIPTION
## Description

- `reverse_sync`에서 callout 매크로(`panel`, `info`, `note` 등) 내부 텍스트 변경이 패치되지 않는 버그를 수정합니다.
- 페이지 544375505 (`menu-improvement-guide-9120.mdx`)에서 발견된 문제입니다.

### Background

3가지 계층에서 동시에 문제가 발생했습니다:

1. **`mapping_recorder.py`**: callout 매크로의 `xhtml_plain_text` 추출 시 `<ac:parameter>` 메타데이터(`:purple_circle:`, `#F4F5F7` 등)가 포함되고, `<ac:emoticon>`의 fallback 텍스트(`🔎`)가 누락되어 sidecar 텍스트 매칭이 실패
2. **`sidecar.py` / `patch_builder.py`**: emoticon 차이로 인한 텍스트 불일치를 허용하는 짧은 prefix 매칭 패스가 없어 매핑 실패
3. **`xhtml_patcher.py`**: modify 검증에서 `element.get_text()`를 사용하여 emoticon fallback 텍스트가 빠진 채 비교, 패치 적용이 skip됨

### 수정 내용

- `mapping_recorder.py`: `_get_text_with_emoticons()` 헬퍼 추가, callout 매크로는 `<ac:rich-text-body>`에서만 텍스트 추출
- `sidecar.py`: `_find_text_match`에 4차 짧은 prefix 포함 매칭 패스 추가
- `patch_builder.py`: `_resolve_child_mapping`에 5차 prefix 매칭 패스 추가
- `xhtml_patcher.py`: modify 검증을 `_get_text_with_emoticons()` 사용으로 변경

## Related tickets & links

- `bin/reverse_sync_cli.py verify --branch=split/ko-proofread-20260221-release-notes` 실패 6건 중 마지막 건
- 관련 PR: #850, #851, #852 (동일 verify 배치의 Bug 1-5 수정)

## Added/updated tests?

- [x] Yes
  - `test_callout_panel_excludes_parameter_metadata`: panel callout의 `xhtml_plain_text`에서 파라미터 메타데이터 제외 검증
  - `test_callout_includes_emoticon_fallback_text`: `<ac:emoticon>` fallback 텍스트 포함 검증
  - `test_short_prefix_match_with_emoticon_difference`: emoticon 차이 시 짧은 prefix 매칭 검증
  - `test_short_prefix_match_with_metadata_prefix`: 메타데이터 prefix 매칭 검증
  - `test_callout_panel_with_emoticon_maps_to_mdx`: panel+emoticon 통합 sidecar 매핑 검증

## Additional notes

- 전체 테스트 433건 통과 (신규 5건 포함)
- verify 결과: 핵심 텍스트 변경("9.12.0부터")은 정상 적용, `🔎` 앞 공백 정규화 차이(double space)만 잔존 (Bug 4와 동일 유형의 XHTML round-trip 정규화)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>