### PR TITLE
confluence-mdx: reverse-sync push 안전성을 강화합니다

### DIFF
--- a/confluence-mdx/bin/reverse_sync/base_parity.py
+++ b/confluence-mdx/bin/reverse_sync/base_parity.py
@@ -35,8 +35,25 @@ def _frontmatter(content: str) -> dict:
 
 
 def _first_h1(content: str) -> str:
-    match = re.search(r"^# ([^\n]+)$", content, flags=re.MULTILINE)
-    return match.group(1).strip() if match else ""
+    fence_char = ""
+    fence_length = 0
+    for line in content.splitlines():
+        fence = re.match(r"^[ \t]{0,3}(`{3,}|~{3,})", line)
+        if fence:
+            marker = fence.group(1)
+            if not fence_char:
+                fence_char = marker[0]
+                fence_length = len(marker)
+            elif marker[0] == fence_char and len(marker) >= fence_length:
+                fence_char = ""
+                fence_length = 0
+            continue
+        if fence_char or line.startswith(("    ", "\t")):
+            continue
+        match = re.match(r"^# ([^\n]+)$", line)
+        if match:
+            return match.group(1).strip()
+    return ""
 
 
 def _content_without_frontmatter(content: str) -> str:

--- a/confluence-mdx/bin/reverse_sync/base_parity.py
+++ b/confluence-mdx/bin/reverse_sync/base_parity.py
@@ -1,0 +1,162 @@
+"""remote PageSnapshot과 original MDX의 push base parity 검사."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import difflib
+import re
+from pathlib import PurePosixPath
+from urllib.parse import unquote, urlparse
+
+import yaml
+
+from reverse_sync.models import PageSnapshot
+from reverse_sync.roundtrip_verifier import verify_roundtrip
+
+
+@dataclass(frozen=True)
+class BaseParityResult:
+    passed: bool
+    reason_code: str = ""
+    diff_report: str = ""
+
+
+def _frontmatter(content: str) -> dict:
+    if not content.startswith("---\n"):
+        return {}
+    end = content.find("\n---", 4)
+    if end < 0:
+        return {}
+    try:
+        value = yaml.safe_load(content[4:end]) or {}
+    except yaml.YAMLError:
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _first_h1(content: str) -> str:
+    match = re.search(r"^# ([^\n]+)$", content, flags=re.MULTILINE)
+    return match.group(1).strip() if match else ""
+
+
+def _content_without_frontmatter(content: str) -> str:
+    if not content.startswith("---\n"):
+        return content
+    end = content.find("\n---", 4)
+    if end < 0:
+        return content
+    return content[end + 4 :].lstrip("\n")
+
+
+def _page_id_from_url(value: object) -> str:
+    if not isinstance(value, str):
+        return ""
+    match = re.search(r"/pages/(\d+)(?:/|$)", value)
+    return match.group(1) if match else ""
+
+
+def _attachment_filenames_from_mdx(content: str) -> set[str]:
+    references = re.findall(r"!\[[^\]]*\]\(([^)\s]+)", content)
+    references += re.findall(
+        r"<img\b[^>]*\bsrc=[\"']([^\"']+)[\"']",
+        content,
+        flags=re.IGNORECASE,
+    )
+    filenames: set[str] = set()
+    for reference in references:
+        parsed = urlparse(reference)
+        if parsed.scheme in ("http", "https", "data"):
+            continue
+        filename = PurePosixPath(unquote(parsed.path)).name
+        if filename:
+            filenames.add(filename)
+    return filenames
+
+
+def verify_attachment_dependencies(
+    snapshot: PageSnapshot,
+    original_mdx: str,
+    improved_mdx: str,
+) -> BaseParityResult:
+    """improved MDX가 base에 없는 새 attachment를 요구하면 차단한다."""
+    original_references = _attachment_filenames_from_mdx(original_mdx)
+    improved_references = _attachment_filenames_from_mdx(improved_mdx)
+    added_references = improved_references - original_references
+    if not added_references:
+        return BaseParityResult(True)
+
+    available = set(
+        re.findall(
+            r"\bri:filename=[\"']([^\"']+)[\"']",
+            snapshot.storage_xhtml,
+            flags=re.IGNORECASE,
+        )
+    )
+    missing = sorted(added_references - available)
+    if missing:
+        return BaseParityResult(
+            False,
+            "missing_attachment",
+            "base page에 없는 attachment: " + ", ".join(missing),
+        )
+    return BaseParityResult(True)
+
+
+def verify_source_identity(
+    snapshot: PageSnapshot,
+    original_mdx: str,
+    improved_mdx: str,
+) -> BaseParityResult:
+    """title/H1/page URL이 같은 page mutation boundary인지 확인한다."""
+    original_meta = _frontmatter(original_mdx)
+    improved_meta = _frontmatter(improved_mdx)
+    original_title = str(original_meta.get("title", "")).strip()
+    improved_title = str(improved_meta.get("title", "")).strip()
+    original_h1 = _first_h1(original_mdx)
+    improved_h1 = _first_h1(improved_mdx)
+
+    if original_title != improved_title or original_h1 != improved_h1:
+        return BaseParityResult(False, "title_change_unsupported")
+
+    declared_title = original_title or original_h1
+    if declared_title and declared_title != snapshot.title:
+        return BaseParityResult(False, "page_identity_mismatch")
+
+    for metadata in (original_meta, improved_meta):
+        declared_page_id = _page_id_from_url(metadata.get("confluenceUrl"))
+        if declared_page_id and declared_page_id != snapshot.page_id:
+            return BaseParityResult(False, "page_identity_mismatch")
+
+    return BaseParityResult(True)
+
+
+def verify_base_parity(
+    snapshot: PageSnapshot,
+    original_mdx: str,
+    converted_base_mdx: str,
+) -> BaseParityResult:
+    """forward(base XHTML)과 original MDX content가 동등한지 확인한다."""
+    identity = verify_source_identity(snapshot, original_mdx, converted_base_mdx)
+    if not identity.passed:
+        return identity
+
+    expected = _content_without_frontmatter(original_mdx)
+    actual = _content_without_frontmatter(converted_base_mdx)
+    result = verify_roundtrip(
+        expected_mdx=expected,
+        actual_mdx=actual,
+        no_normalize=True,
+    )
+    if result.passed:
+        return BaseParityResult(True)
+
+    diff = "".join(
+        difflib.unified_diff(
+            expected.splitlines(keepends=True),
+            actual.splitlines(keepends=True),
+            fromfile="original.mdx",
+            tofile="forward(base.xhtml)",
+            lineterm="",
+        )
+    )
+    return BaseParityResult(False, "base_parity_mismatch", diff)

--- a/confluence-mdx/bin/reverse_sync/confluence_client.py
+++ b/confluence-mdx/bin/reverse_sync/confluence_client.py
@@ -1,9 +1,12 @@
-"""Confluence API 클라이언트 — reverse sync push용."""
+"""Confluence API 클라이언트 — 일관된 snapshot과 version-bound update."""
 from pathlib import Path
 
 import requests
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Dict, Any, Tuple
+
+from reverse_sync.models import PageSnapshot, ReasonCode
 
 CONFIG_FILE = Path.home() / '.config' / 'atlassian' / 'confluence.conf'
 
@@ -23,51 +26,240 @@ class ConfluenceConfig:
     base_url: str = "https://querypie.atlassian.net/wiki"
     email: str = ''
     api_token: str = ''
+    timeout_seconds: float = 30.0
 
     def __post_init__(self):
         if not self.email or not self.api_token:
             self.email, self.api_token = _load_credentials()
 
 
-def get_page_version(config: ConfluenceConfig, page_id: str) -> Dict[str, Any]:
-    """페이지의 현재 version number와 title을 조회한다."""
-    url = f"{config.base_url}/rest/api/content/{page_id}?expand=version"
-    resp = requests.get(url, auth=(config.email, config.api_token),
-                        headers={"Accept": "application/json"})
-    resp.raise_for_status()
-    data = resp.json()
-    return {
-        'version': data['version']['number'],
-        'title': data['title'],
-    }
+class ConfluenceClientError(RuntimeError):
+    """Confluence provider error의 공통 기반."""
+
+    reason_code = ReasonCode.NETWORK_ERROR.value
 
 
-def get_page_body(config: ConfluenceConfig, page_id: str) -> str:
-    """페이지의 현재 storage XHTML body를 조회한다."""
-    url = f"{config.base_url}/rest/api/content/{page_id}?expand=body.storage"
-    resp = requests.get(url, auth=(config.email, config.api_token),
-                        headers={"Accept": "application/json"})
-    resp.raise_for_status()
-    return resp.json()['body']['storage']['value']
+class InvalidPageSnapshotError(ConfluenceClientError):
+    reason_code = ReasonCode.INVALID_PAGE_SNAPSHOT.value
 
 
-def update_page_body(config: ConfluenceConfig, page_id: str,
-                     title: str, version: int, xhtml_body: str) -> Dict[str, Any]:
-    """페이지의 body를 업데이트한다."""
-    url = f"{config.base_url}/rest/api/content/{page_id}"
+class VersionConflictError(ConfluenceClientError):
+    reason_code = ReasonCode.VERSION_CONFLICT.value
+
+
+class PermissionDeniedError(ConfluenceClientError):
+    reason_code = ReasonCode.PERMISSION_DENIED.value
+
+
+class NetworkError(ConfluenceClientError):
+    reason_code = ReasonCode.NETWORK_ERROR.value
+
+
+def _raise_mapped_http_error(exc: requests.HTTPError, *, update: bool = False) -> None:
+    status = exc.response.status_code if exc.response is not None else None
+    if status == 409 or (update and status == 400):
+        raise VersionConflictError("Confluence page version conflict") from exc
+    if status in (401, 403):
+        raise PermissionDeniedError("Confluence page 접근 권한이 없습니다") from exc
+    raise NetworkError(f"Confluence API 요청이 실패했습니다 (HTTP {status})") from exc
+
+
+def _request_json(method: str, url: str, config: ConfluenceConfig, **kwargs) -> Dict[str, Any]:
+    try:
+        kwargs.setdefault("timeout", config.timeout_seconds)
+        response = requests.request(
+            method,
+            url,
+            auth=(config.email, config.api_token),
+            headers={
+                "Accept": "application/json",
+                **kwargs.pop("headers", {}),
+            },
+            **kwargs,
+        )
+        response.raise_for_status()
+        return response.json()
+    except requests.HTTPError as exc:
+        _raise_mapped_http_error(exc, update=method.upper() == "PUT")
+    except (requests.RequestException, ValueError) as exc:
+        raise NetworkError("Confluence API 응답을 읽지 못했습니다") from exc
+
+
+def _parse_page_snapshot(
+    data: Dict[str, Any],
+    page_id: str,
+    *,
+    expected_status: str,
+    fetched_at: datetime,
+) -> PageSnapshot:
+    try:
+        response_page_id = str(data["id"])
+        status = data["status"]
+        title = data["title"]
+        version = data["version"]["number"]
+        storage = data["body"]["storage"]
+        representation = storage["representation"]
+        storage_xhtml = storage["value"]
+    except (KeyError, TypeError) as exc:
+        raise InvalidPageSnapshotError(
+            f"페이지 {page_id} snapshot의 필수 field가 없습니다"
+        ) from exc
+
+    invalid = (
+        response_page_id != str(page_id)
+        or status != expected_status
+        or representation != "storage"
+        or not isinstance(title, str)
+        or not title
+        or not isinstance(version, int)
+        or version < 1
+        or not isinstance(storage_xhtml, str)
+    )
+    if invalid:
+        raise InvalidPageSnapshotError(
+            f"페이지 {page_id} snapshot identity/representation이 올바르지 않습니다"
+        )
+
+    return PageSnapshot(
+        page_id=response_page_id,
+        status=status,
+        title=title,
+        version=version,
+        storage_xhtml=storage_xhtml,
+        fetched_at=fetched_at.astimezone(timezone.utc).isoformat(),
+        api="confluence-v2",
+    )
+
+
+def get_page_snapshot(
+    config: ConfluenceConfig,
+    page_id: str,
+    *,
+    fetched_at: datetime | None = None,
+) -> PageSnapshot:
+    """version/title/Storage body를 하나의 v2 response에서 획득한다."""
+    url = f"{config.base_url}/api/v2/pages/{page_id}"
+    captured_at = fetched_at or datetime.now(timezone.utc)
+    try:
+        response = requests.get(
+            url,
+            params={
+                "body-format": "storage",
+                "status": ["current"],
+                "include-version": True,
+            },
+            auth=(config.email, config.api_token),
+            headers={"Accept": "application/json"},
+            timeout=config.timeout_seconds,
+        )
+        response.raise_for_status()
+        data = response.json()
+    except requests.HTTPError as exc:
+        _raise_mapped_http_error(exc)
+    except (requests.RequestException, ValueError) as exc:
+        raise NetworkError("Confluence page snapshot을 읽지 못했습니다") from exc
+    return _parse_page_snapshot(
+        data,
+        page_id,
+        expected_status="current",
+        fetched_at=captured_at,
+    )
+
+
+def get_active_draft(
+    config: ConfluenceConfig,
+    page_id: str,
+    *,
+    fetched_at: datetime | None = None,
+) -> PageSnapshot | None:
+    """active draft가 있으면 draft snapshot을 반환하고, 없으면 None을 반환한다."""
+    url = f"{config.base_url}/api/v2/pages/{page_id}"
+    captured_at = fetched_at or datetime.now(timezone.utc)
+    try:
+        response = requests.get(
+            url,
+            params={
+                "body-format": "storage",
+                "get-draft": True,
+                "status": ["draft"],
+                "include-version": True,
+            },
+            auth=(config.email, config.api_token),
+            headers={"Accept": "application/json"},
+            timeout=config.timeout_seconds,
+        )
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
+        data = response.json()
+    except requests.HTTPError as exc:
+        _raise_mapped_http_error(exc)
+    except (requests.RequestException, ValueError) as exc:
+        raise NetworkError("Confluence draft snapshot을 읽지 못했습니다") from exc
+
+    if data.get("status") != "draft":
+        return None
+    return _parse_page_snapshot(
+        data,
+        page_id,
+        expected_status="draft",
+        fetched_at=captured_at,
+    )
+
+
+def update_page(
+    config: ConfluenceConfig,
+    page_id: str,
+    *,
+    title: str,
+    version: int,
+    xhtml_body: str,
+) -> Dict[str, Any]:
+    """base version + 1로 Storage body를 한 번만 갱신한다."""
+    url = f"{config.base_url}/api/v2/pages/{page_id}"
     payload = {
-        "type": "page",
+        "id": str(page_id),
+        "status": "current",
         "title": title,
-        "version": {"number": version},
         "body": {
-            "storage": {
-                "value": xhtml_body,
-                "representation": "storage",
-            }
+            "representation": "storage",
+            "value": xhtml_body,
         },
+        "version": {"number": version},
     }
-    resp = requests.put(url, json=payload, auth=(config.email, config.api_token),
-                        headers={"Content-Type": "application/json",
-                                 "Accept": "application/json"})
-    resp.raise_for_status()
-    return resp.json()
+    return _request_json(
+        "PUT",
+        url,
+        config,
+        json=payload,
+        headers={"Content-Type": "application/json"},
+    )
+
+
+class ConfluenceGateway:
+    """publisher가 사용하는 Confluence adapter."""
+
+    def __init__(self, config: ConfluenceConfig):
+        self.config = config
+
+    def get_current_page(self, page_id: str) -> PageSnapshot:
+        return get_page_snapshot(self.config, page_id)
+
+    def get_active_draft(self, page_id: str) -> PageSnapshot | None:
+        return get_active_draft(self.config, page_id)
+
+    def update_page(
+        self,
+        page_id: str,
+        *,
+        title: str,
+        version: int,
+        xhtml_body: str,
+    ) -> Dict[str, Any]:
+        return update_page(
+            self.config,
+            page_id,
+            title=title,
+            version=version,
+            xhtml_body=xhtml_body,
+        )

--- a/confluence-mdx/bin/reverse_sync/manifest.py
+++ b/confluence-mdx/bin/reverse_sync/manifest.py
@@ -1,0 +1,250 @@
+"""실행별 reverse-sync artifact와 immutable manifest 관리."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Iterable
+
+from reverse_sync.models import (
+    ArtifactRef,
+    PageSnapshot,
+    ReasonCode,
+    SyncManifest,
+    VerificationGate,
+    sha256_text,
+)
+
+
+MANIFEST_SCHEMA_VERSION = 1
+SUPPORTED_VERIFIER_POLICIES = frozenset({"reverse-sync-push-v1"})
+CURRENT_TOOL_VERSION = "reverse-sync-cli-v1"
+REQUIRED_PUSH_GATES = frozenset(
+    {
+        "source_identity",
+        "base_parity",
+        "intent_complete",
+        "semantic_roundtrip",
+        "artifact_integrity",
+    }
+)
+REQUIRED_ARTIFACTS = frozenset(
+    {"base_xhtml", "original_mdx", "improved_mdx", "candidate_xhtml"}
+)
+
+
+class ArtifactTamperedError(ValueError):
+    """manifest 또는 referenced artifact의 hash가 달라졌습니다."""
+
+    reason_code = ReasonCode.ARTIFACT_TAMPERED.value
+
+
+class StaleVerificationError(ValueError):
+    """현재 publisher가 이해하지 못하는 검증 계약입니다."""
+
+    reason_code = ReasonCode.STALE_VERIFICATION.value
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _write_immutable(path: Path, content: str) -> None:
+    """같은 경로에는 같은 bytes만 허용한다."""
+    encoded = content.encode("utf-8")
+    if path.exists():
+        if path.read_bytes() != encoded:
+            raise ArtifactTamperedError(f"immutable artifact가 변경되었습니다: {path.name}")
+        return
+    path.write_bytes(encoded)
+
+
+def _artifact_ref(run_dir: Path, name: str, filename: str, content: str) -> ArtifactRef:
+    path = run_dir / filename
+    _write_immutable(path, content)
+    return ArtifactRef(name=name, path=filename, sha256=sha256_text(content))
+
+
+def _derive_run_id(
+    *,
+    base: PageSnapshot,
+    original_mdx: str,
+    improved_mdx: str,
+    candidate_xhtml: str,
+    verifier_policy: str,
+    tool_version: str,
+) -> str:
+    identity = {
+        "base_storage_sha256": base.storage_sha256,
+        "base_title": base.title,
+        "base_version": base.version,
+        "base_fetched_at": base.fetched_at,
+        "candidate_sha256": sha256_text(candidate_xhtml),
+        "improved_sha256": sha256_text(improved_mdx),
+        "original_sha256": sha256_text(original_mdx),
+        "page_id": base.page_id,
+        "tool_version": tool_version,
+        "verifier_policy": verifier_policy,
+    }
+    canonical = json.dumps(identity, separators=(",", ":"), sort_keys=True)
+    return sha256_text(canonical)[:20]
+
+
+def create_sync_manifest(
+    *,
+    runs_dir: Path,
+    base: PageSnapshot,
+    original_mdx: str,
+    original_descriptor: str,
+    improved_mdx: str,
+    improved_descriptor: str,
+    candidate_xhtml: str,
+    verifier_policy: str,
+    tool_version: str,
+    push_eligible: bool,
+    gates: Iterable[VerificationGate] = (),
+) -> Path:
+    """실행별 artifact와 canonical manifest를 생성하고 manifest 경로를 반환한다."""
+    if verifier_policy not in SUPPORTED_VERIFIER_POLICIES:
+        raise StaleVerificationError(
+            f"지원하지 않는 verifier policy입니다: {verifier_policy}"
+        )
+    if tool_version != CURRENT_TOOL_VERSION:
+        raise StaleVerificationError(
+            f"지원하지 않는 tool version입니다: {tool_version}"
+        )
+
+    run_id = _derive_run_id(
+        base=base,
+        original_mdx=original_mdx,
+        improved_mdx=improved_mdx,
+        candidate_xhtml=candidate_xhtml,
+        verifier_policy=verifier_policy,
+        tool_version=tool_version,
+    )
+    run_dir = Path(runs_dir) / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    gate_results = tuple(gates)
+    if push_eligible:
+        passed_gates = {gate.name for gate in gate_results if gate.passed}
+        if not REQUIRED_PUSH_GATES.issubset(passed_gates):
+            missing = sorted(REQUIRED_PUSH_GATES - passed_gates)
+            raise StaleVerificationError(
+                "push manifest의 required gate가 통과하지 않았습니다: "
+                + ", ".join(missing)
+            )
+
+    artifacts = (
+        _artifact_ref(run_dir, "base_xhtml", "base.xhtml", base.storage_xhtml),
+        _artifact_ref(run_dir, "original_mdx", "original.mdx", original_mdx),
+        _artifact_ref(run_dir, "improved_mdx", "improved.mdx", improved_mdx),
+        _artifact_ref(run_dir, "candidate_xhtml", "candidate.xhtml", candidate_xhtml),
+    )
+    manifest = SyncManifest(
+        schema_version=MANIFEST_SCHEMA_VERSION,
+        run_id=run_id,
+        page_id=base.page_id,
+        base_status=base.status,
+        base_title=base.title,
+        base_version=base.version,
+        base_storage_sha256=base.storage_sha256,
+        base_fetched_at=base.fetched_at,
+        base_api=base.api,
+        original_descriptor=original_descriptor,
+        improved_descriptor=improved_descriptor,
+        verifier_policy=verifier_policy,
+        tool_version=tool_version,
+        push_eligible=push_eligible,
+        artifacts=artifacts,
+        gates=gate_results,
+    )
+    manifest_path = run_dir / "manifest.json"
+    manifest_content = manifest.to_canonical_json()
+    _write_immutable(manifest_path, manifest_content)
+    _write_immutable(run_dir / "manifest.sha256", sha256_text(manifest_content) + "\n")
+    return manifest_path
+
+
+def load_sync_manifest(path: Path) -> SyncManifest:
+    try:
+        value = json.loads(Path(path).read_text())
+        if type(value.get("push_eligible")) is not bool:
+            raise ValueError("push_eligible은 boolean이어야 합니다")
+        manifest = SyncManifest.from_dict(value)
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise ArtifactTamperedError(f"manifest 형식이 올바르지 않습니다: {path}") from exc
+    if manifest.schema_version != MANIFEST_SCHEMA_VERSION:
+        raise StaleVerificationError(
+            f"지원하지 않는 manifest schema입니다: {manifest.schema_version}"
+        )
+    if manifest.verifier_policy not in SUPPORTED_VERIFIER_POLICIES:
+        raise StaleVerificationError(
+            f"지원하지 않는 verifier policy입니다: {manifest.verifier_policy}"
+        )
+    if manifest.tool_version != CURRENT_TOOL_VERSION:
+        raise StaleVerificationError(
+            f"지원하지 않는 tool version입니다: {manifest.tool_version}"
+        )
+    return manifest
+
+
+def verify_manifest_integrity(path: Path, manifest: SyncManifest) -> None:
+    """manifest sidecar와 모든 referenced artifact hash를 재검산한다."""
+    path = Path(path)
+    expected_manifest_hash_path = path.parent / "manifest.sha256"
+    if not expected_manifest_hash_path.is_file():
+        raise ArtifactTamperedError("manifest.sha256이 없습니다")
+    expected_manifest_hash = expected_manifest_hash_path.read_text().strip()
+    actual_manifest_hash = sha256_bytes(path.read_bytes())
+    if expected_manifest_hash != actual_manifest_hash:
+        raise ArtifactTamperedError("manifest.json hash가 일치하지 않습니다")
+
+    if manifest.run_id != path.parent.name:
+        raise ArtifactTamperedError("manifest run_id와 artifact directory가 다릅니다")
+    if manifest.base_status != "current":
+        raise ArtifactTamperedError("manifest base status가 current가 아닙니다")
+    if manifest.base_version < 1:
+        raise ArtifactTamperedError("manifest base version이 올바르지 않습니다")
+
+    artifact_names = [artifact.name for artifact in manifest.artifacts]
+    if len(artifact_names) != len(set(artifact_names)):
+        raise ArtifactTamperedError("manifest artifact name이 중복되었습니다")
+    if not REQUIRED_ARTIFACTS.issubset(artifact_names):
+        missing = sorted(REQUIRED_ARTIFACTS - set(artifact_names))
+        raise ArtifactTamperedError(
+            "manifest required artifact가 없습니다: " + ", ".join(missing)
+        )
+    if manifest.push_eligible:
+        gate_names = [gate.name for gate in manifest.gates]
+        if len(gate_names) != len(set(gate_names)):
+            raise ArtifactTamperedError("manifest verification gate가 중복되었습니다")
+        passed_gates = {gate.name for gate in manifest.gates if gate.passed}
+        if not REQUIRED_PUSH_GATES.issubset(passed_gates):
+            missing = sorted(REQUIRED_PUSH_GATES - passed_gates)
+            raise ArtifactTamperedError(
+                "manifest required gate가 통과하지 않았습니다: "
+                + ", ".join(missing)
+            )
+
+    resolved_run_dir = path.parent.resolve()
+    for artifact in manifest.artifacts:
+        artifact_path = (path.parent / artifact.path).resolve()
+        try:
+            artifact_path.relative_to(resolved_run_dir)
+        except ValueError as exc:
+            raise ArtifactTamperedError(
+                f"artifact 경로가 run directory를 벗어납니다: {artifact.path}"
+            ) from exc
+        if not artifact_path.is_file():
+            raise ArtifactTamperedError(f"artifact가 없습니다: {artifact.path}")
+        actual_hash = sha256_bytes(artifact_path.read_bytes())
+        if actual_hash != artifact.sha256:
+            raise ArtifactTamperedError(
+                f"artifact hash가 일치하지 않습니다: {artifact.path}"
+            )
+
+    base_ref = manifest.artifact("base_xhtml")
+    if base_ref.sha256 != manifest.base_storage_sha256:
+        raise ArtifactTamperedError("base snapshot hash와 base.xhtml hash가 다릅니다")

--- a/confluence-mdx/bin/reverse_sync/models.py
+++ b/confluence-mdx/bin/reverse_sync/models.py
@@ -1,0 +1,236 @@
+"""reverse-sync의 snapshot, manifest, receipt 불변 모델."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import hashlib
+import json
+from typing import Any
+
+
+def sha256_text(value: str) -> str:
+    """UTF-8 문자열의 SHA-256을 반환한다."""
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+class SyncStatus(str, Enum):
+    """reverse-sync 실행 상태."""
+
+    VERIFIED_LOCAL = "verified_local"
+    REMOTE_VERIFIED = "remote_verified"
+    ALREADY_APPLIED = "already_applied"
+    POSTCONDITION_FAILED = "postcondition_failed"
+
+
+class ReasonCode(str, Enum):
+    """자동화가 분기할 수 있는 안정적인 block reason."""
+
+    INVALID_PAGE_SNAPSHOT = "invalid_page_snapshot"
+    ARTIFACT_TAMPERED = "artifact_tampered"
+    STALE_VERIFICATION = "stale_verification"
+    REMOTE_DRIFT = "remote_drift"
+    ACTIVE_DRAFT = "active_draft"
+    VERSION_CONFLICT = "version_conflict"
+    PERMISSION_DENIED = "permission_denied"
+    NETWORK_ERROR = "network_error"
+    POSTCONDITION_FAILED = "postcondition_failed"
+
+
+@dataclass(frozen=True)
+class PageSnapshot:
+    """한 API response에서 획득한 Confluence page의 일관된 상태."""
+
+    page_id: str
+    status: str
+    title: str
+    version: int
+    storage_xhtml: str
+    fetched_at: str
+    api: str
+
+    @property
+    def storage_sha256(self) -> str:
+        return sha256_text(self.storage_xhtml)
+
+    def to_dict(self, *, include_body: bool = True) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "api": self.api,
+            "fetched_at": self.fetched_at,
+            "page_id": self.page_id,
+            "status": self.status,
+            "storage_sha256": self.storage_sha256,
+            "title": self.title,
+            "version": self.version,
+        }
+        if include_body:
+            result["storage_xhtml"] = self.storage_xhtml
+        return result
+
+
+@dataclass(frozen=True)
+class ArtifactRef:
+    """manifest가 참조하는 실행별 artifact."""
+
+    name: str
+    path: str
+    sha256: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"name": self.name, "path": self.path, "sha256": self.sha256}
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> "ArtifactRef":
+        return cls(
+            name=str(value["name"]),
+            path=str(value["path"]),
+            sha256=str(value["sha256"]),
+        )
+
+
+@dataclass(frozen=True)
+class VerificationGate:
+    """local proof의 개별 gate 결과."""
+
+    name: str
+    passed: bool
+    reason_code: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {"name": self.name, "passed": self.passed}
+        if self.reason_code:
+            result["reason_code"] = self.reason_code
+        return result
+
+
+@dataclass(frozen=True)
+class SyncManifest:
+    """verify 결과와 publisher 입력을 hash로 결합하는 immutable 계약."""
+
+    schema_version: int
+    run_id: str
+    page_id: str
+    base_status: str
+    base_title: str
+    base_version: int
+    base_storage_sha256: str
+    base_fetched_at: str
+    base_api: str
+    original_descriptor: str
+    improved_descriptor: str
+    verifier_policy: str
+    tool_version: str
+    push_eligible: bool
+    artifacts: tuple[ArtifactRef, ...]
+    gates: tuple[VerificationGate, ...] = ()
+
+    def artifact(self, name: str) -> ArtifactRef:
+        for artifact in self.artifacts:
+            if artifact.name == name:
+                return artifact
+        raise KeyError(name)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "artifacts": [artifact.to_dict() for artifact in self.artifacts],
+            "base": {
+                "api": self.base_api,
+                "fetched_at": self.base_fetched_at,
+                "status": self.base_status,
+                "storage_sha256": self.base_storage_sha256,
+                "title": self.base_title,
+                "version": self.base_version,
+            },
+            "gates": [gate.to_dict() for gate in self.gates],
+            "improved_mdx": {"descriptor": self.improved_descriptor},
+            "original_mdx": {"descriptor": self.original_descriptor},
+            "page_id": self.page_id,
+            "push_eligible": self.push_eligible,
+            "run_id": self.run_id,
+            "schema_version": self.schema_version,
+            "tool": {
+                "version": self.tool_version,
+                "verifier_policy": self.verifier_policy,
+            },
+        }
+
+    def to_canonical_json(self) -> str:
+        return json.dumps(
+            self.to_dict(),
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ) + "\n"
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> "SyncManifest":
+        base = value["base"]
+        tool = value["tool"]
+        return cls(
+            schema_version=int(value["schema_version"]),
+            run_id=str(value["run_id"]),
+            page_id=str(value["page_id"]),
+            base_status=str(base["status"]),
+            base_title=str(base["title"]),
+            base_version=int(base["version"]),
+            base_storage_sha256=str(base["storage_sha256"]),
+            base_fetched_at=str(base["fetched_at"]),
+            base_api=str(base["api"]),
+            original_descriptor=str(value["original_mdx"]["descriptor"]),
+            improved_descriptor=str(value["improved_mdx"]["descriptor"]),
+            verifier_policy=str(tool["verifier_policy"]),
+            tool_version=str(tool["version"]),
+            push_eligible=bool(value["push_eligible"]),
+            artifacts=tuple(
+                ArtifactRef.from_dict(item) for item in value.get("artifacts", [])
+            ),
+            gates=tuple(
+                VerificationGate(
+                    name=str(item["name"]),
+                    passed=bool(item["passed"]),
+                    reason_code=str(item.get("reason_code", "")),
+                )
+                for item in value.get("gates", [])
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class PushReceipt:
+    """manifest를 변경하지 않고 기록하는 remote publish 결과."""
+
+    status: SyncStatus
+    page_id: str
+    version: int
+    title: str
+    manifest_sha256: str
+    base_version: int
+    candidate_sha256: str
+    persisted_sha256: str
+    response_version: int | None = None
+    reason_code: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "base_version": self.base_version,
+            "candidate_sha256": self.candidate_sha256,
+            "manifest_sha256": self.manifest_sha256,
+            "page_id": self.page_id,
+            "persisted_sha256": self.persisted_sha256,
+            "status": self.status.value,
+            "title": self.title,
+            "version": self.version,
+        }
+        if self.response_version is not None:
+            result["response_version"] = self.response_version
+        if self.reason_code:
+            result["reason_code"] = self.reason_code
+        return result
+
+    def to_canonical_json(self) -> str:
+        return json.dumps(
+            self.to_dict(),
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ) + "\n"

--- a/confluence-mdx/bin/reverse_sync/publisher.py
+++ b/confluence-mdx/bin/reverse_sync/publisher.py
@@ -1,0 +1,239 @@
+"""검증된 SyncManifest만 소비하는 transaction-safe Confluence publisher."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Protocol
+
+from reverse_sync.manifest import (
+    ArtifactTamperedError,
+    load_sync_manifest,
+    sha256_bytes,
+    verify_manifest_integrity,
+)
+from reverse_sync.models import (
+    PageSnapshot,
+    PushReceipt,
+    ReasonCode,
+    SyncManifest,
+    SyncStatus,
+)
+
+
+class PageGateway(Protocol):
+    def get_current_page(self, page_id: str) -> PageSnapshot: ...
+
+    def get_active_draft(self, page_id: str) -> PageSnapshot | None: ...
+
+    def update_page(
+        self,
+        page_id: str,
+        *,
+        title: str,
+        version: int,
+        xhtml_body: str,
+    ) -> dict: ...
+
+
+class PublishBlockedError(RuntimeError):
+    reason_code = ""
+
+
+class RemoteDriftError(PublishBlockedError):
+    reason_code = ReasonCode.REMOTE_DRIFT.value
+
+
+class ActiveDraftError(PublishBlockedError):
+    reason_code = ReasonCode.ACTIVE_DRAFT.value
+
+
+class PostconditionError(PublishBlockedError):
+    reason_code = ReasonCode.POSTCONDITION_FAILED.value
+
+
+def _write_snapshot(path: Path, snapshot: PageSnapshot) -> None:
+    _write_json(path, snapshot.to_dict(include_body=True))
+
+
+def _write_json(path: Path, value: dict) -> None:
+    import json
+
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+        + "\n"
+    )
+
+
+def _write_receipt(path: Path, receipt: PushReceipt) -> None:
+    path.write_text(receipt.to_canonical_json())
+
+
+def _manifest_hash(path: Path) -> str:
+    return sha256_bytes(path.read_bytes())
+
+
+def _candidate_body(path: Path, manifest: SyncManifest) -> str:
+    candidate = manifest.artifact("candidate_xhtml")
+    return (path.parent / candidate.path).read_text()
+
+
+def _assert_remote_identity(manifest: SyncManifest, remote: PageSnapshot) -> None:
+    mismatches: list[str] = []
+    if remote.page_id != manifest.page_id:
+        mismatches.append("page_id")
+    if remote.status != manifest.base_status:
+        mismatches.append("status")
+    if remote.title != manifest.base_title:
+        mismatches.append("title")
+    if mismatches:
+        raise RemoteDriftError(
+            f"원격 page identity가 검증 base와 다릅니다: {', '.join(mismatches)}"
+        )
+
+
+def _assert_remote_base(manifest: SyncManifest, remote: PageSnapshot) -> None:
+    mismatches: list[str] = []
+    if remote.version != manifest.base_version:
+        mismatches.append("version")
+    if remote.storage_sha256 != manifest.base_storage_sha256:
+        mismatches.append("storage_xhtml")
+    if mismatches:
+        raise RemoteDriftError(
+            f"원격 page가 검증 base 이후 변경되었습니다: {', '.join(mismatches)}"
+        )
+
+
+def _response_version(response: dict) -> int | None:
+    version = response.get("version")
+    if isinstance(version, dict) and isinstance(version.get("number"), int):
+        return version["number"]
+    return None
+
+
+def publish_verified_manifest(
+    manifest_path: Path,
+    gateway: PageGateway,
+    *,
+    semantic_verifier: Callable[[PageSnapshot, Path], bool] | None = None,
+) -> PushReceipt:
+    """verified manifest에 대해 preflight → PUT → postcondition을 수행한다.
+
+    conflict가 발생해도 최신 version을 새 base로 채택하거나 PUT을 재시도하지 않는다.
+    """
+    manifest_path = Path(manifest_path)
+    manifest = load_sync_manifest(manifest_path)
+    if not manifest.push_eligible:
+        raise ArtifactTamperedError("manifest가 push eligible 상태가 아닙니다")
+    verify_manifest_integrity(manifest_path, manifest)
+
+    candidate_body = _candidate_body(manifest_path, manifest)
+    candidate_hash = manifest.artifact("candidate_xhtml").sha256
+    manifest_hash = _manifest_hash(manifest_path)
+
+    preflight = gateway.get_current_page(manifest.page_id)
+    run_dir = manifest_path.parent
+    _write_snapshot(run_dir / "preflight.snapshot.json", preflight)
+    _assert_remote_identity(manifest, preflight)
+    draft = gateway.get_active_draft(manifest.page_id)
+    if draft is not None:
+        _write_snapshot(run_dir / "draft.snapshot.json", draft)
+        raise ActiveDraftError(
+            f"페이지 {manifest.page_id}에 active draft가 있어 push를 중단합니다"
+        )
+
+    if preflight.storage_sha256 == candidate_hash:
+        receipt = PushReceipt(
+            status=SyncStatus.ALREADY_APPLIED,
+            page_id=manifest.page_id,
+            version=preflight.version,
+            title=preflight.title,
+            manifest_sha256=manifest_hash,
+            base_version=manifest.base_version,
+            candidate_sha256=candidate_hash,
+            persisted_sha256=preflight.storage_sha256,
+        )
+        _write_snapshot(run_dir / "post.snapshot.json", preflight)
+        _write_receipt(run_dir / "push-receipt.json", receipt)
+        return receipt
+
+    try:
+        _assert_remote_base(manifest, preflight)
+    except RemoteDriftError:
+        semantically_applied = False
+        if semantic_verifier is not None:
+            try:
+                semantically_applied = semantic_verifier(preflight, manifest_path)
+            except Exception:
+                semantically_applied = False
+        if not semantically_applied:
+            raise
+        receipt = PushReceipt(
+            status=SyncStatus.ALREADY_APPLIED,
+            page_id=manifest.page_id,
+            version=preflight.version,
+            title=preflight.title,
+            manifest_sha256=manifest_hash,
+            base_version=manifest.base_version,
+            candidate_sha256=candidate_hash,
+            persisted_sha256=preflight.storage_sha256,
+        )
+        _write_snapshot(run_dir / "post.snapshot.json", preflight)
+        _write_receipt(run_dir / "push-receipt.json", receipt)
+        return receipt
+
+    expected_version = manifest.base_version + 1
+    response = gateway.update_page(
+        manifest.page_id,
+        title=manifest.base_title,
+        version=expected_version,
+        xhtml_body=candidate_body,
+    )
+    _write_json(run_dir / "update.response.json", response)
+
+    persisted = gateway.get_current_page(manifest.page_id)
+    _write_snapshot(run_dir / "post.snapshot.json", persisted)
+    response_version = _response_version(response)
+    identity_and_version_ok = (
+        persisted.page_id == manifest.page_id
+        and persisted.status == manifest.base_status
+        and persisted.title == manifest.base_title
+        and persisted.version == expected_version
+    )
+    semantic_ok = persisted.storage_sha256 == candidate_hash
+    if not semantic_ok and semantic_verifier is not None:
+        try:
+            semantic_ok = semantic_verifier(persisted, manifest_path)
+        except Exception:
+            semantic_ok = False
+    postcondition_ok = identity_and_version_ok and semantic_ok
+    if not postcondition_ok:
+        receipt = PushReceipt(
+            status=SyncStatus.POSTCONDITION_FAILED,
+            page_id=manifest.page_id,
+            version=persisted.version,
+            title=persisted.title,
+            manifest_sha256=manifest_hash,
+            base_version=manifest.base_version,
+            candidate_sha256=candidate_hash,
+            persisted_sha256=persisted.storage_sha256,
+            response_version=response_version,
+            reason_code=ReasonCode.POSTCONDITION_FAILED.value,
+        )
+        _write_receipt(run_dir / "push-receipt.json", receipt)
+        raise PostconditionError(
+            f"페이지 {manifest.page_id}의 persisted snapshot이 target과 다릅니다"
+        )
+
+    receipt = PushReceipt(
+        status=SyncStatus.REMOTE_VERIFIED,
+        page_id=manifest.page_id,
+        version=persisted.version,
+        title=persisted.title,
+        manifest_sha256=manifest_hash,
+        base_version=manifest.base_version,
+        candidate_sha256=candidate_hash,
+        persisted_sha256=persisted.storage_sha256,
+        response_version=response_version,
+    )
+    _write_receipt(run_dir / "push-receipt.json", receipt)
+    return receipt

--- a/confluence-mdx/bin/reverse_sync_cli.py
+++ b/confluence-mdx/bin/reverse_sync_cli.py
@@ -1167,6 +1167,7 @@ def _do_push(page_id: str, config=None, manifest_path: str = None):
             str(persisted_mdx_path),
             page_id,
             language=_detect_language(manifest.improved_descriptor),
+            page_dir=str(var_dir),
         )
         actual_mdx = persisted_mdx_path.read_text()
         from reverse_sync.base_parity import verify_source_identity

--- a/confluence-mdx/bin/reverse_sync_cli.py
+++ b/confluence-mdx/bin/reverse_sync_cli.py
@@ -32,6 +32,9 @@ from reverse_sync.roundtrip_verifier import verify_roundtrip
 from reverse_sync.patch_builder import build_patches
 from xhtml_beautify_diff import xhtml_diff
 
+_PUSH_VERIFIER_POLICY = "reverse-sync-push-v1"
+_TOOL_VERSION = "reverse-sync-cli-v1"
+
 
 @dataclass
 class MdxSource:
@@ -242,6 +245,7 @@ def _compile_result(
     result = {
         'page_id': page_id, 'created_at': now,
         'status': status,
+        'push_eligible': False,
         'changes_count': changes_count,
         'mdx_diff_report': mdx_diff_report,
         'xhtml_diff_report': xhtml_diff_report,
@@ -256,6 +260,31 @@ def _compile_result(
         result['skipped_changes'] = skipped_changes
     (var_dir / 'reverse-sync.result.yaml').write_text(
         yaml.dump(result, allow_unicode=True, default_flow_style=False))
+    return result
+
+
+def _blocked_result(
+    var_dir: Path,
+    page_id: str,
+    now: str,
+    reason_code: str,
+    *,
+    detail: str = "",
+) -> Dict[str, Any]:
+    """push proof가 fail-closed된 결과를 저장한다."""
+    result = {
+        "page_id": page_id,
+        "created_at": now,
+        "status": "blocked",
+        "push_eligible": False,
+        "changes_count": 0,
+        "reason_code": reason_code,
+    }
+    if detail:
+        result["detail"] = detail
+    (var_dir / "reverse-sync.result.yaml").write_text(
+        yaml.dump(result, allow_unicode=True, default_flow_style=False)
+    )
     return result
 
 
@@ -331,6 +360,8 @@ def run_verify(
     no_normalize: bool = False,
     language: str = None,
     page_dir: str = None,
+    base_snapshot=None,
+    for_push: bool = False,
 ) -> Dict[str, Any]:
     """로컬 검증 파이프라인을 실행한다.
 
@@ -346,9 +377,95 @@ def run_verify(
 
     _validate_improved_mdx(improved_mdx, improved_src.descriptor)
 
-    if not xhtml_path:
-        xhtml_path = str(_PROJECT_DIR / 'var' / page_id / 'page.xhtml')
-    xhtml = Path(xhtml_path).read_text()
+    if for_push and base_snapshot is None:
+        return _blocked_result(
+            var_dir,
+            page_id,
+            now,
+            "invalid_page_snapshot",
+            detail="online push에는 remote PageSnapshot이 필요합니다.",
+        )
+    if for_push and lenient:
+        return _blocked_result(
+            var_dir,
+            page_id,
+            now,
+            "lenient_verification_not_pushable",
+            detail="--lenient 결과는 진단용이며 push proof로 사용할 수 없습니다.",
+        )
+
+    if base_snapshot is not None:
+        from reverse_sync.base_parity import (
+            verify_attachment_dependencies,
+            verify_base_parity,
+            verify_source_identity,
+        )
+
+        if base_snapshot.page_id != str(page_id) or base_snapshot.status != "current":
+            return _blocked_result(
+                var_dir,
+                page_id,
+                now,
+                "invalid_page_snapshot",
+                detail="snapshot page ID 또는 status가 요청과 다릅니다.",
+            )
+        source_identity = verify_source_identity(
+            base_snapshot,
+            original_mdx,
+            improved_mdx,
+        )
+        if not source_identity.passed:
+            return _blocked_result(
+                var_dir,
+                page_id,
+                now,
+                source_identity.reason_code,
+                detail=source_identity.diff_report,
+            )
+        dependency = verify_attachment_dependencies(
+            base_snapshot,
+            original_mdx,
+            improved_mdx,
+        )
+        if not dependency.passed:
+            return _blocked_result(
+                var_dir,
+                page_id,
+                now,
+                dependency.reason_code,
+                detail=dependency.diff_report,
+            )
+
+        base_xhtml_path = var_dir / "reverse-sync.base.xhtml"
+        base_mdx_path = var_dir / "reverse-sync.base.mdx"
+        base_xhtml_path.write_text(base_snapshot.storage_xhtml)
+        _forward_convert(
+            str(base_xhtml_path),
+            str(base_mdx_path),
+            page_id,
+            language=language or _detect_language(improved_src.descriptor),
+            page_dir=page_dir,
+        )
+        converted_base_mdx = base_mdx_path.read_text()
+        base_parity = verify_base_parity(
+            base_snapshot,
+            original_mdx,
+            converted_base_mdx,
+        )
+        if not base_parity.passed:
+            return _blocked_result(
+                var_dir,
+                page_id,
+                now,
+                base_parity.reason_code,
+                detail=base_parity.diff_report,
+            )
+        xhtml_path = str(base_xhtml_path)
+        xhtml = base_snapshot.storage_xhtml
+    else:
+        if not xhtml_path:
+            xhtml_path = str(_PROJECT_DIR / 'var' / page_id / 'page.xhtml')
+        xhtml = Path(xhtml_path).read_text()
 
     # Step 1-2: MDX 파싱 + diff
     changes, alignment, original_blocks, improved_blocks = _parse_and_diff(
@@ -358,6 +475,7 @@ def run_verify(
     if not changes:
         result = {'page_id': page_id, 'created_at': now,
                   'status': 'no_changes', 'changes_count': 0,
+                  'push_eligible': False,
                   'mdx_diff_report': '', 'xhtml_diff_report': ''}
         if title:
             result['title'] = title
@@ -430,6 +548,20 @@ def run_verify(
         page_dir=page_dir,
     )
     verify_mdx = (var_dir / 'verify.mdx').read_text()
+    if for_push:
+        candidate_identity = verify_source_identity(
+            base_snapshot,
+            improved_mdx,
+            verify_mdx,
+        )
+        if not candidate_identity.passed:
+            return _blocked_result(
+                var_dir,
+                page_id,
+                now,
+                candidate_identity.reason_code,
+                detail=candidate_identity.diff_report,
+            )
 
     # MDX input diff (original → improved)
     orig_stripped = _strip_frontmatter(original_mdx)
@@ -449,7 +581,7 @@ def run_verify(
         expected_mdx=impr_stripped,
         actual_mdx=verify_stripped,
         lenient=lenient,
-        no_normalize=no_normalize,
+        no_normalize=True if for_push else no_normalize,
     )
     # Roundtrip diff (improved → verify): PASS/FAIL 무관하게 항상 생성
     roundtrip_diff_lines = difflib.unified_diff(
@@ -461,11 +593,62 @@ def run_verify(
     )
     roundtrip_diff_report = ''.join(roundtrip_diff_lines)
 
-    return _compile_result(
+    result = _compile_result(
         var_dir, page_id, now, len(changes),
         mdx_diff_report, xhtml_diff_report,
         verify_result, roundtrip_diff_report, title=title,
         skipped_changes=skipped_changes)
+
+    if for_push and result["status"] == "pass" and skipped_changes:
+        result.update(
+            status="blocked",
+            push_eligible=False,
+            reason_code="incomplete_patch_plan",
+        )
+    elif for_push and result["status"] == "pass":
+        from reverse_sync.manifest import create_sync_manifest
+        from reverse_sync.models import VerificationGate, sha256_text
+
+        manifest_path = create_sync_manifest(
+            runs_dir=var_dir / "reverse-sync",
+            base=base_snapshot,
+            original_mdx=original_mdx,
+            original_descriptor=original_src.descriptor,
+            improved_mdx=improved_mdx,
+            improved_descriptor=improved_src.descriptor,
+            candidate_xhtml=patched_xhtml,
+            verifier_policy=_PUSH_VERIFIER_POLICY,
+            tool_version=_TOOL_VERSION,
+            push_eligible=True,
+            gates=(
+                VerificationGate("source_identity", True),
+                VerificationGate("base_parity", True),
+                VerificationGate("intent_complete", True),
+                VerificationGate("semantic_roundtrip", True),
+                VerificationGate("artifact_integrity", True),
+            ),
+        )
+        result.update(
+            push_eligible=True,
+            manifest_path=str(manifest_path),
+            run_id=manifest_path.parent.name,
+            base_version=base_snapshot.version,
+            base_storage_sha256=base_snapshot.storage_sha256,
+            candidate_sha256=sha256_text(patched_xhtml),
+            local_gates=[
+                "source_identity",
+                "base_parity",
+                "intent_complete",
+                "semantic_roundtrip",
+                "artifact_integrity",
+            ],
+        )
+        (var_dir / "reverse-sync.manifest.path").write_text(str(manifest_path) + "\n")
+
+    (var_dir / "reverse-sync.result.yaml").write_text(
+        yaml.dump(result, allow_unicode=True, default_flow_style=False)
+    )
+    return result
 
 
 def _strip_frontmatter(mdx: str) -> str:
@@ -506,12 +689,14 @@ def _display_status(result: Dict[str, Any]) -> str:
         return 'push_conflict'
     if push_status == 'error':
         return 'push_error'
+    if push_status == 'postcondition_failed':
+        return 'push_postcondition_failed'
     return result.get('status', 'unknown')
 
 
 def _display_error(result: Dict[str, Any], status: str) -> str:
     """출력용 에러 메시지를 반환한다."""
-    if status in ('push_conflict', 'push_error'):
+    if status in ('push_conflict', 'push_error', 'push_postcondition_failed'):
         return (result.get('push') or {}).get('error', '')
     return result.get('error', '')
 
@@ -547,6 +732,8 @@ def _print_results(results: List[Dict[str, Any]], *, show_all_diffs: bool = Fals
             badge = c(YELLOW, 'PUSH CONFLICT')
         elif status == 'push_error':
             badge = c(YELLOW, 'PUSH ERROR')
+        elif status == 'push_postcondition_failed':
+            badge = c(RED, 'POSTCONDITION FAILED')
         elif status == 'error':
             badge = c(YELLOW, 'ERROR')
         else:
@@ -555,7 +742,12 @@ def _print_results(results: List[Dict[str, Any]], *, show_all_diffs: bool = Fals
         print(f'\n{c(BOLD, file_path)}  {badge}  ({changes} change(s))')
 
         # 에러 메시지
-        if status in ('error', 'push_conflict', 'push_error'):
+        if status in (
+            'error',
+            'push_conflict',
+            'push_error',
+            'push_postcondition_failed',
+        ):
             print(f'  {c(RED, _display_error(r, status))}')
             continue
 
@@ -604,6 +796,9 @@ def _print_results(results: List[Dict[str, Any]], *, show_all_diffs: bool = Fals
     errors = sum(1 for status in display_statuses if status == 'error')
     conflicts = sum(1 for status in display_statuses if status == 'push_conflict')
     push_errors = sum(1 for status in display_statuses if status == 'push_error')
+    postcondition_failures = sum(
+        1 for status in display_statuses if status == 'push_postcondition_failed'
+    )
     no_chg = sum(1 for status in display_statuses if status == 'no_changes')
 
     parts = []
@@ -617,6 +812,8 @@ def _print_results(results: List[Dict[str, Any]], *, show_all_diffs: bool = Fals
         parts.append(c(YELLOW, f'{conflicts} conflicts'))
     if push_errors:
         parts.append(c(YELLOW, f'{push_errors} push errors'))
+    if postcondition_failures:
+        parts.append(c(RED, f'{postcondition_failures} postcondition failures'))
     if no_chg:
         parts.append(c(DIM, f'{no_chg} no changes'))
 
@@ -636,9 +833,10 @@ Usage:
   reverse-sync -h | --help
 
 Commands:
-  push     verify 수행 후 Confluence에 반영 (--dry-run으로 검증만 가능)
-  verify   push --dry-run의 alias
-  debug    verify + MDX diff, XHTML diff, Verify diff 상세 출력
+  push     원격 current snapshot을 기준으로 검증 후 Confluence에 반영
+           (--dry-run은 manifest까지만 만들고 PUT을 생략)
+  verify   로컬 page.xhtml 기반 진단 (push_eligible은 항상 false)
+  debug    로컬 verify + MDX diff, XHTML diff, Verify diff 상세 출력
 
 Arguments:
   <mdx>
@@ -663,8 +861,8 @@ Options:
 
   --lenient
     관대 모드: trailing whitespace, 날짜 형식 등 XHTML↔MDX 변환기 한계에
-    의한 차이를 정규화한 후 비교한다. 기본 동작은 정규화 없이 문자 그대로
-    비교하는 엄격 모드이다.
+    의한 차이를 기본 비교보다 더 넓게 정규화한다.
+    진단 전용이며 push에는 사용할 수 없다.
 
 Examples:
   # 단일 파일 검증
@@ -679,25 +877,26 @@ Examples:
   # 브랜치 전체 배치 push
   reverse-sync push --branch proofread/fix-typo
 
-  # push --dry-run = verify
+  # 원격 snapshot을 사용하되 PUT은 생략
   reverse-sync push --dry-run "proofread/fix-typo:src/content/ko/user-manual/user-agent.mdx"
 
 Run 'reverse-sync <command> -h' for command-specific help and more examples.
 """
 
 _PUSH_HELP = """\
-MDX 변경사항을 XHTML에 패치하고, round-trip 검증 후 Confluence에 반영한다.
+MDX 변경사항을 검증한 Confluence snapshot에 패치하고, manifest로 결합한 뒤 반영한다.
 
 파이프라인:
-  1. original / improved MDX를 블록 단위로 파싱
-  2. 블록 diff 추출
-  3. 원본 XHTML 블록 매핑 생성
-  4. XHTML 패치 적용
-  5. 패치된 XHTML을 다시 MDX로 forward 변환 (round-trip)
-  6. improved MDX와 비교하여 pass/fail 판정
-  7. pass인 경우 Confluence API로 업데이트 (--dry-run 시 생략)
+  1. version/title/Storage body를 단일 remote PageSnapshot으로 조회
+  2. snapshot의 forward conversion과 original MDX base parity 검증
+  3. original / improved MDX diff를 snapshot XHTML에 적용
+  4. candidate XHTML round-trip과 dependency gate 검증
+  5. snapshot/MDX/candidate hash를 immutable SyncManifest로 기록
+  6. PUT 직전 remote snapshot과 manifest base를 다시 비교
+  7. base version + 1로 한 번만 업데이트하고 persisted snapshot을 재검증
 
-중간 산출물은 var/<page-id>/ 에 reverse-sync.* prefix로 저장된다.
+실행별 산출물은 var/<page-id>/reverse-sync/<run-id>/ 에 저장된다.
+기존 reverse-sync.* 파일은 진단용 compatibility output이며 push payload가 아니다.
 
 MDX 소스 지정 방식:
   ref:path  git ref와 파일 경로를 콜론으로 구분
@@ -756,7 +955,7 @@ def _add_common_args(parser: argparse.ArgumentParser):
                         help='원시 모드: 정규화 없이 비교 (FC/패치 차이의 실제 규모를 확인)')
 
 
-def _do_verify(args) -> dict:
+def _do_verify(args, *, config=None, prepare_push: bool = False) -> dict:
     """공통 verify 로직: MDX 소스 해석 → run_verify() 실행 → 결과 반환."""
     improved_src = _resolve_mdx_source(args.improved_mdx)
     if args.original_mdx:
@@ -772,6 +971,13 @@ def _do_verify(args) -> dict:
     # --page-dir: var/<page_id>/ 를 대체하는 디렉토리 (page.xhtml, page.v1.yaml 제공)
     page_dir = getattr(args, 'page_dir', None)
     xhtml_path = str(Path(page_dir) / 'page.xhtml') if page_dir else None
+    base_snapshot = None
+    if prepare_push:
+        from reverse_sync.confluence_client import get_page_snapshot
+
+        if config is None:
+            config = _ensure_confluence_config()
+        base_snapshot = get_page_snapshot(config, page_id)
 
     return run_verify(
         page_id=page_id,
@@ -781,6 +987,8 @@ def _do_verify(args) -> dict:
         lenient=getattr(args, 'lenient', False),
         no_normalize=getattr(args, 'no_normalize', False),
         page_dir=page_dir,
+        base_snapshot=base_snapshot,
+        for_push=prepare_push,
     )
 
 
@@ -802,7 +1010,8 @@ def _confirm(prompt: str) -> bool:
 def _do_verify_batch(branch: str, limit: int = 0, failures_only: bool = False,
                      push: bool = False, yes: bool = False,
                      lenient: bool = False,
-                     no_normalize: bool = False) -> List[dict]:
+                     no_normalize: bool = False,
+                     prepare_push: bool = False) -> List[dict]:
     """브랜치의 변경 ko MDX 파일을 배치 처리한다.
 
     push=True이면 verify 전체 완료 후 pass 건만 일괄 push한다.
@@ -818,6 +1027,8 @@ def _do_verify_batch(branch: str, limit: int = 0, failures_only: bool = False,
     print(f"Processing {'up to ' + str(total) if failures_only and limit > 0 else str(len(files))}/{total} file(s) from branch {branch}...", file=sys.stderr)
     results = []
     failure_count = 0
+    online = push or prepare_push
+    config = _ensure_confluence_config() if online else None
     for idx, ko_path in enumerate(files, 1):
         print(f"[{idx}/{len(files)}] {ko_path} ... ", end='', file=sys.stderr, flush=True)
         try:
@@ -827,7 +1038,21 @@ def _do_verify_batch(branch: str, limit: int = 0, failures_only: bool = False,
                 lenient=lenient,
                 no_normalize=no_normalize,
             )
-            result = _do_verify(args)
+            if online:
+                result = _do_verify(
+                    args,
+                    config=config,
+                    prepare_push=True,
+                )
+            else:
+                result = _do_verify(args)
+            if online and result.get("status") == "pass" and not result.get(
+                "push_eligible"
+            ):
+                result.update(
+                    status="blocked",
+                    reason_code="not_push_eligible",
+                )
             result['file'] = ko_path
             status = result.get('status', 'unknown')
             print(status, file=sys.stderr)
@@ -844,7 +1069,10 @@ def _do_verify_batch(branch: str, limit: int = 0, failures_only: bool = False,
         return results
 
     # push 대상 집계
-    pushable = [r for r in results if r.get('status') == 'pass']
+    pushable = [
+        r for r in results
+        if r.get('status') == 'pass' and r.get('push_eligible') is True
+    ]
     if not pushable:
         print("\nPush 대상 없음 (pass 0건)", file=sys.stderr)
         return results
@@ -857,12 +1085,15 @@ def _do_verify_batch(branch: str, limit: int = 0, failures_only: bool = False,
             return results
 
     # 일괄 push
-    config = _ensure_confluence_config()
     push_count = 0
     for r in pushable:
         page_id = r['page_id']
         try:
-            push_result = _do_push(page_id, config=config)
+            push_result = _do_push(
+                page_id,
+                config=config,
+                manifest_path=r.get("manifest_path"),
+            )
             r['push'] = push_result
             push_count += 1
             print(f"  pushed {page_id} (v{push_result.get('version', '?')})", file=sys.stderr)
@@ -870,6 +1101,10 @@ def _do_verify_batch(branch: str, limit: int = 0, failures_only: bool = False,
             r['push'] = {'status': 'conflict', 'error': str(e)}
             print(f"  conflict {page_id}: {e}", file=sys.stderr)
         except Exception as e:
+            if getattr(e, "reason_code", "") == "postcondition_failed":
+                r['push'] = {'status': 'postcondition_failed', 'error': str(e)}
+                print(f"  postcondition failed {page_id}: {e}", file=sys.stderr)
+                break
             r['push'] = {'status': 'error', 'error': str(e)}
             print(f"  error {page_id}: {e}", file=sys.stderr)
 
@@ -893,50 +1128,83 @@ def _ensure_confluence_config():
     return config
 
 
-def _do_push(page_id: str, config=None):
-    """verify 통과 후 Confluence에 push한다.
-
-    1. 현재 페이지 XHTML을 백업 (reverse-sync.backup.xhtml)
-    2. patched XHTML을 Confluence에 push
-    3. 409 충돌 시 PushConflictError 발생
-    """
-    from reverse_sync.confluence_client import get_page_version, get_page_body, update_page_body
-    import requests as _requests
+def _do_push(page_id: str, config=None, manifest_path: str = None):
+    """verified manifest에 결합된 candidate만 안전하게 push한다."""
+    from reverse_sync.confluence_client import ConfluenceGateway, VersionConflictError
+    from reverse_sync.manifest import load_sync_manifest, verify_manifest_integrity
+    from reverse_sync.publisher import publish_verified_manifest
 
     if config is None:
         config = _ensure_confluence_config()
 
     var_dir = _PROJECT_DIR / 'var' / page_id
-    patched_path = var_dir / 'reverse-sync.patched.xhtml'
-    xhtml_body = patched_path.read_text()
+    if manifest_path is None:
+        pointer_path = var_dir / "reverse-sync.manifest.path"
+        if not pointer_path.is_file():
+            raise ValueError(
+                f"페이지 {page_id}의 verified manifest가 없습니다. "
+                "online verify를 다시 실행하세요."
+            )
+        manifest_path = pointer_path.read_text().strip()
+    resolved_manifest_path = Path(manifest_path)
+    manifest = load_sync_manifest(resolved_manifest_path)
+    if manifest.page_id != str(page_id):
+        raise ValueError(
+            f"manifest page ID({manifest.page_id})와 요청 page ID({page_id})가 다릅니다."
+        )
+    verify_manifest_integrity(resolved_manifest_path, manifest)
 
-    # 1) 현재 페이지 정보 조회 + XHTML 백업
-    page_info = get_page_version(config, page_id)
-    current_xhtml = get_page_body(config, page_id)
-    backup_path = var_dir / 'reverse-sync.backup.xhtml'
-    backup_path.write_text(current_xhtml)
+    def semantic_verifier(snapshot, verified_manifest_path: Path) -> bool:
+        improved_ref = manifest.artifact("improved_mdx")
+        expected_mdx = (
+            verified_manifest_path.parent / improved_ref.path
+        ).read_text()
+        persisted_xhtml_path = verified_manifest_path.parent / "postcondition.xhtml"
+        persisted_mdx_path = verified_manifest_path.parent / "postcondition.mdx"
+        persisted_xhtml_path.write_text(snapshot.storage_xhtml)
+        _forward_convert(
+            str(persisted_xhtml_path),
+            str(persisted_mdx_path),
+            page_id,
+            language=_detect_language(manifest.improved_descriptor),
+        )
+        actual_mdx = persisted_mdx_path.read_text()
+        from reverse_sync.base_parity import verify_source_identity
 
-    # 2) push (optimistic locking — version mismatch → 409)
-    new_version = page_info['version'] + 1
+        identity = verify_source_identity(snapshot, expected_mdx, actual_mdx)
+        if not identity.passed:
+            return False
+        return verify_roundtrip(
+            expected_mdx=_strip_frontmatter(expected_mdx),
+            actual_mdx=_strip_frontmatter(actual_mdx),
+            no_normalize=True,
+        ).passed
+
     try:
-        resp = update_page_body(config, page_id,
-                                title=page_info['title'],
-                                version=new_version,
-                                xhtml_body=xhtml_body)
-    except _requests.HTTPError as e:
-        if e.response is not None and e.response.status_code == 409:
-            raise PushConflictError(
-                f"페이지 {page_id} ({page_info['title']})가 Confluence에서 변경되었습니다. "
-                f"fetch로 최신 버전을 가져온 후 다시 시도하세요."
-            ) from e
-        raise
+        receipt = publish_verified_manifest(
+            resolved_manifest_path,
+            ConfluenceGateway(config),
+            semantic_verifier=semantic_verifier,
+        )
+    except VersionConflictError as exc:
+        raise PushConflictError(
+            f"페이지 {page_id} ({manifest.base_title})가 preflight 이후 변경되었습니다. "
+            "최신 snapshot으로 online verify를 다시 실행하세요."
+        ) from exc
+
+    backup_path = var_dir / 'reverse-sync.backup.xhtml'
+    base_ref = manifest.artifact("base_xhtml")
+    shutil.copy2(resolved_manifest_path.parent / base_ref.path, backup_path)
 
     return {
         'page_id': page_id,
-        'title': resp.get('title', page_info['title']),
-        'version': resp.get('version', {}).get('number', new_version),
-        'url': resp.get('_links', {}).get('webui', ''),
+        'status': receipt.status.value,
+        'title': receipt.title,
+        'version': receipt.version,
+        'url': '',
         'backup': str(backup_path),
+        'manifest_path': str(resolved_manifest_path),
+        'manifest_sha256': receipt.manifest_sha256,
     }
 
 
@@ -1012,55 +1280,105 @@ def main():
 
             if getattr(args, 'branch', None):
                 # 배치 모드
-                results = _do_verify_batch(args.branch, limit=getattr(args, 'limit', 0),
-                                           failures_only=failures_only, push=not dry_run,
-                                           yes=auto_yes,
-                                           lenient=getattr(args, 'lenient', False),
-                                           no_normalize=getattr(args, 'no_normalize', False))
+                batch_kwargs = {
+                    "limit": getattr(args, "limit", 0),
+                    "failures_only": failures_only,
+                    "push": not dry_run,
+                    "yes": auto_yes,
+                    "lenient": getattr(args, "lenient", False),
+                    "no_normalize": getattr(args, "no_normalize", False),
+                }
+                if args.command == "push" and dry_run:
+                    batch_kwargs["prepare_push"] = True
+                results = _do_verify_batch(args.branch, **batch_kwargs)
                 if use_json:
                     output = results
                     if failures_only:
                         output = [r for r in results
                                   if r.get('status') not in ('pass', 'no_changes')
-                                  or r.get('push', {}).get('status') in ('conflict', 'error')]
+                                  or r.get('push', {}).get('status')
+                                  in ('conflict', 'error', 'postcondition_failed')]
                     print(json.dumps(output, ensure_ascii=False, indent=2))
                 else:
                     _print_results(results, show_all_diffs=show_all_diffs,
                                    failures_only=failures_only)
                 has_failure = any(r.get('status') not in ('pass', 'no_changes') for r in results)
                 has_push_failure = any(
-                    r.get('push', {}).get('status') in ('conflict', 'error')
+                    r.get('push', {}).get('status')
+                    in ('conflict', 'error', 'postcondition_failed')
                     for r in results
                 )
                 if has_failure or has_push_failure:
                     sys.exit(1)
             else:
                 # 기존 단일 파일 모드
-                result = _do_verify(args)
+                config = _ensure_confluence_config() if args.command == 'push' else None
+                result = _do_verify(
+                    args,
+                    config=config,
+                    prepare_push=args.command == 'push',
+                )
                 if use_json:
                     print(json.dumps(result, ensure_ascii=False, indent=2))
                 else:
                     _print_results([result], show_all_diffs=show_all_diffs)
 
-                if not dry_run and result.get('status') == 'pass':
+                if (not dry_run
+                        and result.get('status') == 'pass'
+                        and result.get('push_eligible') is True):
                     page_id = result['page_id']
                     title = result.get('title', page_id)
                     if not auto_yes:
-                        if not _confirm(f"Push {title} ({page_id}) to Confluence? [y/N] "):
+                        base_version = result.get("base_version", "?")
+                        target_version = (
+                            base_version + 1 if isinstance(base_version, int) else "?"
+                        )
+                        candidate_hash = result.get("candidate_sha256", "unknown")[:12]
+                        changes_count = result.get("changes_count", 0)
+                        prompt = (
+                            f"Push {title} ({page_id}) "
+                            f"v{base_version}→v{target_version}, "
+                            f"{changes_count} change(s), "
+                            f"candidate {candidate_hash} to Confluence? [y/N] "
+                        )
+                        if not _confirm(prompt):
                             print("Push 취소", file=sys.stderr)
                             sys.exit(0)
                     try:
-                        push_result = _do_push(page_id)
+                        push_result = _do_push(
+                            page_id,
+                            config=config,
+                            manifest_path=result.get("manifest_path"),
+                        )
                         print(json.dumps(push_result, ensure_ascii=False, indent=2))
                     except PushConflictError as e:
                         print(f"Error: {e}", file=sys.stderr)
                         sys.exit(1)
+                    except Exception as e:
+                        reason_code = getattr(e, "reason_code", "push_error")
+                        print(f"Error [{reason_code}]: {e}", file=sys.stderr)
+                        sys.exit(1)
+                elif not dry_run and result.get('status') == 'no_changes':
+                    print("변경 사항이 없어 Confluence update를 생략합니다.", file=sys.stderr)
                 elif not dry_run and result.get('status') != 'pass':
                     print(f"Error: 검증 상태가 '{result.get('status')}'입니다. push하지 않습니다.",
                           file=sys.stderr)
                     sys.exit(1)
+                elif not dry_run:
+                    print("Error: 검증 결과가 push eligible 상태가 아닙니다.", file=sys.stderr)
+                    sys.exit(1)
+                elif (args.command == "push"
+                      and result.get("status") == "pass"
+                      and result.get("push_eligible") is not True):
+                    print("Error: online verify 결과가 push eligible 상태가 아닙니다.",
+                          file=sys.stderr)
+                    sys.exit(1)
         except ValueError as e:
             print(f'Error: {e}', file=sys.stderr)
+            sys.exit(1)
+        except Exception as e:
+            reason_code = getattr(e, "reason_code", "reverse_sync_error")
+            print(f"Error [{reason_code}]: {e}", file=sys.stderr)
             sys.exit(1)
 
 

--- a/confluence-mdx/tests/test_reverse_sync_cli.py
+++ b/confluence-mdx/tests/test_reverse_sync_cli.py
@@ -1377,6 +1377,54 @@ class TestPushConflictError:
 class TestPushBackup:
     """push 시 backup.xhtml 생성 확인."""
 
+    def test_postcondition_conversion_uses_page_metadata(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        monkeypatch.setattr('reverse_sync_cli._PROJECT_DIR', tmp_path)
+        page_id = 'metadata-page'
+        manifest_path, base, persisted = _create_push_manifest(
+            tmp_path,
+            page_id,
+        )
+        persisted = PageSnapshot(
+            page_id=persisted.page_id,
+            status=persisted.status,
+            title=persisted.title,
+            version=persisted.version,
+            storage_xhtml="<p>New</p>\n",
+            fetched_at=persisted.fetched_at,
+            api=persisted.api,
+        )
+        gateway = MagicMock()
+        gateway.get_current_page.side_effect = [base, persisted]
+        gateway.get_active_draft.return_value = None
+        gateway.update_page.return_value = {"version": {"number": 6}}
+        converted = []
+
+        def forward_convert(_input_path, output_path, _page_id, **kwargs):
+            assert kwargs["page_dir"] == str(tmp_path / "var" / page_id)
+            converted.append(Path(output_path))
+            content = "# Test\n\nNew\n"
+            Path(output_path).write_text(content)
+            return content
+
+        with patch(
+            'reverse_sync.confluence_client.ConfluenceGateway',
+            return_value=gateway,
+        ), patch(
+            'reverse_sync_cli._forward_convert',
+            side_effect=forward_convert,
+        ):
+            _do_push(
+                page_id,
+                config=MagicMock(),
+                manifest_path=str(manifest_path),
+            )
+
+        assert converted
+
     def test_backup_created(self, tmp_path, monkeypatch):
         monkeypatch.setattr('reverse_sync_cli._PROJECT_DIR', tmp_path)
         page_id = 'backup-page'

--- a/confluence-mdx/tests/test_reverse_sync_cli.py
+++ b/confluence-mdx/tests/test_reverse_sync_cli.py
@@ -1,6 +1,7 @@
 import json
 import os
 import pytest
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 from reverse_sync_cli import (
@@ -15,6 +16,62 @@ from reverse_sync_cli import (
 )
 from text_utils import normalize_mdx_to_plain
 from reverse_sync.patch_builder import build_patches
+from reverse_sync.confluence_client import NetworkError, VersionConflictError
+from reverse_sync.manifest import create_sync_manifest
+from reverse_sync.models import PageSnapshot, VerificationGate
+from reverse_sync.publisher import PostconditionError
+
+
+def _create_push_manifest(
+    tmp_path: Path,
+    page_id: str,
+    *,
+    base_body: str = "<p>Old</p>",
+    candidate_body: str = "<p>New</p>",
+) -> tuple[Path, PageSnapshot, PageSnapshot]:
+    var_dir = tmp_path / "var" / page_id
+    var_dir.mkdir(parents=True, exist_ok=True)
+    base = PageSnapshot(
+        page_id=page_id,
+        status="current",
+        title="Test",
+        version=5,
+        storage_xhtml=base_body,
+        fetched_at=datetime(2026, 7, 24, tzinfo=timezone.utc).isoformat(),
+        api="confluence-v2",
+    )
+    persisted = PageSnapshot(
+        page_id=page_id,
+        status="current",
+        title="Test",
+        version=6,
+        storage_xhtml=candidate_body,
+        fetched_at=datetime(2026, 7, 24, tzinfo=timezone.utc).isoformat(),
+        api="confluence-v2",
+    )
+    manifest_path = create_sync_manifest(
+        runs_dir=var_dir / "reverse-sync",
+        base=base,
+        original_mdx="# Test\n\nOld\n",
+        original_descriptor="main:src/content/ko/test.mdx",
+        improved_mdx="# Test\n\nNew\n",
+        improved_descriptor="src/content/ko/test.mdx",
+        candidate_xhtml=candidate_body,
+        verifier_policy="reverse-sync-push-v1",
+        tool_version="reverse-sync-cli-v1",
+        push_eligible=True,
+        gates=tuple(
+            VerificationGate(name, True)
+            for name in (
+                "source_identity",
+                "base_parity",
+                "intent_complete",
+                "semantic_roundtrip",
+                "artifact_integrity",
+            )
+        ),
+    )
+    return manifest_path, base, persisted
 
 
 @pytest.fixture
@@ -112,39 +169,30 @@ def test_push_verify_pass_then_pushes(tmp_path, monkeypatch):
     monkeypatch.setattr('sys.argv', ['reverse_sync_cli.py', 'push', '--yes', '--json', mdx_arg])
     monkeypatch.setattr('reverse_sync_cli._PROJECT_DIR', tmp_path)
 
-    # var 디렉토리에 patched xhtml 준비
-    var_dir = tmp_path / 'var' / page_id
-    var_dir.mkdir(parents=True)
-    (var_dir / 'reverse-sync.patched.xhtml').write_text('<p>Updated</p>')
-
-    pass_result = {'status': 'pass', 'page_id': page_id, 'changes_count': 1}
-
-    mock_get_version = MagicMock(return_value={'version': 5, 'title': 'Test'})
-    mock_get_body = MagicMock(return_value='<p>Original</p>')
-    mock_update = MagicMock(return_value={
-        'title': 'Test', 'version': {'number': 6},
-        '_links': {'webui': '/test'},
-    })
+    manifest_path = tmp_path / "manifest.json"
+    pass_result = {
+        'status': 'pass',
+        'page_id': page_id,
+        'changes_count': 1,
+        'push_eligible': True,
+        'manifest_path': str(manifest_path),
+    }
+    push_result = {
+        "page_id": page_id,
+        "status": "remote_verified",
+        "title": "Test",
+        "version": 6,
+    }
 
     with patch('reverse_sync_cli._do_verify', return_value=pass_result), \
-         patch('reverse_sync.confluence_client._load_credentials',
-               return_value=('e@x.com', 'tok')), \
-         patch('reverse_sync.confluence_client.get_page_version', mock_get_version), \
-         patch('reverse_sync.confluence_client.get_page_body', mock_get_body), \
-         patch('reverse_sync.confluence_client.update_page_body', mock_update), \
+         patch('reverse_sync_cli._ensure_confluence_config', return_value=MagicMock()), \
+         patch('reverse_sync_cli._do_push', return_value=push_result) as mock_push, \
          patch('builtins.print') as mock_print:
         main()
 
-    # push API 호출 확인
-    mock_update.assert_called_once()
-    call_args = mock_update.call_args
-    assert call_args[0][1] == page_id
-    assert call_args[1]['xhtml_body'] == '<p>Updated</p>'
-
-    # 백업 파일 생성 확인
-    backup_path = var_dir / 'reverse-sync.backup.xhtml'
-    assert backup_path.exists()
-    assert backup_path.read_text() == '<p>Original</p>'
+    mock_push.assert_called_once()
+    assert mock_push.call_args.args[0] == page_id
+    assert mock_push.call_args.kwargs["manifest_path"] == str(manifest_path)
 
     # 출력 확인: verify 결과 + push 결과 2번 출력
     assert mock_print.call_count == 2
@@ -157,15 +205,73 @@ def test_push_dry_run_skips_push(monkeypatch):
     """push --dry-run은 verify만 수행하고 push하지 않는다."""
     mdx_arg = 'src/content/ko/test/page.mdx'
     monkeypatch.setattr('sys.argv', ['reverse_sync_cli.py', 'push', '--dry-run', mdx_arg])
-    pass_result = {'status': 'pass', 'page_id': 'test-page-001', 'changes_count': 1}
+    pass_result = {
+        'status': 'pass',
+        'page_id': 'test-page-001',
+        'changes_count': 1,
+        'push_eligible': True,
+    }
 
     with patch('reverse_sync_cli._do_verify', return_value=pass_result) as mock_verify, \
+         patch('reverse_sync_cli._ensure_confluence_config', return_value=MagicMock()), \
          patch('reverse_sync_cli._do_push') as mock_push, \
          patch('builtins.print'):
         main()
 
     mock_verify.assert_called_once()
     mock_push.assert_not_called()
+
+
+def test_push_yes_does_not_bypass_push_eligibility(monkeypatch):
+    """--yes는 사용자 확인만 생략하고 safety gate는 우회하지 않습니다."""
+    mdx_arg = 'src/content/ko/test/page.mdx'
+    monkeypatch.setattr(
+        'sys.argv',
+        ['reverse_sync_cli.py', 'push', '--yes', mdx_arg],
+    )
+    diagnostic_result = {
+        'status': 'pass',
+        'page_id': 'test-page-001',
+        'changes_count': 1,
+        'push_eligible': False,
+    }
+
+    with patch(
+        'reverse_sync_cli._do_verify',
+        return_value=diagnostic_result,
+    ), patch(
+        'reverse_sync_cli._ensure_confluence_config',
+        return_value=MagicMock(),
+    ), patch('reverse_sync_cli._do_push') as push, patch('builtins.print'):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+    assert exc_info.value.code == 1
+    push.assert_not_called()
+
+
+def test_push_no_changes_is_successful_noop(monkeypatch):
+    mdx_arg = 'src/content/ko/test/page.mdx'
+    monkeypatch.setattr(
+        'sys.argv',
+        ['reverse_sync_cli.py', 'push', '--yes', mdx_arg],
+    )
+
+    with patch(
+        'reverse_sync_cli._do_verify',
+        return_value={
+            'status': 'no_changes',
+            'page_id': 'test-page-001',
+            'changes_count': 0,
+            'push_eligible': False,
+        },
+    ), patch(
+        'reverse_sync_cli._ensure_confluence_config',
+        return_value=MagicMock(),
+    ), patch('reverse_sync_cli._do_push') as push, patch('builtins.print'):
+        main()
+
+    push.assert_not_called()
 
 
 def test_verify_is_dry_run_alias(monkeypatch):
@@ -1236,46 +1342,36 @@ class TestPushConflictError:
     def test_conflict_raises(self, tmp_path, monkeypatch):
         monkeypatch.setattr('reverse_sync_cli._PROJECT_DIR', tmp_path)
         page_id = 'conflict-page'
-        var_dir = tmp_path / 'var' / page_id
-        var_dir.mkdir(parents=True)
-        (var_dir / 'reverse-sync.patched.xhtml').write_text('<p>New</p>')
+        manifest_path, base, _ = _create_push_manifest(tmp_path, page_id)
+        gateway = MagicMock()
+        gateway.get_current_page.return_value = base
+        gateway.get_active_draft.return_value = None
+        gateway.update_page.side_effect = VersionConflictError("race")
 
-        mock_response = MagicMock()
-        mock_response.status_code = 409
-        http_error = __import__('requests').HTTPError(response=mock_response)
+        with patch(
+            'reverse_sync.confluence_client.ConfluenceGateway',
+            return_value=gateway,
+        ):
+            with pytest.raises(PushConflictError, match="preflight 이후 변경"):
+                _do_push(page_id, config=MagicMock(), manifest_path=str(manifest_path))
 
-        with patch('reverse_sync.confluence_client._load_credentials',
-                   return_value=('e@x.com', 'tok')), \
-             patch('reverse_sync.confluence_client.get_page_version',
-                   return_value={'version': 5, 'title': 'Test'}), \
-             patch('reverse_sync.confluence_client.get_page_body',
-                   return_value='<p>Old</p>'), \
-             patch('reverse_sync.confluence_client.update_page_body',
-                   side_effect=http_error):
-            with pytest.raises(PushConflictError, match="Confluence에서 변경"):
-                _do_push(page_id)
+        gateway.update_page.assert_called_once()
 
     def test_non_409_reraises(self, tmp_path, monkeypatch):
         monkeypatch.setattr('reverse_sync_cli._PROJECT_DIR', tmp_path)
         page_id = 'error-page'
-        var_dir = tmp_path / 'var' / page_id
-        var_dir.mkdir(parents=True)
-        (var_dir / 'reverse-sync.patched.xhtml').write_text('<p>New</p>')
+        manifest_path, base, _ = _create_push_manifest(tmp_path, page_id)
+        gateway = MagicMock()
+        gateway.get_current_page.return_value = base
+        gateway.get_active_draft.return_value = None
+        gateway.update_page.side_effect = NetworkError("network")
 
-        mock_response = MagicMock()
-        mock_response.status_code = 500
-        http_error = __import__('requests').HTTPError(response=mock_response)
-
-        with patch('reverse_sync.confluence_client._load_credentials',
-                   return_value=('e@x.com', 'tok')), \
-             patch('reverse_sync.confluence_client.get_page_version',
-                   return_value={'version': 5, 'title': 'Test'}), \
-             patch('reverse_sync.confluence_client.get_page_body',
-                   return_value='<p>Old</p>'), \
-             patch('reverse_sync.confluence_client.update_page_body',
-                   side_effect=http_error):
-            with pytest.raises(__import__('requests').HTTPError):
-                _do_push(page_id)
+        with patch(
+            'reverse_sync.confluence_client.ConfluenceGateway',
+            return_value=gateway,
+        ):
+            with pytest.raises(NetworkError):
+                _do_push(page_id, config=MagicMock(), manifest_path=str(manifest_path))
 
 
 class TestPushBackup:
@@ -1284,21 +1380,27 @@ class TestPushBackup:
     def test_backup_created(self, tmp_path, monkeypatch):
         monkeypatch.setattr('reverse_sync_cli._PROJECT_DIR', tmp_path)
         page_id = 'backup-page'
+        manifest_path, base, persisted = _create_push_manifest(
+            tmp_path,
+            page_id,
+            base_body="<p>Before Push</p>",
+        )
+        gateway = MagicMock()
+        gateway.get_current_page.side_effect = [base, persisted]
+        gateway.get_active_draft.return_value = None
+        gateway.update_page.return_value = {"version": {"number": 6}}
+
+        with patch(
+            'reverse_sync.confluence_client.ConfluenceGateway',
+            return_value=gateway,
+        ):
+            result = _do_push(
+                page_id,
+                config=MagicMock(),
+                manifest_path=str(manifest_path),
+            )
+
         var_dir = tmp_path / 'var' / page_id
-        var_dir.mkdir(parents=True)
-        (var_dir / 'reverse-sync.patched.xhtml').write_text('<p>New</p>')
-
-        with patch('reverse_sync.confluence_client._load_credentials',
-                   return_value=('e@x.com', 'tok')), \
-             patch('reverse_sync.confluence_client.get_page_version',
-                   return_value={'version': 5, 'title': 'Test'}), \
-             patch('reverse_sync.confluence_client.get_page_body',
-                   return_value='<p>Before Push</p>'), \
-             patch('reverse_sync.confluence_client.update_page_body',
-                   return_value={'title': 'Test', 'version': {'number': 6},
-                                 '_links': {'webui': '/t'}}):
-            result = _do_push(page_id)
-
         backup = var_dir / 'reverse-sync.backup.xhtml'
         assert backup.exists()
         assert backup.read_text() == '<p>Before Push</p>'
@@ -1312,11 +1414,21 @@ class TestPushConfirmPrompt:
         """단일 push 시 확인 거부 → push 안 함."""
         mdx_arg = 'src/content/ko/test/page.mdx'
         monkeypatch.setattr('sys.argv', ['reverse_sync_cli.py', 'push', mdx_arg])
-        pass_result = {'status': 'pass', 'page_id': 'p1', 'title': 'Test', 'changes_count': 1}
+        pass_result = {
+            'status': 'pass',
+            'page_id': 'p1',
+            'title': 'Test',
+            'changes_count': 1,
+            'push_eligible': True,
+            'manifest_path': '/tmp/manifest.json',
+            'base_version': 5,
+            'candidate_sha256': 'a' * 64,
+        }
 
         with patch('reverse_sync_cli._do_verify', return_value=pass_result), \
+             patch('reverse_sync_cli._ensure_confluence_config', return_value=MagicMock()), \
              patch('reverse_sync_cli.sys.stdin') as mock_stdin, \
-             patch('reverse_sync_cli._confirm', return_value=False), \
+             patch('reverse_sync_cli._confirm', return_value=False) as confirm, \
              patch('reverse_sync_cli._do_push') as mock_push, \
              patch('builtins.print'):
             mock_stdin.isatty.return_value = True
@@ -1325,6 +1437,10 @@ class TestPushConfirmPrompt:
 
         assert exc_info.value.code == 0
         mock_push.assert_not_called()
+        prompt = confirm.call_args.args[0]
+        assert "v5→v6" in prompt
+        assert "1 change(s)" in prompt
+        assert "candidate aaaaaaaaaaaa" in prompt
 
     def test_yes_flag_skips_confirm_single(self, tmp_path, monkeypatch):
         """--yes 시 확인 프롬프트 없이 push."""
@@ -1337,18 +1453,19 @@ class TestPushConfirmPrompt:
         var_dir.mkdir(parents=True)
         (var_dir / 'reverse-sync.patched.xhtml').write_text('<p>New</p>')
 
-        pass_result = {'status': 'pass', 'page_id': page_id, 'changes_count': 1}
+        pass_result = {
+            'status': 'pass',
+            'page_id': page_id,
+            'changes_count': 1,
+            'push_eligible': True,
+            'manifest_path': '/tmp/manifest.json',
+        }
 
         with patch('reverse_sync_cli._do_verify', return_value=pass_result), \
-             patch('reverse_sync.confluence_client._load_credentials',
-                   return_value=('e@x.com', 'tok')), \
-             patch('reverse_sync.confluence_client.get_page_version',
-                   return_value={'version': 5, 'title': 'Test'}), \
-             patch('reverse_sync.confluence_client.get_page_body',
-                   return_value='<p>Old</p>'), \
-             patch('reverse_sync.confluence_client.update_page_body',
-                   return_value={'title': 'Test', 'version': {'number': 6},
-                                 '_links': {'webui': '/t'}}), \
+             patch('reverse_sync_cli._ensure_confluence_config', return_value=MagicMock()), \
+             patch('reverse_sync_cli._do_push', return_value={
+                 'page_id': page_id, 'title': 'Test', 'version': 6,
+             }), \
              patch('reverse_sync_cli._confirm') as mock_confirm, \
              patch('builtins.print'):
             main()
@@ -1358,10 +1475,17 @@ class TestPushConfirmPrompt:
     def test_batch_confirm_no_aborts(self, monkeypatch):
         """배치 push 시 확인 거부 → push 안 함."""
         files = ['src/content/ko/a.mdx']
-        verify_result = {'status': 'pass', 'page_id': 'p1', 'changes_count': 1}
+        verify_result = {
+            'status': 'pass',
+            'page_id': 'p1',
+            'changes_count': 1,
+            'push_eligible': True,
+        }
 
         with patch('reverse_sync_cli._get_changed_ko_mdx_files', return_value=files), \
              patch('reverse_sync_cli._do_verify', return_value=verify_result), \
+             patch('reverse_sync_cli._ensure_confluence_config',
+                   return_value=MagicMock()), \
              patch('reverse_sync_cli._confirm', return_value=False), \
              patch('reverse_sync_cli._do_push') as mock_push, \
              patch('builtins.print'):
@@ -1379,7 +1503,13 @@ class TestPushConfirmPrompt:
         (var_dir / 'reverse-sync.patched.xhtml').write_text('<p>New</p>')
 
         files = ['src/content/ko/a.mdx']
-        verify_result = {'status': 'pass', 'page_id': page_id, 'changes_count': 1}
+        verify_result = {
+            'status': 'pass',
+            'page_id': page_id,
+            'changes_count': 1,
+            'push_eligible': True,
+            'manifest_path': '/tmp/manifest.json',
+        }
         push_result = {'page_id': page_id, 'title': 'T', 'version': 2, 'url': '/t', 'backup': str(var_dir / 'reverse-sync.backup.xhtml')}
 
         with patch('reverse_sync_cli._get_changed_ko_mdx_files', return_value=files), \
@@ -1393,6 +1523,45 @@ class TestPushConfirmPrompt:
         mock_confirm.assert_not_called()
         mock_push.assert_called_once()
         assert results[0]['push']['version'] == 2
+
+    def test_batch_stops_after_postcondition_failure(self, monkeypatch):
+        """저장 결과가 target과 다르면 후속 page push를 중단합니다."""
+        files = ['src/content/ko/a.mdx', 'src/content/ko/b.mdx']
+        verify_results = [
+            {
+                'status': 'pass',
+                'page_id': 'p1',
+                'changes_count': 1,
+                'push_eligible': True,
+                'manifest_path': '/tmp/p1/manifest.json',
+            },
+            {
+                'status': 'pass',
+                'page_id': 'p2',
+                'changes_count': 1,
+                'push_eligible': True,
+                'manifest_path': '/tmp/p2/manifest.json',
+            },
+        ]
+
+        with patch(
+            'reverse_sync_cli._get_changed_ko_mdx_files',
+            return_value=files,
+        ), patch(
+            'reverse_sync_cli._do_verify',
+            side_effect=verify_results,
+        ), patch(
+            'reverse_sync_cli._do_push',
+            side_effect=PostconditionError('persisted mismatch'),
+        ) as push, patch(
+            'reverse_sync_cli._ensure_confluence_config',
+            return_value=MagicMock(),
+        ), patch('builtins.print'):
+            results = _do_verify_batch('test-branch', push=True, yes=True)
+
+        push.assert_called_once()
+        assert results[0]['push']['status'] == 'postcondition_failed'
+        assert 'push' not in results[1]
 
 
 class TestPushNonTtyRequiresYes:
@@ -1419,18 +1588,19 @@ class TestPushNonTtyRequiresYes:
         var_dir.mkdir(parents=True)
         (var_dir / 'reverse-sync.patched.xhtml').write_text('<p>New</p>')
 
-        pass_result = {'status': 'pass', 'page_id': page_id, 'changes_count': 1}
+        pass_result = {
+            'status': 'pass',
+            'page_id': page_id,
+            'changes_count': 1,
+            'push_eligible': True,
+            'manifest_path': '/tmp/manifest.json',
+        }
 
         with patch('reverse_sync_cli._do_verify', return_value=pass_result), \
-             patch('reverse_sync.confluence_client._load_credentials',
-                   return_value=('e@x.com', 'tok')), \
-             patch('reverse_sync.confluence_client.get_page_version',
-                   return_value={'version': 5, 'title': 'Test'}), \
-             patch('reverse_sync.confluence_client.get_page_body',
-                   return_value='<p>Old</p>'), \
-             patch('reverse_sync.confluence_client.update_page_body',
-                   return_value={'title': 'Test', 'version': {'number': 6},
-                                 '_links': {'webui': '/t'}}), \
+             patch('reverse_sync_cli._ensure_confluence_config', return_value=MagicMock()), \
+             patch('reverse_sync_cli._do_push', return_value={
+                 'page_id': page_id, 'title': 'Test', 'version': 6,
+             }), \
              patch('builtins.print'):
             main()  # Should not exit with error
 

--- a/confluence-mdx/tests/test_reverse_sync_e2e.py
+++ b/confluence-mdx/tests/test_reverse_sync_e2e.py
@@ -124,6 +124,9 @@ class TestE2ERoundTrip:
         monkeypatch.chdir(tmp_path)
         dest = tmp_path / "var" / "793608206"
         shutil.copytree(VAR_DIR, dest)
+        # var/는 실행 중 정리될 수 있는 cache이므로 canonical testcase를 fallback으로 사용한다.
+        if not (dest / "page.xhtml").exists():
+            shutil.copy2(TESTCASE_DIR / "page.xhtml", dest / "page.xhtml")
         # pages.<code>.yaml 복사 (converter가 {input_dir}/../pages.qm.yaml 을 참조)
         # pages.qm.yaml 우선, 없으면 레거시 pages.yaml fallback
         pages_yaml_src = VAR_DIR.parent / "pages.qm.yaml"

--- a/confluence-mdx/tests/test_reverse_sync_push_transaction.py
+++ b/confluence-mdx/tests/test_reverse_sync_push_transaction.py
@@ -19,7 +19,7 @@ from reverse_sync.confluence_client import (
     get_page_snapshot,
     update_page,
 )
-from reverse_sync.base_parity import verify_base_parity
+from reverse_sync.base_parity import verify_base_parity, verify_source_identity
 from reverse_sync.manifest import (
     ArtifactTamperedError,
     StaleVerificationError,
@@ -677,6 +677,28 @@ def test_push_base_parity_does_not_hide_visible_spacing():
 
     assert result.passed is False
     assert result.reason_code == "base_parity_mismatch"
+
+
+def test_source_identity_ignores_h1_like_shell_comments():
+    original = """---
+title: Test page
+---
+
+```bash
+# old shell comment
+```
+
+# Test page
+"""
+    improved = original.replace("# old shell comment", "# new shell comment")
+
+    result = verify_source_identity(
+        _snapshot(title="Test page"),
+        original,
+        improved,
+    )
+
+    assert result.passed is True
 
 
 def test_online_verify_blocks_title_change(tmp_path, monkeypatch):

--- a/confluence-mdx/tests/test_reverse_sync_push_transaction.py
+++ b/confluence-mdx/tests/test_reverse_sync_push_transaction.py
@@ -1,0 +1,738 @@
+"""검증한 snapshot과 Confluence PUT을 결합하는 transaction 계약 테스트."""
+
+import argparse
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from reverse_sync.confluence_client import (
+    ConfluenceConfig,
+    InvalidPageSnapshotError,
+    NetworkError,
+    PermissionDeniedError,
+    VersionConflictError,
+    get_active_draft,
+    get_page_snapshot,
+    update_page,
+)
+from reverse_sync.base_parity import verify_base_parity
+from reverse_sync.manifest import (
+    ArtifactTamperedError,
+    StaleVerificationError,
+    create_sync_manifest,
+    load_sync_manifest,
+)
+from reverse_sync.models import PageSnapshot, SyncStatus, VerificationGate
+from reverse_sync.publisher import (
+    ActiveDraftError,
+    PostconditionError,
+    RemoteDriftError,
+    publish_verified_manifest,
+)
+from reverse_sync_cli import MdxSource, _do_verify, run_verify
+
+
+NOW = datetime(2026, 7, 24, tzinfo=timezone.utc)
+
+
+def _snapshot(
+    *,
+    page_id: str = "123",
+    version: int = 5,
+    title: str = "Test page",
+    body: str = "<p>Before</p>",
+    status: str = "current",
+) -> PageSnapshot:
+    return PageSnapshot(
+        page_id=page_id,
+        status=status,
+        title=title,
+        version=version,
+        storage_xhtml=body,
+        fetched_at=NOW.isoformat(),
+        api="confluence-v2",
+    )
+
+
+def _manifest(tmp_path: Path, base: PageSnapshot | None = None) -> Path:
+    return create_sync_manifest(
+        runs_dir=tmp_path / "reverse-sync",
+        base=base or _snapshot(),
+        original_mdx="# Test page\n\nBefore\n",
+        original_descriptor="main:src/content/ko/test.mdx",
+        improved_mdx="# Test page\n\nAfter\n",
+        improved_descriptor="src/content/ko/test.mdx",
+        candidate_xhtml="<p>After</p>",
+        verifier_policy="reverse-sync-push-v1",
+        tool_version="reverse-sync-cli-v1",
+        push_eligible=True,
+        gates=tuple(
+            VerificationGate(name, True)
+            for name in (
+                "source_identity",
+                "base_parity",
+                "intent_complete",
+                "semantic_roundtrip",
+                "artifact_integrity",
+            )
+        ),
+    )
+
+
+class FakeGateway:
+    def __init__(
+        self,
+        current_snapshots: list[PageSnapshot],
+        *,
+        draft: PageSnapshot | None = None,
+        update_error: Exception | None = None,
+    ):
+        self.current_snapshots = list(current_snapshots)
+        self.draft = draft
+        self.update_error = update_error
+        self.current_calls = 0
+        self.draft_calls = 0
+        self.update_calls: list[dict] = []
+
+    def get_current_page(self, page_id: str) -> PageSnapshot:
+        snapshot = self.current_snapshots[self.current_calls]
+        self.current_calls += 1
+        assert snapshot.page_id == page_id
+        return snapshot
+
+    def get_active_draft(self, page_id: str) -> PageSnapshot | None:
+        self.draft_calls += 1
+        if self.draft is not None:
+            assert self.draft.page_id == page_id
+        return self.draft
+
+    def update_page(
+        self,
+        page_id: str,
+        *,
+        title: str,
+        version: int,
+        xhtml_body: str,
+    ) -> dict:
+        self.update_calls.append(
+            {
+                "page_id": page_id,
+                "title": title,
+                "version": version,
+                "xhtml_body": xhtml_body,
+            }
+        )
+        if self.update_error is not None:
+            raise self.update_error
+        return {"id": page_id, "version": {"number": version}, "title": title}
+
+
+def test_manifest_is_deterministic_and_uses_run_scoped_artifacts(tmp_path):
+    first = _manifest(tmp_path / "first")
+    second = _manifest(tmp_path / "second")
+
+    assert first.parent.name == second.parent.name
+    assert first.name == "manifest.json"
+    assert first.read_bytes() == second.read_bytes()
+    assert (first.parent / "base.xhtml").read_text() == "<p>Before</p>"
+    assert (first.parent / "candidate.xhtml").read_text() == "<p>After</p>"
+
+
+def test_candidate_tampering_blocks_before_remote_read(tmp_path):
+    manifest_path = _manifest(tmp_path)
+    (manifest_path.parent / "candidate.xhtml").write_text("<p>Tampered</p>")
+    gateway = FakeGateway([_snapshot()])
+
+    with pytest.raises(ArtifactTamperedError, match="candidate.xhtml"):
+        publish_verified_manifest(manifest_path, gateway)
+
+    assert gateway.current_calls == 0
+    assert gateway.update_calls == []
+
+
+def test_remote_drift_blocks_without_adopting_latest_version(tmp_path):
+    manifest_path = _manifest(tmp_path)
+    remote_edit = _snapshot(version=6, body="<p>Remote edit</p>")
+    gateway = FakeGateway([remote_edit])
+
+    with pytest.raises(RemoteDriftError) as exc_info:
+        publish_verified_manifest(manifest_path, gateway)
+
+    assert exc_info.value.reason_code == "remote_drift"
+    assert gateway.current_calls == 1
+    assert gateway.update_calls == []
+
+
+def test_title_drift_blocks_even_if_version_and_body_match(tmp_path):
+    manifest_path = _manifest(tmp_path)
+    renamed = _snapshot(title="Renamed")
+    gateway = FakeGateway([renamed])
+
+    with pytest.raises(RemoteDriftError, match="title"):
+        publish_verified_manifest(manifest_path, gateway)
+
+    assert gateway.update_calls == []
+
+
+def test_active_draft_blocks_before_put(tmp_path):
+    manifest_path = _manifest(tmp_path)
+    draft = _snapshot(version=6, status="draft", body="<p>Draft edit</p>")
+    gateway = FakeGateway([_snapshot()], draft=draft)
+
+    with pytest.raises(ActiveDraftError) as exc_info:
+        publish_verified_manifest(manifest_path, gateway)
+
+    assert exc_info.value.reason_code == "active_draft"
+    assert gateway.update_calls == []
+
+
+def test_preflight_put_race_is_not_retried_with_latest_version(tmp_path):
+    manifest_path = _manifest(tmp_path)
+    gateway = FakeGateway(
+        [_snapshot()],
+        update_error=VersionConflictError("concurrent update"),
+    )
+
+    with pytest.raises(VersionConflictError):
+        publish_verified_manifest(manifest_path, gateway)
+
+    assert gateway.current_calls == 1
+    assert len(gateway.update_calls) == 1
+    assert gateway.update_calls[0]["version"] == 6
+
+
+def test_put_uses_manifest_candidate_and_base_version_plus_one(tmp_path):
+    base = _snapshot()
+    manifest_path = _manifest(tmp_path, base)
+    persisted = replace(base, version=6, storage_xhtml="<p>After</p>")
+    gateway = FakeGateway([base, persisted])
+
+    receipt = publish_verified_manifest(manifest_path, gateway)
+
+    assert receipt.status is SyncStatus.REMOTE_VERIFIED
+    assert receipt.version == 6
+    assert gateway.update_calls == [
+        {
+            "page_id": "123",
+            "title": "Test page",
+            "version": 6,
+            "xhtml_body": "<p>After</p>",
+        }
+    ]
+
+
+def test_postcondition_mismatch_preserves_failure_evidence(tmp_path):
+    base = _snapshot()
+    manifest_path = _manifest(tmp_path, base)
+    persisted = replace(base, version=6, storage_xhtml="<p>Unexpected</p>")
+    gateway = FakeGateway([base, persisted])
+
+    with pytest.raises(PostconditionError) as exc_info:
+        publish_verified_manifest(manifest_path, gateway)
+
+    assert exc_info.value.reason_code == "postcondition_failed"
+    receipt_path = manifest_path.parent / "push-receipt.json"
+    post_path = manifest_path.parent / "post.snapshot.json"
+    assert receipt_path.exists()
+    assert post_path.exists()
+    assert (manifest_path.parent / "update.response.json").exists()
+    assert '"status":"postcondition_failed"' in receipt_path.read_text()
+    assert "<p>Unexpected</p>" in post_path.read_text()
+
+
+def test_semantically_equivalent_persisted_body_satisfies_postcondition(tmp_path):
+    base = _snapshot()
+    manifest_path = _manifest(tmp_path, base)
+    canonicalized = replace(base, version=6, storage_xhtml="<p>After</p>\n")
+    gateway = FakeGateway([base, canonicalized])
+    verifier_calls = []
+
+    def semantic_verifier(snapshot, verified_manifest_path):
+        verifier_calls.append((snapshot, verified_manifest_path))
+        return snapshot.storage_xhtml.strip() == "<p>After</p>"
+
+    receipt = publish_verified_manifest(
+        manifest_path,
+        gateway,
+        semantic_verifier=semantic_verifier,
+    )
+
+    assert receipt.status is SyncStatus.REMOTE_VERIFIED
+    assert verifier_calls == [(canonicalized, manifest_path)]
+
+
+def test_already_applied_candidate_skips_put(tmp_path):
+    manifest_path = _manifest(tmp_path)
+    already_applied = _snapshot(version=6, body="<p>After</p>")
+    gateway = FakeGateway([already_applied])
+
+    receipt = publish_verified_manifest(manifest_path, gateway)
+
+    assert receipt.status is SyncStatus.ALREADY_APPLIED
+    assert receipt.version == 6
+    assert gateway.draft_calls == 1
+    assert gateway.update_calls == []
+
+
+def test_semantically_already_applied_remote_skips_put(tmp_path):
+    manifest_path = _manifest(tmp_path)
+    already_applied = _snapshot(version=6, body="<p>After</p>\n")
+    gateway = FakeGateway([already_applied])
+
+    receipt = publish_verified_manifest(
+        manifest_path,
+        gateway,
+        semantic_verifier=lambda snapshot, _path: snapshot.storage_xhtml.strip()
+        == "<p>After</p>",
+    )
+
+    assert receipt.status is SyncStatus.ALREADY_APPLIED
+    assert gateway.update_calls == []
+
+
+def test_unverified_manifest_cannot_be_published(tmp_path):
+    manifest_path = _manifest(tmp_path)
+    manifest = load_sync_manifest(manifest_path)
+    unverified = replace(manifest, push_eligible=False)
+    manifest_path.write_text(unverified.to_canonical_json())
+    gateway = FakeGateway([_snapshot()])
+
+    with pytest.raises(ArtifactTamperedError, match="push eligible"):
+        publish_verified_manifest(manifest_path, gateway)
+
+    assert gateway.current_calls == 0
+
+
+def test_stale_tool_version_requires_reverification(tmp_path):
+    manifest_path = _manifest(tmp_path)
+    manifest = load_sync_manifest(manifest_path)
+    stale = replace(manifest, tool_version="reverse-sync-cli-v0")
+    manifest_path.write_text(stale.to_canonical_json())
+
+    with pytest.raises(StaleVerificationError, match="tool version"):
+        load_sync_manifest(manifest_path)
+
+
+def test_manifest_never_contains_credentials(tmp_path):
+    manifest_path = _manifest(tmp_path)
+    serialized_run = "".join(
+        path.read_text()
+        for path in manifest_path.parent.iterdir()
+        if path.is_file()
+    )
+
+    assert "person@example.com" not in serialized_run
+    assert "secret-api-token" not in serialized_run
+    assert "Authorization" not in serialized_run
+
+
+def test_push_manifest_requires_all_local_proof_gates(tmp_path):
+    with pytest.raises(StaleVerificationError, match="required gate"):
+        create_sync_manifest(
+            runs_dir=tmp_path / "reverse-sync",
+            base=_snapshot(),
+            original_mdx="# Test page\n\nBefore\n",
+            original_descriptor="main:src/content/ko/test.mdx",
+            improved_mdx="# Test page\n\nAfter\n",
+            improved_descriptor="src/content/ko/test.mdx",
+            candidate_xhtml="<p>After</p>",
+            verifier_policy="reverse-sync-push-v1",
+            tool_version="reverse-sync-cli-v1",
+            push_eligible=True,
+            gates=(VerificationGate("semantic_roundtrip", True),),
+        )
+
+
+def test_v2_snapshot_uses_one_response_for_version_title_and_body():
+    response = MagicMock()
+    response.json.return_value = {
+        "id": "123",
+        "status": "current",
+        "title": "Test page",
+        "version": {"number": 5},
+        "body": {
+            "storage": {
+                "representation": "storage",
+                "value": "<p>Before</p>",
+            }
+        },
+    }
+    response.raise_for_status.return_value = None
+
+    with patch("reverse_sync.confluence_client.requests.get", return_value=response) as get:
+        snapshot = get_page_snapshot(
+            ConfluenceConfig(base_url="https://example.atlassian.net/wiki", email="e", api_token="t"),
+            "123",
+            fetched_at=NOW,
+        )
+
+    get.assert_called_once()
+    assert get.call_args.args[0] == "https://example.atlassian.net/wiki/api/v2/pages/123"
+    assert get.call_args.kwargs["params"] == {
+        "body-format": "storage",
+        "status": ["current"],
+        "include-version": True,
+    }
+    assert snapshot.version == 5
+    assert snapshot.title == "Test page"
+    assert snapshot.storage_xhtml == "<p>Before</p>"
+    assert len(snapshot.storage_sha256) == 64
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"id": "different", "status": "current", "title": "T", "version": {"number": 1}},
+        {"id": "123", "status": "draft", "title": "T", "version": {"number": 1}},
+        {
+            "id": "123",
+            "status": "current",
+            "title": "T",
+            "version": {"number": 1},
+            "body": {"storage": {"representation": "view", "value": "<p>x</p>"}},
+        },
+    ],
+)
+def test_invalid_v2_snapshot_is_fail_closed(payload):
+    response = MagicMock()
+    response.json.return_value = payload
+    response.raise_for_status.return_value = None
+
+    with patch("reverse_sync.confluence_client.requests.get", return_value=response):
+        with pytest.raises(InvalidPageSnapshotError):
+            get_page_snapshot(
+                ConfluenceConfig(base_url="https://example.atlassian.net/wiki", email="e", api_token="t"),
+                "123",
+                fetched_at=NOW,
+            )
+
+
+def test_v2_snapshot_maps_conflict_without_retry():
+    response = MagicMock()
+    response.status_code = 409
+    response.raise_for_status.side_effect = requests.HTTPError(response=response)
+
+    with patch("reverse_sync.confluence_client.requests.get", return_value=response) as get:
+        with pytest.raises(VersionConflictError):
+            get_page_snapshot(
+                ConfluenceConfig(base_url="https://example.atlassian.net/wiki", email="e", api_token="t"),
+                "123",
+                fetched_at=NOW,
+            )
+
+    get.assert_called_once()
+
+
+def test_v2_active_draft_adapter_parses_draft_snapshot():
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {
+        "id": "123",
+        "status": "draft",
+        "title": "Test page",
+        "version": {"number": 6},
+        "body": {
+            "storage": {
+                "representation": "storage",
+                "value": "<p>Draft</p>",
+            }
+        },
+    }
+    response.raise_for_status.return_value = None
+
+    with patch("reverse_sync.confluence_client.requests.get", return_value=response) as get:
+        snapshot = get_active_draft(
+            ConfluenceConfig(base_url="https://example.atlassian.net/wiki", email="e", api_token="t"),
+            "123",
+            fetched_at=NOW,
+        )
+
+    assert snapshot is not None
+    assert snapshot.status == "draft"
+    assert snapshot.storage_xhtml == "<p>Draft</p>"
+    assert get.call_args.kwargs["params"]["get-draft"] is True
+    assert get.call_args.kwargs["params"]["status"] == ["draft"]
+
+
+def test_v2_active_draft_adapter_returns_none_on_not_found():
+    response = MagicMock()
+    response.status_code = 404
+
+    with patch("reverse_sync.confluence_client.requests.get", return_value=response) as get:
+        snapshot = get_active_draft(
+            ConfluenceConfig(base_url="https://example.atlassian.net/wiki", email="e", api_token="t"),
+            "123",
+            fetched_at=NOW,
+        )
+
+    assert snapshot is None
+    get.assert_called_once()
+
+
+def test_v2_update_uses_exact_requested_version_and_candidate_once():
+    response = MagicMock()
+    response.json.return_value = {
+        "id": "123",
+        "title": "Test page",
+        "version": {"number": 6},
+    }
+    response.raise_for_status.return_value = None
+    config = ConfluenceConfig(
+        base_url="https://example.atlassian.net/wiki",
+        email="e",
+        api_token="t",
+    )
+
+    with patch(
+        "reverse_sync.confluence_client.requests.request",
+        return_value=response,
+    ) as request:
+        update_page(
+            config,
+            "123",
+            title="Test page",
+            version=6,
+            xhtml_body="<p>After</p>",
+        )
+
+    request.assert_called_once()
+    assert request.call_args.args[:2] == (
+        "PUT",
+        "https://example.atlassian.net/wiki/api/v2/pages/123",
+    )
+    assert request.call_args.kwargs["json"]["version"] == {"number": 6}
+    assert request.call_args.kwargs["json"]["body"]["value"] == "<p>After</p>"
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected_error"),
+    [
+        (400, VersionConflictError),
+        (409, VersionConflictError),
+        (403, PermissionDeniedError),
+    ],
+)
+def test_v2_update_maps_provider_errors(status_code, expected_error):
+    response = MagicMock()
+    response.status_code = status_code
+    response.raise_for_status.side_effect = requests.HTTPError(response=response)
+    config = ConfluenceConfig(
+        base_url="https://example.atlassian.net/wiki",
+        email="e",
+        api_token="t",
+    )
+
+    with patch(
+        "reverse_sync.confluence_client.requests.request",
+        return_value=response,
+    ) as request:
+        with pytest.raises(expected_error):
+            update_page(
+                config,
+                "123",
+                title="Test page",
+                version=6,
+                xhtml_body="<p>After</p>",
+            )
+
+    request.assert_called_once()
+
+
+def test_v2_update_maps_network_error_without_retry():
+    config = ConfluenceConfig(
+        base_url="https://example.atlassian.net/wiki",
+        email="e",
+        api_token="t",
+    )
+
+    with patch(
+        "reverse_sync.confluence_client.requests.request",
+        side_effect=requests.Timeout("timeout"),
+    ) as request:
+        with pytest.raises(NetworkError):
+            update_page(
+                config,
+                "123",
+                title="Test page",
+                version=6,
+                xhtml_body="<p>After</p>",
+            )
+
+    request.assert_called_once()
+
+
+def test_prepare_push_fetches_one_snapshot_and_passes_it_to_verify():
+    args = argparse.Namespace(
+        improved_mdx="src/content/ko/test.mdx",
+        original_mdx=None,
+        page_id=None,
+        page_dir=None,
+        lenient=False,
+        no_normalize=False,
+    )
+    base = _snapshot()
+    improved = MdxSource("# Test page\n\nAfter\n", "src/content/ko/test.mdx")
+    original = MdxSource("# Test page\n\nBefore\n", "main:src/content/ko/test.mdx")
+    expected = {"status": "pass", "page_id": "123", "push_eligible": True}
+
+    with patch(
+        "reverse_sync_cli._resolve_mdx_source",
+        side_effect=[improved, original],
+    ), patch(
+        "reverse_sync_cli._resolve_page_id",
+        return_value="123",
+    ), patch(
+        "reverse_sync.confluence_client.get_page_snapshot",
+        return_value=base,
+    ) as get_snapshot, patch(
+        "reverse_sync_cli.run_verify",
+        return_value=expected,
+    ) as verify:
+        result = _do_verify(args, config=MagicMock(), prepare_push=True)
+
+    assert result == expected
+    get_snapshot.assert_called_once()
+    assert verify.call_args.kwargs["base_snapshot"] is base
+    assert verify.call_args.kwargs["for_push"] is True
+
+
+def test_online_verify_builds_manifest_from_remote_snapshot(tmp_path, monkeypatch):
+    monkeypatch.setattr("reverse_sync_cli._PROJECT_DIR", tmp_path)
+    page_id = "123"
+    (tmp_path / "var" / page_id).mkdir(parents=True)
+    base = _snapshot(
+        title="Test page",
+        body="<h2>Section</h2><p>Before</p>",
+    )
+    original = "# Test page\n\n## Section\n\nBefore\n"
+    improved = "# Test page\n\n## Section\n\nAfter\n"
+
+    def forward_convert(input_path, output_path, _page_id, **_kwargs):
+        content = original if Path(output_path).name == "reverse-sync.base.mdx" else improved
+        Path(output_path).write_text(content)
+        return content
+
+    with patch("reverse_sync_cli._forward_convert", side_effect=forward_convert):
+        result = run_verify(
+            page_id=page_id,
+            original_src=MdxSource(original, "main:src/content/ko/test.mdx"),
+            improved_src=MdxSource(improved, "src/content/ko/test.mdx"),
+            base_snapshot=base,
+            for_push=True,
+        )
+
+    assert result["status"] == "pass"
+    assert result["push_eligible"] is True
+    assert result["base_version"] == 5
+    assert result["base_storage_sha256"] == base.storage_sha256
+    assert len(result["candidate_sha256"]) == 64
+    assert "semantic_roundtrip" in result["local_gates"]
+    manifest_path = Path(result["manifest_path"])
+    assert manifest_path.is_file()
+    manifest = load_sync_manifest(manifest_path)
+    assert manifest.base_version == 5
+    assert manifest.base_storage_sha256 == base.storage_sha256
+    assert (manifest_path.parent / "candidate.xhtml").read_text() == (
+        tmp_path / "var" / page_id / "reverse-sync.patched.xhtml"
+    ).read_text()
+
+
+def test_online_verify_blocks_stale_original_before_patch(tmp_path, monkeypatch):
+    monkeypatch.setattr("reverse_sync_cli._PROJECT_DIR", tmp_path)
+    page_id = "123"
+    (tmp_path / "var" / page_id).mkdir(parents=True)
+    base = _snapshot(title="Test page", body="<p>Remote edit</p>")
+    original = "# Test page\n\nBefore\n"
+    improved = "# Test page\n\nAfter\n"
+
+    def forward_convert(_input_path, output_path, _page_id, **_kwargs):
+        Path(output_path).write_text("# Test page\n\nRemote edit\n")
+        return "# Test page\n\nRemote edit\n"
+
+    with patch("reverse_sync_cli._forward_convert", side_effect=forward_convert):
+        result = run_verify(
+            page_id=page_id,
+            original_src=MdxSource(original, "main:src/content/ko/test.mdx"),
+            improved_src=MdxSource(improved, "src/content/ko/test.mdx"),
+            base_snapshot=base,
+            for_push=True,
+        )
+
+    assert result["status"] == "blocked"
+    assert result["reason_code"] == "base_parity_mismatch"
+    assert result["push_eligible"] is False
+    assert not (tmp_path / "var" / page_id / "reverse-sync.patched.xhtml").exists()
+
+
+def test_push_base_parity_does_not_hide_visible_spacing():
+    result = verify_base_parity(
+        _snapshot(title="Test page"),
+        "# Test page\n\nVisible  spacing\n",
+        "# Test page\n\nVisible spacing\n",
+    )
+
+    assert result.passed is False
+    assert result.reason_code == "base_parity_mismatch"
+
+
+def test_online_verify_blocks_title_change(tmp_path, monkeypatch):
+    monkeypatch.setattr("reverse_sync_cli._PROJECT_DIR", tmp_path)
+    page_id = "123"
+    (tmp_path / "var" / page_id).mkdir(parents=True)
+    base = _snapshot(title="Test page")
+
+    result = run_verify(
+        page_id=page_id,
+        original_src=MdxSource("# Test page\n\nBefore\n", "original.mdx"),
+        improved_src=MdxSource("# Renamed\n\nBefore\n", "improved.mdx"),
+        base_snapshot=base,
+        for_push=True,
+    )
+
+    assert result["status"] == "blocked"
+    assert result["reason_code"] == "title_change_unsupported"
+    assert result["push_eligible"] is False
+
+
+def test_lenient_verify_is_never_push_eligible(tmp_path, monkeypatch):
+    monkeypatch.setattr("reverse_sync_cli._PROJECT_DIR", tmp_path)
+    page_id = "123"
+    (tmp_path / "var" / page_id).mkdir(parents=True)
+
+    result = run_verify(
+        page_id=page_id,
+        original_src=MdxSource("# Test page\n\nBefore\n", "original.mdx"),
+        improved_src=MdxSource("# Test page\n\nAfter\n", "improved.mdx"),
+        base_snapshot=_snapshot(title="Test page"),
+        for_push=True,
+        lenient=True,
+    )
+
+    assert result["status"] == "blocked"
+    assert result["reason_code"] == "lenient_verification_not_pushable"
+    assert result["push_eligible"] is False
+
+
+def test_online_verify_blocks_missing_attachment(tmp_path, monkeypatch):
+    monkeypatch.setattr("reverse_sync_cli._PROJECT_DIR", tmp_path)
+    page_id = "123"
+    (tmp_path / "var" / page_id).mkdir(parents=True)
+
+    result = run_verify(
+        page_id=page_id,
+        original_src=MdxSource("# Test page\n\nBefore\n", "original.mdx"),
+        improved_src=MdxSource(
+            "# Test page\n\nBefore\n\n![new](/images/new.png)\n",
+            "improved.mdx",
+        ),
+        base_snapshot=_snapshot(title="Test page"),
+        for_push=True,
+    )
+
+    assert result["status"] == "blocked"
+    assert result["reason_code"] == "missing_attachment"
+    assert "new.png" in result["detail"]

--- a/openspec/changes/complete-reverse-sync/specs/contract-reverse-sync/spec.md
+++ b/openspec/changes/complete-reverse-sync/specs/contract-reverse-sync/spec.md
@@ -13,7 +13,7 @@ MDX 변경을 기존 Confluence Storage XHTML의 보존 정보와 안전하게 �
 - `confluence-mdx/bin/reverse_sync/**`
 - [Confluence Cloud REST API v2 Page](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/)
 
-## Requirements
+## ADDED Requirements
 
 ### Requirement: Consistent PageSnapshot
 

--- a/openspec/changes/complete-reverse-sync/tasks.md
+++ b/openspec/changes/complete-reverse-sync/tasks.md
@@ -14,13 +14,13 @@
 
 ### 2.1 P0 — 현재 unsafe push를 red test로 고정
 
-- [ ] `confluence-mdx/tests/test_reverse_sync_push_transaction.py`를 추가합니다.
-- [ ] stale local `page.xhtml` + latest remote version 조합이 PUT으로 이어지는 현재 문제를 재현합니다.
-- [ ] version과 body를 별도 GET으로 읽을 때 서로 다른 snapshot이 될 수 있는 문제를 재현합니다.
-- [ ] preflight 이후 concurrent update가 발생하면 자동 retry하지 않는 계약을 테스트합니다.
-- [ ] verify 후 candidate body가 바뀌면 push를 차단하는 테스트를 추가합니다.
-- [ ] PUT 성공 후 remote body가 target과 다르면 `postcondition_failed`가 되는 테스트를 추가합니다.
-- [ ] active draft, title 변경, missing attachment, lenient-only pass가 push blocked인지 테스트합니다.
+- [x] `confluence-mdx/tests/test_reverse_sync_push_transaction.py`를 추가합니다.
+- [x] stale local `page.xhtml` + latest remote version 조합이 PUT으로 이어지는 현재 문제를 재현합니다.
+- [x] version과 body를 별도 GET으로 읽을 때 서로 다른 snapshot이 될 수 있는 문제를 재현합니다.
+- [x] preflight 이후 concurrent update가 발생하면 자동 retry하지 않는 계약을 테스트합니다.
+- [x] verify 후 candidate body가 바뀌면 push를 차단하는 테스트를 추가합니다.
+- [x] PUT 성공 후 remote body가 target과 다르면 `postcondition_failed`가 되는 테스트를 추가합니다.
+- [x] active draft, title 변경, missing attachment, lenient-only pass가 push blocked인지 테스트합니다.
 
 완료 gate:
 
@@ -29,21 +29,21 @@
 
 ### 2.2 P0 — immutable model과 artifact layout
 
-- [ ] `confluence-mdx/bin/reverse_sync/models.py`를 추가합니다.
+- [x] `confluence-mdx/bin/reverse_sync/models.py`를 추가합니다.
   - `PageSnapshot`
   - `SyncManifest`
   - `VerificationGate`
   - `SyncStatus`
   - `ReasonCode`
   - `PushReceipt`
-- [ ] `confluence-mdx/bin/reverse_sync/manifest.py`를 추가합니다.
+- [x] `confluence-mdx/bin/reverse_sync/manifest.py`를 추가합니다.
   - canonical serialization
   - SHA-256 계산
   - referenced artifact integrity 검사
   - schema version 및 verifier policy 검사
-- [ ] artifact를 `var/<page_id>/reverse-sync/<run_id>/`에 실행별로 저장합니다.
+- [x] artifact를 `var/<page_id>/reverse-sync/<run_id>/`에 실행별로 저장합니다.
 - [ ] 기존 `reverse-sync.*` 경로는 최신 run을 가리키는 read-only compatibility output으로 제한합니다.
-- [ ] email, token, Authorization header redaction test를 추가합니다.
+- [x] email, token, Authorization header redaction test를 추가합니다.
 
 완료 gate:
 
@@ -52,12 +52,12 @@
 
 ### 2.3 P0 — consistent Confluence snapshot adapter
 
-- [ ] `confluence-mdx/bin/reverse_sync/confluence_client.py`에 v2 page snapshot 조회를 추가합니다.
-- [ ] `GET /wiki/api/v2/pages/{id}`에서 Storage body와 version을 한 snapshot으로 획득합니다.
-- [ ] `page_id`, `status=current`, body representation, title, version 필수 필드를 검증합니다.
-- [ ] active draft 조회/감지 adapter를 분리하고 실제 API 응답 fixture를 추가합니다.
-- [ ] HTTP 400/409 등 provider response를 `version_conflict`, `permission_denied`, `network_error`로 변환합니다.
-- [ ] 기존 `get_page_version()` + `get_page_body()` 조합을 push 경로에서 제거합니다.
+- [x] `confluence-mdx/bin/reverse_sync/confluence_client.py`에 v2 page snapshot 조회를 추가합니다.
+- [x] `GET /wiki/api/v2/pages/{id}`에서 Storage body와 version을 한 snapshot으로 획득합니다.
+- [x] `page_id`, `status=current`, body representation, title, version 필수 필드를 검증합니다.
+- [x] active draft 조회/감지 adapter를 분리하고 실제 API 응답 fixture를 추가합니다.
+- [x] HTTP 400/409 등 provider response를 `version_conflict`, `permission_denied`, `network_error`로 변환합니다.
+- [x] 기존 `get_page_version()` + `get_page_body()` 조합을 push 경로에서 제거합니다.
 
 완료 gate:
 
@@ -67,14 +67,14 @@
 
 ### 2.4 P0 — base parity와 dependency gate
 
-- [ ] `confluence-mdx/bin/reverse_sync/base_parity.py`를 추가합니다.
-- [ ] remote snapshot의 forward conversion 결과와 original MDX를 비교합니다.
+- [x] `confluence-mdx/bin/reverse_sync/base_parity.py`를 추가합니다.
+- [x] remote snapshot의 forward conversion 결과와 original MDX를 비교합니다.
 - [ ] page ID, `confluenceUrl`, repository MDX path를 함께 검증합니다.
 - [ ] `stale_original_mdx`, `forward_converter_drift`, `page_identity_mismatch`를 구분합니다.
-- [ ] original/improved title과 첫 H1 invariant를 검증하고 title change를 block합니다.
+- [x] original/improved title과 첫 H1 invariant를 검증하고 title change를 block합니다.
 - [ ] attachment catalog에서 improved MDX의 attachment reference를 검증합니다.
 - [ ] internal link resolver error와 ambiguous target을 dependency failure로 변환합니다.
-- [ ] snapshot metadata가 없는 offline verify는 `push_eligible: false`로 표시합니다.
+- [x] snapshot metadata가 없는 offline verify는 `push_eligible: false`로 표시합니다.
 
 완료 gate:
 
@@ -86,7 +86,7 @@
 - [ ] `confluence-mdx/bin/reverse_sync/proof.py`를 추가하여 필수 gate를 orchestration합니다.
 - [ ] `roundtrip_verifier.py` normalization을 source formatting, rendered-visible, unsupported/lossy로 분류합니다.
 - [ ] push equivalence v1 typed canonical model을 구현합니다.
-- [ ] `skipped_changes > 0`이면 `intent_complete`를 실패시킵니다.
+- [x] `skipped_changes > 0`이면 `intent_complete`를 실패시킵니다.
 - [ ] `--lenient`와 `--no-normalize` 결과를 diagnostic field로 이동합니다.
 - [ ] unchanged fragment, separator, document envelope byte-equal을 proof에 포함합니다.
 - [ ] well-formed Storage XHTML, determinism, idempotency 검사를 추가합니다.
@@ -100,17 +100,17 @@
 
 ### 2.6 P0 — transaction-safe publisher
 
-- [ ] `confluence-mdx/bin/reverse_sync/publisher.py`를 추가합니다.
-- [ ] verified manifest와 candidate artifact hash를 다시 검증합니다.
-- [ ] remote preflight snapshot의 page ID/status/version/title/body hash를 base와 비교합니다.
-- [ ] active draft가 있으면 PUT 전에 block합니다.
-- [ ] base version + 1과 base title, manifest candidate body로 update합니다.
-- [ ] conflict 시 latest version으로 자동 retry하지 않습니다.
-- [ ] update 후 persisted snapshot을 다시 조회합니다.
-- [ ] persisted version과 target MDX semantic postcondition을 검증합니다.
-- [ ] base, candidate, response, post-snapshot을 recovery evidence로 저장합니다.
-- [ ] postcondition failure 시 batch 후속 push를 기본 중단합니다.
-- [ ] 현재 `_do_push()`가 `reverse-sync.patched.xhtml`을 직접 읽는 경로를 제거합니다.
+- [x] `confluence-mdx/bin/reverse_sync/publisher.py`를 추가합니다.
+- [x] verified manifest와 candidate artifact hash를 다시 검증합니다.
+- [x] remote preflight snapshot의 page ID/status/version/title/body hash를 base와 비교합니다.
+- [x] active draft가 있으면 PUT 전에 block합니다.
+- [x] base version + 1과 base title, manifest candidate body로 update합니다.
+- [x] conflict 시 latest version으로 자동 retry하지 않습니다.
+- [x] update 후 persisted snapshot을 다시 조회합니다.
+- [x] persisted version과 target MDX semantic postcondition을 검증합니다.
+- [x] base, candidate, response, post-snapshot을 recovery evidence로 저장합니다.
+- [x] postcondition failure 시 batch 후속 push를 기본 중단합니다.
+- [x] 현재 `_do_push()`가 `reverse-sync.patched.xhtml`을 직접 읽는 경로를 제거합니다.
 
 완료 gate:
 
@@ -121,13 +121,14 @@
 ### 2.7 P1 — CLI와 batch state 전환
 
 - [ ] `reverse_sync_cli.py`를 prepare/verify/push lifecycle orchestration으로 축소합니다.
-- [ ] `verify` 출력에 run ID, base version/hash, local gates, push eligibility, reason code를 표시합니다.
+- [x] online verify(`push --dry-run`) 출력에 run ID, base version/hash, local gates,
+  push eligibility, reason code를 표시합니다.
 - [ ] `push`가 explicit run/manifest를 받도록 합니다.
-- [ ] interactive confirmation에 page ID, base version, target version, change count, candidate hash를 표시합니다.
-- [ ] batch는 모든 local proof 후 page별 transaction을 실행합니다.
+- [x] interactive confirmation에 page ID, base version, target version, change count, candidate hash를 표시합니다.
+- [x] batch는 모든 local proof 후 page별 transaction을 실행합니다.
 - [ ] batch partial success, conflict, postcondition failure exit code와 JSON schema를 정의합니다.
 - [ ] resume는 `remote_verified`/blocked 상태를 재해석하지 않고 명시적 manifest 목록으로 수행합니다.
-- [ ] `--yes`가 safety gate를 우회하지 못하도록 테스트합니다.
+- [x] `--yes`가 safety gate를 우회하지 못하도록 테스트합니다.
 
 완료 gate:
 
@@ -163,20 +164,18 @@
 
 ### 3.1 Focused contract test
 
-- [ ] 다음 명령으로 snapshot, manifest, proof, publisher contract test를 실행합니다.
+- [x] 다음 명령으로 현재 구현된 snapshot, manifest, publisher contract test를 실행합니다.
 
 ```bash
 cd confluence-mdx/tests
-../venv/bin/python3 -m pytest -q \
-  test_reverse_sync_snapshot.py \
-  test_reverse_sync_manifest.py \
-  test_reverse_sync_proof.py \
-  test_reverse_sync_push_transaction.py
+../venv/bin/python3 -m pytest -q test_reverse_sync_push_transaction.py
 ```
+
+`proof.py`와 typed equivalence contract test는 2.5 구현 시 별도 test module로 분리합니다.
 
 ### 3.2 Existing reverse-sync unit regression
 
-- [ ] 기존 reverse-sync unit suite를 실행합니다.
+- [x] 기존 reverse-sync unit suite를 실행합니다.
 
 ```bash
 cd confluence-mdx/tests
@@ -189,7 +188,7 @@ cd confluence-mdx/tests
 
 ### 3.3 Page fixture regression
 
-- [ ] 정밀 golden fixture와 실제 회귀 fixture를 실행합니다.
+- [x] 정밀 golden fixture와 실제 회귀 fixture를 실행합니다.
 
 ```bash
 cd confluence-mdx/tests
@@ -203,7 +202,7 @@ make test-reverse-sync
 
 ### 3.4 Byte preservation
 
-- [ ] fast path와 forced splice byte-equal을 실행합니다.
+- [x] fast path와 forced splice byte-equal을 실행합니다.
 
 ```bash
 cd confluence-mdx/tests
@@ -226,7 +225,10 @@ make test-reverse-sync
 make test-byte-verify
 ```
 
-- [ ] 영향도에 따라 전체 Python test와 render test를 실행합니다.
+- [x] 영향도에 따라 전체 Python test와 render test를 실행합니다.
+
+이번 변경은 Python CLI/API adapter 범위이므로 전체 Python test(`1033 passed, 2 skipped`)를
+실행했고 frontend render test는 영향 범위에서 제외했습니다.
 
 ```bash
 cd confluence-mdx/tests
@@ -245,13 +247,13 @@ make test-render
 
 ## 4. Spec / 구현 drift 확인
 
-- [ ] `PageSnapshot` 구현이 version/body를 하나의 논리적 response에서 가져오는지 source scan합니다.
-- [ ] publisher가 latest remote version을 새 base로 채택하는 fallback이 없는지 검색합니다.
-- [ ] `skipped_changes`, `--lenient`, title strip이 push eligibility를 부여하지 않는지 확인합니다.
-- [ ] push가 filename이 아니라 manifest candidate hash를 소비하는지 확인합니다.
-- [ ] 모든 PUT 호출 경로가 preflight와 postcondition을 거치는지 확인합니다.
-- [ ] batch output이 page별 상태와 partial success를 노출하는지 확인합니다.
-- [ ] credential이 manifest/log/fixture에 포함되지 않았는지 검색합니다.
+- [x] `PageSnapshot` 구현이 version/body를 하나의 논리적 response에서 가져오는지 source scan합니다.
+- [x] publisher가 latest remote version을 새 base로 채택하는 fallback이 없는지 검색합니다.
+- [x] `skipped_changes`, `--lenient`, title strip이 push eligibility를 부여하지 않는지 확인합니다.
+- [x] push가 filename이 아니라 manifest candidate hash를 소비하는지 확인합니다.
+- [x] 모든 PUT 호출 경로가 preflight와 postcondition을 거치는지 확인합니다.
+- [x] batch output이 page별 상태와 partial success를 노출하는지 확인합니다.
+- [x] credential이 manifest/log/fixture에 포함되지 않았는지 검색합니다.
 
 ```bash
 rg -n "update_page|requests\\.put|method.?=.?(PUT|put)" confluence-mdx/bin


### PR DESCRIPTION
## Summary
검증한 Confluence snapshot과 실제 page update를 동일한 manifest로 결합하여 stale XHTML overwrite와 검증 후 artifact 변조를 차단합니다.

- 단일 Confluence v2 응답으로 `PageSnapshot`을 만들고 remote XHTML과 original MDX의 base parity를 검증합니다.
- `var/<page-id>/reverse-sync/<run-id>/`에 base/original/improved/candidate와 canonical `SyncManifest`를 저장하고 push 직전에 hash를 재검산합니다.
- remote preflight, active draft gate, `base version + 1` PUT, persisted snapshot semantic postcondition을 순서대로 적용합니다.
- remote drift와 PUT race에서 latest version을 새 base로 채택하거나 자동 retry하지 않습니다.
- batch postcondition 실패 시 후속 page push를 중단하고 page별 상태를 노출합니다.
- `complete-reverse-sync` OpenSpec task와 delta section 형식을 현재 구현 상태에 맞게 갱신합니다.

## 기존 문제
기존 `_do_push()`는 로컬 `page.xhtml`로 만든 candidate에 원격 latest version만 결합했습니다. 따라서 검증 base 이후 Confluence page가 변경되어도 stale candidate가 최신 version 위에 반영될 수 있었고, version과 body를 별도 GET으로 읽어 일관된 snapshot을 보장하지 못했습니다.

## 기대 효과
- 검증 base와 PUT base가 page ID, status, title, version, body hash까지 동일할 때만 update합니다.
- candidate 또는 manifest가 verify 후 바뀌면 원격 조회 전에 `artifact_tampered`로 중단합니다.
- PUT 성공 응답만으로 성공 처리하지 않고 persisted version과 target MDX 동등성을 확인한 뒤 `remote_verified`를 기록합니다.
- `--yes`는 사용자 확인만 생략하며 push eligibility와 remote safety gate를 우회하지 못합니다.

## Test plan
- [x] `cd confluence-mdx/tests && ../venv/bin/python3 -m pytest -q` — 1033 passed, 2 skipped
- [x] `cd confluence-mdx/tests && make test-reverse-sync` — golden 16 passed, regression 43 passed
- [x] `cd confluence-mdx/tests && make test-byte-verify` — fast/splice 각각 21/21 passed
- [x] `openspec validate complete-reverse-sync --strict`
- [x] `git diff --check`

## Related tickets & links
- #994
- [Confluence Cloud REST API v2 Page](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/)

## Additional notes
- 실제 Confluence canary PUT은 별도 승인과 대상 page 확인이 필요한 단계이므로 이 PR에서 실행하지 않았습니다.
- typed push equivalence, provenance-first planner, explicit resume는 OpenSpec의 후속 task로 남겨 둡니다.

🤖 Generated with Codex

Co-Authored-By: Atlas <atlas@jk.agent>