### PR TITLE
confluence-mdx: reverse-sync target identity를 엄격하게 검증합니다

### DIFF
--- a/confluence-mdx/bin/reverse_sync/manifest.py
+++ b/confluence-mdx/bin/reverse_sync/manifest.py
@@ -19,7 +19,7 @@ from reverse_sync.models import (
 
 MANIFEST_SCHEMA_VERSION = 2
 SUPPORTED_VERIFIER_POLICIES = frozenset({"reverse-sync-equivalence-v1"})
-CURRENT_TOOL_VERSION = "reverse-sync-cli-v3"
+CURRENT_TOOL_VERSION = "reverse-sync-cli-v4"
 REQUIRED_PUSH_GATES = frozenset(
     {
         "source_identity",

--- a/confluence-mdx/bin/reverse_sync/patch_builder.py
+++ b/confluence-mdx/bin/reverse_sync/patch_builder.py
@@ -1173,6 +1173,14 @@ def build_patches(
             if text_fallback is not None:
                 mapping = text_fallback
                 mapping_via_v3_fallback = True
+        elif (
+            not allow_text_identity_fallback
+            and strategy == 'list'
+            and mapping is not None
+            and _contains_preserved_anchor_markup(mapping.xhtml_text)
+            and old_plain[:40].strip() not in mapping.xhtml_plain_text
+        ):
+            mapping = None
 
         if mapping is None:
             block = change.old_block or change.new_block

--- a/confluence-mdx/bin/reverse_sync/patch_builder.py
+++ b/confluence-mdx/bin/reverse_sync/patch_builder.py
@@ -940,6 +940,7 @@ def build_patches(
     page_xhtml: Optional[str] = None,
     link_resolver: Optional[LinkResolver] = None,
     attachment_filenames: frozenset[str] = frozenset(),
+    allow_text_identity_fallback: bool = True,
 ) -> Tuple[List[Dict[str, str]], List[BlockMapping], List[Dict[str, str]]]:
     """diff 변경과 매핑을 결합하여 XHTML 패치 목록을 구성한다.
 
@@ -1150,7 +1151,11 @@ def build_patches(
 
         # v3 identity fallback도 실패한 경우: old_plain prefix text matching으로 최종 복원
         # type-based sidecar 타입 불일치로 mapping=None이 된 list 블록을 복원한다
-        if mapping is None and strategy == 'list':
+        if (
+            allow_text_identity_fallback
+            and mapping is None
+            and strategy == 'list'
+        ):
             text_fallback = _find_best_list_mapping_by_text(
                 old_plain, mappings, used_ids)
             if text_fallback is not None:
@@ -1159,7 +1164,8 @@ def build_patches(
 
         # sidecar가 잘못된 list mapping을 반환한 경우 (ac: 포함 + plain text 불일치):
         # plain text prefix로 올바른 mapping 복원
-        if (strategy == 'list' and mapping is not None
+        if (allow_text_identity_fallback
+                and strategy == 'list' and mapping is not None
                 and _contains_preserved_anchor_markup(mapping.xhtml_text)
                 and old_plain[:40].strip() not in mapping.xhtml_plain_text):
             text_fallback = _find_best_list_mapping_by_text(

--- a/confluence-mdx/bin/reverse_sync_cli.py
+++ b/confluence-mdx/bin/reverse_sync_cli.py
@@ -37,7 +37,7 @@ from reverse_sync.equivalence import (
 from xhtml_beautify_diff import xhtml_diff
 
 _PUSH_VERIFIER_POLICY = PUSH_EQUIVALENCE_POLICY
-_TOOL_VERSION = "reverse-sync-cli-v3"
+_TOOL_VERSION = "reverse-sync-cli-v4"
 
 
 @dataclass
@@ -533,6 +533,7 @@ def run_verify(
         roundtrip_sidecar=roundtrip_sidecar,
         link_resolver=link_resolver,
         attachment_filenames=attachment_filenames,
+        allow_text_identity_fallback=not for_push,
     )
 
     # mapping.original.yaml artifact 저장
@@ -665,6 +666,7 @@ def run_verify(
             roundtrip_sidecar=roundtrip_sidecar,
             link_resolver=link_resolver,
             attachment_filenames=attachment_filenames,
+            allow_text_identity_fallback=False,
         )
         deterministic_plan_json = canonical_plan_json(
             changes=changes,
@@ -706,6 +708,7 @@ def run_verify(
                     roundtrip_sidecar=candidate_sidecar,
                     link_resolver=link_resolver,
                     attachment_filenames=attachment_filenames,
+                    allow_text_identity_fallback=False,
                 )
                 idempotent_candidate = (
                     ""

--- a/confluence-mdx/tests/test_reverse_sync_cli.py
+++ b/confluence-mdx/tests/test_reverse_sync_cli.py
@@ -74,7 +74,7 @@ def _create_push_manifest(
             '"status":"verified_local"}\n'
         ),
         verifier_policy="reverse-sync-equivalence-v1",
-        tool_version="reverse-sync-cli-v3",
+        tool_version="reverse-sync-cli-v4",
         push_eligible=True,
         gates=tuple(
             VerificationGate(name, True)

--- a/confluence-mdx/tests/test_reverse_sync_patch_builder.py
+++ b/confluence-mdx/tests/test_reverse_sync_patch_builder.py
@@ -259,6 +259,42 @@ class TestBuildPatches:
         assert patches[0]['xhtml_xpath'] == 'ul[1]'
         assert patches[0]['action'] == 'replace_fragment'
 
+    def test_path1d_strict_identity_blocks_text_fallback(self):
+        """push path는 normalized text prefix로 list target을 선택하지 않는다."""
+        list_mapping = _make_mapping(
+            'lm1', '검색이 가능합니다 조건으로 검색', xpath='ul[1]', type_='list')
+        mappings = [list_mapping]
+        xpath_to_mapping = {m.xhtml_xpath: m for m in mappings}
+        change = _make_change(
+            0,
+            '1. 검색이 가능합니다 조건으로 검색\n',
+            '1. 검색할 수 있습니다 조건으로 검색\n',
+            type_='list',
+        )
+        roundtrip_sidecar = _make_roundtrip_sidecar([
+            SidecarBlock(
+                0,
+                'ul[1]',
+                '<li><p>검색이 가능합니다 조건으로 검색</p></li>',
+                'different_hash',
+                (10, 10),
+            ),
+        ])
+
+        patches, _, skipped_changes = build_patches(
+            [change],
+            [change.old_block],
+            [change.new_block],
+            mappings,
+            {},
+            xpath_to_mapping,
+            roundtrip_sidecar=roundtrip_sidecar,
+            allow_text_identity_fallback=False,
+        )
+
+        assert patches == []
+        assert skipped_changes[0]['reason'] == 'no_mapping'
+
     # Path 1e: type-based sidecar 타입 불일치 + roundtrip_sidecar=None + content change
     #          → text fallback으로 mapping 복원 → clean list → replace_fragment
     def test_path1e_no_sidecar_match_no_roundtrip_sidecar_with_content_change_patches(self):

--- a/confluence-mdx/tests/test_reverse_sync_patch_builder.py
+++ b/confluence-mdx/tests/test_reverse_sync_patch_builder.py
@@ -295,6 +295,41 @@ class TestBuildPatches:
         assert patches == []
         assert skipped_changes[0]['reason'] == 'no_mapping'
 
+    def test_strict_identity_blocks_stale_preserved_list_mapping(self):
+        """push path는 text가 다른 preserved list sidecar target을 거부한다."""
+        list_mapping = _make_mapping(
+            'lm1',
+            '다른 목록',
+            xpath='ul[1]',
+            type_='list',
+        )
+        list_mapping.xhtml_text = (
+            '<ul><li><p><ac:link><ri:page ri:content-title="Other">'
+            '</ri:page><ac:link-body>다른 목록</ac:link-body></ac:link>'
+            '</p></li></ul>'
+        )
+        mappings = [list_mapping]
+        xpath_to_mapping = {list_mapping.xhtml_xpath: list_mapping}
+        change = _make_change(
+            0,
+            '1. 원래 목록\n',
+            '1. 수정한 목록\n',
+            type_='list',
+        )
+
+        patches, _, skipped_changes = build_patches(
+            [change],
+            [change.old_block],
+            [change.new_block],
+            mappings,
+            self._setup_sidecar('ul[1]', 0),
+            xpath_to_mapping,
+            allow_text_identity_fallback=False,
+        )
+
+        assert patches == []
+        assert skipped_changes[0]['reason'] == 'no_mapping'
+
     # Path 1e: type-based sidecar 타입 불일치 + roundtrip_sidecar=None + content change
     #          → text fallback으로 mapping 복원 → clean list → replace_fragment
     def test_path1e_no_sidecar_match_no_roundtrip_sidecar_with_content_change_patches(self):

--- a/confluence-mdx/tests/test_reverse_sync_push_transaction.py
+++ b/confluence-mdx/tests/test_reverse_sync_push_transaction.py
@@ -38,6 +38,7 @@ from reverse_sync.models import (
     SyncStatus,
     VerificationGate,
 )
+from reverse_sync.patch_builder import build_patches as real_build_patches
 from reverse_sync.publisher import (
     ActiveDraftError,
     DependencyChangedError,
@@ -152,7 +153,7 @@ def _manifest(
         candidate_xhtml="<p>After</p>",
         local_proof=local_proof,
         verifier_policy="reverse-sync-equivalence-v1",
-        tool_version="reverse-sync-cli-v3",
+        tool_version="reverse-sync-cli-v4",
         push_eligible=True,
         gates=tuple(
             VerificationGate(name, True)
@@ -624,7 +625,7 @@ def test_push_manifest_requires_all_local_proof_gates(tmp_path):
                 '"status":"verified_local"}\n'
             ),
             verifier_policy="reverse-sync-equivalence-v1",
-            tool_version="reverse-sync-cli-v3",
+            tool_version="reverse-sync-cli-v4",
             push_eligible=True,
             gates=(VerificationGate("semantic_roundtrip", True),),
         )
@@ -1110,7 +1111,13 @@ def test_online_verify_builds_manifest_from_remote_snapshot(tmp_path, monkeypatc
         Path(output_path).write_text(content)
         return content
 
-    with patch("reverse_sync_cli._forward_convert", side_effect=forward_convert):
+    with patch(
+        "reverse_sync_cli._forward_convert",
+        side_effect=forward_convert,
+    ), patch(
+        "reverse_sync_cli.build_patches",
+        wraps=real_build_patches,
+    ) as planner:
         result = run_verify(
             page_id=page_id,
             original_src=MdxSource(original, "main:src/content/ko/test.mdx"),
@@ -1134,7 +1141,12 @@ def test_online_verify_builds_manifest_from_remote_snapshot(tmp_path, monkeypatc
     assert manifest.base_version == 5
     assert manifest.base_storage_sha256 == base.storage_sha256
     assert manifest.verifier_policy == "reverse-sync-equivalence-v1"
-    assert manifest.tool_version == "reverse-sync-cli-v3"
+    assert manifest.tool_version == "reverse-sync-cli-v4"
+    assert planner.call_count == 2
+    assert all(
+        call.kwargs["allow_text_identity_fallback"] is False
+        for call in planner.call_args_list
+    )
     assert (manifest_path.parent / "patch-plan.json").is_file()
     assert (manifest_path.parent / "local-proof.json").is_file()
     assert (manifest_path.parent / "candidate.xhtml").read_text() == (

--- a/openspec/changes/complete-reverse-sync/design.md
+++ b/openspec/changes/complete-reverse-sync/design.md
@@ -220,6 +220,12 @@ frontmatter title과 첫 H1도 각 문서 안에서 같아야 하며 original/im
 
 normalized text prefix는 push-eligible path에서 identity source로 사용하지 않습니다. 중복 block 또는 다중 후보가 있으면 `ambiguous_target`으로 block합니다.
 
+현재 migration adapter는 offline diagnostic fixture 호환성을 위해 list의 normalized
+text prefix fallback을 유지합니다. online verify는
+`allow_text_identity_fallback=false`를 모든 최초·determinism·idempotency planning
+호출에 강제하고, provenance mapping을 찾지 못하면 `no_mapping`으로 기록하여
+`intent_complete` gate에서 block합니다.
+
 추가/삭제/reorder는 stable neighbor identity를 기준으로 계획합니다.
 
 - insert는 `before_block_id`와 `after_block_id` 중 하나 이상을 가져야 합니다.

--- a/openspec/changes/complete-reverse-sync/tasks.md
+++ b/openspec/changes/complete-reverse-sync/tasks.md
@@ -140,7 +140,7 @@
 - [ ] `patch_builder.py`의 capability 판별을 `capabilities.py`와 planner로 추출합니다.
 - [ ] planning output을 typed `PatchPlan`/operation으로 바꾸고 raw patch dict를 boundary 안에 가둡니다.
 - [ ] block identity를 provenance-first 순서로 바꿉니다.
-- [ ] normalized text prefix fallback을 push-eligible path에서 제거합니다.
+- [x] normalized text prefix fallback을 push-eligible path에서 제거합니다.
 - [ ] visible segment model을 paragraph, heading, list에 확장합니다.
 - [ ] strategy를 text block, list, preserved anchor, container, table로 분리합니다.
 - [ ] unsupported table/macro 구조를 explicit block reason으로 전환합니다.
@@ -195,7 +195,7 @@ cd confluence-mdx/tests
 
 기준선: 2026-07-24 `origin/main`에서 676 passed입니다.
 
-현재 변경 결과: 762 passed입니다.
+현재 변경 결과: 763 passed입니다.
 
 ### 3.3 Page fixture regression
 
@@ -241,13 +241,13 @@ strict proof 구현 branch 검증 결과:
 - `make test-convert`: 21 passed
 - `make test-reverse-sync`: golden 16 passed, regression 43 passed
 - `make test-byte-verify`: fast/splice 각각 21/21 passed
-- 전체 Python test: 1085 passed, 2 skipped
+- 전체 Python test: 1086 passed, 2 skipped
 - 16개 golden page shadow online verify: 4개 `verified_local`, 나머지는
   visible whitespace, unresolved link, raw HTML table mutation 등에서 fail-closed
 
 - [x] 영향도에 따라 전체 Python test와 render test를 실행합니다.
 
-이번 변경은 Python CLI/API adapter 범위이므로 전체 Python test(`1085 passed, 2 skipped`)를
+이번 변경은 Python CLI/API adapter 범위이므로 전체 Python test(`1086 passed, 2 skipped`)를
 실행했고 frontend render test는 영향 범위에서 제외했습니다.
 
 ```bash


### PR DESCRIPTION
## Summary
push-eligible planning에서 provenance가 없는 normalized text prefix target 선택을 제거합니다.

- offline diagnostic fixture는 기존 list text fallback을 유지합니다.
- online verify는 최초 candidate, determinism 재생성, idempotency 재계획 모두 `allow_text_identity_fallback=false`를 강제합니다.
- provenance mapping을 찾지 못하면 `no_mapping`으로 기록하고 `intent_complete` gate에서 block합니다.
- tool version을 `reverse-sync-cli-v4`로 올려 과거 manifest의 재검증을 요구합니다.
- OpenSpec planner/renderer migration boundary와 task를 갱신합니다.

## Why
normalized text prefix는 중복 list나 유사 content에서 다른 XHTML fragment를 선택할 수 있습니다. 진단 경로에서는 fixture migration을 위해 유지할 수 있지만, remote update를 허용하는 proof의 target identity로 사용할 수는 없습니다.

## Test plan
- [x] 전체 Python test: 1086 passed, 2 skipped
- [x] reverse-sync Python test: 763 passed
- [x] `make test-reverse-sync`: golden 16 passed, regression fixture 통과
- [x] `make test-byte-verify`: fast/splice 각각 21/21 passed
- [x] `openspec validate complete-reverse-sync --strict`
- [x] `git diff --check`

## Stack
- Base: #1031
- Strict proof: #1030
- Publisher foundation: #1029
- 이 PR은 선행 PR merge 후 base를 순차적으로 `main`으로 변경할 수 있습니다.

🤖 Generated with Codex