### PR TITLE
fix(confluence-mdx/mdx_to_storage): inline code span 내 HTML 특수문자를 이스케이프합니다

### DIFF
--- a/confluence-mdx/bin/mdx_to_storage/inline.py
+++ b/confluence-mdx/bin/mdx_to_storage/inline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import html
 import re
 
 from .link_resolver import LinkResolver
@@ -63,7 +64,7 @@ def convert_inline(text: str, link_resolver: LinkResolver | None = None) -> str:
 
     def _restore_code(match: re.Match[str]) -> str:
         idx = int(match.group(1))
-        return f"<code>{placeholders[idx]}</code>"
+        return f"<code>{html.escape(placeholders[idx])}</code>"
 
     converted = re.sub(r"\x00CODE(\d+)\x00", _restore_code, converted)
     return converted
@@ -91,7 +92,7 @@ def convert_heading_inline(
 
     def _restore_code(match: re.Match[str]) -> str:
         idx = int(match.group(1))
-        return f"<code>{placeholders[idx]}</code>"
+        return f"<code>{html.escape(placeholders[idx])}</code>"
 
     converted = re.sub(r"\x00CODE(\d+)\x00", _restore_code, converted)
     return converted

--- a/confluence-mdx/bin/reverse_sync/mdx_to_xhtml_inline.py
+++ b/confluence-mdx/bin/reverse_sync/mdx_to_xhtml_inline.py
@@ -3,6 +3,7 @@
 MDX 블록의 content를 파싱하여 대상 XHTML 요소의 innerHTML로
 직접 교체할 수 있는 HTML 문자열을 생성한다.
 """
+import html
 import re
 from typing import List
 
@@ -119,7 +120,7 @@ def _convert_html_block_inner(text: str) -> str:
 
 def _convert_code_spans(text: str) -> str:
     """code span만 변환 (`text` → <code>text</code>)."""
-    return re.sub(r'`([^`]+)`', r'<code>\1</code>', text)
+    return re.sub(r'`([^`]+)`', lambda m: f'<code>{html.escape(m.group(1))}</code>', text)
 
 
 def _convert_links(text: str) -> str:

--- a/confluence-mdx/tests/test_reverse_sync_mdx_to_xhtml_inline.py
+++ b/confluence-mdx/tests/test_reverse_sync_mdx_to_xhtml_inline.py
@@ -43,6 +43,22 @@ class TestConvertInline:
         result = convert_inline("line1<br/>line2")
         assert result == "line1<br />line2"
 
+    def test_code_with_less_than(self):
+        """`a < b` → <code>a &lt; b</code>"""
+        assert convert_inline("`a < b`") == "<code>a &lt; b</code>"
+
+    def test_code_with_greater_than(self):
+        """`a > b` → <code>a &gt; b</code>"""
+        assert convert_inline("`a > b`") == "<code>a &gt; b</code>"
+
+    def test_code_with_ampersand(self):
+        """`a & b` → <code>a &amp; b</code>"""
+        assert convert_inline("`a & b`") == "<code>a &amp; b</code>"
+
+    def test_code_with_html_tag_like_string(self):
+        """`<script>` → <code>&lt;script&gt;</code>"""
+        assert convert_inline("`<script>`") == "<code>&lt;script&gt;</code>"
+
 
 # --- mdx_block_to_inner_xhtml 블록 변환 테스트 ---
 
@@ -107,6 +123,16 @@ class TestBlockConversion:
         content = "```\nline1\nline2\nline3\n```\n"
         result = mdx_block_to_inner_xhtml(content, "code_block")
         assert result == "line1\nline2\nline3"
+
+    def test_paragraph_code_html_escape(self):
+        """paragraph 내 code span의 < > 이스케이프"""
+        result = mdx_block_to_inner_xhtml("`a < b`\n", "paragraph")
+        assert result == "<code>a &lt; b</code>"
+
+    def test_heading_code_html_escape(self):
+        """heading 내 code span의 HTML 특수문자 이스케이프"""
+        result = mdx_block_to_inner_xhtml("## `SELECT * FROM t WHERE x < 10`\n", "heading")
+        assert result == "<code>SELECT * FROM t WHERE x &lt; 10</code>"
 
 
 # --- _parse_list_items 테스트 ---


### PR DESCRIPTION
## Description

\`<\`, \`>\`, \`&\` 등 HTML 특수문자가 포함된 코드 스니펫을 XHTML로 변환할 때
이스케이프되지 않아 XHTML 파싱 오류나 렌더링 깨짐이 발생하는 버그를 수정합니다.

**변경 전**: \`\`\`SELECT * FROM t WHERE x < 10\`\`\` → \`<code>SELECT * FROM t WHERE x < 10</code>\` ❌
**변경 후**: \`\`\`SELECT * FROM t WHERE x < 10\`\`\` → \`<code>SELECT * FROM t WHERE x &lt; 10</code>\` ✅

### 변경 파일

- \`bin/mdx_to_storage/inline.py\`: \`convert_inline\`, \`convert_heading_inline\`의 \`_restore_code\`에 \`html.escape()\` 적용

### reverse_sync 동일 버그

\`reverse_sync/mdx_to_xhtml_inline.py\`의 \`_convert_code_spans\`도 동일한 버그가 있으며 #910에서 수정됩니다.

## Added/updated tests?

- [x] Yes — \`TestConvertInline\`에 \`<\`, \`>\`, \`&\`, HTML 태그 형식 escape 케이스 4개 추가

## 관련 PR

- \`reverse_sync\` 동일 버그 수정: #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)