### PR TITLE
confluence-mdx: lost_info 이미지 지원 추가 및 블록 레벨 분배 기반 구축

### DIFF
--- a/confluence-mdx/bin/converter/core.py
+++ b/confluence-mdx/bin/converter/core.py
@@ -584,6 +584,7 @@ class SingleLineParser:
 
         # Find matching attachment in attachments list
         markdown = ''
+        img_src = ''
         image_filename = unicodedata.normalize('NFC', image_filename)
         if image_filename:
             attachments = get_attachments()
@@ -591,12 +592,17 @@ class SingleLineParser:
                 if it.original == image_filename:
                     it.used = True
                     markdown = it.as_markdown(width=width, align=align)
+                    img_src = f'{it.output_dir}/{it.filename}'
                     break
 
         if not markdown:
             # If no matching attachment found, use the filename as fallback
             logging.warning(f'No matching attachment found for filename: {image_filename}')
             markdown = f'[{image_filename}]()'
+
+        # Record image lost_info
+        if self.collector and img_src:
+            self.collector.add_image(node, img_src)
 
         # Add the image in Markdown format
         self.markdown_lines.append(markdown)
@@ -938,6 +944,7 @@ class MultiLineParser:
                 caption_text = SingleLineParser(caption_paragraph, collector=self.collector).as_markdown
 
         markdown = ''
+        img_src = ''
         image_filename = unicodedata.normalize('NFC', image_filename)
         if image_filename:
             attachments = get_attachments()
@@ -945,12 +952,17 @@ class MultiLineParser:
                 if it.original == image_filename:
                     it.used = True
                     markdown = it.as_markdown(caption_text, width, align)
+                    img_src = f'{it.output_dir}/{it.filename}'
                     break
 
         if not markdown:
             # If no matching attachment found, use the filename as fallback
             logging.warning(f'No matching attachment found for filename: {image_filename}')
             markdown = f'[{image_filename}]()'
+
+        # Record image lost_info
+        if self.collector and img_src:
+            self.collector.add_image(node, img_src)
 
         # Add the image in Markdown format
         self.markdown_lines.append(f'<figure data-layout="{align}" data-align="{align}">\n')

--- a/confluence-mdx/bin/converter/lost_info.py
+++ b/confluence-mdx/bin/converter/lost_info.py
@@ -12,6 +12,7 @@ class LostInfoCollector:
         self._links: list[dict] = []
         self._filenames: list[dict] = []
         self._adf_extensions: list[dict] = []
+        self._images: list[dict] = []
 
     def add_emoticon(self, node: Tag) -> None:
         self._emoticons.append({
@@ -43,6 +44,13 @@ class LostInfoCollector:
             'raw': str(node),
         })
 
+    def add_image(self, node: Tag, img_src: str) -> None:
+        """<ac:image> → <img> 변환 시 원본 태그와 img src를 기록한다."""
+        self._images.append({
+            'src': img_src,
+            'raw': str(node),
+        })
+
     def to_dict(self) -> dict:
         """빈 카테고리를 제외하고 반환한다."""
         result: dict = {}
@@ -54,4 +62,6 @@ class LostInfoCollector:
             result['filenames'] = self._filenames
         if self._adf_extensions:
             result['adf_extensions'] = self._adf_extensions
+        if self._images:
+            result['images'] = self._images
         return result

--- a/confluence-mdx/bin/reverse_sync_cli.py
+++ b/confluence-mdx/bin/reverse_sync_cli.py
@@ -286,7 +286,14 @@ def run_verify(
         SidecarEntry, generate_sidecar_mapping,
         build_mdx_to_sidecar_index, build_xpath_to_mapping,
     )
-    sidecar_yaml = generate_sidecar_mapping(xhtml, original_mdx, page_id)
+    # forward converter가 생성한 mapping.yaml에서 lost_info를 보존
+    existing_mapping = var_dir / 'mapping.yaml'
+    existing_lost_info = None
+    if existing_mapping.exists():
+        existing_data = yaml.safe_load(existing_mapping.read_text()) or {}
+        existing_lost_info = existing_data.get('lost_info') or None
+    sidecar_yaml = generate_sidecar_mapping(
+        xhtml, original_mdx, page_id, lost_infos=existing_lost_info)
     (var_dir / 'mapping.yaml').write_text(sidecar_yaml)
     sidecar_data = yaml.safe_load(sidecar_yaml) or {}
     page_lost_info = sidecar_data.get('lost_info', {})

--- a/confluence-mdx/tests/test_lost_info_collector.py
+++ b/confluence-mdx/tests/test_lost_info_collector.py
@@ -56,6 +56,19 @@ class TestLostInfoCollector:
         assert len(result['adf_extensions']) == 1
         assert result['adf_extensions'][0]['panel_type'] == 'note'
 
+    def test_add_image(self):
+        c = LostInfoCollector()
+        node = _tag(
+            '<ac:image ac:width="760">'
+            '<ri:attachment ri:filename="img.png"/>'
+            '</ac:image>'
+        )
+        c.add_image(node, 'attachments/img.png')
+        result = c.to_dict()
+        assert len(result['images']) == 1
+        assert result['images'][0]['src'] == 'attachments/img.png'
+        assert 'ac:image' in result['images'][0]['raw']
+
     def test_multiple_categories(self):
         c = LostInfoCollector()
         node = _tag('<ac:emoticon ac:name="tick"/>')


### PR DESCRIPTION
## Summary
- R1(inner XHTML 재생성 전환)의 선행 작업으로 lost_info 인프라를 확장합니다
- `<ac:image>` → `<img>` 변환 시 원본 태그 추적 및 복원 메커니즘 추가
- page-level lost_info를 BlockMapping별로 분배하는 `distribute_lost_info_to_mappings()` 추가
- `reverse_sync_cli.py`에서 forward converter의 mapping.yaml lost_info가 sidecar 재생성 시 유실되던 버그 수정

## 변경 내역

### 1. Forward converter 이미지 추적
- `LostInfoCollector.add_image(node, img_src)` 메서드 추가
- `SingleLineParser.convert_inline_image()`, `MultiLineParser.convert_image()` 양쪽에서 호출
- mapping.yaml에 `lost_info.images` 카테고리로 저장

### 2. lost_info_patcher 이미지 복원
- `_patch_images()`: `<img src="...">` 태그를 src 매칭으로 찾아 원본 `<ac:image>` 태그로 교체
- `apply_lost_info()`에 images 카테고리 연결

### 3. 블록 레벨 분배
- `distribute_lost_info_to_mappings(mappings, page_lost_info)`: page-level lost_info를 각 BlockMapping의 `xhtml_text` 매칭으로 분배
- R1 구현 시 direct path에서 블록별 lost_info 적용에 사용 예정
- 기존 `distribute_lost_info(blocks, page_lost_info)`도 images 카테고리 지원 추가

### 4. CLI lost_info 보존
- `reverse_sync_cli.py`: `generate_sidecar_mapping()` 호출 전 기존 mapping.yaml에서 lost_info를 읽어 전달

## Test plan
- [x] `TestPatchImages` — 5개 케이스 (교체, width 속성, 불일치 skip, 복수 이미지, self-closing)
- [x] `TestDistributeLostInfoToMappings` — 4개 케이스 (emoticon/image 분배, empty, filename)
- [x] `TestLostInfoCollector.test_add_image` — add_image 메서드 검증
- [x] 기존 테스트 771 passed (실패 2건은 기존 실제 데이터 의존 테스트)

🤖 Generated with [Claude Code](https://claude.com/claude-code)