### PR TITLE
confluence-mdx: 문장 분리 시 닫는 괄호 뒤에서도 분리되도록 개선합니다

### DIFF
--- a/confluence-mdx/bin/converter/context.py
+++ b/confluence-mdx/bin/converter/context.py
@@ -478,7 +478,9 @@ def split_into_sentences(line):
     #   - This condition prevents splitting on `Q. Question... A. Answer`.
     # Using positive lookbehind to ensure 3 non-digit characters before punctuation
     # Using capturing group to preserve the punctuation in the split result
-    pattern = r'(?<=\D{3})([.!?])\s+'
+    # Optionally includes a closing parenthesis after the punctuation
+    #   - e.g. `입니다.) 따라서` → splits into `입니다.)` and `따라서`
+    pattern = r'(?<=\D{3})([.!?]\)?)\s+'
 
     # Split the string and preserve punctuation marks
     parts = re.split(pattern, line)

--- a/confluence-mdx/tests/test_split_into_sentences.py
+++ b/confluence-mdx/tests/test_split_into_sentences.py
@@ -1,0 +1,20 @@
+"""split_into_sentences 유닛 테스트."""
+from converter.context import split_into_sentences
+
+
+class TestSplitIntoSentences:
+    def test_korean_paragraph_with_parentheses_and_bold(self):
+        """괄호와 bold 마크다운이 포함된 한국어 문단의 문장 분리."""
+        line = (
+            '+srv 스킴은 TLS 옵션이 자동으로 true이므로 standard string으로 변환하면'
+            ' **tls=true**를 수동으로 입력해 주어야 합니다.'
+            ' (TXT 레코드에 TLS 옵션이 없기 때문입니다.)'
+            ' 따라서 Other options 항목에 위 그림과 같이  **&tls=true**를 입력합니다.'
+        )
+        result = split_into_sentences(line)
+        assert result == [
+            '+srv 스킴은 TLS 옵션이 자동으로 true이므로 standard string으로 변환하면'
+            ' **tls=true**를 수동으로 입력해 주어야 합니다.',
+            '(TXT 레코드에 TLS 옵션이 없기 때문입니다.)',
+            '따라서 Other options 항목에 위 그림과 같이  **&tls=true**를 입력합니다.',
+        ]


### PR DESCRIPTION
## Summary
- `split_into_sentences()` 정규식에서 마침표/느낌표/물음표 뒤 닫는 괄호 `)`도 문장 종결로 인식하도록 개선합니다.
- 예: `입니다.) 따라서` → `입니다.)` 와 `따라서` 로 분리
- `test_split_into_sentences.py` 테스트를 추가합니다.

## Test plan
- [x] `pytest tests/test_split_into_sentences.py` 통과
- [x] `pytest tests/` 전체 통과 (775 passed, 기존 실패 2건은 로컬 데이터 의존)
- [x] `npm test` 전체 통과 (74 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)