### PR TITLE
confluence-mdx: reverse_sync `<ac:link-body>` trailing space 제거 미반영 수정

### DIFF
--- a/confluence-mdx/bin/reverse_sync/table_patcher.py
+++ b/confluence-mdx/bin/reverse_sync/table_patcher.py
@@ -49,8 +49,7 @@ def normalize_table_row(row: str) -> str:
         )
         s = re.sub(r'<[^>]+/?>', '', s)
         s = html_module.unescape(s)
-        s = s.strip()
-        if s:
+        if s.strip():
             parts.append(s)
     return ' '.join(parts)
 

--- a/confluence-mdx/bin/reverse_sync/xhtml_patcher.py
+++ b/confluence-mdx/bin/reverse_sync/xhtml_patcher.py
@@ -344,6 +344,21 @@ def _apply_text_changes(element: Tag, old_text: str, new_text: str):
         effective_end = (node_end + 1
                          if i == last_nonempty_idx and node_end >= len(old_stripped)
                          else node_end)
+
+        node_str = str(node)
+        leading = node_str[:len(node_str) - len(node_str.lstrip())]
+        trailing = node_str[len(node_str.rstrip()):]
+
+        # 내부 노드의 trailing whitespace가 old_stripped에 존재하면
+        # diff 범위를 확장하여 자연스럽게 처리한다.
+        # (예: <ac:link-body>text </ac:link-body> 의 trailing space)
+        trailing_in_range = False
+        if trailing and effective_end < len(old_stripped):
+            potential = old_stripped[node_end:node_end + len(trailing)]
+            if potential == trailing:
+                effective_end = node_end + len(trailing)
+                trailing_in_range = True
+
         # 블록 경계에서는 include_insert_at_end/exclude_insert_at_start로
         # insert를 올바른 노드에 할당한다.
         include_at_end = i in claim_end_set and i != last_nonempty_idx
@@ -353,11 +368,6 @@ def _apply_text_changes(element: Tag, old_text: str, new_text: str):
             include_insert_at_end=include_at_end,
             exclude_insert_at_start=exclude_at_start,
         )
-
-        node_str = str(node)
-        # 원본 whitespace 보존 (단, diff에서 삭제된 선행 공백은 제거)
-        leading = node_str[:len(node_str) - len(node_str.lstrip())]
-        trailing = node_str[len(node_str.rstrip()):]
 
         # 직전 노드 범위와 현재 노드 범위 사이의 gap이 diff로 삭제된 경우,
         # leading whitespace를 제거한다.
@@ -371,7 +381,17 @@ def _apply_text_changes(element: Tag, old_text: str, new_text: str):
                 if not gap_new:
                     leading = ''
 
-        node.replace_with(NavigableString(leading + new_node_text + trailing))
+        if trailing_in_range:
+            # diff가 trailing whitespace를 처리했으므로 별도 보존 불필요
+            node.replace_with(NavigableString(leading + new_node_text))
+        else:
+            # 마지막 노드의 edge trailing whitespace가 변경된 경우 반영
+            if trailing and i == last_nonempty_idx:
+                old_edge_trailing = old_text[len(old_text.rstrip()):]
+                new_edge_trailing = new_text[len(new_text.rstrip()):]
+                if old_edge_trailing != new_edge_trailing:
+                    trailing = new_edge_trailing
+            node.replace_with(NavigableString(leading + new_node_text + trailing))
 
 
 def _find_block_ancestor(node):

--- a/confluence-mdx/bin/text_utils.py
+++ b/confluence-mdx/bin/text_utils.py
@@ -158,10 +158,9 @@ def normalize_mdx_to_plain(content: str, block_type: str) -> str:
         )
         s = re.sub(r'<[^>]+/?>', '', s)
         s = html_module.unescape(s)
-        s = s.strip()
-        if s:
+        if s.strip():
             parts.append(s)
-    return ' '.join(parts)
+    return '\n'.join(parts)
 
 
 def collapse_ws(text: str) -> str:

--- a/confluence-mdx/tests/test_reverse_sync_cli.py
+++ b/confluence-mdx/tests/test_reverse_sync_cli.py
@@ -500,8 +500,8 @@ def test_normalize_mdx_list():
     )
     result = normalize_mdx_to_plain(content, 'paragraph')
     expected = (
-        "Administrator > Audit > ... 메뉴로 이동합니다. "
-        "당월 기준으로... "
+        "Administrator > Audit > ... 메뉴로 이동합니다.\n"
+        "당월 기준으로...\n"
         "Access Control Updated  : 커넥션 접근 권한 수정이력"
     )
     assert result == expected
@@ -515,7 +515,7 @@ def test_normalize_mdx_list_with_figure():
         "2. 두 번째 항목"
     )
     result = normalize_mdx_to_plain(content, 'paragraph')
-    assert result == '첫 번째 항목 두 번째 항목'
+    assert result == '첫 번째 항목\n두 번째 항목'
 
 
 # --- build_patches index-based mapping tests ---

--- a/confluence-mdx/tests/test_reverse_sync_patch_builder.py
+++ b/confluence-mdx/tests/test_reverse_sync_patch_builder.py
@@ -16,6 +16,7 @@ from reverse_sync.patch_builder import (
     _resolve_mapping_for_change,
     build_patches,
 )
+from reverse_sync.xhtml_patcher import patch_xhtml
 from reverse_sync.table_patcher import (
     build_table_row_patches,
     is_markdown_table,
@@ -1491,3 +1492,122 @@ class TestBuildPatchesIdempotency:
                     f"XHTML이 이미 변경된 상태에서 불필요한 패치 생성: "
                     f"new={p['new_plain_text']!r}"
                 )
+
+
+# ── Link body trailing space 제거 ──
+
+
+class TestLinkBodyTrailingSpaceStrip:
+    """<ac:link-body> trailing space가 파이프라인을 통해 자연스럽게 제거된다.
+
+    재현 시나리오 (administrator-manual.mdx, page 544178405):
+      Original MDX: `[Okta 연동하기 ](url)` (trailing space)
+      Improved MDX: `[Okta 연동하기](url)` (trailing space 제거)
+      XHTML: `<ac:link-body>Okta 연동하기 </ac:link-body>`
+      기대: normalize_mdx_to_plain이 trailing space를 보존하여
+            transfer_text_changes로 자연스럽게 전이된다.
+    """
+
+    def test_normalize_preserves_link_trailing_space(self):
+        """normalize_mdx_to_plain이 link text의 trailing space를 보존한다."""
+        with_space = '* [Okta 연동하기 ](url1)\n* [LDAP 연동하기](url2)'
+        without_space = '* [Okta 연동하기](url1)\n* [LDAP 연동하기](url2)'
+        old_plain = normalize_mdx_to_plain(with_space, 'html_block')
+        new_plain = normalize_mdx_to_plain(without_space, 'html_block')
+        assert old_plain != new_plain
+        # trailing space 보존: 'Okta 연동하기 \n' vs 'Okta 연동하기\n'
+        assert 'Okta 연동하기 \n' in old_plain
+        assert 'Okta 연동하기 \n' not in new_plain
+
+    def test_build_patches_transfers_trailing_space_change(self):
+        """build_patches가 trailing space 변경을 text transfer로 전이한다."""
+        xhtml_text = (
+            '<table><tbody><tr><td>'
+            '<ul><li><p>'
+            '<ac:link><ri:page ri:content-title="Okta 연동하기"/>'
+            '<ac:link-body>Okta 연동하기 </ac:link-body></ac:link>'
+            '</p></li><li><p>'
+            '<ac:link><ri:page ri:content-title="LDAP 연동하기"/>'
+            '<ac:link-body>LDAP 연동하기</ac:link-body></ac:link>'
+            '</p></li></ul>'
+            '</td></tr></tbody></table>'
+        )
+        xhtml_plain = 'Okta 연동하기 LDAP 연동하기'
+        mapping = BlockMapping(
+            block_id='table-1', type='table',
+            xhtml_xpath='table[1]',
+            xhtml_text=xhtml_text,
+            xhtml_plain_text=xhtml_plain,
+            xhtml_element_index=0,
+        )
+        old_content = (
+            '<table>\n<tbody>\n<tr>\n<td>\n'
+            '* [Okta 연동하기 ](general/okta)\n'
+            '* [LDAP 연동하기](general/ldap)\n'
+            '</td>\n</tr>\n</tbody>\n</table>\n'
+        )
+        new_content = (
+            '<table>\n<tbody>\n<tr>\n<td>\n'
+            '* [Okta 연동하기](general/okta)\n'
+            '* [LDAP 연동하기](general/ldap)\n'
+            '</td>\n</tr>\n</tbody>\n</table>\n'
+        )
+        change = _make_change(0, old_content, new_content, type_='html_block')
+        mdx_to_sidecar = {0: _make_sidecar('table[1]', [0])}
+        xpath_to_mapping = {'table[1]': mapping}
+
+        patches = build_patches(
+            [change], [change.old_block], [change.new_block],
+            [mapping], mdx_to_sidecar, xpath_to_mapping)
+
+        assert len(patches) == 1
+        assert 'link_body_strips' not in patches[0]
+        # trailing space가 제거된 new_plain_text가 생성됨
+        assert patches[0]['old_plain_text'] != patches[0]['new_plain_text']
+
+    def test_patch_xhtml_strips_link_body_trailing_space(self):
+        """patch_xhtml가 <ac:link-body> trailing space를 자연스럽게 제거한다.
+
+        end-to-end 테스트: text transfer 파이프라인으로 trailing space 제거.
+        """
+        xhtml = (
+            '<table><tbody><tr><td>'
+            '<ul><li><p>'
+            '<ac:link><ri:page ri:content-title="Okta 연동하기"/>'
+            '<ac:link-body>Okta 연동하기 </ac:link-body></ac:link>'
+            '</p></li><li><p>'
+            '<ac:link><ri:page ri:content-title="LDAP 연동하기"/>'
+            '<ac:link-body>LDAP 연동하기</ac:link-body></ac:link>'
+            '</p></li></ul>'
+            '</td></tr></tbody></table>'
+        )
+        # trailing space가 제거되면 두 텍스트 사이의 separator도 사라짐
+        patches = [{
+            'xhtml_xpath': 'table[1]',
+            'old_plain_text': 'Okta 연동하기 LDAP 연동하기',
+            'new_plain_text': 'Okta 연동하기LDAP 연동하기',
+        }]
+
+        result = patch_xhtml(xhtml, patches)
+        assert '<ac:link-body>Okta 연동하기</ac:link-body>' in result
+        assert '<ac:link-body>Okta 연동하기 </ac:link-body>' not in result
+        # LDAP은 원래 trailing space가 없으므로 변경 없음
+        assert '<ac:link-body>LDAP 연동하기</ac:link-body>' in result
+
+    def test_single_link_in_p_trailing_space(self):
+        """<p> 내 단일 link의 trailing space가 edge trailing 로직으로 제거된다."""
+        xhtml = (
+            '<p>'
+            '<ac:link><ri:page ri:content-title="Okta 연동하기"/>'
+            '<ac:link-body>Okta 연동하기 </ac:link-body></ac:link>'
+            '</p>'
+        )
+        patches = [{
+            'xhtml_xpath': 'p[1]',
+            'old_plain_text': 'Okta 연동하기 ',
+            'new_plain_text': 'Okta 연동하기',
+        }]
+
+        result = patch_xhtml(xhtml, patches)
+        assert '<ac:link-body>Okta 연동하기</ac:link-body>' in result
+        assert '<ac:link-body>Okta 연동하기 </ac:link-body>' not in result

--- a/confluence-mdx/tests/test_reverse_sync_text_normalizer.py
+++ b/confluence-mdx/tests/test_reverse_sync_text_normalizer.py
@@ -124,26 +124,26 @@ class TestNormalizeMdxToPlain:
 
     def test_paragraph_skips_empty_lines(self):
         result = normalize_mdx_to_plain('line1\n\nline2', 'paragraph')
-        assert result == 'line1 line2'
+        assert result == 'line1\nline2'
 
     def test_list_strips_marker(self):
         result = normalize_mdx_to_plain('- item one\n- item two', 'list')
-        assert result == 'item one item two'
+        assert result == 'item one\nitem two'
 
     def test_numbered_list_strips_marker(self):
         result = normalize_mdx_to_plain('1. first\n2. second', 'list')
-        assert result == 'first second'
+        assert result == 'first\nsecond'
 
     def test_table_row_extracts_cells(self):
         content = '| col1 | col2 |\n| --- | --- |\n| a | b |'
         result = normalize_mdx_to_plain(content, 'paragraph')
-        assert result == 'col1 col2 a b'
+        assert result == 'col1 col2\na b'
 
     def test_unescapes_html_entities(self):
         result = normalize_mdx_to_plain('A &lt; B &amp; C', 'paragraph')
         assert result == 'A < B & C'
 
     def test_strips_html_tags(self):
-        # tag 제거 후 양쪽 공백이 남아 'text  more'가 됨 (join 전 strip으로 정리)
+        # tag 제거 후 양쪽 공백이 남아 'text  more'가 됨
         result = normalize_mdx_to_plain('text <br/> more', 'paragraph')
         assert result == 'text  more'


### PR DESCRIPTION
## Description
- `normalize_mdx_to_plain`의 `' '.join` → `'\n'.join` 변경으로 trailing space가 구분자와 구별되어 diff에서 정확히 감지됩니다.
- `text_utils.py`, `table_patcher.py`에서 `s.strip()` → `if s.strip():` 변경으로 텍스트의 trailing space를 보존합니다.
- `mapping_recorder.py`에서 `.strip()` → `.lstrip().rstrip('\n\t\r')` 변경으로 XHTML plain text의 content space를 보존합니다.
- `xhtml_patcher.py`에서 trailing whitespace를 internal node/edge node 두 케이스로 나누어 자연스럽게 처리합니다.
- `link_body_strips` 특수 패치 operation 코드를 전부 제거합니다.

### Background
`[Okta 연동하기 ](url)` → `[Okta 연동하기](url)` 변경이 `<ac:link-body>`에 반영되지 않던 문제의 근본 원인은 normalization 과정에서 trailing space가 소실되어 old_plain == new_plain이 되는 것이었습니다.

별도 patch operation(`link_body_strips`)을 추가하지 않고, 기존 파이프라인이 trailing space 차이를 자연스럽게 감지·처리하도록 수정했습니다.

## Related tickets & links
- split/ko-proofread-20260221-administrator-manual-root 브랜치 verify 실패 2건

## Added/updated tests?
- [x] Yes

## Additional notes
- `bin/reverse_sync_cli.py verify --branch=split/ko-proofread-20260221-administrator-manual-root` → 8/8 PASS
- reverse_sync 관련 테스트 446개 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)