### PR TITLE
fix: PR #921 MCP 엔드포인트 리뷰 항목을 반영합니다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ next-env.d.ts
 .vscode
 .env*.local
 /public/_pagefind
+/public/_doc-search
 /public/sitemap.xml
 /public/*/sitemap.xml
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -14,6 +14,21 @@ QueryPie 제품의 Docs를 관리하는 Git Repository입니다.
 npm run dev
 ```
 
+### MCP 문서 검색 인덱스 빌드 (로컬)
+
+`/mcp` 엔드포인트가 사용하는 검색 인덱스(`public/_doc-search/`)는 빌드 시 자동 생성됩니다.
+`npm run dev`에서는 자동 실행되지 않으므로, 처음 실행하거나 콘텐츠가 변경된 경우 아래 명령을 수동으로 실행하세요.
+
+```shell
+# 전체 언어(ko, en, ja) 인덱스 빌드
+npm run build-doc-search-index
+
+# 특정 언어만 빌드 (예: ko)
+npx tsx scripts/build-doc-search-index/index.ts ko
+```
+
+> `public/_doc-search/`는 `.gitignore`에 포함되어 있으며, 배포 시 `npm run build`(`prebuild` 훅)가 자동으로 생성합니다.
+
 ## 빌드 및 실행
 - 빌드 후 실행하면 Production과 마찬가지로 빠릅니다.
 - `http://localhost:3000`

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "test:ui": "vitest --ui",
     "test:run": "vitest run",
     "build-doc-search-index": "npx tsx scripts/build-doc-search-index/index.ts",
-    "predev": "npm run build-doc-search-index",
     "prebuild": "npm run build-doc-search-index"
   },
   "repository": {

--- a/scripts/build-doc-search-index/index.ts
+++ b/scripts/build-doc-search-index/index.ts
@@ -7,7 +7,9 @@ import { buildChunksFromDocument } from './chunker';
 import { inferDocMetadata } from './metadata';
 import { parseMdxDocument } from './mdx-parser';
 
-const CONTENT_ROOT = path.join(process.cwd(), 'src', 'content', 'ko');
+const SUPPORTED_LANGS = ['ko', 'en', 'ja'] as const;
+type SupportedLang = (typeof SUPPORTED_LANGS)[number];
+
 const OUTPUT_ROOT = path.join(process.cwd(), 'public', '_doc-search');
 
 function listMdxFiles(dir: string): string[] {
@@ -27,8 +29,9 @@ function toRepoRelative(filePath: string): string {
   return path.relative(process.cwd(), filePath).split(path.sep).join('/');
 }
 
-export function buildDocSearchArtifacts(): { index: DocSearchArtifact; pages: DocSearchPagesArtifact } {
-  const files = listMdxFiles(CONTENT_ROOT);
+export function buildDocSearchArtifacts(lang: SupportedLang): { index: DocSearchArtifact; pages: DocSearchPagesArtifact } {
+  const contentRoot = path.join(process.cwd(), 'src', 'content', lang);
+  const files = listMdxFiles(contentRoot);
   const chunks = [] as DocSearchArtifact['chunks'];
   const pages: Record<string, DocSearchPage> = {};
   const generatedAt = new Date().toISOString();
@@ -36,10 +39,10 @@ export function buildDocSearchArtifacts(): { index: DocSearchArtifact; pages: Do
   for (const file of files) {
     const source = fs.readFileSync(file, 'utf8');
     const relativeFilePath = toRepoRelative(file);
-    const document = parseMdxDocument(source, { filePath: relativeFilePath, lang: 'ko' });
+    const document = parseMdxDocument(source, { filePath: relativeFilePath, lang });
     const metadata = inferDocMetadata({
       filePath: relativeFilePath,
-      lang: 'ko',
+      lang,
       title: document.title,
       description: document.description,
       content: document.content,
@@ -67,26 +70,30 @@ export function buildDocSearchArtifacts(): { index: DocSearchArtifact; pages: Do
     index: {
       version: 1,
       generatedAt,
-      lang: 'ko',
+      lang,
       chunks,
     },
     pages: {
       version: 1,
       generatedAt,
-      lang: 'ko',
+      lang,
       pages,
     },
   };
 }
 
-export function writeDocSearchArtifacts(): void {
+export function writeDocSearchArtifacts(langs: SupportedLang[] = [...SUPPORTED_LANGS]): void {
   ensureOutputDir();
-  const { index, pages } = buildDocSearchArtifacts();
-  fs.writeFileSync(path.join(OUTPUT_ROOT, 'ko-index.json'), JSON.stringify(index));
-  fs.writeFileSync(path.join(OUTPUT_ROOT, 'ko-pages.json'), JSON.stringify(pages));
+  for (const lang of langs) {
+    const { index, pages } = buildDocSearchArtifacts(lang);
+    fs.writeFileSync(path.join(OUTPUT_ROOT, `${lang}-index.json`), JSON.stringify(index));
+    fs.writeFileSync(path.join(OUTPUT_ROOT, `${lang}-pages.json`), JSON.stringify(pages));
+    console.log(`Generated docs search artifacts for lang: ${lang}`);
+  }
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  writeDocSearchArtifacts();
-  console.log('Generated docs search artifacts');
+  const langArg = process.argv[2] as SupportedLang | undefined;
+  const langs = langArg ? [langArg] : [...SUPPORTED_LANGS];
+  writeDocSearchArtifacts(langs);
 }

--- a/src/app/mcp/route.ts
+++ b/src/app/mcp/route.ts
@@ -4,6 +4,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { handleMcpJsonRpc, MCP_PROTOCOL_VERSION, SUPPORTED_PROTOCOL_VERSIONS } from '@/lib/doc-search/mcp';
 
 const MAX_REQUESTS_PER_MINUTE = 120;
+// TODO(#922): This in-memory store is ineffective in serverless environments — each cold start
+// resets the counter and multiple instances each have their own store. Expired entries also
+// accumulate indefinitely. Replace with a distributed KV store (e.g. Upstash) when stricter
+// rate limiting is required. https://github.com/querypie/querypie-docs/issues/922
 const rateLimitStore = new Map<string, { count: number; resetAt: number }>();
 const ALLOWED_CORS_HEADERS = [
   'content-type',
@@ -15,6 +19,9 @@ const ALLOWED_CORS_HEADERS = [
 
 function getClientKey(request: NextRequest): string {
   const forwardedFor = request.headers.get('x-forwarded-for');
+  // NOTE(#922): Clients without x-forwarded-for share the 'unknown' bucket, which can cause
+  // unrelated clients to block each other. Acceptable until a distributed rate limiter is in place.
+  // https://github.com/querypie/querypie-docs/issues/922
   return forwardedFor?.split(',')[0]?.trim() || 'unknown';
 }
 
@@ -50,6 +57,8 @@ function isAllowedOrigin(origin: string, requestHost: string): boolean {
       return true;
     }
 
+    // /mcp is a public API — all HTTPS origins are intentionally allowed so that any
+    // MCP client or web application can call this endpoint without CORS restrictions.
     return originUrl.protocol === 'https:';
   } catch {
     return false;

--- a/src/lib/doc-search/load-index.ts
+++ b/src/lib/doc-search/load-index.ts
@@ -3,23 +3,23 @@ import path from 'node:path';
 
 import type { DocSearchArtifact, DocSearchPagesArtifact } from '@/lib/doc-search/types';
 
-let artifactCache: DocSearchArtifact | null = null;
-let pagesCache: DocSearchPagesArtifact | null = null;
+const artifactCache = new Map<string, DocSearchArtifact>();
+const pagesCache = new Map<string, DocSearchPagesArtifact>();
 
 function readJsonFile<T>(filePath: string): T {
   return JSON.parse(fs.readFileSync(filePath, 'utf8')) as T;
 }
 
 export function loadDocSearchArtifact(lang = 'ko'): DocSearchArtifact {
-  if (!artifactCache) {
-    artifactCache = readJsonFile<DocSearchArtifact>(path.join(process.cwd(), 'public', '_doc-search', `${lang}-index.json`));
+  if (!artifactCache.has(lang)) {
+    artifactCache.set(lang, readJsonFile<DocSearchArtifact>(path.join(process.cwd(), 'public', '_doc-search', `${lang}-index.json`)));
   }
-  return artifactCache;
+  return artifactCache.get(lang)!;
 }
 
 export function loadDocSearchPagesArtifact(lang = 'ko'): DocSearchPagesArtifact {
-  if (!pagesCache) {
-    pagesCache = readJsonFile<DocSearchPagesArtifact>(path.join(process.cwd(), 'public', '_doc-search', `${lang}-pages.json`));
+  if (!pagesCache.has(lang)) {
+    pagesCache.set(lang, readJsonFile<DocSearchPagesArtifact>(path.join(process.cwd(), 'public', '_doc-search', `${lang}-pages.json`)));
   }
-  return pagesCache;
+  return pagesCache.get(lang)!;
 }

--- a/src/lib/doc-search/mcp.ts
+++ b/src/lib/doc-search/mcp.ts
@@ -3,8 +3,11 @@ import { getDocPage } from '@/lib/doc-search/get-page';
 import { loadDocSearchArtifact } from '@/lib/doc-search/load-index';
 import { searchDocs } from '@/lib/doc-search/search';
 
-export const MCP_PROTOCOL_VERSION = '2025-06-18';
-export const SUPPORTED_PROTOCOL_VERSIONS = ['2025-06-18', '2025-03-26', '2025-11-25'] as const;
+// Versions listed in descending order (newest first).
+// Default is set to the latest supported version per MCP spec:
+// the server should advertise the highest version it supports.
+export const MCP_PROTOCOL_VERSION = '2025-11-25';
+export const SUPPORTED_PROTOCOL_VERSIONS = ['2025-11-25', '2025-06-18', '2025-03-26'] as const;
 
 interface JsonRpcRequest {
   jsonrpc: '2.0';
@@ -40,7 +43,7 @@ function getTools() {
         type: 'object',
         properties: {
           query: { type: 'string', description: 'Natural language or keyword query.' },
-          lang: { type: 'string', enum: ['ko'], default: 'ko' },
+          lang: { type: 'string', enum: ['ko', 'en', 'ja'], default: 'ko' },
           topK: { type: 'integer', minimum: 1, maximum: 10, default: 5 },
           manualType: {
             type: 'string',
@@ -58,7 +61,7 @@ function getTools() {
         type: 'object',
         properties: {
           pagePath: { type: 'string', description: 'Page path without locale prefix.' },
-          lang: { type: 'string', enum: ['ko'], default: 'ko' },
+          lang: { type: 'string', enum: ['ko', 'en', 'ja'], default: 'ko' },
         },
         required: ['pagePath'],
         additionalProperties: false,


### PR DESCRIPTION
## Description

PR #921 코드 리뷰 항목을 반영한 follow-up PR입니다.

### Critical

- `.gitignore`에 `public/_doc-search/` 추가 — 빌드 생성물이 커밋에 포함되지 않도록 합니다
- `load-index.ts` 캐시 버그 수정 — `Map<string, ...>` 캐시로 교체하여 `lang` 파라미터가 두 번째 호출부터 무시되던 문제를 수정합니다

### 다국어 지원 확장

- `build-doc-search-index`: `ko` 전용이었던 빌드를 `ko/en/ja` 전체 지원으로 확장합니다
  - CLI 인자로 특정 언어만 빌드 가능: `npx tsx scripts/build-doc-search-index/index.ts ko`
- `mcp.ts`: `search_docs` / `get_doc_page` 의 `lang` enum을 `['ko', 'en', 'ja']`로 확장합니다

### Warning

- `route.ts`: CORS 전체 허용 의도를 코드 주석으로 명시합니다 (`/mcp`는 공개 API)
- `route.ts`: rate limiter 한계(서버리스 비효과, 만료 엔트리 누적, unknown 공유 버킷)에 대해 Issue #922 참조 TODO 주석을 추가합니다

### MCP Protocol Version

- `SUPPORTED_PROTOCOL_VERSIONS`를 내림차순(최신순) 정렬합니다
- 기본 버전을 MCP 스펙 권장에 따라 최신 버전 `2025-11-25`로 올립니다

### predev 제거

- `package.json`에서 `predev` 훅을 제거합니다 — `npm run dev` 실행마다 전체 MDX를 재스캔하지 않도록 합니다
- `docs/DEVELOPMENT.md`에 수동 빌드 가이드를 추가합니다

## Added/updated tests?

- [x] No, and this is why: 기존 테스트 56개 모두 통과 확인. 로직 변경 없이 구조/설정 수정이므로 별도 테스트 추가 없음

## Additional notes

- Rate limiter 근본 해결은 Issue #922에서 추적합니다: https://github.com/querypie/querypie-docs/issues/922