### PR TITLE
docs: repo 구조 및 Skeleton 비교 경로 안내 문서를 추가합니다

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,10 +42,10 @@ QueryPie 제품 문서 사이트 (Next.js 16 + Nextra 4 + MDX)
 Skeleton MDX 비교 시 반드시 `target/{lang}/` 경로를 사용하세요:
 ```bash
 # ✅ 올바른 사용
-python3 bin/skeleton/cli.py target/ko/path/to/file.mdx
+bin/skeleton/cli.py target/ko/path/to/file.mdx
 
 # ❌ 작동하지 않음
-python3 bin/skeleton/cli.py ../src/content/ko/path/to/file.mdx
+bin/skeleton/cli.py ../src/content/ko/path/to/file.mdx
 ```
 
 상세 내용: `docs/content-structure.md`

--- a/docs/content-structure.md
+++ b/docs/content-structure.md
@@ -30,10 +30,10 @@ confluence-mdx/target/public  →  ../../public
 ```bash
 # ✅ 올바른 사용법 — target/ko/ 경로 사용
 cd confluence-mdx
-python3 bin/skeleton/cli.py target/ko/installation/some-page.mdx
+bin/skeleton/cli.py target/ko/installation/some-page.mdx
 
 # ❌ 작동하지 않음 — src/content 경로는 인식 불가
-python3 bin/skeleton/cli.py ../src/content/ko/installation/some-page.mdx
+bin/skeleton/cli.py ../src/content/ko/installation/some-page.mdx
 # WARNING: Corresponding Korean MDX file not found: ...
 ```
 


### PR DESCRIPTION
## 배경

Claude/Codex가 Skeleton MDX 비교 실행 시 `src/content/` 경로를 사용하여 도구가 작동하지 않는 문제가 반복됐습니다.
`skeleton/cli.py`는 `target/{lang}/` 경로 형식을 요구하지만, `src/content/`와 `target/`이 심볼릭 링크로 연결된 사실을 모르면 혼동하기 쉽습니다.

## 변경 내용

### `docs/content-structure.md` (신규)
- `confluence-mdx/target/{ko,en,ja}/` ↔ `src/content/{ko,en,ja}/` 심볼릭 링크 관계 설명
- Skeleton MDX 비교 시 반드시 `target/{lang}/` 경로를 사용해야 하는 이유와 올바른/잘못된 사용 예시
- 작업 종류별 올바른 경로 선택 기준 표

### `CLAUDE.md` (수정)
- 심볼릭 링크 주의사항 섹션 추가 (Skeleton 비교 경로 코드 예시 포함)
- `docs/content-structure.md`를 콘텐츠 위치 목록에 (필독) 표시로 추가

## Claude/Codex 참조 보장 방법

`CLAUDE.md`는 Claude Code가 대화 시작 시 자동으로 로드하는 파일입니다.
Codex의 경우 `AGENTS.md` 또는 `CLAUDE.md`를 참조합니다.
두 파일 모두 `docs/content-structure.md`를 명시적으로 안내하므로, 이후 대화에서 혼동이 방지됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Atlas <atlas@jk.agent>