### PR TITLE
confluence-mdx: blockquote 내 문장 분리 시 줄바꿈 누락을 수정합니다

### DIFF
--- a/confluence-mdx/bin/converter/core.py
+++ b/confluence-mdx/bin/converter/core.py
@@ -765,7 +765,7 @@ class MultiLineParser:
                 markdown.extend(MultiLineParser(child, collector=self.collector).as_markdown)
             lines = ''.join(markdown).splitlines()
             for to_quote in lines:
-                self.markdown_lines.append(f'> {to_quote}')
+                self.markdown_lines.append(f'> {to_quote}\n')
         elif node.name in [
             'ac:rich-text-body',  # Child of <ac:structured-macro name="panel">
             'ac:adf-content',  # Child of <ac:adf-extension>

--- a/confluence-mdx/tests/test_split_into_sentences.py
+++ b/confluence-mdx/tests/test_split_into_sentences.py
@@ -1,5 +1,9 @@
-"""split_into_sentences 유닛 테스트."""
+"""split_into_sentences 및 blockquote 문장 분리 유닛 테스트."""
+from bs4 import BeautifulSoup
+
 from converter.context import split_into_sentences
+from converter.core import MultiLineParser
+from converter.lost_info import LostInfoCollector
 
 
 class TestSplitIntoSentences:
@@ -18,3 +22,25 @@ class TestSplitIntoSentences:
             '(TXT 레코드에 TLS 옵션이 없기 때문입니다.)',
             '따라서 Other options 항목에 위 그림과 같이  **&tls=true**를 입력합니다.',
         ]
+
+
+class TestBlockquoteSentenceSplit:
+    def test_blockquote_sentences_have_newlines(self):
+        """blockquote 안의 문장 분리 결과가 각 줄마다 개행을 포함해야 한다."""
+        html = (
+            '<blockquote><p>'
+            '+srv 스킴은 TLS 옵션이 자동으로 true이므로 standard string으로 변환하면'
+            ' tls=true를 수동으로 입력해 주어야 합니다.'
+            ' (TXT 레코드에 TLS 옵션이 없기 때문입니다.)'
+            ' 따라서 Other options 항목에 위 그림과 같이 tls=true를 입력합니다.'
+            '</p></blockquote>'
+        )
+        soup = BeautifulSoup(html, 'html.parser')
+        result = MultiLineParser(soup, collector=LostInfoCollector()).as_markdown
+        output = ''.join(result)
+        assert output == (
+            '> +srv 스킴은 TLS 옵션이 자동으로 true이므로 standard string으로 변환하면'
+            ' tls=true를 수동으로 입력해 주어야 합니다.\n'
+            '> (TXT 레코드에 TLS 옵션이 없기 때문입니다.)\n'
+            '> 따라서 Other options 항목에 위 그림과 같이 tls=true를 입력합니다.\n'
+        )


### PR DESCRIPTION
## Summary
- `MultiLineParser`의 blockquote 처리에서 `> ` prefix 추가 시 `\n`이 누락되어, 여러 문장이 한 줄로 이어 붙는 버그를 수정합니다.
- `TestBlockquoteSentenceSplit` 테스트케이스를 추가합니다.

## Test plan
- [x] `pytest tests/test_split_into_sentences.py` 2건 통과
- [x] `pytest tests/` 전체 통과 (781 passed)
- [x] `npm test` 전체 통과 (74 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)