### PR TITLE
feat: 내부 테스트 페이지 route 추가

### DIFF
--- a/src/app/[lang]/internal/page.test.tsx
+++ b/src/app/[lang]/internal/page.test.tsx
@@ -28,4 +28,11 @@ describe('/[lang]/internal page', () => {
       title: '내부 페이지',
     });
   });
+
+  it('falls back to English metadata when static generation omits params', async () => {
+    await expect(generateMetadata({})).resolves.toMatchObject({
+      description: 'A list of internal component and page examples maintained for review and implementation reference.',
+      title: 'Internal Pages',
+    });
+  });
 });

--- a/src/app/[lang]/internal/page.test.tsx
+++ b/src/app/[lang]/internal/page.test.tsx
@@ -1,0 +1,31 @@
+import { render, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import InternalPage, { generateMetadata, generateStaticParams } from './page';
+
+describe('/[lang]/internal page', () => {
+  it('generates locale params for internal test pages', () => {
+    expect(generateStaticParams()).toEqual([{ lang: 'en' }, { lang: 'ja' }, { lang: 'ko' }]);
+  });
+
+  it('renders the Korean internal page title and description only', async () => {
+    const container = document.createElement('div');
+    const result = render(await InternalPage({ params: Promise.resolve({ lang: 'ko' }) }), {
+      baseElement: container,
+      container,
+    });
+
+    expect(within(result.container).getByRole('heading', { level: 1, name: '내부 페이지' })).toBeTruthy();
+    expect(
+      within(result.container).getByText('검토와 구현 참고를 위해 유지 중인 내부 컴포넌트 및 페이지 예시 목록입니다.'),
+    ).toBeTruthy();
+    expect(within(result.container).queryByRole('list')).not.toBeInTheDocument();
+  });
+
+  it('uses the same copy for route metadata', async () => {
+    await expect(generateMetadata({ params: Promise.resolve({ lang: 'ko' }) })).resolves.toMatchObject({
+      description: '검토와 구현 참고를 위해 유지 중인 내부 컴포넌트 및 페이지 예시 목록입니다.',
+      title: '내부 페이지',
+    });
+  });
+});

--- a/src/app/[lang]/internal/page.tsx
+++ b/src/app/[lang]/internal/page.tsx
@@ -1,0 +1,88 @@
+import type { Metadata } from 'next';
+
+type InternalPageParams = {
+  lang: string;
+};
+
+type InternalPageProps = {
+  params: Promise<InternalPageParams>;
+};
+
+type InternalPageCopy = {
+  description: string;
+  title: string;
+};
+
+const internalPageCopy: Record<string, InternalPageCopy> = {
+  en: {
+    description: 'A list of internal component and page examples maintained for review and implementation reference.',
+    title: 'Internal Pages',
+  },
+  ja: {
+    description: 'レビューと実装参考のために維持している内部コンポーネントおよびページ例の一覧です。',
+    title: '内部ページ',
+  },
+  ko: {
+    description: '검토와 구현 참고를 위해 유지 중인 내부 컴포넌트 및 페이지 예시 목록입니다.',
+    title: '내부 페이지',
+  },
+};
+
+const locales = Object.keys(internalPageCopy);
+
+function getInternalPageCopy(lang: string) {
+  return internalPageCopy[lang] ?? internalPageCopy.en;
+}
+
+export function generateStaticParams() {
+  return locales.map(lang => ({ lang }));
+}
+
+export async function generateMetadata({ params }: InternalPageProps): Promise<Metadata> {
+  const { lang } = await params;
+  const copy = getInternalPageCopy(lang);
+
+  return {
+    description: copy.description,
+    title: copy.title,
+  };
+}
+
+export default async function InternalPage({ params }: InternalPageProps) {
+  const { lang } = await params;
+  const copy = getInternalPageCopy(lang);
+
+  return (
+    <section
+      style={{
+        margin: '0 auto',
+        maxWidth: '768px',
+        padding: '64px 24px',
+      }}
+    >
+      <h1
+        style={{
+          color: '#111318',
+          fontSize: '36px',
+          fontWeight: 700,
+          letterSpacing: '0',
+          lineHeight: 1.2,
+          margin: '0 0 16px',
+        }}
+      >
+        {copy.title}
+      </h1>
+      <p
+        style={{
+          color: '#454a53',
+          fontSize: '17px',
+          letterSpacing: '0',
+          lineHeight: 1.7,
+          margin: 0,
+        }}
+      >
+        {copy.description}
+      </p>
+    </section>
+  );
+}

--- a/src/app/[lang]/internal/page.tsx
+++ b/src/app/[lang]/internal/page.tsx
@@ -5,7 +5,7 @@ type InternalPageParams = {
 };
 
 type InternalPageProps = {
-  params: Promise<InternalPageParams>;
+  params?: Promise<InternalPageParams | undefined>;
 };
 
 type InternalPageCopy = {
@@ -34,12 +34,18 @@ function getInternalPageCopy(lang: string) {
   return internalPageCopy[lang] ?? internalPageCopy.en;
 }
 
+async function getInternalPageLang(params: InternalPageProps['params']) {
+  const resolvedParams = await params;
+
+  return resolvedParams?.lang ?? 'en';
+}
+
 export function generateStaticParams() {
   return locales.map(lang => ({ lang }));
 }
 
 export async function generateMetadata({ params }: InternalPageProps): Promise<Metadata> {
-  const { lang } = await params;
+  const lang = await getInternalPageLang(params);
   const copy = getInternalPageCopy(lang);
 
   return {
@@ -49,7 +55,7 @@ export async function generateMetadata({ params }: InternalPageProps): Promise<M
 }
 
 export default async function InternalPage({ params }: InternalPageProps) {
-  const { lang } = await params;
+  const lang = await getInternalPageLang(params);
   const copy = getInternalPageCopy(lang);
 
   return (


### PR DESCRIPTION
## 기존 문제

`/{locale}/internal` 경로에 기능 테스트와 구현 참고를 위한 내부 페이지 진입점이 없었습니다.

## 구현 내용

- `src/app/[lang]/internal/page.tsx`를 추가해 App Router 기반 독립 페이지를 구성했습니다.
- 현재는 실제 내부 컴포넌트 목록을 넣지 않고 제목과 설명만 노출합니다.
- `ko`, `en`, `ja` locale별 최소 copy와 route metadata를 제공합니다.
- route 출력, static params, metadata를 검증하는 테스트를 추가했습니다.
- 정적 생성 중 metadata 함수가 `params` 없이 호출되는 경우에도 안전하게 fallback하도록 보강했습니다.

## CI/배포 오류 대응

- 실패 원인: Next/Nextra 정적 생성 과정에서 internal route의 `generateMetadata`가 `params` 없이 호출되어 `lang` destructuring 오류로 `npm run build`가 실패했습니다.
- 조치: `params`를 optional로 처리하고 누락 시 `en` copy로 fallback하도록 변경했습니다.
- 영향: 기존 `/{locale}/internal` 출력은 유지하면서, CI build와 Preview Deploy가 같은 오류로 중단되지 않도록 했습니다.

## 검증

- `npm run test:run -- 'src/app/[lang]/internal/page.test.tsx'`
- `npm run lint -- 'src/app/[lang]/internal/page.tsx' 'src/app/[lang]/internal/page.test.tsx'`
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`

## 참고

Refs #1004
