### PR TITLE
docs: 한국어 문서 교정/교열 스타일 가이드 추가

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ QueryPie 문서 사이트 프로젝트의 지식, 정보, 가이드 문서를 �
 | [DEVELOPMENT.md](DEVELOPMENT.md) | 기술 스택, 로컬 실행, 빌드, 배포 방법 |
 | [commit-pr-guide.md](commit-pr-guide.md) | 커밋 메시지 및 PR 작성 컨벤션 |
 | [translation.md](translation.md) | 다국어 번역 상세 지침 (ko, en, ja) |
+| [ko-writing-style-guide.md](ko-writing-style-guide.md) | 한국어 문장 표현 및 교정/교열 가이드 |
 | [api-naming-guide.md](api-naming-guide.md) | QueryPie ACP 제품명 및 API 명칭 지침 |
 
 ### 기술 문서


### PR DESCRIPTION
## 변경 요약

- `docs/README.md` 업데이트 — 기존에 추가된 `docs/ko-writing-style-guide.md` 링크를 문서 목록에 추가

## 참고

`docs/ko-writing-style-guide.md`는 이미 main 브랜치에 존재하며, 이 PR은 `docs/README.md` 목록에 해당 파일 링크가 누락된 것을 보완합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)