### PR TITLE
confluence-mdx: R1 direct path를 inner XHTML 재생성 기본 전환

### DIFF
--- a/confluence-mdx/tests/test_reverse_sync_cli.py
+++ b/confluence-mdx/tests/test_reverse_sync_cli.py
@@ -567,7 +567,7 @@ def testbuild_patches_index_mapping():
     assert len(patches) == 1
     assert patches[0]['xhtml_xpath'] == 'p[1]'
     assert patches[0]['old_plain_text'] == 'Old text.'
-    assert patches[0]['new_plain_text'] == 'New text.'
+    assert patches[0]['new_inner_xhtml'] == 'New text.'
 
 
 def testbuild_patches_skips_non_content():
@@ -871,7 +871,7 @@ def testbuild_patches_child_resolved():
 
     assert len(patches) == 1
     assert patches[0]['xhtml_xpath'] == 'macro-info[1]/p[1]'
-    assert patches[0]['new_plain_text'] == 'New child text.'
+    assert patches[0]['new_inner_xhtml'] == 'New child text.'
 
 
 def testbuild_patches_child_fallback_to_parent_containing():

--- a/confluence-mdx/tests/test_reverse_sync_patch_builder.py
+++ b/confluence-mdx/tests/test_reverse_sync_patch_builder.py
@@ -327,7 +327,7 @@ class TestBuildPatches:
 
         assert len(patches) == 1
         assert patches[0]['xhtml_xpath'] == 'li[1]'
-        assert 'updated child' in patches[0]['new_plain_text']
+        assert 'updated child' in patches[0]['new_inner_xhtml']
 
     # Path 2: sidecar 매칭 → children 있음 → child 해석 실패
     #          → 텍스트 불일치 → list 분리 (item 수 불일치 → inner XHTML 재생성)
@@ -436,8 +436,8 @@ class TestBuildPatches:
             mappings, mdx_to_sidecar, xpath_to_mapping)
 
         assert len(patches) == 1
-        # text_transfer가 XHTML 공백을 보존하면서 변경 적용
-        assert 'earth' in patches[0]['new_plain_text']
+        # R1: 항상 inner XHTML 재생성
+        assert 'earth' in patches[0]['new_inner_xhtml']
 
     # 직접 매칭 + text_transfer 미사용 (텍스트 동일)
     def test_direct_match_no_transfer(self):
@@ -453,7 +453,7 @@ class TestBuildPatches:
             mappings, mdx_to_sidecar, xpath_to_mapping)
 
         assert len(patches) == 1
-        assert patches[0]['new_plain_text'] == 'hello earth'
+        assert patches[0]['new_inner_xhtml'] == 'hello earth'
 
     # NON_CONTENT_TYPES 스킵
     def test_skips_non_content_types(self):
@@ -495,8 +495,8 @@ class TestBuildPatches:
         assert '<code>https://example.com/</code>' in patches[0]['new_inner_xhtml']
         assert 'new_plain_text' not in patches[0]
 
-    def test_direct_text_only_change_uses_plain_text_patch(self):
-        """inline format 변경 없이 텍스트만 바뀌면 기존 text patch를 사용한다."""
+    def test_direct_text_only_change_uses_inner_xhtml_patch(self):
+        """R1: 텍스트만 바뀌어도 inner XHTML 재생성 패치를 사용한다."""
         m1 = _make_mapping('m1', 'hello world', xpath='p[1]')
         mappings = [m1]
         xpath_to_mapping = {m.xhtml_xpath: m for m in mappings}
@@ -509,8 +509,8 @@ class TestBuildPatches:
             mappings, mdx_to_sidecar, xpath_to_mapping)
 
         assert len(patches) == 1
-        assert 'new_plain_text' in patches[0]
-        assert 'new_inner_xhtml' not in patches[0]
+        assert 'new_inner_xhtml' in patches[0]
+        assert 'new_plain_text' not in patches[0]
 
     # 여러 변경이 동일 containing block에 그룹화
     def test_multiple_changes_grouped_to_containing(self):


### PR DESCRIPTION
## Summary

- `build_patches` direct 경로에서 `has_inline_format_change` 조건 분기를 제거하고, 항상 `mdx_block_to_inner_xhtml`로 inner XHTML을 재생성하도록 변경
- `distribute_lost_info_to_mappings`로 블록 레벨 lost_info를 분배한 뒤 `apply_lost_info`로 Confluence 전용 태그(emoticon, ac:image 등) 복원
- 멱등성 체크: `old != xhtml && new == xhtml` 복합 조건으로 이미 적용된 변경 건너뜀
- `inline_detector` import 제거 (patch_builder에서 더 이상 미사용)

## Background

Analysis doc R1: "`build_patches` direct 경로: text transfer → inner XHTML 재생성 기본 전환"

기존 direct 경로는 `has_inline_format_change`로 inline 포맷 변경을 감지한 경우에만 `new_inner_xhtml` 패치를 생성하고, 그 외에는 `transfer_text_changes`로 텍스트만 전달했습니다. 이 방식은 inline 감지 로직의 false negative 시 포맷 손실이 발생하는 문제가 있었습니다.

R1은 항상 inner XHTML을 재생성하여 이 문제를 근본적으로 해결하며, PR #856의 lost_info 확장을 활용하여 Confluence 전용 태그 손실을 방지합니다.

## Test plan

- [x] 기존 170개 patch_builder/CLI 테스트 통과 확인 (전체 751개 통과)
- [x] direct path 테스트 6개 assertion을 `new_inner_xhtml`로 업데이트
- [x] `test_direct_inline_code_added_generates_inner_xhtml` — inline 포맷만 변경 시 패치 생성 확인
- [x] 멱등성 테스트 2건 — push 후 재실행 시 불필요한 패치 미생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)