### PR TITLE
confluence-mdx: roundtrip verifier 정규화를 정비합니다

### DIFF
--- a/confluence-mdx/bin/reverse_sync/roundtrip_verifier.py
+++ b/confluence-mdx/bin/reverse_sync/roundtrip_verifier.py
@@ -141,26 +141,50 @@ def _normalize_empty_bold(text: str) -> str:
 
 
 def _normalize_empty_list_items(text: str) -> str:
-    """내용 없는 번호 리스트 항목(예: ``    12.``)을 빈 줄로 치환한다.
+    """내용 없는 번호 리스트 항목(예: ``    12.``)을 줄째 제거한다.
 
     Forward converter가 XHTML의 텍스트 없는 ``<li>`` (이미지만 포함)를
     번호만 있는 항목(``12.``)으로 변환한다. 이 항목은 시각적으로 무의미하므로
     improved.mdx에서 제거하더라도 XHTML 패치로 ``<li>`` 구조를 삭제할 수 없다.
-    양쪽을 빈 줄로 정규화하여 이 차이를 무시한다.
+    줄 전체(newline 포함)를 제거하여 이 차이를 무시한다.
     """
-    return re.sub(r'^([ \t]+)\d+\.\s*$', '', text, flags=re.MULTILINE)
+    return re.sub(r'^[ \t]+\d+\.\s*\n', '', text, flags=re.MULTILINE)
+
+
+def _normalize_consecutive_blank_lines(text: str) -> str:
+    """연속 빈 줄(3개 이상의 개행)을 단일 빈 줄(2개 개행)로 정규화한다.
+
+    Forward converter가 블록 요소 사이에 추가 빈 줄을 삽입하거나,
+    _normalize_empty_list_items가 줄을 제거한 뒤 남은 연속 빈 줄을
+    정규화한다. MDX에서 빈 줄 수는 시각적으로 동일하다.
+    """
+    return re.sub(r'\n{3,}', '\n\n', text)
+
+
+def _normalize_blank_line_after_br(text: str) -> str:
+    """<br/> 로 끝나는 줄 뒤의 빈 줄을 제거한다.
+
+    <br/> 자체가 줄바꿈을 생성하므로, 뒤따르는 빈 줄은 시각적으로
+    무의미하다. improved.mdx에서 빈 리스트 번호(12.)를 제거한 뒤
+    남은 빈 줄과 FC가 빈 줄 없이 출력하는 차이를 정규화한다.
+    """
+    return re.sub(r'(<br\s*/>\n)\n+', r'\1', text)
 
 
 def _apply_minimal_normalizations(text: str) -> str:
     """항상 적용하는 최소 정규화 (strict/lenient 모드 공통).
 
     forward converter의 체계적 출력 특성에 의한 차이만 처리한다:
-    - 인라인 이중 공백 → 단일 공백 (_normalize_consecutive_spaces_in_text)
-    - <br/> 앞 공백 제거 (_normalize_br_space)
-    - 링크 텍스트 앞뒤 공백 제거 (_normalize_link_text_spacing)
-    - 빈 bold 마커(****) 정규화 (_normalize_empty_bold)
-    - 내용 없는 번호 리스트 항목 제거 (_normalize_empty_list_items)
-    - 문장 경계 줄바꿈 결합 (_normalize_sentence_breaks)
+    - 인라인 이중 공백 → 단일 공백
+    - <br/> 앞 공백 제거
+    - 링크 텍스트 앞뒤 공백 제거
+    - 빈 bold 마커(****) 정규화
+    - 내용 없는 번호 리스트 항목 제거
+    - 연속 빈 줄 정규화
+    - 테이블 셀 패딩 정규화
+    - 문장 경계 줄바꿈 결합
+    - 첫 번째 h1 heading 제거
+    - trailing 빈 줄 정규화
 
     lenient 모드에서는 이 정규화 이후 _apply_normalizations가 추가로 적용된다.
     """
@@ -169,6 +193,8 @@ def _apply_minimal_normalizations(text: str) -> str:
     text = _normalize_link_text_spacing(text)
     text = _normalize_empty_bold(text)
     text = _normalize_empty_list_items(text)
+    text = _normalize_consecutive_blank_lines(text)
+    text = _normalize_blank_line_after_br(text)
     text = _normalize_table_cell_padding(text)
     text = _normalize_sentence_breaks(text)
     text = _strip_first_heading(text)

--- a/confluence-mdx/tests/test_reverse_sync_roundtrip_verifier.py
+++ b/confluence-mdx/tests/test_reverse_sync_roundtrip_verifier.py
@@ -9,6 +9,9 @@ from reverse_sync.roundtrip_verifier import (
     _normalize_link_text_spacing,
     _normalize_sentence_breaks,
     _normalize_table_cell_padding,
+    _normalize_empty_list_items,
+    _normalize_consecutive_blank_lines,
+    _normalize_blank_line_after_br,
 )
 
 
@@ -218,6 +221,78 @@ class TestNormalizeLinkTextSpacing:
         assert result == "* [**A**](a) and [**B**](b)"
 
 
+# --- _normalize_empty_list_items 단위 테스트 ---
+
+
+class TestNormalizeEmptyListItems:
+    def test_removes_number_only_line(self):
+        """번호만 있는 리스트 항목(예: '    12.')을 줄째 제거한다.
+
+        재현: integrating-with-email.mdx — FC가 이미지만 포함된 <li>를
+        '    12.'로 변환하지만, improved.mdx에서는 제거됨.
+        """
+        text = "    11. item\n    12.\n    13. next\n"
+        assert _normalize_empty_list_items(text) == "    11. item\n    13. next\n"
+
+    def test_preserves_item_with_content(self):
+        """내용이 있는 리스트 항목은 제거하지 않는다."""
+        text = "    1. first item\n    2. second item\n"
+        assert _normalize_empty_list_items(text) == text
+
+    def test_removes_with_tab_indent(self):
+        """탭 들여쓰기인 경우에도 제거한다."""
+        text = "\t5.\n\t6. content\n"
+        assert _normalize_empty_list_items(text) == "\t6. content\n"
+
+
+# --- _normalize_consecutive_blank_lines 단위 테스트 ---
+
+
+class TestNormalizeConsecutiveBlankLines:
+    def test_triple_newline_collapsed(self):
+        """3개 이상 연속 개행을 2개로 정규화한다.
+
+        재현: identity-providers.mdx, user-management.mdx — FC가 블록 사이에
+        추가 빈 줄을 삽입하거나, empty list item 제거 후 연속 빈 줄이 남음.
+        """
+        text = "para1\n\n\npara2\n"
+        assert _normalize_consecutive_blank_lines(text) == "para1\n\npara2\n"
+
+    def test_double_newline_unchanged(self):
+        """2개 개행(단일 빈 줄)은 변경하지 않는다."""
+        text = "para1\n\npara2\n"
+        assert _normalize_consecutive_blank_lines(text) == text
+
+    def test_quadruple_newline_collapsed(self):
+        """4개 이상 연속 개행도 2개로 정규화한다."""
+        text = "para1\n\n\n\npara2\n"
+        assert _normalize_consecutive_blank_lines(text) == "para1\n\npara2\n"
+
+
+# --- _normalize_blank_line_after_br 단위 테스트 ---
+
+
+class TestNormalizeBlankLineAfterBr:
+    def test_removes_blank_after_br(self):
+        """<br/> 뒤의 빈 줄을 제거한다.
+
+        재현: integrating-with-email.mdx — improved.mdx에서 빈 리스트 번호
+        제거 후 <br/> 바로 뒤에 빈 줄이 남음. FC는 빈 줄 없이 출력.
+        """
+        text = "text<br/>\n\nnext\n"
+        assert _normalize_blank_line_after_br(text) == "text<br/>\nnext\n"
+
+    def test_preserves_br_without_blank(self):
+        """<br/> 뒤에 빈 줄이 없으면 변경하지 않는다."""
+        text = "text<br/>\nnext\n"
+        assert _normalize_blank_line_after_br(text) == text
+
+    def test_handles_self_closing_variants(self):
+        """<br /> 형태도 처리한다."""
+        text = "text<br />\n\nnext\n"
+        assert _normalize_blank_line_after_br(text) == "text<br />\nnext\n"
+
+
 # --- _normalize_table_cell_padding 단위 테스트 ---
 
 
@@ -298,6 +373,44 @@ def test_minimal_norm_link_spacing_multiple_items():
             "* [**General**](url1) : desc1\n"
             "* [**Security**](url2) : desc2\n"
         ),
+    )
+    assert result.passed is True
+
+
+def test_minimal_norm_empty_list_item_passes():
+    """빈 리스트 번호 차이는 최소 정규화로 통과한다.
+
+    재현: integrating-with-email.mdx — improved.mdx에서 '12.' 제거,
+    FC verify.mdx에서 '12.' 출력. 정규화로 양쪽 모두 해당 줄 제거.
+    """
+    result = verify_roundtrip(
+        expected_mdx="    11. item\n    13. next\n",
+        actual_mdx="    11. item\n    12.\n    13. next\n",
+    )
+    assert result.passed is True
+
+
+def test_minimal_norm_consecutive_blank_lines_passes():
+    """연속 빈 줄 차이는 최소 정규화로 통과한다.
+
+    재현: identity-providers.mdx — FC가 블록 사이에 빈 줄을 추가 삽입.
+    """
+    result = verify_roundtrip(
+        expected_mdx="para1\n\npara2\n",
+        actual_mdx="para1\n\n\npara2\n",
+    )
+    assert result.passed is True
+
+
+def test_minimal_norm_blank_line_after_br_passes():
+    """<br/> 뒤 빈 줄 차이는 최소 정규화로 통과한다.
+
+    재현: integrating-with-email.mdx — empty list item 제거 후
+    <br/> 뒤에 빈 줄이 남는 차이.
+    """
+    result = verify_roundtrip(
+        expected_mdx="text<br/>\n\nnext\n",
+        actual_mdx="text<br/>\nnext\n",
     )
     assert result.passed is True
 

--- a/confluence-mdx/tests/test_reverse_sync_roundtrip_verifier.py
+++ b/confluence-mdx/tests/test_reverse_sync_roundtrip_verifier.py
@@ -266,7 +266,7 @@ def test_minimal_norm_double_space_passes():
 
 
 def test_minimal_norm_br_space_passes():
-    """<br/> 앞 공백 차이는 strict 모드에서도 정규화된다."""
+    """<br/> 앞 공백 차이는 최소 정규화로 통과한다."""
     result = verify_roundtrip(
         expected_mdx="item <br/>next\n",
         actual_mdx="item<br/>next\n",


### PR DESCRIPTION
## Description

`bin/reverse-sync verify --branch=split/ko-proofread-20260221-administrator-manual-general` 실행 시 발생하는 verify diff의 원인을 조사하고, roundtrip verifier 정규화를 정비합니다.

### 목표

verifier 정규화를 정비하여, MDX 교정이 실질적으로 Confluence XHTML 수정으로 이어지는지 검증 가능하게 합니다. 장기적으로는 패처/변환기의 근본 원인을 수정하여 정규화를 줄여나가는 것이 목표입니다.

### 불일치 현상 및 원인

`--no-normalize` 모드(PR #983)로 정규화를 전부 비활성화하면 **45건 중 6건 FAIL** (총 diff 11쌍)이 발생합니다. 유형별 분석:

> **참고**: PR #974 최초 작성 시 11건 FAIL이었으나, PR #985(인라인 공백 감지), #982(Badge roundtrip) 등이 main에 머지되면서 5건이 해소되어 현재 6건입니다.

#### 유형 A: `<li><p>` 선행 공백 (3건, diff 3쌍)

Confluence XHTML 원본의 `<li><p>` 안에 선행 공백이 있어 FC가 이중 공백을 출력하는 패턴입니다.

| 파일 | XHTML 원본 | diff (improved → verify) | 원인 |
|------|-----------|--------------------------|------|
| api-token.mdx | `<li><p> Admin >` | `* Admin` → `*  Admin` | `<p>` 내 선행 공백 |
| integrating-with-google-saml.mdx | `<p>7.  생성이` | `7. 생성이` → `7.  생성이` | `<p>` 내 이중 공백 |
| custom-attribute.mdx | `<li><p> Workflow` | `* Workflow` → `*  Workflow` | `<p>` 내 선행 공백 |

**기본 모드 처리**: `_normalize_consecutive_spaces_in_text` (연속 공백 → 단일 공백)
**근본 해결**: 패처가 XHTML `<p>` 내 선행/연속 공백을 정규화하여 패치, 또는 FC가 `<p>` 내 leading whitespace를 trim

#### 유형 B: `<br/>` 인접 공백 (2건, diff 3쌍)

FC가 XHTML의 `<br/>` 태그 전후 텍스트 노드를 결합할 때 공백이 추가/변형되는 패턴입니다.

| 파일 | XHTML 원본 | diff (improved → verify) | 원인 |
|------|-----------|--------------------------|------|
| integrating-with-event-callback.mdx | `<code>Delete</code>버튼을 클릭합니다</p><ac:image` (XHTML에 `<br/>` 없음) | `클릭합니다.<br/>` → `클릭합니다. <br/>` | FC가 `<br/>` 앞에 공백 추가 |
| setting-up-multi-factor-authentication.mdx (2쌍) | `인 경우<br /> </p>`, `경우<br /></p>` | `<br/> <br/>` → `<br/>  <br/>` | FC가 `<br/>` 사이 공백 노드를 이중 공백으로 출력 |

**기본 모드 처리**: `_normalize_br_space` (`<br/>` 앞 공백 제거)
**근본 해결**: FC의 `<br/>` 인접 공백 처리 개선, 또는 패처가 `<br/>` 인접 공백을 정규화

#### 유형 C: 테이블 셀 패딩 (1건, diff 5쌍)

FC의 컬럼 폭 계산(`_display_width`)과 improved.mdx의 수동 패딩이 수 글자 차이나는 패턴입니다.

| 파일 | diff | 원인 |
|------|------|------|
| maintenance.mdx | 헤더 행 + 구분자 행 + 데이터 행 3개의 셀 패딩 공백 수 차이 | FC와 improved.mdx의 CJK 포함 컬럼 폭 계산이 2~4자 차이 |

**기본 모드 처리**: `_normalize_table_cell_padding` (셀 패딩 공백 정규화)
**근본 해결**: 테이블 패딩은 시각적 서식이므로 정규화가 올바른 접근 (해결 불필요)

### 유형별 요약

| 유형 | 건수 | diff 쌍 | 기본 모드 정규화 | 근본 해결 방향 |
|------|------|---------|-----------------|---------------|
| A: `<li><p>` 선행 공백 | 3 | 3 | `_normalize_consecutive_spaces_in_text` | 패처/FC 개선 |
| B: `<br/>` 인접 공백 | 2 | 3 | `_normalize_br_space` | FC 개선 |
| C: 테이블 셀 패딩 | 1 | 5 | `_normalize_table_cell_padding` | 정규화 유지 (해결 불필요) |

### 변경 내용

**`roundtrip_verifier.py`**:
- `_normalize_empty_list_items`: 빈 줄 치환(`^([ \t]+)\d+\.\s*$` → `''`) → 줄째 제거(`^[ \t]+\d+\.\s*\n` → `''`)로 개선 — 기존 정규식은 빈 줄을 남겨서 연속 빈 줄 문제를 유발
- `_normalize_consecutive_blank_lines` 추가: 3개 이상 연속 개행 → 2개로 정규화
- `_normalize_blank_line_after_br` 추가: `<br/>` 뒤 빈 줄 제거

**`test_reverse_sync_roundtrip_verifier.py`**:
- `_normalize_empty_list_items` 단위 테스트 3건
- `_normalize_consecutive_blank_lines` 단위 테스트 3건
- `_normalize_blank_line_after_br` 단위 테스트 3건
- `verify_roundtrip` 통합 테스트 3건 (각 패턴이 정규화로 PASS되는지 검증)

### 검증

```
main 기준 (PR #974 적용 전):
  기본 모드: 45/45 PASS
  --no-normalize: 39/45 (6 FAIL — 유형 A:3 B:2 C:1)

PR #974 브랜치 기준:
  기본 모드: 45/45 PASS
  --no-normalize: 39/45 (6 FAIL — 동일)
```

> **참고**: PR #974의 정규화 추가분(`_normalize_consecutive_blank_lines`, `_normalize_blank_line_after_br`, `_normalize_empty_list_items` 수정)은 현재 main에서 이미 해결된 문제를 다루고 있어 FAIL/PASS 결과에 영향을 주지 않습니다. 이 PR을 머지할 실질적 이유가 남아 있는지 재검토가 필요합니다.

## Added/updated tests?

- [x] Yes — 단위 테스트 9건 + 통합 테스트 3건 추가

## Additional notes

- 테이블 셀 CJK 패딩 원인인 FC `len()` → `_display_width()` 수정은 별도 PR #975로 머지 완료
- PR #982에서 heading 내 Badge 컴포넌트 roundtrip 소실이 수정되어, 기존 FAIL(alerts.mdx)이 해소됨
- PR #985에서 인라인 공백 감지가 수정되어, 기존 유형 A의 5건이 3건으로 감소 (general.mdx, identity-providers.mdx, approval-rules.mdx, workflow-configurations.mdx, integrating-with-okta.mdx 해소)
- `--no-normalize` 옵션은 PR #983에서 별도로 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)