### PR TITLE
confluence-mdx: callout/이미지 XHTML 패치 파괴 수정 및 방어 코드 추가

### DIFF
--- a/confluence-mdx/bin/reverse_sync/patch_builder.py
+++ b/confluence-mdx/bin/reverse_sync/patch_builder.py
@@ -208,6 +208,8 @@ def build_patches(
         if idx not in _add_by_idx:
             continue
         add_change = _add_by_idx[idx]
+        if del_change.old_block.type in NON_CONTENT_TYPES:
+            continue
         mapping = find_mapping_by_sidecar(
             idx, mdx_to_sidecar, xpath_to_mapping)
         if mapping is None:
@@ -224,6 +226,7 @@ def build_patches(
             'new_plain_text': xhtml_text,
         })
         _paired_indices.add(idx)
+        _mark_used(mapping.block_id, mapping)
 
     # 상위 블록에 대한 그룹화된 변경
     containing_changes: dict = {}  # block_id → (mapping, [(old_plain, new_plain)])


### PR DESCRIPTION
## Summary

- #878 의 callout delete+add 쌍 처리 및 `<ri:attachment>` 가드 수정을 포함합니다
- 코드 리뷰에서 발견된 방어 코드 2건을 추가합니다:
  - `NON_CONTENT_TYPES` 체크: frontmatter/import_statement 등 비콘텐츠 블록이 쌍 탐지에서 잘못 처리되는 것을 방지
  - `_mark_used()` 호출: 동일 매핑에 대한 중복 패치 생성을 방지

### 검증 결과

- Python 단위 테스트 754/754 통과 (test_unused_attachments 2건 pre-existing 제외)
- 873136365 (callout) 통합 테스트 통과
- 544379937 (image) 통합 테스트 통과

## Related tickets & links

- #878

## Added/updated tests?

- [x] No, and this is why: #878 에서 추가된 통합 테스트로 충분히 커버됩니다. 방어 코드는 엣지 케이스 방지 목적입니다.

## Additional notes

- #878 이 이미 머지된 상태이므로, 해당 커밋 위에 방어 코드를 추가하는 형태입니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)