### PR TITLE
fix: Spotlight를 internal 페이지로 한정합니다

### DIFF
--- a/src/app/[lang]/layout.test.ts
+++ b/src/app/[lang]/layout.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const layoutSource = readFileSync(join(process.cwd(), 'src/app/[lang]/layout.tsx'), 'utf8');
+
+describe('/[lang] root layout', () => {
+  it('keeps Spotlight out of the global Nextra layout', () => {
+    expect(layoutSource).not.toContain('DocsSpotlightSidebar');
+    expect(layoutSource).toContain('extraContent: <ConfluenceSourceLink/>');
+  });
+});

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -9,7 +9,6 @@ import { LastUpdated } from '@/components/last-updated';
 import LanguageSelector2 from "@/components/language-selector2";
 import ConfluenceSourceLink from "@/components/confluence-source-link";
 import { QueryPieLogo } from '@/components/querypie-logo';
-import { DocsSpotlightSidebar } from '@/components/docs-spotlight-sidebar';
 import { filterDynamicPageMapRoutes } from '@/lib/nextra-page-map';
 
 const defaultMetadata: Metadata = {
@@ -86,12 +85,7 @@ export default async function RootLayout({ children, params }) {
                 <p>On This Page</p>
               </>
             ),
-            extraContent: (
-              <>
-                <DocsSpotlightSidebar locale={lang} />
-                <ConfluenceSourceLink/>
-              </>
-            ),
+            extraContent: <ConfluenceSourceLink/>,
           }}
           lastUpdated={<LastUpdated locale={lang} />}
         >


### PR DESCRIPTION
## Summary
PR #1017 병합 후 Spotlight가 전체 문서 페이지 TOC에 노출되는 문제를 수정합니다.

- root Nextra layout에서 `DocsSpotlightSidebar` 주입을 제거합니다.
- Spotlight는 `/{locale}/internal` 페이지 전용 렌더만 유지합니다.
- root layout에 Spotlight가 다시 들어오지 않도록 회귀 테스트를 추가합니다.

## Test plan
- [x] `npm run test:run -- src/app/[lang]/layout.test.ts src/app/[lang]/internal/page.test.tsx src/components/docs-spotlight-card.test.tsx src/lib/docs-spotlight/content.test.ts`
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `git diff --check`
- [x] headless Chrome에서 `/ko/internal`은 Spotlight 표시, `/ko/overview`는 Spotlight 미표시를 확인했습니다.

## Related tickets & links
- Fixes #1017 follow-up
- Related to #1004

## Additional notes
- headless 검증 중 기존 `LanguageSelector2`의 잘못된 `<p>` 중첩 hydration 경고가 dev 로그에 보였지만, 이번 Spotlight 전역 노출 문제와는 별개입니다.

🤖 Generated with Codex
