### PR TITLE
confluence-mdx: LLM Provider 제목 번역 추가

### DIFF
--- a/confluence-mdx/etc/korean-titles-translations.txt
+++ b/confluence-mdx/etc/korean-titles-translations.txt
@@ -80,6 +80,7 @@ Event Callback 연동 | Integrating with Event Callback
 OAuth 2.0을 사용하기 위한 Google Cloud API 연동 | Integrating Google Cloud API for OAuth 2.0
 Slack DM 연동 | Integrating with Slack DM
 Slack DM - Workflow 알림 유형 | Slack DM - Workflow Notification Types
+LLM Provider 설정 | LLM Provider Configuration
 
 # Databases > DAC General Configurations
 Masking Pattern (메뉴 위치 이동) | Masking Pattern (Menu Relocated)


### PR DESCRIPTION
## Summary
최근 Confluence 동기화 데이터에 추가된 `LLM Provider 설정` 문서가 번역 테이블에 없어 `convert_all.py` 실행이 중단되는 문제에 대응합니다.

- 최근 추가된 Confluence 문서를 확인합니다.
- `etc/korean-titles-translations.txt`에 `LLM Provider 설정`의 영문 번역을 추가합니다.
- 번역 검증에서 301개 페이지의 한국어 제목 누락이 없도록 합니다.

## Recently added Confluence pages
- `2166784044` / `LLM Provider 설정`
  - 위치: `관리자 매뉴얼 > General > System > Integrations > LLM Provider 설정`
  - 경로: `administrator-manual/general/system/integrations/llm-provider`

## Test plan
- [x] `bin/convert_all.py --verify-translations`

## Additional notes
- 기존 미커밋 변경 `confluence-mdx/var/pages.qm.yaml`은 PR 범위에 포함하지 않습니다.
- PR diff는 `confluence-mdx/etc/korean-titles-translations.txt` 한 파일만 포함합니다.

🤖 Generated with Codex