### PR TITLE
fix(confluence-mdx): build_cross_reference_index 동명 첨부파일 오탐 수정

### DIFF
--- a/confluence-mdx/bin/unused_attachments.py
+++ b/confluence-mdx/bin/unused_attachments.py
@@ -99,14 +99,21 @@ def build_cross_reference_index(references: dict[str, set[str]],
         }
 
     # 모든 페이지의 XHTML에서 참조된 파일명 중,
-    # 해당 페이지가 아닌 다른 페이지의 첨부파일과 이름이 일치하는 것을 탐지
+    # 해당 페이지가 아닌 다른 페이지의 첨부파일과 이름이 일치하는 것을 탐지.
+    # 단, 참조하는 페이지가 동일한 이름의 첨부파일을 자체 보유한 경우는 제외한다:
+    # ri:attachment ri:filename="foo.png"은 같은 페이지의 첨부파일을 의미하므로
+    # 다른 페이지의 동명 첨부파일을 교차 참조하는 것으로 볼 수 없다.
     cross_refs: dict[str, set[str]] = {}
     for ref_page_id, ref_filenames in references.items():
+        ref_own_att_names = att_names_by_page.get(ref_page_id, set())
         for owner_page_id, owner_att_names in att_names_by_page.items():
             if owner_page_id == ref_page_id:
                 continue
             shared = ref_filenames & owner_att_names
             for filename in shared:
+                # 참조하는 페이지가 같은 이름의 첨부파일을 보유하면 교차 참조가 아님
+                if filename in ref_own_att_names:
+                    continue
                 key = f"{owner_page_id}/{filename}"
                 cross_refs.setdefault(key, set()).add(ref_page_id)
 

--- a/confluence-mdx/tests/test_unused_attachments.py
+++ b/confluence-mdx/tests/test_unused_attachments.py
@@ -264,11 +264,10 @@ class TestRealData:
     def test_sample_page(self):
         """실제 페이지 데이터로 미사용 첨부파일을 검출합니다."""
         unused = find_unused_attachments(self.VAR_DIR, page_ids=[self.SAMPLE_PAGE_ID])
-        # 이 페이지는 10개 첨부파일 중 5개가 미사용
-        assert len(unused) == 5
+        # 이 페이지는 6개 첨부파일 중 1개가 미사용
+        assert len(unused) == 1
         unused_titles = {u["title"] for u in unused}
-        assert "image-20240801-074431.png" in unused_titles
-        assert "image-20241103-071004.png" in unused_titles
+        assert "Screenshot 2025-08-26 at 12.43.46\u202fAM.png" in unused_titles
 
     @pytest.mark.skipif(
         not (VAR_DIR / SAMPLE_PAGE_ID).is_dir(),


### PR DESCRIPTION
## Summary
- `build_cross_reference_index` 버그 수정: 참조 페이지가 동일한 이름의 첨부파일을 자체 보유하는 경우 교차 참조로 잘못 처리하던 오탐을 제거합니다.
- `TestRealData.test_sample_page` 기대값을 현행 데이터 기준으로 갱신합니다.

## Background

### 버그 현상
`find_unused_attachments(var_dir)` — 전체 스캔 — 시 미사용 첨부파일이 0개로 잘못 보고되었습니다.

### 원인
Confluence XHTML에서 `<ri:attachment ri:filename="foo.png" />`은 **동일 페이지**의 첨부파일을 가리킵니다. 그러나 기존 `build_cross_reference_index` 로직은 페이지 A가 `foo.png`를 참조하면, 페이지 A가 자체적으로 `foo.png`를 보유하고 있어도 다른 모든 페이지의 동명 첨부파일을 "교차 참조됨"으로 처리했습니다.

294개 페이지 전체 스캔 시 248건의 오탐이 발생하여 실질적인 미사용 첨부파일을 모두 놓쳤습니다.

### 수정
참조하는 페이지가 동일한 이름의 첨부파일을 자체 보유하는 경우 교차 참조에서 제외합니다:

```python
# Before
shared = ref_filenames & owner_att_names
for filename in shared:
    key = f"{owner_page_id}/{filename}"
    cross_refs.setdefault(key, set()).add(ref_page_id)

# After
ref_own_att_names = att_names_by_page.get(ref_page_id, set())
for filename in shared:
    if filename in ref_own_att_names:  # 자체 보유 → 교차 참조 아님
        continue
    key = f"{owner_page_id}/{filename}"
    cross_refs.setdefault(key, set()).add(ref_page_id)
```

수정 후 전체 스캔에서 139개 미사용 첨부파일을 정상 검출합니다.

## Test plan
- [x] `python3 -m pytest tests/test_unused_attachments.py` — 22 passed
- [x] `python3 -m pytest tests/` — 787 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)