### PR TITLE
ci: build-and-push 워크플로우에 fetch_cli.py 실행 옵션을 추가합니다

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -2,6 +2,15 @@ name: Build and Push Docker Image
 
 on:
   workflow_dispatch:
+    inputs:
+      fetch_arguments:
+        description: 'Arguments for fetch_cli.py (Dockerfile Stage 1)'
+        required: false
+        type: choice
+        options:
+          - '--recent --attachments'
+          - '--remote --attachments'
+        default: '--recent --attachments'
   push:
     branches:
       - main
@@ -45,7 +54,8 @@ jobs:
         working-directory: ./confluence-mdx
         run: |
           set -o errexit -o nounset -o pipefail -o xtrace
-          docker compose --progress=plain build
+          docker compose --progress=plain build \
+            --build-arg "FETCH_ARGS=${{ inputs.fetch_arguments || '--recent --attachments' }}"
 
       - name: Push Docker image
         if: github.event_name != 'pull_request'

--- a/confluence-mdx/Dockerfile
+++ b/confluence-mdx/Dockerfile
@@ -23,10 +23,12 @@ COPY etc/ ./etc/
 # Restore cache at its expected path (for Stage 3 attachment fallback)
 COPY cache/ ./cache/
 
-# Populate var/ baseline from cache and fetch recent updates in one step.
+# Populate var/ baseline from cache and fetch updates in one step.
 # cp -a creates var/ with all cached YAML/content/attachment files,
-# then fetch_cli.py downloads only recently modified pages.
-RUN cp -a cache/. var/ && python3 bin/fetch_cli.py --recent --attachments
+# then fetch_cli.py downloads pages according to FETCH_ARGS.
+# Default: --recent --attachments (incremental). Use --remote --attachments for full fetch.
+ARG FETCH_ARGS="--recent --attachments"
+RUN cp -a cache/. var/ && python3 bin/fetch_cli.py ${FETCH_ARGS}
 
 # ── Stage 2: Final image ────────────────────────────
 FROM python:3.12-slim


### PR DESCRIPTION
## Description

- Dockerfile Stage 1의 `fetch_cli.py` 인자를 `ARG FETCH_ARGS`로 파라미터화합니다.
- `workflow_dispatch` 수동 실행 시 fetch 방식을 선택할 수 있습니다.
  - `--recent --attachments` (기본값) — `fetch_state.yaml`의 마지막 수집 시점 이후 변경 페이지만 수집
  - `--remote --attachments` — 전체 페이지 트리를 API로 다시 수집
- `push` / `pull_request` 자동 트리거 시에는 기본값 `--recent --attachments`가 적용됩니다.
- `--build-arg "FETCH_ARGS=..."` 로 Dockerfile에 전달되어 이미지에 결과가 반영됩니다.

## Added/updated tests?
- [x] No, and this is why: CI 워크플로우 및 Dockerfile 설정 변경으로 별도 테스트 불필요

## Additional notes
- Confluence 공간(QM)은 공개 접근 가능하므로 인증 없이 API 호출이 성공합니다.