### PR TITLE
confluence-mdx: reverse-sync 버그 재현 테스트 인프라 개선

### DIFF
--- a/.claude/skills/reverse-sync-debugging.md
+++ b/.claude/skills/reverse-sync-debugging.md
@@ -180,6 +180,15 @@ make test-reverse-sync-bugs-one TEST_ID=<page_id>
 
 결과는 `reverse-sync/<page_id>/output.verify.log`에서 확인할 수 있다.
 
+전체 버그 케이스 실행 및 현황 파악:
+```bash
+make test-reverse-sync-bugs
+```
+
+- **FAIL** = 버그가 아직 존재함 (예상된 실패, `expected_status: fail`)
+- **PASS** = 버그가 수정됨 (`expected_status: fail` 케이스가 통과 전환)
+- 자세한 사용법은 `tests/reverse-sync/README.md` 참조
+
 #### 방법 B: Python pytest 단위 테스트
 
 버그가 발생하는 함수를 직접 호출하여 재현하는 방법이다.

--- a/confluence-mdx/tests/Makefile
+++ b/confluence-mdx/tests/Makefile
@@ -53,10 +53,11 @@ test-skeleton-one:
 	fi
 	@$(TEST_SCRIPT) --type skeleton --test-id $(TEST_ID) $(VERBOSE_FLAG)
 
-# Run reverse-sync tests
+# Run reverse-sync tests (testcases/ 와 reverse-sync/ 모두 실행)
 .PHONY: test-reverse-sync
 test-reverse-sync:
 	@$(TEST_SCRIPT) --type reverse-sync $(VERBOSE_FLAG)
+	@$(TEST_SCRIPT) --type reverse-sync --test-dir reverse-sync $(VERBOSE_FLAG)
 
 # Run a specific reverse-sync test
 .PHONY: test-reverse-sync-one
@@ -160,6 +161,7 @@ help:
 	@echo "  test-reverse-sync / test-reverse-sync-one"
 	@echo "    MDX 편집분을 XHTML 에 역패치."
 	@echo "    patched.xhtml, diff.yaml 등 5개 산출물 비교"
+	@echo "    (testcases/ 와 reverse-sync/ 모두 실행)"
 	@echo ""
 	@echo "  test-reverse-sync-bugs / test-reverse-sync-bugs-one"
 	@echo "    reverse-sync 버그 재현 테스트 (tests/reverse-sync/)."

--- a/confluence-mdx/tests/reverse-sync/README.md
+++ b/confluence-mdx/tests/reverse-sync/README.md
@@ -278,10 +278,61 @@ PYEOF
 
 ## 테스트 실행
 
+### make test-reverse-sync-bugs
+
+`tests/reverse-sync/` 아래 모든 테스트케이스에 대해 `reverse_sync_cli.py verify` 를 실행합니다.
+
 ```bash
 # confluence-mdx/tests/ 디렉토리에서
-bash run-tests.sh --type reverse-sync-verify --test-dir reverse-sync
+make test-reverse-sync-bugs
+```
 
-# 단일 케이스
+**결과 해석:**
+
+- **PASS** (녹색): `expected_status: fail` 인 케이스가 pass 로 전환된 경우 = 해당 버그가 수정됨
+- **FAIL** (적색): `expected_status: fail` 인 케이스가 여전히 fail = 버그가 아직 존재함 (예상된 실패)
+- **PASS** (녹색): `expected_status: pass` 인 케이스가 pass = 정상 작동 확인
+
+> **Note:** `make test-reverse-sync-bugs` 의 실패는 대부분 **예상된 실패**입니다.
+> 이 명령은 "현재 수정된 버그 수 / 전체 버그 수" 를 파악하는 용도로 사용합니다.
+> `expected_status: fail` 인 케이스가 모두 PASS 로 전환되면, 해당 버그 유형은 모두 수정된 것입니다.
+
+**단일 케이스 실행:**
+
+```bash
 make test-reverse-sync-bugs-one TEST_ID=<page_id>
 ```
+
+**출력 파일:**
+
+실행 후 각 테스트케이스 디렉토리에 다음 파일이 생성됩니다:
+
+| 파일 | 내용 |
+|------|------|
+| `output.verify.log` | `reverse_sync_cli.py verify` 의 전체 출력 |
+| `output.verify.cmd` | 실행된 정확한 CLI 명령 |
+| `output.reverse-sync.result.yaml` | verify 결과 YAML (status, diff 포함) |
+
+결과 로그 확인:
+```bash
+cat reverse-sync/<page_id>/output.verify.log
+```
+
+실행된 명령 확인:
+```bash
+cat reverse-sync/<page_id>/output.verify.cmd
+```
+
+**버그 수정 확인 워크플로우:**
+
+버그를 수정한 후, 해당 테스트케이스가 PASS 로 전환되었는지 확인합니다:
+
+```bash
+# 1. 단일 케이스로 빠르게 확인
+make test-reverse-sync-bugs-one TEST_ID=<page_id>
+
+# 2. 전체 케이스 실행하여 기존 버그 케이스가 깨지지 않았는지 확인
+make test-reverse-sync-bugs
+```
+
+버그가 수정되었다면 해당 케이스의 `pages.yaml` 항목에서 `expected_status: fail` → `expected_status: pass` 로 변경합니다.

--- a/confluence-mdx/tests/run-tests.sh
+++ b/confluence-mdx/tests/run-tests.sh
@@ -66,6 +66,11 @@ log_cmd() {
     fi
 }
 
+# Print command unconditionally
+log_step() {
+    echo -e "${YELLOW}+ $*${NC}"
+}
+
 # Run command with optional verbose logging
 run_cmd() {
     log_cmd "$@"
@@ -200,7 +205,6 @@ run_reverse_sync_test() {
         --page-id "${test_id}" \
         --original-mdx "tests/${test_path}/original.mdx" \
         --xhtml "tests/${test_path}/page.xhtml" \
-        --json \
         "tests/${test_path}/improved.mdx"
     popd > /dev/null
 
@@ -213,22 +217,41 @@ run_reverse_sync_test() {
     cp "${var_dir}/reverse-sync.mapping.patched.yaml"   "${test_path}/output.reverse-sync.mapping.patched.yaml"
 
     # MDX diff 검증: original.mdx ↔ improved.mdx 차이가 expected와 일치하는지 확인
+    log_step "diff -u --label a/original.mdx --label b/improved.mdx ${test_path}/original.mdx ${test_path}/improved.mdx > ${test_path}/output.mdx.diff"
     diff -u --label a/original.mdx --label b/improved.mdx \
         "${test_path}/original.mdx" "${test_path}/improved.mdx" \
         > "${test_path}/output.mdx.diff" || true
-    diff -u "${test_path}/expected.mdx.diff" "${test_path}/output.mdx.diff"
+    if [[ -f "${test_path}/expected.mdx.diff" ]]; then
+        log_step "diff -u ${test_path}/expected.mdx.diff ${test_path}/output.mdx.diff"
+        diff -u "${test_path}/expected.mdx.diff" "${test_path}/output.mdx.diff"
+    fi
 
     # expected와 비교 (timestamp/경로 필드 제외)
-    diff -u <(grep -v 'created_at' "${test_path}/expected.reverse-sync.result.yaml") \
-            <(grep -v 'created_at' "${test_path}/output.reverse-sync.result.yaml")
-    diff -u "${test_path}/expected.reverse-sync.patched.xhtml" \
-            "${test_path}/output.reverse-sync.patched.xhtml"
-    diff -u <(grep -v 'created_at\|original_mdx\|improved_mdx' "${test_path}/expected.reverse-sync.diff.yaml") \
-            <(grep -v 'created_at\|original_mdx\|improved_mdx' "${test_path}/output.reverse-sync.diff.yaml")
-    diff -u <(grep -v 'created_at\|source_xhtml' "${test_path}/expected.reverse-sync.mapping.original.yaml") \
-            <(grep -v 'created_at\|source_xhtml' "${test_path}/output.reverse-sync.mapping.original.yaml")
-    diff -u <(grep -v 'created_at\|source_xhtml' "${test_path}/expected.reverse-sync.mapping.patched.yaml") \
-            <(grep -v 'created_at\|source_xhtml' "${test_path}/output.reverse-sync.mapping.patched.yaml")
+    if [[ -f "${test_path}/expected.reverse-sync.result.yaml" ]]; then
+        log_step "diff -u ${test_path}/expected.reverse-sync.result.yaml ${test_path}/output.reverse-sync.result.yaml"
+        diff -u <(grep -v 'created_at' "${test_path}/expected.reverse-sync.result.yaml") \
+                <(grep -v 'created_at' "${test_path}/output.reverse-sync.result.yaml")
+    fi
+    if [[ -f "${test_path}/expected.reverse-sync.patched.xhtml" ]]; then
+        log_step "diff -u ${test_path}/expected.reverse-sync.patched.xhtml ${test_path}/output.reverse-sync.patched.xhtml"
+        diff -u "${test_path}/expected.reverse-sync.patched.xhtml" \
+                "${test_path}/output.reverse-sync.patched.xhtml"
+    fi
+    if [[ -f "${test_path}/expected.reverse-sync.diff.yaml" ]]; then
+        log_step "diff -u ${test_path}/expected.reverse-sync.diff.yaml ${test_path}/output.reverse-sync.diff.yaml"
+        diff -u <(grep -v 'created_at\|original_mdx\|improved_mdx' "${test_path}/expected.reverse-sync.diff.yaml") \
+                <(grep -v 'created_at\|original_mdx\|improved_mdx' "${test_path}/output.reverse-sync.diff.yaml")
+    fi
+    if [[ -f "${test_path}/expected.reverse-sync.mapping.original.yaml" ]]; then
+        log_step "diff -u ${test_path}/expected.reverse-sync.mapping.original.yaml ${test_path}/output.reverse-sync.mapping.original.yaml"
+        diff -u <(grep -v 'created_at\|source_xhtml' "${test_path}/expected.reverse-sync.mapping.original.yaml") \
+                <(grep -v 'created_at\|source_xhtml' "${test_path}/output.reverse-sync.mapping.original.yaml")
+    fi
+    if [[ -f "${test_path}/expected.reverse-sync.mapping.patched.yaml" ]]; then
+        log_step "diff -u ${test_path}/expected.reverse-sync.mapping.patched.yaml ${test_path}/output.reverse-sync.mapping.patched.yaml"
+        diff -u <(grep -v 'created_at\|source_xhtml' "${test_path}/expected.reverse-sync.mapping.patched.yaml") \
+                <(grep -v 'created_at\|source_xhtml' "${test_path}/output.reverse-sync.mapping.patched.yaml")
+    fi
 }
 
 has_reverse_sync_input() {
@@ -251,18 +274,23 @@ run_reverse_sync_verify_test() {
     local result_file="${test_path}/output.reverse-sync.result.yaml"
 
     local output_log="${test_path}/output.verify.log"
+    local output_cmd="${test_path}/output.verify.cmd"
 
     # 결과 파일이 없을 때만 verify 실행
     if [[ ! -f "${result_file}" ]]; then
         mkdir -p "../var/${test_id}"
         pushd .. > /dev/null
+        local -a cmd_reverse_sync_cli_verify=(
+            bin/reverse_sync_cli.py verify
+            --page-id "${test_id}"
+            --original-mdx "tests/${test_path}/original.mdx"
+            --xhtml "tests/${test_path}/page.xhtml"
+            "tests/${test_path}/improved.mdx"
+        )
+        # 실행 명령을 파일에 저장
+        echo "${cmd_reverse_sync_cli_verify[*]}" > "tests/${output_cmd}"
         # 출력을 파일로 저장 (run_all_tests의 재실행 시 재사용)
-        bin/reverse_sync_cli.py verify \
-            --page-id "${test_id}" \
-            --original-mdx "tests/${test_path}/original.mdx" \
-            --xhtml "tests/${test_path}/page.xhtml" \
-            "tests/${test_path}/improved.mdx" \
-            > "tests/${output_log}" 2>&1
+        "${cmd_reverse_sync_cli_verify[@]}" > "tests/${output_log}" 2>&1
         popd > /dev/null
 
         # var/에 생성된 중간 결과물을 output.* 으로 복사
@@ -284,6 +312,9 @@ print(r.get('status', 'error'))
 
     # 저장된 CLI 출력 표시
     if [[ -f "${output_log}" ]]; then
+        if [[ -f "${output_cmd}" ]]; then
+            log_step "$(cat "${output_cmd}")"
+        fi
         cat "${output_log}"
     fi
 
@@ -379,7 +410,7 @@ run_all_tests() {
             continue
         fi
 
-        echo "Testing case: ${test_id}"
+        echo "Testing case: ${TEST_DIR}/${test_id}"
 
         if [[ "${VERBOSE}" == "true" ]]; then
             # Show all output in verbose mode
@@ -418,7 +449,7 @@ run_single_test() {
     local test_label="$2"
     local test_id="$3"
 
-    echo "Testing case: ${test_id} (${test_label})"
+    echo "Testing case: ${TEST_DIR}/${test_id} (${test_label})"
 
     if [[ "${VERBOSE}" == "true" ]]; then
         # Show all output in verbose mode


### PR DESCRIPTION
## Description

- `make test-reverse-sync` 가 `testcases/` 와 `reverse-sync/` 를 모두 실행하도록 변경합니다.
- 테스트 출력에서 `Testing case:` 뒤에 디렉토리 경로를 포함하여 실행 위치를 명확히 표시합니다.
- `run_reverse_sync_test` 에서 `--json` 옵션을 제거하여 실패 출력이 과도하게 길어지는 문제를 해결합니다.
- `log_step` 함수를 추가합니다. `VERBOSE` 여부에 관계없이 실행 명령을 항상 콘솔에 표시합니다.
- diff 명령과 verify CLI 명령을 `log_step` 으로 표시하여 어떤 명령의 출력인지 즉시 파악할 수 있게 합니다.
- verify CLI 실행 명령을 `output.verify.cmd` 파일에 저장하여 나중에도 재현/참조할 수 있게 합니다.
- verify CLI 명령을 bash 배열로 정의하여 실행과 파일 저장에 재사용합니다.
- expected 파일이 없는 경우 diff 를 건너뛰어, `reverse-sync/` 디렉토리를 `reverse-sync` 타입으로 실행 시 오류가 없게 합니다.
- `make test-reverse-sync-bugs` 사용법 및 결과 해석 방법을 `tests/reverse-sync/README.md` 에 추가합니다.
- `.claude/skills/reverse-sync-debugging.md` 에 `make test-reverse-sync-bugs` 참조를 추가합니다.

## Changed Files

| 파일 | 변경 내용 |
|------|-----------|
| `confluence-mdx/tests/run-tests.sh` | `log_step` 함수 추가, `--json` 제거, verify cmd 파일 저장, 배열 기반 명령 정의 |
| `confluence-mdx/tests/Makefile` | `test-reverse-sync` 타겟에서 `reverse-sync/` 디렉토리 추가 실행 |
| `confluence-mdx/tests/reverse-sync/README.md` | `make test-reverse-sync-bugs` 사용법/결과 해석 문서 추가 |
| `.claude/skills/reverse-sync-debugging.md` | `make test-reverse-sync-bugs` 참조 추가 |

## Added/updated tests?

- [x] No, and this is why: 이 PR 자체가 테스트 인프라 개선입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)