### PR TITLE
feat: add public docs mcp search endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "fetch-openapi-spec": "npx tsx scripts/fetch-openapi-spec/index.ts",
     "test": "vitest",
     "test:ui": "vitest --ui",
-    "test:run": "vitest run"
+    "test:run": "vitest run",
+    "build-doc-search-index": "npx tsx scripts/build-doc-search-index/index.ts",
+    "predev": "npm run build-doc-search-index",
+    "prebuild": "npm run build-doc-search-index"
   },
   "repository": {
     "type": "git",

--- a/scripts/build-doc-search-index/__tests__/chunker.test.ts
+++ b/scripts/build-doc-search-index/__tests__/chunker.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseMdxDocument } from '../mdx-parser';
+import { buildChunksFromDocument } from '../chunker';
+import { inferDocMetadata } from '../metadata';
+
+const sampleMdx = `---
+title: 'Google Cloud에서 DB 리소스 동기화'
+description: 'GCP 연동 가이드'
+confluenceUrl: 'https://example.com/confluence'
+---
+
+import { Callout } from 'nextra/components'
+
+# Google Cloud에서 DB 리소스 동기화
+
+### Overview
+
+QueryPie에서는 데이터베이스 등록 및 관리를 위한 Google Cloud(GCP) 연동을 지원합니다.
+
+<Callout type="info">
+11.3.0에서 특정 태그가 있는 리소스만 동기화할 수 있도록 Search Filter 기능이 추가되었습니다.
+</Callout>
+
+### QueryPie에서 GCP 연동 정보 등록하기
+
+1. Database 설정 메뉴에서 Cloud Provider 메뉴로 이동합니다.
+2. \
+
+aaa
+3. **Search Filter** 를 사용하여 동기화하고자 하는 일부 유형의 리소스 목록을 가져올 수 있습니다.
+
+<figure>
+<img src="/foo.png" alt="Cloud Provider 화면" />
+<figcaption>Cloud Provider 화면</figcaption>
+</figure>
+`;
+
+describe('parseMdxDocument', () => {
+  it('strips frontmatter/imports and keeps searchable text', () => {
+    const document = parseMdxDocument(sampleMdx, {
+      filePath: 'src/content/ko/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-google-cloud.mdx',
+      lang: 'ko',
+    });
+
+    expect(document.title).toBe('Google Cloud에서 DB 리소스 동기화');
+    expect(document.description).toBe('GCP 연동 가이드');
+    expect(document.content).not.toContain("import { Callout }");
+    expect(document.content).not.toContain('---');
+    expect(document.content).toContain('11.3.0에서 특정 태그가 있는 리소스만 동기화할 수 있도록 Search Filter 기능이 추가되었습니다.');
+    expect(document.content).toContain('Cloud Provider 화면');
+  });
+});
+
+describe('inferDocMetadata', () => {
+  it('infers path-driven metadata and version hints', () => {
+    const metadata = inferDocMetadata({
+      filePath: 'src/content/ko/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-google-cloud.mdx',
+      lang: 'ko',
+      title: 'Google Cloud에서 DB 리소스 동기화',
+      description: 'GCP 연동 가이드',
+      content: sampleMdx,
+    });
+
+    expect(metadata.url).toBe('/ko/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-google-cloud');
+    expect(metadata.pagePath).toBe('administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-google-cloud');
+    expect(metadata.manualType).toBe('administrator-manual');
+    expect(metadata.productArea).toBe('databases');
+    expect(metadata.versionHints).toContain('11.3.0');
+    expect(metadata.isUnreleased).toBe(false);
+  });
+});
+
+describe('buildChunksFromDocument', () => {
+  it('builds heading-based chunks with breadcrumbs and rich text', () => {
+    const document = parseMdxDocument(sampleMdx, {
+      filePath: 'src/content/ko/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-google-cloud.mdx',
+      lang: 'ko',
+    });
+    const metadata = inferDocMetadata({
+      filePath: document.filePath,
+      lang: document.lang,
+      title: document.title,
+      description: document.description,
+      content: document.content,
+    });
+
+    const chunks = buildChunksFromDocument(document, metadata);
+
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
+    expect(chunks[0].headingPath).toEqual(['Google Cloud에서 DB 리소스 동기화', 'Overview']);
+    expect(chunks[0].content).toContain('QueryPie에서는 데이터베이스 등록 및 관리를 위한 Google Cloud(GCP) 연동을 지원합니다.');
+
+    const registrationChunk = chunks.find(chunk => chunk.headingPath.includes('QueryPie에서 GCP 연동 정보 등록하기'));
+    expect(registrationChunk).toBeDefined();
+    expect(registrationChunk?.content).toContain('Search Filter');
+    expect(registrationChunk?.content).toContain('Cloud Provider 화면');
+    expect(registrationChunk?.excerpt.length).toBeLessThanOrEqual(220);
+  });
+});

--- a/scripts/build-doc-search-index/chunker.ts
+++ b/scripts/build-doc-search-index/chunker.ts
@@ -1,0 +1,80 @@
+import crypto from 'node:crypto';
+
+import type { DocSearchChunk } from '@/lib/doc-search/types';
+import type { ParsedMdxDocument } from './mdx-parser';
+import type { InferredDocMetadata } from './metadata';
+
+function makeExcerpt(content: string, maxLength = 220): string {
+  return content.length <= maxLength ? content : `${content.slice(0, maxLength - 1).trim()}…`;
+}
+
+function finalizeChunk(
+  chunks: DocSearchChunk[],
+  document: ParsedMdxDocument,
+  metadata: InferredDocMetadata,
+  headingPath: string[],
+  buffer: string[],
+): void {
+  const content = buffer.join('\n').trim();
+  if (!content) return;
+
+  chunks.push({
+    id: crypto.createHash('sha1').update(`${metadata.pagePath}:${headingPath.join('>')}:${content}`).digest('hex'),
+    pagePath: metadata.pagePath,
+    url: metadata.url,
+    title: document.title,
+    description: document.description,
+    headingPath,
+    content,
+    excerpt: makeExcerpt(content),
+    metadata: {
+      lang: metadata.lang,
+      manualType: metadata.manualType,
+      productArea: metadata.productArea,
+      versionHints: metadata.versionHints,
+      isUnreleased: metadata.isUnreleased,
+    },
+  });
+}
+
+export function buildChunksFromDocument(document: ParsedMdxDocument, metadata: InferredDocMetadata): DocSearchChunk[] {
+  const lines = document.content.split('\n');
+  const chunks: DocSearchChunk[] = [];
+  let currentHeadingPath = [document.title];
+  let buffer: string[] = [];
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line) {
+      if (buffer.at(-1) !== '') buffer.push('');
+      continue;
+    }
+
+    const headingMatch = /^(#{1,6})\s+(.*)$/.exec(line);
+    if (headingMatch) {
+      const level = headingMatch[1].length;
+      const headingText = headingMatch[2].trim();
+
+      if (level === 1) {
+        currentHeadingPath = [headingText];
+        continue;
+      }
+
+      finalizeChunk(chunks, document, metadata, currentHeadingPath, buffer);
+      buffer = [];
+
+      const parentTitle = currentHeadingPath[0] || document.title;
+      if (level === 2 || level === 3) {
+        currentHeadingPath = [parentTitle, headingText];
+      } else {
+        currentHeadingPath = [...currentHeadingPath.slice(0, 2), headingText];
+      }
+      continue;
+    }
+
+    buffer.push(line);
+  }
+
+  finalizeChunk(chunks, document, metadata, currentHeadingPath, buffer);
+  return chunks;
+}

--- a/scripts/build-doc-search-index/index.ts
+++ b/scripts/build-doc-search-index/index.ts
@@ -1,0 +1,92 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { DocSearchArtifact, DocSearchPage, DocSearchPagesArtifact } from '@/lib/doc-search/types';
+import { extractTableOfContents } from '@/lib/doc-search/normalize-mdx';
+import { buildChunksFromDocument } from './chunker';
+import { inferDocMetadata } from './metadata';
+import { parseMdxDocument } from './mdx-parser';
+
+const CONTENT_ROOT = path.join(process.cwd(), 'src', 'content', 'ko');
+const OUTPUT_ROOT = path.join(process.cwd(), 'public', '_doc-search');
+
+function listMdxFiles(dir: string): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  return entries.flatMap((entry) => {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) return listMdxFiles(fullPath);
+    return entry.name.endsWith('.mdx') ? [fullPath] : [];
+  });
+}
+
+function ensureOutputDir(): void {
+  fs.mkdirSync(OUTPUT_ROOT, { recursive: true });
+}
+
+function toRepoRelative(filePath: string): string {
+  return path.relative(process.cwd(), filePath).split(path.sep).join('/');
+}
+
+export function buildDocSearchArtifacts(): { index: DocSearchArtifact; pages: DocSearchPagesArtifact } {
+  const files = listMdxFiles(CONTENT_ROOT);
+  const chunks = [] as DocSearchArtifact['chunks'];
+  const pages: Record<string, DocSearchPage> = {};
+  const generatedAt = new Date().toISOString();
+
+  for (const file of files) {
+    const source = fs.readFileSync(file, 'utf8');
+    const relativeFilePath = toRepoRelative(file);
+    const document = parseMdxDocument(source, { filePath: relativeFilePath, lang: 'ko' });
+    const metadata = inferDocMetadata({
+      filePath: relativeFilePath,
+      lang: 'ko',
+      title: document.title,
+      description: document.description,
+      content: document.content,
+    });
+
+    chunks.push(...buildChunksFromDocument(document, metadata));
+    pages[metadata.pagePath] = {
+      pagePath: metadata.pagePath,
+      url: metadata.url,
+      title: document.title,
+      description: document.description,
+      content: document.content,
+      tableOfContents: extractTableOfContents(source),
+      metadata: {
+        lang: metadata.lang,
+        manualType: metadata.manualType,
+        productArea: metadata.productArea,
+        versionHints: metadata.versionHints,
+        isUnreleased: metadata.isUnreleased,
+      },
+    };
+  }
+
+  return {
+    index: {
+      version: 1,
+      generatedAt,
+      lang: 'ko',
+      chunks,
+    },
+    pages: {
+      version: 1,
+      generatedAt,
+      lang: 'ko',
+      pages,
+    },
+  };
+}
+
+export function writeDocSearchArtifacts(): void {
+  ensureOutputDir();
+  const { index, pages } = buildDocSearchArtifacts();
+  fs.writeFileSync(path.join(OUTPUT_ROOT, 'ko-index.json'), JSON.stringify(index));
+  fs.writeFileSync(path.join(OUTPUT_ROOT, 'ko-pages.json'), JSON.stringify(pages));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  writeDocSearchArtifacts();
+  console.log('Generated docs search artifacts');
+}

--- a/scripts/build-doc-search-index/mdx-parser.ts
+++ b/scripts/build-doc-search-index/mdx-parser.ts
@@ -1,0 +1,37 @@
+import matter from 'gray-matter';
+
+import { normalizeMdxForLLM } from '@/lib/doc-search/normalize-mdx';
+
+export interface ParsedMdxDocument {
+  filePath: string;
+  lang: string;
+  title: string;
+  description: string;
+  content: string;
+  rawContent: string;
+}
+
+export function parseMdxDocument(
+  source: string,
+  options: { filePath: string; lang: string },
+): ParsedMdxDocument {
+  const parsed = matter(source);
+  const normalizedContent = normalizeMdxForLLM(source);
+  const headingTitle = normalizedContent
+    .split('\n')
+    .find(line => line.startsWith('# '))
+    ?.replace(/^#\s+/, '')
+    .trim();
+
+  const title = String(parsed.data.title || headingTitle || options.filePath.split('/').pop()?.replace(/\.mdx$/, '') || 'Untitled');
+  const description = String(parsed.data.description || '');
+
+  return {
+    filePath: options.filePath,
+    lang: options.lang,
+    title,
+    description,
+    content: normalizedContent,
+    rawContent: source,
+  };
+}

--- a/scripts/build-doc-search-index/metadata.ts
+++ b/scripts/build-doc-search-index/metadata.ts
@@ -1,0 +1,58 @@
+import type { DocSearchMetadata } from '@/lib/doc-search/types';
+
+export interface InferredDocMetadata extends DocSearchMetadata {
+  pagePath: string;
+  url: string;
+}
+
+const VERSION_PATTERN = /\b\d+\.\d+\.\d+\b/g;
+
+function stripContentPrefix(filePath: string): string {
+  return filePath.replace(/^src\/content\/[a-z]{2}\//, '').replace(/\.mdx$/, '');
+}
+
+function inferManualTypeFromPath(pagePath: string): DocSearchMetadata['manualType'] {
+  const firstSegment = pagePath.split('/')[0];
+  switch (firstSegment) {
+    case 'overview':
+    case 'user-manual':
+    case 'administrator-manual':
+    case 'installation':
+    case 'release-notes':
+    case 'api-reference':
+    case 'support':
+    case 'unreleased':
+      return firstSegment;
+    default:
+      return 'unknown';
+  }
+}
+
+function inferProductArea(pagePath: string, manualType: DocSearchMetadata['manualType']): string {
+  const segments = pagePath.split('/');
+  return segments[1] || manualType;
+}
+
+export function inferDocMetadata(input: {
+  filePath: string;
+  lang: string;
+  title: string;
+  description: string;
+  content: string;
+}): InferredDocMetadata {
+  const pagePath = stripContentPrefix(input.filePath);
+  const manualType = inferManualTypeFromPath(pagePath);
+  const productArea = inferProductArea(pagePath, manualType);
+  const versionHints = Array.from(new Set(input.content.match(VERSION_PATTERN) ?? []));
+  const isUnreleased = manualType === 'unreleased' || pagePath.startsWith('unreleased');
+
+  return {
+    pagePath,
+    url: `/${input.lang}/${pagePath}`,
+    lang: input.lang,
+    manualType,
+    productArea,
+    versionHints,
+    isUnreleased,
+  };
+}

--- a/src/app/mcp/route.test.ts
+++ b/src/app/mcp/route.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { GET, OPTIONS, POST, DELETE } from './route';
+
+function makeRequest(url: string, init?: RequestInit) {
+  return new NextRequest(new Request(url, init));
+}
+
+describe('/mcp transport', () => {
+  it('returns CORS preflight headers for inspector', async () => {
+    const response = await OPTIONS(
+      makeRequest('http://localhost:3000/mcp', {
+        method: 'OPTIONS',
+        headers: {
+          Origin: 'https://modelcontextprotocol.io',
+          'Access-Control-Request-Method': 'POST',
+          'Access-Control-Request-Headers': 'content-type,mcp-protocol-version',
+        },
+      }),
+    );
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('access-control-allow-origin')).toBe('https://modelcontextprotocol.io');
+    expect(response.headers.get('access-control-allow-methods')).toContain('POST');
+    expect(response.headers.get('access-control-allow-headers')).toContain('mcp-protocol-version');
+  });
+
+  it('returns SSE stream for GET requests that ask for text/event-stream', async () => {
+    const response = await GET(
+      makeRequest('http://localhost:3000/mcp', {
+        method: 'GET',
+        headers: {
+          Accept: 'text/event-stream',
+          Origin: 'https://modelcontextprotocol.io',
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/event-stream');
+    expect(response.headers.get('mcp-protocol-version')).toBeTruthy();
+  });
+
+  it('returns protocol headers on initialize POST', async () => {
+    const response = await POST(
+      makeRequest('http://localhost:3000/mcp', {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          'Content-Type': 'application/json',
+          Origin: 'https://modelcontextprotocol.io',
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2025-06-18',
+            capabilities: {},
+            clientInfo: { name: 'mcp-inspector', version: '1.0.0' },
+          },
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('application/json');
+    expect(response.headers.get('mcp-protocol-version')).toBe('2025-06-18');
+    expect(response.headers.get('access-control-allow-origin')).toBe('https://modelcontextprotocol.io');
+  });
+
+  it('accepts notifications with 202', async () => {
+    const response = await POST(
+      makeRequest('http://localhost:3000/mcp', {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'notifications/initialized',
+          params: {},
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(202);
+  });
+
+  it('supports DELETE session cleanup as a no-op', async () => {
+    const response = await DELETE(
+      makeRequest('http://localhost:3000/mcp', {
+        method: 'DELETE',
+        headers: {
+          Origin: 'https://modelcontextprotocol.io',
+        },
+      }),
+    );
+
+    expect(response.status).toBe(204);
+  });
+});

--- a/src/app/mcp/route.ts
+++ b/src/app/mcp/route.ts
@@ -1,0 +1,199 @@
+import { randomUUID } from 'node:crypto';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { handleMcpJsonRpc, MCP_PROTOCOL_VERSION, SUPPORTED_PROTOCOL_VERSIONS } from '@/lib/doc-search/mcp';
+
+const MAX_REQUESTS_PER_MINUTE = 120;
+const rateLimitStore = new Map<string, { count: number; resetAt: number }>();
+const ALLOWED_CORS_HEADERS = [
+  'content-type',
+  'accept',
+  'mcp-protocol-version',
+  'mcp-session-id',
+  'last-event-id',
+];
+
+function getClientKey(request: NextRequest): string {
+  const forwardedFor = request.headers.get('x-forwarded-for');
+  return forwardedFor?.split(',')[0]?.trim() || 'unknown';
+}
+
+function isRateLimited(clientKey: string): boolean {
+  const now = Date.now();
+  const existing = rateLimitStore.get(clientKey);
+  if (!existing || existing.resetAt <= now) {
+    rateLimitStore.set(clientKey, { count: 1, resetAt: now + 60_000 });
+    return false;
+  }
+
+  existing.count += 1;
+  rateLimitStore.set(clientKey, existing);
+  return existing.count > MAX_REQUESTS_PER_MINUTE;
+}
+
+function isAllowedOrigin(origin: string, requestHost: string): boolean {
+  try {
+    const originUrl = new URL(origin);
+    const hostname = originUrl.hostname;
+    const isLocalHost = ['localhost', '127.0.0.1'].includes(requestHost);
+
+    if (isLocalHost) {
+      return [
+        'localhost',
+        '127.0.0.1',
+        'modelcontextprotocol.io',
+        'inspector.modelcontextprotocol.io',
+      ].includes(hostname);
+    }
+
+    if (hostname === requestHost || hostname === 'docs.querypie.com' || hostname === 'docs-staging.querypie.io') {
+      return true;
+    }
+
+    return originUrl.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function buildCorsHeaders(request: NextRequest): Headers {
+  const headers = new Headers();
+  const origin = request.headers.get('origin');
+
+  if (origin && isAllowedOrigin(origin, request.nextUrl.hostname)) {
+    headers.set('Access-Control-Allow-Origin', origin);
+    headers.set('Vary', 'Origin');
+  }
+
+  headers.set('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+  headers.set('Access-Control-Allow-Headers', ALLOWED_CORS_HEADERS.join(', '));
+  headers.set('Access-Control-Expose-Headers', 'MCP-Protocol-Version, MCP-Session-Id');
+  headers.set('Access-Control-Max-Age', '86400');
+  return headers;
+}
+
+function forbiddenOriginResponse(request: NextRequest): NextResponse | null {
+  const origin = request.headers.get('origin');
+  if (!origin) {
+    return null;
+  }
+
+  if (!isAllowedOrigin(origin, request.nextUrl.hostname)) {
+    return NextResponse.json({ error: 'Forbidden origin' }, { status: 403 });
+  }
+
+  return null;
+}
+
+function getProtocolVersion(request: NextRequest, bodyVersion?: unknown): string {
+  const requestedVersion = String(bodyVersion || request.headers.get('mcp-protocol-version') || MCP_PROTOCOL_VERSION);
+  if (SUPPORTED_PROTOCOL_VERSIONS.includes(requestedVersion as (typeof SUPPORTED_PROTOCOL_VERSIONS)[number])) {
+    return requestedVersion;
+  }
+  return MCP_PROTOCOL_VERSION;
+}
+
+function withCommonHeaders(response: NextResponse, request: NextRequest, protocolVersion: string): NextResponse {
+  const corsHeaders = buildCorsHeaders(request);
+  corsHeaders.forEach((value, key) => response.headers.set(key, value));
+  response.headers.set('MCP-Protocol-Version', protocolVersion);
+  response.headers.set('Allow', 'GET, POST, DELETE, OPTIONS');
+  return response;
+}
+
+function createSseResponse(request: NextRequest, protocolVersion: string): NextResponse {
+  const stream = new ReadableStream({
+    start(controller) {
+      const encoder = new TextEncoder();
+      controller.enqueue(encoder.encode(`id: ${randomUUID()}\n`));
+      controller.enqueue(encoder.encode('event: message\n'));
+      controller.enqueue(encoder.encode('data: {}\n\n'));
+      controller.close();
+    },
+  });
+
+  const response = new NextResponse(stream, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/event-stream; charset=utf-8',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+    },
+  });
+
+  return withCommonHeaders(response, request, protocolVersion);
+}
+
+export async function OPTIONS(request: NextRequest) {
+  const forbidden = forbiddenOriginResponse(request);
+  if (forbidden) {
+    return forbidden;
+  }
+
+  return withCommonHeaders(new NextResponse(null, { status: 204 }), request, getProtocolVersion(request));
+}
+
+export async function GET(request: NextRequest) {
+  const forbidden = forbiddenOriginResponse(request);
+  if (forbidden) {
+    return forbidden;
+  }
+
+  const protocolVersion = getProtocolVersion(request);
+  const accept = request.headers.get('accept') || '';
+  if (accept.includes('text/event-stream')) {
+    return createSseResponse(request, protocolVersion);
+  }
+
+  return withCommonHeaders(
+    NextResponse.json(
+      {
+        name: 'querypie-docs-mcp',
+        transport: 'streamable-http',
+        methods: ['GET', 'POST', 'DELETE', 'OPTIONS'],
+        tools: ['search_docs', 'get_doc_page'],
+      },
+      { status: 200 },
+    ),
+    request,
+    protocolVersion,
+  );
+}
+
+export async function DELETE(request: NextRequest) {
+  const forbidden = forbiddenOriginResponse(request);
+  if (forbidden) {
+    return forbidden;
+  }
+
+  return withCommonHeaders(new NextResponse(null, { status: 204 }), request, getProtocolVersion(request));
+}
+
+export async function POST(request: NextRequest) {
+  const forbidden = forbiddenOriginResponse(request);
+  if (forbidden) {
+    return forbidden;
+  }
+
+  const clientKey = getClientKey(request);
+  if (isRateLimited(clientKey)) {
+    return withCommonHeaders(NextResponse.json({ error: 'Too many requests' }, { status: 429 }), request, getProtocolVersion(request));
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return withCommonHeaders(NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }), request, getProtocolVersion(request));
+  }
+
+  const protocolVersion = getProtocolVersion(request, body.params && typeof body.params === 'object' ? (body.params as Record<string, unknown>).protocolVersion : undefined);
+
+  if (body.id === undefined || body.id === null) {
+    await handleMcpJsonRpc(body as never);
+    return withCommonHeaders(new NextResponse(null, { status: 202 }), request, protocolVersion);
+  }
+
+  const responseBody = await handleMcpJsonRpc(body as never);
+  return withCommonHeaders(NextResponse.json(responseBody, { status: 200 }), request, protocolVersion);
+}

--- a/src/lib/doc-search/__tests__/mcp.test.ts
+++ b/src/lib/doc-search/__tests__/mcp.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DocSearchArtifact, DocSearchPagesArtifact } from '@/lib/doc-search/types';
+import { handleMcpJsonRpc, MCP_PROTOCOL_VERSION } from '@/lib/doc-search/mcp';
+
+const artifact: DocSearchArtifact = {
+  version: 1,
+  generatedAt: '2026-03-16T00:00:00.000Z',
+  lang: 'ko',
+  chunks: [
+    {
+      id: '1',
+      pagePath: 'administrator-manual/databases/monitoring',
+      url: '/ko/administrator-manual/databases/monitoring',
+      title: 'Monitoring',
+      description: '모니터링 기능 설명',
+      headingPath: ['Monitoring', 'Overview'],
+      content: 'Running Queries 기능과 Proxy Management를 통해 상태를 확인하고 강제 중지할 수 있습니다.',
+      excerpt: 'Running Queries 기능과 Proxy Management를 통해 상태를 확인하고 강제 중지할 수 있습니다.',
+      metadata: {
+        lang: 'ko',
+        manualType: 'administrator-manual',
+        productArea: 'databases',
+        versionHints: ['10.3.0'],
+        isUnreleased: false,
+      },
+    },
+  ],
+};
+
+const pages: DocSearchPagesArtifact = {
+  version: 1,
+  generatedAt: '2026-03-16T00:00:00.000Z',
+  lang: 'ko',
+  pages: {
+    'administrator-manual/databases/monitoring': {
+      pagePath: 'administrator-manual/databases/monitoring',
+      url: '/ko/administrator-manual/databases/monitoring',
+      title: 'Monitoring',
+      description: '모니터링 기능 설명',
+      content: '# Monitoring\n\n### Overview\n\nRunning Queries 기능 설명',
+      tableOfContents: ['Monitoring', 'Overview'],
+      metadata: {
+        lang: 'ko',
+        manualType: 'administrator-manual',
+        productArea: 'databases',
+        versionHints: ['10.3.0'],
+        isUnreleased: false,
+      },
+    },
+  },
+};
+
+describe('handleMcpJsonRpc', () => {
+  it('responds to initialize', async () => {
+    const response = await handleMcpJsonRpc(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' },
+        },
+      },
+      { artifact, pages },
+    );
+
+    expect(response.result.protocolVersion).toBe(MCP_PROTOCOL_VERSION);
+    expect(response.result.capabilities.tools).toEqual({});
+  });
+
+  it('lists search tools', async () => {
+    const response = await handleMcpJsonRpc(
+      { jsonrpc: '2.0', id: 2, method: 'tools/list' },
+      { artifact, pages },
+    );
+
+    expect(response.result.tools.map((tool: { name: string }) => tool.name)).toEqual(['search_docs', 'get_doc_page']);
+  });
+
+  it('calls search_docs and returns structured content', async () => {
+    const response = await handleMcpJsonRpc(
+      {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: { name: 'search_docs', arguments: { query: 'Running Queries', topK: 3 } },
+      },
+      { artifact, pages },
+    );
+
+    expect(response.result.structuredContent.results[0].pagePath).toBe('administrator-manual/databases/monitoring');
+    expect(response.result.content[0].type).toBe('text');
+  });
+
+  it('calls get_doc_page and returns full page content', async () => {
+    const response = await handleMcpJsonRpc(
+      {
+        jsonrpc: '2.0',
+        id: 4,
+        method: 'tools/call',
+        params: { name: 'get_doc_page', arguments: { pagePath: 'administrator-manual/databases/monitoring' } },
+      },
+      { artifact, pages },
+    );
+
+    expect(response.result.structuredContent.page.title).toBe('Monitoring');
+    expect(response.result.structuredContent.page.tableOfContents).toEqual(['Monitoring', 'Overview']);
+  });
+
+  it('returns json-rpc error for unknown tools', async () => {
+    const response = await handleMcpJsonRpc(
+      {
+        jsonrpc: '2.0',
+        id: 5,
+        method: 'tools/call',
+        params: { name: 'nope', arguments: {} },
+      },
+      { artifact, pages },
+    );
+
+    expect(response.error.code).toBe(-32601);
+  });
+});

--- a/src/lib/doc-search/__tests__/normalize-mdx.test.ts
+++ b/src/lib/doc-search/__tests__/normalize-mdx.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeMdxForLLM, extractTableOfContents } from '@/lib/doc-search/normalize-mdx';
+
+const sampleMdx = `---
+title: Monitoring
+---
+
+import { Callout } from 'nextra/components'
+
+# Monitoring
+
+### Overview
+
+<Callout type="info">
+10.3.0부터 Audit의 하위 항목으로 모니터링만 가능했던 Running Queries 기능에 쿼리 강제 중지 기능이 추가되었습니다.
+</Callout>
+
+<figure>
+<img src="/foo.png" alt="Running Queries 화면" />
+<figcaption>Running Queries 화면</figcaption>
+</figure>
+`;
+
+describe('normalizeMdxForLLM', () => {
+  it('removes frontmatter/imports but keeps useful text', () => {
+    const result = normalizeMdxForLLM(sampleMdx);
+
+    expect(result).not.toContain('import { Callout }');
+    expect(result).not.toContain('---');
+    expect(result).toContain('10.3.0부터 Audit의 하위 항목으로 모니터링만 가능했던 Running Queries 기능에 쿼리 강제 중지 기능이 추가되었습니다.');
+    expect(result).toContain('Running Queries 화면');
+  });
+});
+
+describe('extractTableOfContents', () => {
+  it('returns heading labels in source order', () => {
+    expect(extractTableOfContents(sampleMdx)).toEqual(['Monitoring', 'Overview']);
+  });
+});

--- a/src/lib/doc-search/__tests__/search.test.ts
+++ b/src/lib/doc-search/__tests__/search.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DocSearchArtifact } from '@/lib/doc-search/types';
+import { searchDocs } from '@/lib/doc-search/search';
+
+const artifact: DocSearchArtifact = {
+  version: 1,
+  generatedAt: '2026-03-16T00:00:00.000Z',
+  lang: 'ko',
+  chunks: [
+    {
+      id: '1',
+      pagePath: 'administrator-manual/general/system/integrations/identity-providers',
+      url: '/ko/administrator-manual/general/system/integrations/identity-providers',
+      title: 'Identity Providers',
+      description: 'LDAP 및 SSO 연동',
+      headingPath: ['Identity Providers', 'LDAP 연동', 'User Search Filter'],
+      content: 'User Search Filter는 사용자가 로그인 시 입력한 아이디를 기반으로 LDAP에서 사용자를 찾는 데 사용할 쿼리입니다.',
+      excerpt: 'User Search Filter는 사용자가 로그인 시 입력한 아이디를 기반으로 LDAP에서 사용자를 찾는 데 사용할 쿼리입니다.',
+      metadata: {
+        lang: 'ko',
+        manualType: 'administrator-manual',
+        productArea: 'general',
+        versionHints: [],
+        isUnreleased: false,
+      },
+    },
+    {
+      id: '2',
+      pagePath: 'administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-google-cloud',
+      url: '/ko/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-google-cloud',
+      title: 'Google Cloud에서 DB 리소스 동기화',
+      description: 'GCP 연동 가이드',
+      headingPath: ['Google Cloud에서 DB 리소스 동기화', 'QueryPie에서 GCP 연동 정보 등록하기'],
+      content: 'Search Filter를 사용하여 동기화하고자 하는 일부 유형의 리소스 목록을 가져올 수 있습니다.',
+      excerpt: 'Search Filter를 사용하여 동기화하고자 하는 일부 유형의 리소스 목록을 가져올 수 있습니다.',
+      metadata: {
+        lang: 'ko',
+        manualType: 'administrator-manual',
+        productArea: 'databases',
+        versionHints: ['11.3.0'],
+        isUnreleased: false,
+      },
+    },
+    {
+      id: '3',
+      pagePath: 'unreleased',
+      url: '/ko/unreleased',
+      title: 'Unreleased',
+      description: '미출시 기능 문서',
+      headingPath: ['Unreleased'],
+      content: '아직 출시되지 않은 기능 문서를 이곳에서 미리 작성하고 검토합니다.',
+      excerpt: '아직 출시되지 않은 기능 문서를 이곳에서 미리 작성하고 검토합니다.',
+      metadata: {
+        lang: 'ko',
+        manualType: 'unreleased',
+        productArea: 'unreleased',
+        versionHints: [],
+        isUnreleased: true,
+      },
+    },
+  ],
+};
+
+describe('searchDocs', () => {
+  it('ranks exact heading/title matches first', () => {
+    const results = searchDocs({ artifact, query: 'LDAP 연동 사용자 검색 필터', topK: 3 });
+
+    expect(results[0]?.pagePath).toBe('administrator-manual/general/system/integrations/identity-providers');
+  });
+
+  it('matches section phrases for cloud provider docs', () => {
+    const results = searchDocs({ artifact, query: 'GCP DB 리소스 동기화 Search Filter', topK: 3 });
+
+    expect(results[0]?.pagePath).toBe('administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-google-cloud');
+  });
+
+  it('downranks unreleased content by default', () => {
+    const results = searchDocs({ artifact, query: '기능 문서', topK: 3 });
+
+    expect(results.at(-1)?.pagePath).toBe('unreleased');
+  });
+
+  it('honors manual type filters', () => {
+    const results = searchDocs({ artifact, query: 'Search Filter', topK: 3, manualType: 'administrator-manual' });
+
+    expect(results).toHaveLength(2);
+    expect(results.every(result => result.metadata.manualType === 'administrator-manual')).toBe(true);
+  });
+});

--- a/src/lib/doc-search/get-page.ts
+++ b/src/lib/doc-search/get-page.ts
@@ -1,0 +1,7 @@
+import type { DocSearchPage } from '@/lib/doc-search/types';
+import { loadDocSearchPagesArtifact } from '@/lib/doc-search/load-index';
+
+export function getDocPage(pagePath: string, lang = 'ko'): DocSearchPage | null {
+  const artifact = loadDocSearchPagesArtifact(lang);
+  return artifact.pages[pagePath] ?? null;
+}

--- a/src/lib/doc-search/load-index.ts
+++ b/src/lib/doc-search/load-index.ts
@@ -1,0 +1,25 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { DocSearchArtifact, DocSearchPagesArtifact } from '@/lib/doc-search/types';
+
+let artifactCache: DocSearchArtifact | null = null;
+let pagesCache: DocSearchPagesArtifact | null = null;
+
+function readJsonFile<T>(filePath: string): T {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8')) as T;
+}
+
+export function loadDocSearchArtifact(lang = 'ko'): DocSearchArtifact {
+  if (!artifactCache) {
+    artifactCache = readJsonFile<DocSearchArtifact>(path.join(process.cwd(), 'public', '_doc-search', `${lang}-index.json`));
+  }
+  return artifactCache;
+}
+
+export function loadDocSearchPagesArtifact(lang = 'ko'): DocSearchPagesArtifact {
+  if (!pagesCache) {
+    pagesCache = readJsonFile<DocSearchPagesArtifact>(path.join(process.cwd(), 'public', '_doc-search', `${lang}-pages.json`));
+  }
+  return pagesCache;
+}

--- a/src/lib/doc-search/mcp.ts
+++ b/src/lib/doc-search/mcp.ts
@@ -1,0 +1,159 @@
+import type { DocSearchArtifact, DocSearchPagesArtifact, ManualType } from '@/lib/doc-search/types';
+import { getDocPage } from '@/lib/doc-search/get-page';
+import { loadDocSearchArtifact } from '@/lib/doc-search/load-index';
+import { searchDocs } from '@/lib/doc-search/search';
+
+export const MCP_PROTOCOL_VERSION = '2025-06-18';
+export const SUPPORTED_PROTOCOL_VERSIONS = ['2025-06-18', '2025-03-26', '2025-11-25'] as const;
+
+interface JsonRpcRequest {
+  jsonrpc: '2.0';
+  id?: string | number | null;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: '2.0';
+  id: string | number | null;
+  result?: unknown;
+  error?: {
+    code: number;
+    message: string;
+  };
+}
+
+function buildSuccess(id: JsonRpcRequest['id'], result: unknown): JsonRpcResponse {
+  return { jsonrpc: '2.0', id: id ?? null, result };
+}
+
+function buildError(id: JsonRpcRequest['id'], code: number, message: string): JsonRpcResponse {
+  return { jsonrpc: '2.0', id: id ?? null, error: { code, message } };
+}
+
+function getTools() {
+  return [
+    {
+      name: 'search_docs',
+      description: 'Search Korean QueryPie docs and return high-signal chunks with citation URLs.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'Natural language or keyword query.' },
+          lang: { type: 'string', enum: ['ko'], default: 'ko' },
+          topK: { type: 'integer', minimum: 1, maximum: 10, default: 5 },
+          manualType: {
+            type: 'string',
+            enum: ['overview', 'user-manual', 'administrator-manual', 'installation', 'release-notes', 'api-reference', 'support', 'unreleased'],
+          },
+        },
+        required: ['query'],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: 'get_doc_page',
+      description: 'Return normalized full-page content for a QueryPie docs page path.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          pagePath: { type: 'string', description: 'Page path without locale prefix.' },
+          lang: { type: 'string', enum: ['ko'], default: 'ko' },
+        },
+        required: ['pagePath'],
+        additionalProperties: false,
+      },
+    },
+  ];
+}
+
+function serializeTextContent(payload: unknown) {
+  return [
+    {
+      type: 'text',
+      text: JSON.stringify(payload, null, 2),
+    },
+  ];
+}
+
+export async function handleMcpJsonRpc(
+  request: JsonRpcRequest,
+  context?: { artifact?: DocSearchArtifact; pages?: DocSearchPagesArtifact },
+): Promise<JsonRpcResponse> {
+  if (request.jsonrpc !== '2.0') {
+    return buildError(request.id, -32600, 'Invalid JSON-RPC version');
+  }
+
+  switch (request.method) {
+    case 'initialize':
+      {
+        const requestedProtocolVersion = String(request.params?.protocolVersion || MCP_PROTOCOL_VERSION);
+        if (!SUPPORTED_PROTOCOL_VERSIONS.includes(requestedProtocolVersion as (typeof SUPPORTED_PROTOCOL_VERSIONS)[number])) {
+          return buildError(request.id, -32602, `Unsupported protocol version: ${requestedProtocolVersion}`);
+        }
+
+      return buildSuccess(request.id, {
+        protocolVersion: requestedProtocolVersion,
+        capabilities: {
+          tools: {},
+        },
+        serverInfo: {
+          name: 'querypie-docs-mcp',
+          version: '0.1.0',
+        },
+      });
+      }
+    case 'notifications/initialized':
+    case 'ping':
+      return buildSuccess(request.id, {});
+    case 'tools/list':
+      return buildSuccess(request.id, {
+        tools: getTools(),
+      });
+    case 'tools/call': {
+      const toolName = String(request.params?.name || '');
+      const args = (request.params?.arguments as Record<string, unknown> | undefined) ?? {};
+      const artifact = context?.artifact ?? loadDocSearchArtifact(String(args.lang || 'ko'));
+
+      if (toolName === 'search_docs') {
+        const query = String(args.query || '').trim();
+        if (!query) {
+          return buildError(request.id, -32602, 'search_docs requires a non-empty query');
+        }
+
+        const results = searchDocs({
+          artifact,
+          query,
+          topK: typeof args.topK === 'number' ? args.topK : 5,
+          manualType: args.manualType as ManualType | undefined,
+        });
+
+        return buildSuccess(request.id, {
+          content: serializeTextContent({ results }),
+          structuredContent: { results },
+        });
+      }
+
+      if (toolName === 'get_doc_page') {
+        const pagePath = String(args.pagePath || '').trim();
+        if (!pagePath) {
+          return buildError(request.id, -32602, 'get_doc_page requires pagePath');
+        }
+
+        const page = context?.pages?.pages[pagePath] ?? getDocPage(pagePath, String(args.lang || 'ko'));
+        if (!page) {
+          return buildError(request.id, -32602, `Unknown pagePath: ${pagePath}`);
+        }
+
+        return buildSuccess(request.id, {
+          content: serializeTextContent({ page }),
+          structuredContent: { page },
+        });
+      }
+
+      return buildError(request.id, -32601, `Unknown tool: ${toolName}`);
+    }
+    default:
+      return buildError(request.id, -32601, `Unknown method: ${request.method}`);
+  }
+}

--- a/src/lib/doc-search/normalize-mdx.ts
+++ b/src/lib/doc-search/normalize-mdx.ts
@@ -1,0 +1,63 @@
+import matter from 'gray-matter';
+
+const FRONTMATTER_SEPARATOR = /^---\s*$/m;
+
+function decodeHtmlEntities(input: string): string {
+  return input
+    .replace(/&gt;/g, '>')
+    .replace(/&lt;/g, '<')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+function stripImports(content: string): string {
+  return content
+    .split('\n')
+    .filter(line => !line.trim().startsWith('import '))
+    .join('\n');
+}
+
+function replaceImageTags(content: string): string {
+  return content.replace(/<img[^>]*alt="([^"]+)"[^>]*\/?>(?:<\/img>)?/g, '$1');
+}
+
+function stripWrapperTags(content: string): string {
+  return content
+    .replace(/<Callout[^>]*>/g, '')
+    .replace(/<\/Callout>/g, '')
+    .replace(/<figure[^>]*>/g, '')
+    .replace(/<\/figure>/g, '')
+    .replace(/<figcaption[^>]*>/g, '')
+    .replace(/<\/figcaption>/g, '')
+    .replace(/<details[^>]*>/g, '')
+    .replace(/<\/details>/g, '')
+    .replace(/<summary[^>]*>/g, '')
+    .replace(/<\/summary>/g, '')
+    .replace(/<[^>]+>/g, ' ');
+}
+
+function normalizeWhitespace(content: string): string {
+  return content
+    .replace(/\r\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/[ \t]{2,}/g, ' ')
+    .replace(/\n +/g, '\n')
+    .trim();
+}
+
+export function normalizeMdxForLLM(source: string): string {
+  const parsed = source.match(FRONTMATTER_SEPARATOR) ? matter(source) : { content: source };
+  const strippedImports = stripImports(parsed.content);
+  const withImageAlt = replaceImageTags(strippedImports);
+  const withoutTags = stripWrapperTags(withImageAlt);
+  return normalizeWhitespace(decodeHtmlEntities(withoutTags));
+}
+
+export function extractTableOfContents(source: string): string[] {
+  const content = normalizeMdxForLLM(source);
+  return content
+    .split('\n')
+    .filter(line => /^(#+)\s+/.test(line))
+    .map(line => line.replace(/^(#+)\s+/, '').trim());
+}

--- a/src/lib/doc-search/search.ts
+++ b/src/lib/doc-search/search.ts
@@ -1,0 +1,53 @@
+import type { DocSearchChunk, SearchDocsParams } from '@/lib/doc-search/types';
+
+function normalizeText(input: string): string {
+  return input.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+function tokenize(input: string): string[] {
+  return normalizeText(input)
+    .split(/[^\p{L}\p{N}.+#-]+/u)
+    .map(token => token.trim())
+    .filter(Boolean);
+}
+
+function scoreChunk(query: string, queryTokens: string[], chunk: DocSearchChunk): number {
+  const title = normalizeText(chunk.title);
+  const heading = normalizeText(chunk.headingPath.join(' '));
+  const content = normalizeText(chunk.content);
+  let score = 0;
+  let matched = false;
+
+  for (const token of queryTokens) {
+    if (title.includes(token)) { score += 12; matched = true; }
+    if (heading.includes(token)) { score += 8; matched = true; }
+    if (content.includes(token)) { score += 4; matched = true; }
+  }
+
+  if (title.includes(query)) { score += 40; matched = true; }
+  if (heading.includes(query)) { score += 28; matched = true; }
+  if (content.includes(query)) { score += 16; matched = true; }
+
+  if (!matched) return 0;
+
+  if (chunk.metadata.isUnreleased) score -= 10;
+  score += Math.max(0, 6 - Math.floor(chunk.content.length / 400));
+
+  return score;
+}
+
+export function searchDocs({ artifact, query, topK = 5, manualType }: SearchDocsParams): DocSearchChunk[] {
+  const normalizedQuery = normalizeText(query);
+  const queryTokens = tokenize(query);
+  if (!normalizedQuery || queryTokens.length === 0) {
+    return [];
+  }
+
+  return artifact.chunks
+    .filter(chunk => !manualType || chunk.metadata.manualType === manualType)
+    .map(chunk => ({ chunk, score: scoreChunk(normalizedQuery, queryTokens, chunk) }))
+    .filter(entry => entry.score > 0)
+    .sort((a, b) => b.score - a.score || a.chunk.title.localeCompare(b.chunk.title, 'ko'))
+    .slice(0, Math.min(topK, 10))
+    .map(entry => ({ ...entry.chunk, score: entry.score } as DocSearchChunk & { score: number })) as DocSearchChunk[];
+}

--- a/src/lib/doc-search/types.ts
+++ b/src/lib/doc-search/types.ts
@@ -1,0 +1,61 @@
+export type ManualType =
+  | 'overview'
+  | 'user-manual'
+  | 'administrator-manual'
+  | 'installation'
+  | 'release-notes'
+  | 'api-reference'
+  | 'support'
+  | 'unreleased'
+  | 'unknown';
+
+export interface DocSearchMetadata {
+  lang: string;
+  manualType: ManualType;
+  productArea: string;
+  versionHints: string[];
+  isUnreleased: boolean;
+}
+
+export interface DocSearchChunk {
+  id: string;
+  pagePath: string;
+  url: string;
+  title: string;
+  description: string;
+  headingPath: string[];
+  content: string;
+  excerpt: string;
+  metadata: DocSearchMetadata;
+}
+
+export interface DocSearchPage {
+  pagePath: string;
+  url: string;
+  title: string;
+  description: string;
+  content: string;
+  tableOfContents: string[];
+  metadata: DocSearchMetadata;
+}
+
+export interface DocSearchArtifact {
+  version: number;
+  generatedAt: string;
+  lang: string;
+  chunks: DocSearchChunk[];
+}
+
+export interface DocSearchPagesArtifact {
+  version: number;
+  generatedAt: string;
+  lang: string;
+  pages: Record<string, DocSearchPage>;
+}
+
+export interface SearchDocsParams {
+  artifact: DocSearchArtifact;
+  query: string;
+  topK?: number;
+  manualType?: ManualType;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -10,6 +10,7 @@ const SKIP_MIDDLEWARE_URIS = new Map<string, string>([
   ['robots.txt', 'Handled by route handler'],
   ['.well-known', 'Handled by route handler'],
   ['api', 'Handled by API route handler'],
+  ['mcp', 'Handled by MCP route handler'],
   // slugs[0] - Served in public
   ['BingSiteAuth.xml', 'Served in public'],
   ['google7b73baf7a3209e6f.html', 'Served in public'],


### PR DESCRIPTION
## Summary
- add a public /mcp endpoint with streamable HTTP-compatible transport behavior for MCP clients and Inspector
- build a Korean docs search index from src/content/ko and expose search_docs / get_doc_page tools
- add tests for chunking, search ranking, MCP handlers, and transport/CORS behavior

## Test Plan
- [x] npm run test:run
- [x] npm run lint
- [x] npm run build
- [x] manual curl checks against /mcp for initialize, tools/list, search_docs, get_doc_page, SSE GET, and CORS preflight