### PR TITLE
confluence-mdx: reverse-sync typed plan 경계를 도입합니다

### DIFF
--- a/confluence-mdx/bin/reverse_sync/capabilities.py
+++ b/confluence-mdx/bin/reverse_sync/capabilities.py
@@ -1,0 +1,196 @@
+"""reverse-sync planner가 사용하는 capability registry와 판별 규칙."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from reverse_sync.mapping_recorder import BlockMapping
+from reverse_sync.sidecar import SidecarBlock
+
+
+class SupportLevel(str, Enum):
+    """capability의 push 지원 수준."""
+
+    SUPPORTED = "supported"
+    CONDITIONAL = "conditional"
+    BLOCKED = "blocked"
+
+
+@dataclass(frozen=True)
+class CapabilitySpec:
+    """planner와 proof가 공유하는 capability 계약."""
+
+    capability_id: str
+    support_level: SupportLevel
+    renderer_owner: str
+    required_proof: tuple[str, ...]
+    block_reason: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        result: dict[str, object] = {
+            "capability_id": self.capability_id,
+            "renderer_owner": self.renderer_owner,
+            "required_proof": list(self.required_proof),
+            "support_level": self.support_level.value,
+        }
+        if self.block_reason:
+            result["block_reason"] = self.block_reason
+        return result
+
+
+_COMMON_PROOF = (
+    "target_identity",
+    "preservation",
+    "semantic_roundtrip",
+    "determinism",
+    "idempotency",
+)
+
+
+CAPABILITY_REGISTRY: dict[str, CapabilitySpec] = {
+    "paragraph_visible_edit": CapabilitySpec(
+        "paragraph_visible_edit",
+        SupportLevel.SUPPORTED,
+        "legacy_adapter/paragraph",
+        _COMMON_PROOF,
+    ),
+    "heading_visible_edit": CapabilitySpec(
+        "heading_visible_edit",
+        SupportLevel.SUPPORTED,
+        "legacy_adapter/heading",
+        _COMMON_PROOF,
+    ),
+    "code_block_replace": CapabilitySpec(
+        "code_block_replace",
+        SupportLevel.SUPPORTED,
+        "legacy_adapter/code_block",
+        _COMMON_PROOF + ("storage_well_formed",),
+    ),
+    "clean_list_reconstruct": CapabilitySpec(
+        "clean_list_reconstruct",
+        SupportLevel.SUPPORTED,
+        "legacy_adapter/list",
+        _COMMON_PROOF + ("visible_structure",),
+    ),
+    "preserved_anchor_template_rewrite": CapabilitySpec(
+        "preserved_anchor_template_rewrite",
+        SupportLevel.CONDITIONAL,
+        "legacy_adapter/preserved_anchor",
+        _COMMON_PROOF + ("preserved_anchor_identity",),
+    ),
+    "container_body_reconstruct": CapabilitySpec(
+        "container_body_reconstruct",
+        SupportLevel.CONDITIONAL,
+        "legacy_adapter/container",
+        _COMMON_PROOF + ("container_wrapper_preservation",),
+    ),
+    "simple_markdown_table_replace": CapabilitySpec(
+        "simple_markdown_table_replace",
+        SupportLevel.CONDITIONAL,
+        "legacy_adapter/markdown_table",
+        _COMMON_PROOF + ("table_structure",),
+    ),
+    "insert_owned_block": CapabilitySpec(
+        "insert_owned_block",
+        SupportLevel.CONDITIONAL,
+        "legacy_adapter/insert",
+        _COMMON_PROOF + ("neighbor_identity", "dependency"),
+    ),
+    "delete_exact_block": CapabilitySpec(
+        "delete_exact_block",
+        SupportLevel.CONDITIONAL,
+        "legacy_adapter/delete",
+        _COMMON_PROOF + ("exact_fragment_identity",),
+    ),
+    "raw_html_table_edit": CapabilitySpec(
+        "raw_html_table_edit",
+        SupportLevel.BLOCKED,
+        "unimplemented/raw_html_table",
+        _COMMON_PROOF + ("typed_table_cell_proof",),
+        block_reason="unsupported_capability",
+    ),
+    "unknown_macro_mutation": CapabilitySpec(
+        "unknown_macro_mutation",
+        SupportLevel.BLOCKED,
+        "unimplemented/unknown_macro",
+        _COMMON_PROOF + ("macro_preservation_contract",),
+        block_reason="unsupported_capability",
+    ),
+}
+
+
+def get_capability(capability_id: str) -> CapabilitySpec:
+    """등록된 capability를 반환하고 오타나 미등록 ID를 즉시 거부합니다."""
+    try:
+        return CAPABILITY_REGISTRY[capability_id]
+    except KeyError as exc:
+        raise ValueError(
+            f"등록되지 않은 reverse-sync capability입니다: {capability_id}"
+        ) from exc
+
+
+def _contains_preservation_unit(mapping: Optional[BlockMapping]) -> bool:
+    if mapping is None:
+        return False
+    return "<ac:" in mapping.xhtml_text or "<ri:" in mapping.xhtml_text
+
+
+def _is_container(
+    mapping: Optional[BlockMapping],
+    sidecar_block: Optional[SidecarBlock],
+) -> bool:
+    if mapping is not None and mapping.children:
+        return True
+    reconstruction = sidecar_block.reconstruction if sidecar_block is not None else None
+    return bool(reconstruction and reconstruction.get("kind") == "container")
+
+
+def classify_capability(
+    *,
+    action: str,
+    mapping: Optional[BlockMapping],
+    sidecar_block: Optional[SidecarBlock],
+    source_block_types: tuple[str, ...],
+    contains_raw_html_table: bool,
+) -> CapabilitySpec:
+    """legacy patch 하나를 명시적인 capability로 분류합니다.
+
+    분류할 수 없는 macro/HTML mutation은 generic success로 흘려보내지 않고
+    blocked capability로 닫습니다.
+    """
+    if contains_raw_html_table:
+        return get_capability("raw_html_table_edit")
+
+    mapping_type = mapping.type if mapping is not None else ""
+    source_types = set(source_block_types)
+    unknown_html = mapping_type == "html_block" or "html_block" in source_types
+
+    if action == "insert":
+        if unknown_html:
+            return get_capability("unknown_macro_mutation")
+        return get_capability("insert_owned_block")
+
+    if action == "delete":
+        if unknown_html:
+            return get_capability("unknown_macro_mutation")
+        return get_capability("delete_exact_block")
+
+    if _is_container(mapping, sidecar_block):
+        return get_capability("container_body_reconstruct")
+    if unknown_html:
+        return get_capability("unknown_macro_mutation")
+    if mapping_type == "table" or "table" in source_types:
+        return get_capability("simple_markdown_table_replace")
+    if _contains_preservation_unit(mapping):
+        return get_capability("preserved_anchor_template_rewrite")
+    if mapping_type == "list" or "list" in source_types:
+        return get_capability("clean_list_reconstruct")
+    if mapping_type == "heading" or "heading" in source_types:
+        return get_capability("heading_visible_edit")
+    if mapping_type == "code" or "code_block" in source_types:
+        return get_capability("code_block_replace")
+    if mapping_type == "paragraph" or "paragraph" in source_types:
+        return get_capability("paragraph_visible_edit")
+    return get_capability("unknown_macro_mutation")

--- a/confluence-mdx/bin/reverse_sync/manifest.py
+++ b/confluence-mdx/bin/reverse_sync/manifest.py
@@ -19,7 +19,7 @@ from reverse_sync.models import (
 
 MANIFEST_SCHEMA_VERSION = 2
 SUPPORTED_VERIFIER_POLICIES = frozenset({"reverse-sync-equivalence-v1"})
-CURRENT_TOOL_VERSION = "reverse-sync-cli-v4"
+CURRENT_TOOL_VERSION = "reverse-sync-cli-v5"
 REQUIRED_PUSH_GATES = frozenset(
     {
         "source_identity",

--- a/confluence-mdx/bin/reverse_sync/models.py
+++ b/confluence-mdx/bin/reverse_sync/models.py
@@ -43,6 +43,8 @@ class ReasonCode(str, Enum):
     SEMANTIC_ROUNDTRIP_MISMATCH = "semantic_roundtrip_mismatch"
     NON_DETERMINISTIC_OUTPUT = "non_deterministic_output"
     NON_IDEMPOTENT_OUTPUT = "non_idempotent_output"
+    MISSING_IDENTITY = "missing_identity"
+    UNSUPPORTED_CAPABILITY = "unsupported_capability"
     DEPENDENCY_FAILURE = "dependency_failure"
     MISSING_ATTACHMENT = "missing_attachment"
     INTERNAL_LINK_UNRESOLVED = "internal_link_unresolved"

--- a/confluence-mdx/bin/reverse_sync/operations.py
+++ b/confluence-mdx/bin/reverse_sync/operations.py
@@ -1,0 +1,264 @@
+"""reverse-sync planning 결과의 immutable typed boundary."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+import json
+from typing import Any, Iterable
+
+
+PLAN_SCHEMA_VERSION = 2
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+@dataclass(frozen=True)
+class ChangeIntent:
+    """original/improved MDX 사이의 content intent."""
+
+    ordinal: int
+    index: int
+    change_type: str
+    block_type: str
+    old_sha256: str
+    new_sha256: str
+    provenance_xpath: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "block_type": self.block_type,
+            "change_type": self.change_type,
+            "index": self.index,
+            "new_sha256": self.new_sha256,
+            "old_sha256": self.old_sha256,
+            "ordinal": self.ordinal,
+        }
+        if self.provenance_xpath:
+            result["provenance_xpath"] = self.provenance_xpath
+        return result
+
+
+@dataclass(frozen=True)
+class TargetIdentity:
+    """base snapshot 안에서 operation target을 고정하는 provenance."""
+
+    kind: str
+    xpath: str
+    root_xpath: str
+    base_fragment_sha256: str
+    mdx_content_sha256: str = ""
+    mdx_line_range: tuple[int, int] = (0, 0)
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "base_fragment_sha256": self.base_fragment_sha256,
+            "kind": self.kind,
+            "root_xpath": self.root_xpath,
+            "xpath": self.xpath,
+        }
+        if self.mdx_content_sha256:
+            result["mdx_content_sha256"] = self.mdx_content_sha256
+        if self.mdx_line_range != (0, 0):
+            result["mdx_line_range"] = list(self.mdx_line_range)
+        return result
+
+
+@dataclass(frozen=True)
+class PlanIssue:
+    """planner가 fail-closed로 기록하는 typed reason."""
+
+    reason_code: str
+    description: str
+    block_id: str = ""
+    capability_id: str = ""
+    intent_ordinal: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "description": self.description,
+            "reason_code": self.reason_code,
+        }
+        if self.block_id:
+            result["block_id"] = self.block_id
+        if self.capability_id:
+            result["capability_id"] = self.capability_id
+        if self.intent_ordinal is not None:
+            result["intent_ordinal"] = self.intent_ordinal
+        return result
+
+    def to_legacy_dict(self) -> dict[str, Any]:
+        """기존 CLI skipped_changes schema와의 compatibility boundary."""
+        result = self.to_dict()
+        result["reason"] = result.pop("reason_code")
+        return result
+
+
+_VALID_ACTIONS = frozenset({"modify", "delete", "insert", "replace_fragment"})
+
+
+def _validate_legacy_patch(patch: dict[str, Any]) -> tuple[str, str]:
+    action = str(patch.get("action", "modify"))
+    if action not in _VALID_ACTIONS:
+        raise ValueError(f"지원하지 않는 patch action입니다: {action}")
+
+    if action == "insert":
+        if "new_element_xhtml" not in patch:
+            raise ValueError("insert operation에 new_element_xhtml이 없습니다")
+        target = patch.get("after_xpath")
+        return action, "$document-start" if target is None else str(target)
+
+    target = patch.get("xhtml_xpath")
+    if not target:
+        raise ValueError(f"{action} operation에 xhtml_xpath가 없습니다")
+    if action == "replace_fragment" and "new_element_xhtml" not in patch:
+        raise ValueError("replace_fragment operation에 new_element_xhtml이 없습니다")
+    if action == "modify":
+        has_inner = "new_inner_xhtml" in patch
+        has_text = "old_plain_text" in patch and "new_plain_text" in patch
+        if not (has_inner or has_text):
+            raise ValueError("modify operation에 renderer input이 없습니다")
+    return action, str(target)
+
+
+@dataclass(frozen=True)
+class PatchOperation:
+    """capability, target identity, proof 요구사항을 가진 renderer operation."""
+
+    operation_id: str
+    action: str
+    capability_id: str
+    target: TargetIdentity
+    required_proof: tuple[str, ...]
+    intent_ordinals: tuple[int, ...]
+    renderer_input_json: str
+    executable: bool
+    reason_code: str = ""
+
+    @classmethod
+    def from_legacy_patch(
+        cls,
+        *,
+        operation_id: str,
+        patch: dict[str, Any],
+        capability_id: str,
+        target: TargetIdentity,
+        required_proof: Iterable[str],
+        intent_ordinals: Iterable[int],
+        executable: bool,
+        reason_code: str = "",
+    ) -> "PatchOperation":
+        action, patch_target = _validate_legacy_patch(patch)
+        if patch_target != target.xpath:
+            raise ValueError(
+                "operation target과 renderer input target이 다릅니다: "
+                f"{target.xpath} != {patch_target}"
+            )
+        if not capability_id:
+            raise ValueError("operation capability_id가 비어 있습니다")
+        proof = tuple(dict.fromkeys(str(item) for item in required_proof if item))
+        if not proof:
+            raise ValueError("operation required_proof가 비어 있습니다")
+        if executable and reason_code:
+            raise ValueError("실행 가능한 operation에 block reason이 있습니다")
+        if not executable and not reason_code:
+            raise ValueError("실행 불가능한 operation에 block reason이 없습니다")
+        return cls(
+            operation_id=operation_id,
+            action=action,
+            capability_id=capability_id,
+            target=target,
+            required_proof=proof,
+            intent_ordinals=tuple(sorted(set(intent_ordinals))),
+            renderer_input_json=_canonical_json(patch),
+            executable=executable,
+            reason_code=reason_code,
+        )
+
+    def to_patch_dict(self) -> dict[str, Any]:
+        """validated legacy renderer boundary에서만 raw patch dict를 복원합니다."""
+        return json.loads(self.renderer_input_json)
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "action": self.action,
+            "capability_id": self.capability_id,
+            "executable": self.executable,
+            "intent_ordinals": list(self.intent_ordinals),
+            "operation_id": self.operation_id,
+            "reason_code": self.reason_code,
+            "renderer_input": self.to_patch_dict(),
+            "required_proof": list(self.required_proof),
+            "target": self.target.to_dict(),
+        }
+        return result
+
+
+@dataclass(frozen=True)
+class PatchPlan:
+    """MDX intent와 XHTML operation을 결합하는 deterministic plan."""
+
+    intents: tuple[ChangeIntent, ...]
+    operations: tuple[PatchOperation, ...]
+    issues: tuple[PlanIssue, ...]
+    adapter: str = "legacy-patch-builder-v2"
+    schema_version: int = PLAN_SCHEMA_VERSION
+
+    @property
+    def covered_intent_ordinals(self) -> frozenset[int]:
+        return frozenset(
+            ordinal
+            for operation in self.operations
+            if operation.executable
+            for ordinal in operation.intent_ordinals
+        )
+
+    @property
+    def intent_complete(self) -> bool:
+        required = {intent.ordinal for intent in self.intents}
+        coverage = Counter(
+            ordinal
+            for operation in self.executable_operations
+            for ordinal in operation.intent_ordinals
+        )
+        return (
+            bool(required)
+            and not self.issues
+            and bool(self.executable_operations)
+            and set(coverage) == required
+            and all(count == 1 for count in coverage.values())
+        )
+
+    @property
+    def executable_operations(self) -> tuple[PatchOperation, ...]:
+        return tuple(operation for operation in self.operations if operation.executable)
+
+    def to_patch_dicts(self) -> list[dict[str, Any]]:
+        """XHTML renderer에 넘길 validated operation만 raw boundary로 변환합니다."""
+        return [
+            operation.to_patch_dict()
+            for operation in self.executable_operations
+        ]
+
+    def to_legacy_skipped_changes(self) -> list[dict[str, Any]]:
+        return [issue.to_legacy_dict() for issue in self.issues]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "adapter": self.adapter,
+            "intent_complete": self.intent_complete,
+            "intents": [intent.to_dict() for intent in self.intents],
+            "issues": [issue.to_dict() for issue in self.issues],
+            "operations": [operation.to_dict() for operation in self.operations],
+            "schema_version": self.schema_version,
+        }
+
+    def to_canonical_json(self) -> str:
+        return _canonical_json(self.to_dict()) + "\n"

--- a/confluence-mdx/bin/reverse_sync/planner.py
+++ b/confluence-mdx/bin/reverse_sync/planner.py
@@ -1,0 +1,425 @@
+"""legacy patch builder를 typed PatchPlan 경계 뒤에 격리하는 planner."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, Optional
+
+from mdx_to_storage.link_resolver import LinkResolver
+from mdx_to_storage.parser import Block as MdxBlock
+from reverse_sync.block_diff import BlockChange, NON_CONTENT_TYPES
+from reverse_sync.capabilities import SupportLevel, classify_capability
+from reverse_sync.mapping_recorder import BlockMapping
+from reverse_sync.models import sha256_text
+from reverse_sync.operations import (
+    ChangeIntent,
+    PatchOperation,
+    PatchPlan,
+    PlanIssue,
+    TargetIdentity,
+)
+from reverse_sync.patch_builder import build_patches
+from reverse_sync.sidecar import RoundtripSidecar, SidecarBlock, SidecarEntry
+
+
+def _root_xpath(xpath: str) -> str:
+    return xpath.split("/", 1)[0]
+
+
+def _strict_sidecar_identity(
+    block: MdxBlock,
+    sidecar: Optional[RoundtripSidecar],
+) -> Optional[SidecarBlock]:
+    """hash와 line range가 모두 같은 유일한 provenance만 반환합니다."""
+    if sidecar is None or not block.content:
+        return None
+    content_hash = sha256_text(block.content)
+    line_range = (block.line_start, block.line_end)
+    matches = [
+        candidate
+        for candidate in sidecar.blocks
+        if candidate.mdx_content_hash == content_hash
+        and tuple(candidate.mdx_line_range) == line_range
+    ]
+    if len(matches) != 1:
+        return None
+    return matches[0]
+
+
+def _build_intents(
+    changes: list[BlockChange],
+    sidecar: Optional[RoundtripSidecar],
+) -> tuple[ChangeIntent, ...]:
+    deleted_targets: dict[int, str] = {}
+    for change in changes:
+        if change.change_type != "deleted" or change.old_block is None:
+            continue
+        identity = _strict_sidecar_identity(change.old_block, sidecar)
+        if identity is not None:
+            deleted_targets[change.index] = _root_xpath(identity.xhtml_xpath)
+
+    intents: list[ChangeIntent] = []
+    for ordinal, change in enumerate(changes):
+        block = change.old_block or change.new_block
+        if block is None or block.type in NON_CONTENT_TYPES:
+            continue
+        identity = (
+            _strict_sidecar_identity(change.old_block, sidecar)
+            if change.old_block is not None
+            else None
+        )
+        provenance_xpath = (
+            _root_xpath(identity.xhtml_xpath)
+            if identity is not None
+            else deleted_targets.get(change.index, "")
+        )
+        intents.append(
+            ChangeIntent(
+                ordinal=ordinal,
+                index=change.index,
+                change_type=change.change_type,
+                block_type=block.type,
+                old_sha256=sha256_text(change.old_block.content)
+                if change.old_block is not None
+                else "",
+                new_sha256=sha256_text(change.new_block.content)
+                if change.new_block is not None
+                else "",
+                provenance_xpath=provenance_xpath,
+            )
+        )
+    return tuple(intents)
+
+
+def _sidecar_index(sidecar: Optional[RoundtripSidecar]) -> dict[str, SidecarBlock]:
+    if sidecar is None:
+        return {}
+    return {block.xhtml_xpath: block for block in sidecar.blocks}
+
+
+def _mapping_for_patch(
+    patch: dict[str, Any],
+    mappings: list[BlockMapping],
+) -> Optional[BlockMapping]:
+    target = (
+        patch.get("after_xpath")
+        if patch.get("action") == "insert"
+        else patch.get("xhtml_xpath")
+    )
+    if target is None:
+        return None
+    target_text = str(target)
+    exact = {mapping.xhtml_xpath: mapping for mapping in mappings}
+    return exact.get(target_text) or exact.get(_root_xpath(target_text))
+
+
+def _target_identity(
+    patch: dict[str, Any],
+    sidecar: Optional[RoundtripSidecar],
+) -> Optional[TargetIdentity]:
+    action = str(patch.get("action", "modify"))
+    sidecar_by_xpath = _sidecar_index(sidecar)
+    if action == "insert":
+        anchor = patch.get("after_xpath")
+        if anchor is None:
+            if sidecar is None:
+                return None
+            boundary = (
+                sidecar.document_envelope.prefix
+                + (sidecar.blocks[0].xhtml_xpath if sidecar.blocks else "$empty")
+            )
+            return TargetIdentity(
+                kind="document_start",
+                xpath="$document-start",
+                root_xpath="$document-start",
+                base_fragment_sha256=sha256_text(boundary),
+            )
+        xpath = str(anchor)
+        root = _root_xpath(xpath)
+        block = sidecar_by_xpath.get(root)
+        if block is None:
+            return None
+        return TargetIdentity(
+            kind="insert_after",
+            xpath=xpath,
+            root_xpath=root,
+            base_fragment_sha256=sha256_text(block.xhtml_fragment),
+            mdx_content_sha256=block.mdx_content_hash,
+            mdx_line_range=tuple(block.mdx_line_range),
+        )
+
+    xpath_value = patch.get("xhtml_xpath")
+    if not xpath_value:
+        return None
+    xpath = str(xpath_value)
+    root = _root_xpath(xpath)
+    block = sidecar_by_xpath.get(root)
+    if block is None:
+        return None
+    return TargetIdentity(
+        kind="exact_fragment",
+        xpath=xpath,
+        root_xpath=root,
+        base_fragment_sha256=sha256_text(block.xhtml_fragment),
+        mdx_content_sha256=block.mdx_content_hash,
+        mdx_line_range=tuple(block.mdx_line_range),
+    )
+
+
+def _intent_ordinals_for_patch(
+    *,
+    patch: dict[str, Any],
+    intents: tuple[ChangeIntent, ...],
+    changes: list[BlockChange],
+    already_assigned_inserts: set[int],
+) -> tuple[int, ...]:
+    action = str(patch.get("action", "modify"))
+    if action == "insert":
+        intent_by_ordinal = {intent.ordinal: intent for intent in intents}
+        for ordinal, change in enumerate(changes):
+            if change.change_type != "added":
+                continue
+            if ordinal in already_assigned_inserts:
+                continue
+            already_assigned_inserts.add(ordinal)
+            block = change.new_block
+            if block is None or block.type in NON_CONTENT_TYPES:
+                # legacy builder가 empty source line을 <p></p> insert로 바꾸는
+                # operation은 source-formatting intent가 아니므로
+                # renderer에서 제거합니다.
+                return (-1,)
+            intent = intent_by_ordinal.get(ordinal)
+            if intent is None or intent.provenance_xpath:
+                return ()
+            return (intent.ordinal,)
+        return ()
+
+    target = patch.get("xhtml_xpath")
+    if not target:
+        return ()
+    root = _root_xpath(str(target))
+    matched = tuple(
+        intent.ordinal
+        for intent in intents
+        if intent.provenance_xpath == root
+    )
+    return matched
+
+
+def _source_details(
+    intent_ordinals: tuple[int, ...],
+    intents: tuple[ChangeIntent, ...],
+    changes: list[BlockChange],
+) -> tuple[tuple[str, ...], bool]:
+    by_ordinal = {intent.ordinal: intent for intent in intents}
+    block_types: list[str] = []
+    contains_raw_html_table = False
+    for ordinal in intent_ordinals:
+        intent = by_ordinal.get(ordinal)
+        if intent is None:
+            continue
+        block_types.append(intent.block_type)
+        change = changes[ordinal]
+        for block in (change.old_block, change.new_block):
+            if (
+                block is not None
+                and block.type == "html_block"
+                and block.content.lstrip().lower().startswith("<table")
+            ):
+                contains_raw_html_table = True
+    return tuple(block_types), contains_raw_html_table
+
+
+def plan_patches(
+    changes: list[BlockChange],
+    original_blocks: list[MdxBlock],
+    improved_blocks: list[MdxBlock],
+    mappings: Optional[list[BlockMapping]] = None,
+    mdx_to_sidecar: Optional[dict[int, SidecarEntry]] = None,
+    xpath_to_mapping: Optional[dict[str, BlockMapping]] = None,
+    alignment: Optional[dict[int, int]] = None,
+    page_lost_info: Optional[dict] = None,
+    roundtrip_sidecar: Optional[RoundtripSidecar] = None,
+    page_xhtml: Optional[str] = None,
+    link_resolver: Optional[LinkResolver] = None,
+    attachment_filenames: frozenset[str] = frozenset(),
+    allow_text_identity_fallback: bool = True,
+    enforce_capabilities: bool = False,
+    enforce_provenance: bool = False,
+) -> tuple[PatchPlan, list[BlockMapping]]:
+    """legacy builder output을 capability/provenance가 있는 typed plan으로 바꿉니다."""
+    raw_patches, resolved_mappings, legacy_skips = build_patches(
+        changes,
+        original_blocks,
+        improved_blocks,
+        mappings=mappings,
+        mdx_to_sidecar=mdx_to_sidecar,
+        xpath_to_mapping=xpath_to_mapping,
+        alignment=alignment,
+        page_lost_info=page_lost_info,
+        roundtrip_sidecar=roundtrip_sidecar,
+        page_xhtml=page_xhtml,
+        link_resolver=link_resolver,
+        attachment_filenames=attachment_filenames,
+        allow_text_identity_fallback=allow_text_identity_fallback,
+    )
+    intents = _build_intents(changes, roundtrip_sidecar)
+    issues = [
+        PlanIssue(
+            reason_code=str(item.get("reason", "incomplete_patch_plan")),
+            description=str(
+                item.get(
+                    "description",
+                    "legacy planner가 변경을 적용하지 못했습니다",
+                )
+            ),
+            block_id=str(item.get("block_id", "")),
+        )
+        for item in legacy_skips
+    ]
+    sidecar_by_xpath = _sidecar_index(roundtrip_sidecar)
+    assigned_inserts: set[int] = set()
+    operations: list[PatchOperation] = []
+
+    for operation_index, patch in enumerate(raw_patches):
+        target = _target_identity(patch, roundtrip_sidecar)
+        if target is None:
+            if enforce_provenance:
+                issues.append(
+                    PlanIssue(
+                        reason_code="missing_identity",
+                        description=(
+                            "renderer operation의 exact base fragment identity가 없습니다"
+                        ),
+                        block_id=str(
+                            patch.get("xhtml_xpath")
+                            or patch.get("after_xpath")
+                            or "$document-start"
+                        ),
+                    )
+                )
+                continue
+            # offline diagnostic도 typed target shape를 유지하되 push provenance로
+            # 해석할 수 없음을 kind와 빈 fragment hash로 명시합니다.
+            raw_target = (
+                patch.get("after_xpath")
+                if patch.get("action") == "insert"
+                else patch.get("xhtml_xpath")
+            )
+            target_text = "$document-start" if raw_target is None else str(raw_target)
+            target = TargetIdentity(
+                kind="diagnostic_unverified",
+                xpath=target_text,
+                root_xpath=_root_xpath(target_text),
+                base_fragment_sha256="",
+            )
+
+        intent_ordinals = _intent_ordinals_for_patch(
+            patch=patch,
+            intents=intents,
+            changes=changes,
+            already_assigned_inserts=assigned_inserts,
+        )
+        if intent_ordinals == (-1,):
+            continue
+        mapping = _mapping_for_patch(patch, resolved_mappings)
+        source_types, contains_raw_html_table = _source_details(
+            intent_ordinals,
+            intents,
+            changes,
+        )
+        capability = classify_capability(
+            action=str(patch.get("action", "modify")),
+            mapping=mapping,
+            sidecar_block=sidecar_by_xpath.get(target.root_xpath),
+            source_block_types=source_types,
+            contains_raw_html_table=contains_raw_html_table,
+        )
+        capability_blocked = (
+            enforce_capabilities
+            and capability.support_level is SupportLevel.BLOCKED
+        )
+        provenance_blocked = enforce_provenance and not intent_ordinals
+        blocked = capability_blocked or provenance_blocked
+        reason_code = (
+            capability.block_reason
+            if capability_blocked
+            else "missing_identity"
+            if provenance_blocked
+            else ""
+        )
+        operation = PatchOperation.from_legacy_patch(
+            operation_id=f"op-{operation_index + 1:04d}",
+            patch=patch,
+            capability_id=capability.capability_id,
+            target=target,
+            required_proof=capability.required_proof,
+            intent_ordinals=intent_ordinals,
+            executable=not blocked,
+            reason_code=reason_code,
+        )
+        operations.append(operation)
+        if capability_blocked:
+            issues.append(
+                PlanIssue(
+                    reason_code=reason_code,
+                    description=(
+                        f"{capability.capability_id} capability는 push 경로에서 "
+                        "지원되지 않습니다"
+                    ),
+                    block_id=target.xpath,
+                    capability_id=capability.capability_id,
+                )
+            )
+        elif provenance_blocked:
+            issues.append(
+                PlanIssue(
+                    reason_code="missing_identity",
+                    description=(
+                        "renderer operation을 exact MDX intent provenance에 "
+                        "대응시키지 못했습니다"
+                    ),
+                    block_id=target.xpath,
+                    capability_id=capability.capability_id,
+                )
+            )
+
+    if enforce_provenance:
+        mapped = {
+            ordinal
+            for operation in operations
+            for ordinal in operation.intent_ordinals
+        }
+        legacy_skip_indexes: dict[int, int] = defaultdict(int)
+        for item in legacy_skips:
+            block_id = str(item.get("block_id", ""))
+            if block_id.startswith("idx-"):
+                try:
+                    legacy_skip_indexes[int(block_id.removeprefix("idx-"))] += 1
+                except ValueError:
+                    pass
+        for intent in intents:
+            if intent.ordinal in mapped:
+                continue
+            if legacy_skip_indexes.get(intent.index):
+                continue
+            issues.append(
+                PlanIssue(
+                    reason_code="missing_identity",
+                    description=(
+                        f"MDX intent #{intent.ordinal}을 exact target operation에 "
+                        "대응시키지 못했습니다"
+                    ),
+                    block_id=f"idx-{intent.index}",
+                    intent_ordinal=intent.ordinal,
+                )
+            )
+
+    return (
+        PatchPlan(
+            intents=intents,
+            operations=tuple(operations),
+            issues=tuple(issues),
+        ),
+        resolved_mappings,
+    )

--- a/confluence-mdx/bin/reverse_sync/planner.py
+++ b/confluence-mdx/bin/reverse_sync/planner.py
@@ -189,8 +189,10 @@ def _intent_ordinals_for_patch(
                 # renderer에서 제거합니다.
                 return (-1,)
             intent = intent_by_ordinal.get(ordinal)
-            if intent is None or intent.provenance_xpath:
+            if intent is None:
                 return ()
+            if intent.provenance_xpath:
+                continue
             return (intent.ordinal,)
         return ()
 

--- a/confluence-mdx/bin/reverse_sync/preserving_patcher.py
+++ b/confluence-mdx/bin/reverse_sync/preserving_patcher.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 from copy import deepcopy
 import re
-from typing import Any, Iterable
+from typing import TYPE_CHECKING, Any, Iterable
 
+from reverse_sync.models import sha256_text
 from reverse_sync.sidecar import RoundtripSidecar
 from reverse_sync.xhtml_patcher import patch_xhtml
+
+if TYPE_CHECKING:
+    from reverse_sync.operations import PatchPlan
 
 
 class PatchApplicationError(ValueError):
@@ -116,6 +120,73 @@ def patch_xhtml_preserving(
             parts.append(sidecar.separators[position])
     parts.append(sidecar.document_envelope.suffix)
     return "".join(parts)
+
+
+def render_patch_plan_preserving(
+    base_xhtml: str,
+    plan: "PatchPlan",
+    sidecar: RoundtripSidecar,
+) -> str:
+    """typed plan target identity를 재검증한 뒤 XHTML renderer를 호출합니다.
+
+    raw patch dict 복원은 이 validated renderer boundary 안에서만 수행합니다.
+    """
+    if sidecar.reassemble_xhtml() != base_xhtml:
+        raise PatchApplicationError("sidecar가 base XHTML과 byte-equal하지 않습니다")
+
+    sidecar_by_xpath = {
+        block.xhtml_xpath: block
+        for block in sidecar.blocks
+    }
+    if len(sidecar_by_xpath) != len(sidecar.blocks):
+        raise PatchApplicationError("sidecar xpath가 중복되었습니다")
+
+    for operation in plan.executable_operations:
+        target = operation.target
+        if target.kind == "document_start":
+            boundary = (
+                sidecar.document_envelope.prefix
+                + (sidecar.blocks[0].xhtml_xpath if sidecar.blocks else "$empty")
+            )
+            if target.base_fragment_sha256 != sha256_text(boundary):
+                raise PatchApplicationError(
+                    "document start identity hash가 base와 다릅니다"
+                )
+            continue
+
+        block = sidecar_by_xpath.get(target.root_xpath)
+        if block is None:
+            raise PatchApplicationError(
+                f"typed operation target을 찾을 수 없습니다: {target.root_xpath}"
+            )
+        if not target.base_fragment_sha256:
+            raise PatchApplicationError(
+                f"typed operation target hash가 없습니다: {target.xpath}"
+            )
+        if target.base_fragment_sha256 != sha256_text(block.xhtml_fragment):
+            raise PatchApplicationError(
+                f"typed operation target hash가 base와 다릅니다: {target.xpath}"
+            )
+        if (
+            target.mdx_content_sha256
+            and target.mdx_content_sha256 != block.mdx_content_hash
+        ):
+            raise PatchApplicationError(
+                f"typed operation MDX provenance hash가 다릅니다: {target.xpath}"
+            )
+        if (
+            target.mdx_line_range != (0, 0)
+            and tuple(target.mdx_line_range) != tuple(block.mdx_line_range)
+        ):
+            raise PatchApplicationError(
+                f"typed operation MDX line range가 다릅니다: {target.xpath}"
+            )
+
+    return patch_xhtml_preserving(
+        base_xhtml,
+        plan.to_patch_dicts(),
+        sidecar,
+    )
 
 
 def changed_root_xpaths(patches: Iterable[dict[str, Any]]) -> frozenset[str]:

--- a/confluence-mdx/bin/reverse_sync/proof.py
+++ b/confluence-mdx/bin/reverse_sync/proof.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 import html.entities
 import json
 import re
-from typing import Any, Iterable
+from typing import TYPE_CHECKING, Any, Iterable
 from xml.etree import ElementTree
 
 from reverse_sync.dependencies import DependencyEvidence, DependencyResult
@@ -14,6 +14,9 @@ from reverse_sync.equivalence import EquivalenceResult, verify_push_equivalence
 from reverse_sync.models import SyncStatus, VerificationGate, sha256_text
 from reverse_sync.preserving_patcher import changed_root_xpaths
 from reverse_sync.sidecar import RoundtripSidecar
+
+if TYPE_CHECKING:
+    from reverse_sync.operations import PatchPlan
 
 
 REQUIRED_LOCAL_GATES = (
@@ -196,7 +199,7 @@ def build_local_proof(
     candidate_xhtml: str,
     sidecar: RoundtripSidecar,
     changes: Iterable[Any],
-    patches: list[dict[str, Any]],
+    patches: list[dict[str, Any]] | None,
     skipped_changes: list[dict[str, Any]],
     plan_json: str,
     deterministic_plan_json: str,
@@ -205,22 +208,27 @@ def build_local_proof(
     source_identity_passed: bool,
     base_parity_passed: bool,
     dependency_result: DependencyResult,
+    plan: "PatchPlan | None" = None,
 ) -> LocalProof:
     """모든 required local gate를 독립적으로 계산한다."""
+    renderer_patches = plan.to_patch_dicts() if plan is not None else (patches or [])
     equivalence = verify_push_equivalence(improved_mdx, roundtrip_mdx)
     well_formed, well_formed_detail = verify_storage_well_formed(candidate_xhtml)
     preservation, preservation_detail = verify_preservation(
         base_xhtml=base_xhtml,
         candidate_xhtml=candidate_xhtml,
         sidecar=sidecar,
-        patches=patches,
+        patches=renderer_patches,
     )
     changes_tuple = tuple(changes)
-    intent_complete = (
-        bool(changes_tuple)
-        and not skipped_changes
-        and bool(patches)
-    )
+    if plan is not None:
+        intent_complete = plan.intent_complete
+    else:
+        intent_complete = (
+            bool(changes_tuple)
+            and not skipped_changes
+            and bool(renderer_patches)
+        )
     determinism = (
         plan_json == deterministic_plan_json
         and candidate_xhtml == deterministic_candidate_xhtml

--- a/confluence-mdx/bin/reverse_sync_cli.py
+++ b/confluence-mdx/bin/reverse_sync_cli.py
@@ -29,7 +29,7 @@ from reverse_sync.block_diff import diff_blocks
 from reverse_sync.mapping_recorder import record_mapping
 from reverse_sync.xhtml_patcher import patch_xhtml
 from reverse_sync.roundtrip_verifier import verify_roundtrip
-from reverse_sync.patch_builder import build_patches
+from reverse_sync.planner import plan_patches
 from reverse_sync.equivalence import (
     PUSH_EQUIVALENCE_POLICY,
     verify_push_equivalence,
@@ -37,7 +37,7 @@ from reverse_sync.equivalence import (
 from xhtml_beautify_diff import xhtml_diff
 
 _PUSH_VERIFIER_POLICY = PUSH_EQUIVALENCE_POLICY
-_TOOL_VERSION = "reverse-sync-cli-v4"
+_TOOL_VERSION = "reverse-sync-cli-v5"
 
 
 @dataclass
@@ -523,9 +523,8 @@ def run_verify(
     page_lost_info = load_page_lost_info(str(var_dir / 'mapping.yaml'))
     roundtrip_sidecar = build_sidecar(xhtml, original_mdx, page_id=page_id)
 
-    # Step 3+4: XHTML 패치 → patched.xhtml 저장
-    # build_patches()가 내부에서 record_mapping()을 호출하여 mappings를 생성한다
-    patches, original_mappings, skipped_changes = build_patches(
+    # Step 3+4: typed plan → validated renderer operation → patched XHTML
+    patch_plan, original_mappings = plan_patches(
         changes, original_blocks, improved_blocks,
         page_xhtml=xhtml,
         alignment=alignment,
@@ -534,7 +533,10 @@ def run_verify(
         link_resolver=link_resolver,
         attachment_filenames=attachment_filenames,
         allow_text_identity_fallback=not for_push,
+        enforce_capabilities=for_push,
+        enforce_provenance=for_push,
     )
+    skipped_changes = patch_plan.to_legacy_skipped_changes()
 
     # mapping.original.yaml artifact 저장
     original_mapping_data = {
@@ -544,15 +546,16 @@ def run_verify(
     (var_dir / 'reverse-sync.mapping.original.yaml').write_text(
         yaml.dump(original_mapping_data, allow_unicode=True, default_flow_style=False))
     if for_push:
-        from reverse_sync.preserving_patcher import patch_xhtml_preserving
+        from reverse_sync.preserving_patcher import render_patch_plan_preserving
 
-        patched_xhtml = patch_xhtml_preserving(
+        patched_xhtml = render_patch_plan_preserving(
             xhtml,
-            patches,
+            patch_plan,
             roundtrip_sidecar,
         )
     else:
-        patched_xhtml = patch_xhtml(xhtml, patches)
+        diagnostic_patches = patch_plan.to_patch_dicts()
+        patched_xhtml = patch_xhtml(xhtml, diagnostic_patches)
     (var_dir / 'reverse-sync.patched.xhtml').write_text(patched_xhtml)
 
     # XHTML beautify-diff (page.xhtml → patched.xhtml)
@@ -646,17 +649,13 @@ def run_verify(
     if for_push:
         from reverse_sync.manifest import create_sync_manifest
         from reverse_sync.models import sha256_text
-        from reverse_sync.preserving_patcher import patch_xhtml_preserving
-        from reverse_sync.proof import build_local_proof, canonical_plan_json
+        from reverse_sync.preserving_patcher import render_patch_plan_preserving
+        from reverse_sync.proof import build_local_proof
 
-        plan_json = canonical_plan_json(
-            changes=changes,
-            patches=patches,
-            skipped_changes=skipped_changes,
-        )
+        plan_json = patch_plan.to_canonical_json()
         (var_dir / "reverse-sync.plan.json").write_text(plan_json)
 
-        deterministic_patches, _, deterministic_skips = build_patches(
+        deterministic_plan, _ = plan_patches(
             changes,
             original_blocks,
             improved_blocks,
@@ -667,15 +666,13 @@ def run_verify(
             link_resolver=link_resolver,
             attachment_filenames=attachment_filenames,
             allow_text_identity_fallback=False,
+            enforce_capabilities=True,
+            enforce_provenance=True,
         )
-        deterministic_plan_json = canonical_plan_json(
-            changes=changes,
-            patches=deterministic_patches,
-            skipped_changes=deterministic_skips,
-        )
-        deterministic_candidate = patch_xhtml_preserving(
+        deterministic_plan_json = deterministic_plan.to_canonical_json()
+        deterministic_candidate = render_patch_plan_preserving(
             xhtml,
-            deterministic_patches,
+            deterministic_plan,
             roundtrip_sidecar,
         )
 
@@ -695,10 +692,9 @@ def run_verify(
                 idempotent_candidate = patched_xhtml
             else:
                 (
-                    idempotency_patches,
+                    idempotency_plan,
                     _,
-                    idempotency_skips,
-                ) = build_patches(
+                ) = plan_patches(
                     idempotency_changes,
                     idempotency_original_blocks,
                     idempotency_improved_blocks,
@@ -709,13 +705,15 @@ def run_verify(
                     link_resolver=link_resolver,
                     attachment_filenames=attachment_filenames,
                     allow_text_identity_fallback=False,
+                    enforce_capabilities=True,
+                    enforce_provenance=True,
                 )
                 idempotent_candidate = (
                     ""
-                    if idempotency_skips
-                    else patch_xhtml_preserving(
+                    if idempotency_plan.issues
+                    else render_patch_plan_preserving(
                         patched_xhtml,
-                        idempotency_patches,
+                        idempotency_plan,
                         candidate_sidecar,
                     )
                 )
@@ -729,7 +727,7 @@ def run_verify(
             candidate_xhtml=patched_xhtml,
             sidecar=roundtrip_sidecar,
             changes=changes,
-            patches=patches,
+            patches=None,
             skipped_changes=skipped_changes,
             plan_json=plan_json,
             deterministic_plan_json=deterministic_plan_json,
@@ -738,6 +736,7 @@ def run_verify(
             source_identity_passed=True,
             base_parity_passed=True,
             dependency_result=dependency_result,
+            plan=patch_plan,
         )
         proof_json = proof.to_canonical_json()
         (var_dir / "reverse-sync.proof.json").write_text(proof_json)

--- a/confluence-mdx/tests/test_reverse_sync_cli.py
+++ b/confluence-mdx/tests/test_reverse_sync_cli.py
@@ -74,7 +74,7 @@ def _create_push_manifest(
             '"status":"verified_local"}\n'
         ),
         verifier_policy="reverse-sync-equivalence-v1",
-        tool_version="reverse-sync-cli-v4",
+        tool_version="reverse-sync-cli-v5",
         push_eligible=True,
         gates=tuple(
             VerificationGate(name, True)

--- a/confluence-mdx/tests/test_reverse_sync_planner.py
+++ b/confluence-mdx/tests/test_reverse_sync_planner.py
@@ -215,6 +215,41 @@ def test_empty_source_line_insert_is_removed_before_typed_renderer_boundary():
     assert plan.to_patch_dicts()[0]["new_element_xhtml"] == "<p>Added</p>"
 
 
+def test_insert_skips_added_intent_already_covered_by_replacement():
+    original = _block("Before")
+    replacement = _block("First")
+    inserted = Block(
+        type="paragraph",
+        content="Second",
+        line_start=3,
+        line_end=3,
+    )
+    changes = [
+        BlockChange(0, "deleted", original, None),
+        BlockChange(0, "added", None, replacement),
+        BlockChange(1, "added", None, inserted),
+    ]
+    xhtml = "<p>Before</p>"
+
+    plan, _ = plan_patches(
+        changes,
+        [original],
+        [replacement, inserted],
+        page_xhtml=xhtml,
+        alignment={0: 0},
+        roundtrip_sidecar=_sidecar(xhtml, original),
+        allow_text_identity_fallback=False,
+        enforce_capabilities=True,
+        enforce_provenance=True,
+    )
+
+    assert plan.intent_complete is True
+    assert len(plan.operations) == 2
+    assert plan.operations[0].intent_ordinals == (0, 1)
+    assert plan.operations[1].intent_ordinals == (2,)
+    assert plan.to_patch_dicts()[1]["new_element_xhtml"] == "<p>Second</p>"
+
+
 def test_plan_serialization_is_deterministic_and_contains_no_untyped_top_level_patch():
     old = _block("Before")
     new = _block("After")

--- a/confluence-mdx/tests/test_reverse_sync_planner.py
+++ b/confluence-mdx/tests/test_reverse_sync_planner.py
@@ -1,0 +1,372 @@
+"""typed reverse-sync PatchPlan과 capability/provenance boundary 테스트."""
+
+import json
+
+import pytest
+
+from mdx_to_storage.parser import Block
+from reverse_sync.block_diff import BlockChange
+from reverse_sync.capabilities import (
+    CAPABILITY_REGISTRY,
+    SupportLevel,
+)
+from reverse_sync.models import ReasonCode, sha256_text
+from reverse_sync.mapping_recorder import record_mapping
+from reverse_sync.operations import (
+    ChangeIntent,
+    PatchOperation,
+    PatchPlan,
+    TargetIdentity,
+)
+from reverse_sync.planner import plan_patches
+from reverse_sync.preserving_patcher import (
+    PatchApplicationError,
+    render_patch_plan_preserving,
+)
+from reverse_sync.sidecar import (
+    DocumentEnvelope,
+    RoundtripSidecar,
+    SidecarBlock,
+    SidecarEntry,
+)
+
+
+def _block(content: str, block_type: str = "paragraph") -> Block:
+    return Block(
+        type=block_type,
+        content=content,
+        line_start=1,
+        line_end=content.count("\n") + 1,
+    )
+
+
+def _sidecar(xhtml: str, original: Block) -> RoundtripSidecar:
+    return RoundtripSidecar(
+        page_id="123",
+        mdx_sha256=sha256_text(original.content),
+        source_xhtml_sha256=sha256_text(xhtml),
+        blocks=[
+            SidecarBlock(
+                block_index=0,
+                xhtml_xpath="p[1]" if original.type == "paragraph" else "table[1]",
+                xhtml_fragment=xhtml,
+                mdx_content_hash=sha256_text(original.content),
+                mdx_line_range=(original.line_start, original.line_end),
+            )
+        ],
+        separators=[],
+        document_envelope=DocumentEnvelope(),
+    )
+
+
+def test_supported_paragraph_plan_has_capability_and_exact_target_identity():
+    old = _block("Before")
+    new = _block("After")
+    change = BlockChange(0, "modified", old, new)
+    xhtml = "<p>Before</p>"
+
+    plan, _ = plan_patches(
+        [change],
+        [old],
+        [new],
+        page_xhtml=xhtml,
+        roundtrip_sidecar=_sidecar(xhtml, old),
+        allow_text_identity_fallback=False,
+        enforce_capabilities=True,
+        enforce_provenance=True,
+    )
+
+    assert plan.intent_complete is True
+    assert plan.issues == ()
+    assert len(plan.operations) == 1
+    operation = plan.operations[0]
+    assert operation.capability_id == "paragraph_visible_edit"
+    assert operation.intent_ordinals == (0,)
+    assert operation.target.kind == "exact_fragment"
+    assert operation.target.xpath == "p[1]"
+    assert operation.target.base_fragment_sha256 == sha256_text(xhtml)
+    assert "target_identity" in operation.required_proof
+    assert plan.to_patch_dicts()[0]["new_inner_xhtml"] == "After"
+
+
+def test_raw_html_table_is_explicit_unsupported_capability_in_push_plan():
+    old = _block(
+        "<table><tr><td>Before</td></tr></table>",
+        "html_block",
+    )
+    new = _block(
+        "<table><tr><td>After</td></tr></table>",
+        "html_block",
+    )
+    change = BlockChange(0, "modified", old, new)
+    xhtml = "<table><tr><td>Before</td></tr></table>"
+
+    plan, _ = plan_patches(
+        [change],
+        [old],
+        [new],
+        page_xhtml=xhtml,
+        roundtrip_sidecar=_sidecar(xhtml, old),
+        allow_text_identity_fallback=False,
+        enforce_capabilities=True,
+        enforce_provenance=True,
+    )
+
+    assert plan.intent_complete is False
+    assert plan.to_patch_dicts() == []
+    assert plan.operations[0].capability_id == "raw_html_table_edit"
+    assert plan.operations[0].executable is False
+    assert plan.operations[0].reason_code == "unsupported_capability"
+    assert plan.issues[0].capability_id == "raw_html_table_edit"
+    assert plan.issues[0].reason_code == "unsupported_capability"
+    assert json.loads(plan.to_canonical_json())["issues"][0]["reason_code"] == (
+        "unsupported_capability"
+    )
+    assert plan.to_legacy_skipped_changes()[0]["reason"] == (
+        "unsupported_capability"
+    )
+
+
+def test_push_plan_blocks_operation_without_sidecar_provenance():
+    old = _block("Before")
+    new = _block("After")
+    change = BlockChange(0, "modified", old, new)
+
+    mappings = record_mapping("<p>Before</p>")
+    plan, _ = plan_patches(
+        [change],
+        [old],
+        [new],
+        mappings=mappings,
+        mdx_to_sidecar={
+            0: SidecarEntry(
+                xhtml_xpath="p[1]",
+                xhtml_type="paragraph",
+                mdx_blocks=[0],
+            )
+        },
+        xpath_to_mapping={"p[1]": mappings[0]},
+        roundtrip_sidecar=None,
+        allow_text_identity_fallback=False,
+        enforce_capabilities=True,
+        enforce_provenance=True,
+    )
+
+    assert plan.intent_complete is False
+    assert plan.operations == ()
+    assert {issue.reason_code for issue in plan.issues} == {"missing_identity"}
+
+
+def test_hash_mismatched_sidecar_target_is_not_executable():
+    old = _block("Before")
+    new = _block("After")
+    change = BlockChange(0, "modified", old, new)
+    xhtml = "<p>Before</p>"
+    sidecar = _sidecar(xhtml, old)
+    sidecar.blocks[0].mdx_content_hash = sha256_text("Different source")
+
+    plan, _ = plan_patches(
+        [change],
+        [old],
+        [new],
+        page_xhtml=xhtml,
+        roundtrip_sidecar=sidecar,
+        allow_text_identity_fallback=False,
+        enforce_capabilities=True,
+        enforce_provenance=True,
+    )
+
+    assert plan.intent_complete is False
+    assert plan.to_patch_dicts() == []
+    assert plan.operations[0].reason_code == "missing_identity"
+    assert {issue.reason_code for issue in plan.issues} == {"missing_identity"}
+
+
+def test_empty_source_line_insert_is_removed_before_typed_renderer_boundary():
+    original = _block("Before")
+    empty = _block("\n", "empty")
+    added = Block(
+        type="paragraph",
+        content="Added\n",
+        line_start=3,
+        line_end=3,
+    )
+    changes = [
+        BlockChange(1, "added", None, empty),
+        BlockChange(2, "added", None, added),
+    ]
+    xhtml = "<p>Before</p>"
+
+    plan, _ = plan_patches(
+        changes,
+        [original],
+        [original, empty, added],
+        page_xhtml=xhtml,
+        alignment={0: 0},
+        roundtrip_sidecar=_sidecar(xhtml, original),
+        allow_text_identity_fallback=False,
+        enforce_capabilities=True,
+        enforce_provenance=True,
+    )
+
+    assert plan.intent_complete is True
+    assert len(plan.operations) == 1
+    assert plan.operations[0].intent_ordinals == (1,)
+    assert plan.to_patch_dicts()[0]["new_element_xhtml"] == "<p>Added</p>"
+
+
+def test_plan_serialization_is_deterministic_and_contains_no_untyped_top_level_patch():
+    old = _block("Before")
+    new = _block("After")
+    change = BlockChange(0, "modified", old, new)
+    xhtml = "<p>Before</p>"
+    kwargs = dict(
+        changes=[change],
+        original_blocks=[old],
+        improved_blocks=[new],
+        page_xhtml=xhtml,
+        roundtrip_sidecar=_sidecar(xhtml, old),
+        allow_text_identity_fallback=False,
+        enforce_capabilities=True,
+        enforce_provenance=True,
+    )
+
+    first, _ = plan_patches(**kwargs)
+    second, _ = plan_patches(**kwargs)
+    value = json.loads(first.to_canonical_json())
+
+    assert first.to_canonical_json() == second.to_canonical_json()
+    assert value["schema_version"] == 2
+    assert value["adapter"] == "legacy-patch-builder-v2"
+    assert "patches" not in value
+    assert value["operations"][0]["capability_id"] == "paragraph_visible_edit"
+    assert value["operations"][0]["reason_code"] == ""
+
+
+def test_typed_renderer_revalidates_base_fragment_hash():
+    old = _block("Before")
+    new = _block("After")
+    change = BlockChange(0, "modified", old, new)
+    xhtml = "<p>Before</p>"
+    sidecar = _sidecar(xhtml, old)
+    plan, _ = plan_patches(
+        [change],
+        [old],
+        [new],
+        page_xhtml=xhtml,
+        roundtrip_sidecar=sidecar,
+        allow_text_identity_fallback=False,
+        enforce_capabilities=True,
+        enforce_provenance=True,
+    )
+
+    assert render_patch_plan_preserving(xhtml, plan, sidecar) == "<p>After</p>"
+
+    target = TargetIdentity(
+        kind="exact_fragment",
+        xpath="p[1]",
+        root_xpath="p[1]",
+        base_fragment_sha256="0" * 64,
+        mdx_content_sha256=plan.operations[0].target.mdx_content_sha256,
+        mdx_line_range=plan.operations[0].target.mdx_line_range,
+    )
+    tampered_operation = PatchOperation.from_legacy_patch(
+        operation_id="op-0001",
+        patch=plan.operations[0].to_patch_dict(),
+        capability_id=plan.operations[0].capability_id,
+        target=target,
+        required_proof=plan.operations[0].required_proof,
+        intent_ordinals=plan.operations[0].intent_ordinals,
+        executable=True,
+    )
+    tampered_plan = PatchPlan(
+        intents=plan.intents,
+        operations=(tampered_operation,),
+        issues=(),
+    )
+
+    with pytest.raises(PatchApplicationError, match="target hash"):
+        render_patch_plan_preserving(xhtml, tampered_plan, sidecar)
+
+
+def test_patch_operation_rejects_renderer_target_mismatch():
+    target = TargetIdentity(
+        kind="exact_fragment",
+        xpath="p[1]",
+        root_xpath="p[1]",
+        base_fragment_sha256="a" * 64,
+    )
+
+    try:
+        PatchOperation.from_legacy_patch(
+            operation_id="op-0001",
+            patch={
+                "xhtml_xpath": "p[2]",
+                "old_plain_text": "Before",
+                "new_plain_text": "After",
+            },
+            capability_id="paragraph_visible_edit",
+            target=target,
+            required_proof=("target_identity",),
+            intent_ordinals=(0,),
+            executable=True,
+        )
+    except ValueError as exc:
+        assert "target" in str(exc)
+    else:
+        raise AssertionError("target mismatch가 거부되지 않았습니다")
+
+
+def test_patch_plan_requires_exactly_one_operation_per_intent():
+    target = TargetIdentity(
+        kind="exact_fragment",
+        xpath="p[1]",
+        root_xpath="p[1]",
+        base_fragment_sha256="a" * 64,
+    )
+    patch = {
+        "xhtml_xpath": "p[1]",
+        "old_plain_text": "Before",
+        "new_plain_text": "After",
+    }
+    operation = PatchOperation.from_legacy_patch(
+        operation_id="op-0001",
+        patch=patch,
+        capability_id="paragraph_visible_edit",
+        target=target,
+        required_proof=("target_identity",),
+        intent_ordinals=(0,),
+        executable=True,
+    )
+    duplicate = PatchOperation.from_legacy_patch(
+        operation_id="op-0002",
+        patch=patch,
+        capability_id="paragraph_visible_edit",
+        target=target,
+        required_proof=("target_identity",),
+        intent_ordinals=(0,),
+        executable=True,
+    )
+    intent = ChangeIntent(
+        ordinal=0,
+        index=0,
+        change_type="modified",
+        block_type="paragraph",
+        old_sha256="b" * 64,
+        new_sha256="c" * 64,
+        provenance_xpath="p[1]",
+    )
+
+    assert PatchPlan((intent,), (operation,), ()).intent_complete is True
+    assert PatchPlan((intent,), (operation, duplicate), ()).intent_complete is False
+
+
+def test_every_registry_entry_declares_owner_proof_and_block_reason():
+    assert CAPABILITY_REGISTRY
+    for capability in CAPABILITY_REGISTRY.values():
+        assert capability.renderer_owner
+        assert capability.required_proof
+        if capability.support_level is SupportLevel.BLOCKED:
+            assert capability.block_reason == "unsupported_capability"
+    assert ReasonCode.MISSING_IDENTITY.value == "missing_identity"
+    assert ReasonCode.UNSUPPORTED_CAPABILITY.value == "unsupported_capability"

--- a/confluence-mdx/tests/test_reverse_sync_push_transaction.py
+++ b/confluence-mdx/tests/test_reverse_sync_push_transaction.py
@@ -37,8 +37,9 @@ from reverse_sync.models import (
     PageSnapshot,
     SyncStatus,
     VerificationGate,
+    sha256_text,
 )
-from reverse_sync.patch_builder import build_patches as real_build_patches
+from reverse_sync.planner import plan_patches as real_plan_patches
 from reverse_sync.publisher import (
     ActiveDraftError,
     DependencyChangedError,
@@ -153,7 +154,7 @@ def _manifest(
         candidate_xhtml="<p>After</p>",
         local_proof=local_proof,
         verifier_policy="reverse-sync-equivalence-v1",
-        tool_version="reverse-sync-cli-v4",
+        tool_version="reverse-sync-cli-v5",
         push_eligible=True,
         gates=tuple(
             VerificationGate(name, True)
@@ -625,7 +626,7 @@ def test_push_manifest_requires_all_local_proof_gates(tmp_path):
                 '"status":"verified_local"}\n'
             ),
             verifier_policy="reverse-sync-equivalence-v1",
-            tool_version="reverse-sync-cli-v4",
+            tool_version="reverse-sync-cli-v5",
             push_eligible=True,
             gates=(VerificationGate("semantic_roundtrip", True),),
         )
@@ -1115,8 +1116,8 @@ def test_online_verify_builds_manifest_from_remote_snapshot(tmp_path, monkeypatc
         "reverse_sync_cli._forward_convert",
         side_effect=forward_convert,
     ), patch(
-        "reverse_sync_cli.build_patches",
-        wraps=real_build_patches,
+        "reverse_sync_cli.plan_patches",
+        wraps=real_plan_patches,
     ) as planner:
         result = run_verify(
             page_id=page_id,
@@ -1141,13 +1142,27 @@ def test_online_verify_builds_manifest_from_remote_snapshot(tmp_path, monkeypatc
     assert manifest.base_version == 5
     assert manifest.base_storage_sha256 == base.storage_sha256
     assert manifest.verifier_policy == "reverse-sync-equivalence-v1"
-    assert manifest.tool_version == "reverse-sync-cli-v4"
+    assert manifest.tool_version == "reverse-sync-cli-v5"
     assert planner.call_count == 2
     assert all(
         call.kwargs["allow_text_identity_fallback"] is False
         for call in planner.call_args_list
     )
-    assert (manifest_path.parent / "patch-plan.json").is_file()
+    assert all(
+        call.kwargs["enforce_capabilities"] is True
+        and call.kwargs["enforce_provenance"] is True
+        for call in planner.call_args_list
+    )
+    plan_path = manifest_path.parent / "patch-plan.json"
+    assert plan_path.is_file()
+    plan = json.loads(plan_path.read_text())
+    assert plan["schema_version"] == 2
+    assert plan["intent_complete"] is True
+    assert plan["issues"] == []
+    assert plan["operations"][0]["capability_id"] == "paragraph_visible_edit"
+    assert plan["operations"][0]["target"]["base_fragment_sha256"] == (
+        sha256_text("<p>Before</p>")
+    )
     assert (manifest_path.parent / "local-proof.json").is_file()
     assert (manifest_path.parent / "candidate.xhtml").read_text() == (
         tmp_path / "var" / page_id / "reverse-sync.patched.xhtml"

--- a/openspec/changes/complete-reverse-sync/design.md
+++ b/openspec/changes/complete-reverse-sync/design.md
@@ -226,6 +226,13 @@ text prefix fallback을 유지합니다. online verify는
 호출에 강제하고, provenance mapping을 찾지 못하면 `no_mapping`으로 기록하여
 `intent_complete` gate에서 block합니다.
 
+`legacy-patch-builder-v2` adapter는 `build_patches()`가 선택한 target을 그대로
+신뢰하지 않습니다. online plan에서 MDX content hash와 line range가 모두 일치하는
+유일한 sidecar provenance를 `ChangeIntent`에 기록하고, renderer operation의 root
+fragment와 대응하지 않으면 operation을 `missing_identity`로 non-executable
+처리합니다. 따라서 migration 중에는 legacy builder가 잘못된 candidate를
+제안하더라도 strict proof의 `intent_complete`를 얻을 수 없습니다.
+
 추가/삭제/reorder는 stable neighbor identity를 기준으로 계획합니다.
 
 - insert는 `before_block_id`와 `after_block_id` 중 하나 이상을 가져야 합니다.
@@ -276,6 +283,28 @@ registry entry는 다음을 가져야 합니다.
 - required evidence
 - block reason
 - representative unit test와 page fixture
+
+현재 `reverse_sync/capabilities.py`는 이 registry를 코드로 고정하고,
+`reverse_sync/operations.py`는 immutable `ChangeIntent`, `TargetIdentity`,
+`PatchOperation`, `PatchPlan`을 제공합니다. `PatchOperation`은 capability ID,
+base fragment hash를 포함한 target identity, required proof, executable 여부와
+block reason을 항상 기록합니다. raw patch dict는 canonical
+`renderer_input_json` 안에 격리하고 `PatchPlan.to_patch_dicts()`에서 validated
+XHTML renderer boundary로만 복원합니다.
+
+`reverse_sync/planner.py`는 첫 migration 단계로 기존 `build_patches()`를
+`legacy-patch-builder-v2` adapter 뒤에서 호출합니다. push path의
+`raw_html_table_edit`와 `unknown_macro_mutation`은
+`unsupported_capability`로 non-executable 처리하며, source formatting을 나타내는
+empty block insert가 `<p></p>` mutation으로 바뀌지 않도록 plan에서 제거합니다.
+capability별 renderer strategy 자체를 `patch_builder.py`에서 추출하는 작업은
+계속 남아 있습니다.
+
+`render_patch_plan_preserving()`은 executable operation을 raw renderer input으로
+복원하기 직전에 target root fragment hash, sidecar MDX hash, line range를 base
+sidecar와 다시 비교합니다. CLI와 proof는 raw patch dict를 직접 소비하지 않으며,
+typed target identity가 바뀌었거나 다른 base에 plan을 적용하려 하면
+`PatchApplicationError`로 중단합니다.
 
 ### Decision: local proof를 여러 독립 gate로 분해합니다
 
@@ -490,7 +519,11 @@ Confluence update는 외부 side effect이며 postcondition 실패 후 완전한
 | preflight/update/postcondition | `reverse_sync/publisher.py` |
 | CLI orchestration/display | `reverse_sync_cli.py` |
 
-분리는 한 번에 수행하지 않습니다. 먼저 snapshot/manifest/publisher safety seam을 추가한 뒤 기존 `build_patches()`를 adapter로 감싸고, capability별 planner와 strategy를 점진적으로 추출합니다.
+분리는 한 번에 수행하지 않습니다. 먼저 snapshot/manifest/publisher safety seam을
+추가한 뒤 기존 `build_patches()`를 typed `PatchPlan` adapter로 감싸고,
+capability별 planner와 strategy를 점진적으로 추출합니다. CLI와 local proof는
+schema v2 plan을 소비하며 raw patch dict는 validated renderer boundary 밖으로
+노출하지 않습니다.
 
 ## Push Eligibility Matrix
 

--- a/openspec/changes/complete-reverse-sync/tasks.md
+++ b/openspec/changes/complete-reverse-sync/tasks.md
@@ -138,7 +138,12 @@
 ### 2.8 P1 — planner / renderer 책임 분리
 
 - [ ] `patch_builder.py`의 capability 판별을 `capabilities.py`와 planner로 추출합니다.
-- [ ] planning output을 typed `PatchPlan`/operation으로 바꾸고 raw patch dict를 boundary 안에 가둡니다.
+- [x] planning output을 typed `PatchPlan`/operation으로 바꾸고 raw patch dict를 boundary 안에 가둡니다.
+  - `legacy-patch-builder-v2` adapter가 `ChangeIntent`, `TargetIdentity`,
+    capability, required proof, reason code를 canonical schema v2 plan에 기록합니다.
+  - push path는 exact sidecar provenance와 intent가 대응하지 않는 operation을
+    `missing_identity`로 non-executable 처리합니다.
+  - capability별 renderer strategy 추출은 아래 task에 계속 남습니다.
 - [ ] block identity를 provenance-first 순서로 바꿉니다.
 - [x] normalized text prefix fallback을 push-eligible path에서 제거합니다.
 - [ ] visible segment model을 paragraph, heading, list에 확장합니다.
@@ -195,7 +200,7 @@ cd confluence-mdx/tests
 
 기준선: 2026-07-24 `origin/main`에서 676 passed입니다.
 
-현재 변경 결과: 763 passed입니다.
+typed plan 변경 결과: 773 passed입니다.
 
 ### 3.3 Page fixture regression
 
@@ -245,10 +250,18 @@ strict proof 구현 branch 검증 결과:
 - 16개 golden page shadow online verify: 4개 `verified_local`, 나머지는
   visible whitespace, unresolved link, raw HTML table mutation 등에서 fail-closed
 
+typed plan branch 검증 결과:
+
+- `make test-convert`: 21 passed
+- `make test-reverse-sync`: golden 16 passed, regression 43 passed
+- `make test-byte-verify`: fast/splice 각각 21/21 passed
+- 전체 Python test: 1096 passed, 2 skipped
+
 - [x] 영향도에 따라 전체 Python test와 render test를 실행합니다.
 
-이번 변경은 Python CLI/API adapter 범위이므로 전체 Python test(`1086 passed, 2 skipped`)를
-실행했고 frontend render test는 영향 범위에서 제외했습니다.
+이번 변경은 Python CLI/planner 범위이므로 전체 Python test
+(`1096 passed, 2 skipped`)를 실행했고 frontend render test는 영향 범위에서
+제외했습니다.
 
 ```bash
 cd confluence-mdx/tests


### PR DESCRIPTION
## Summary
reverse-sync push 경로가 `build_patches()`의 raw dict를 직접 신뢰하지 않도록 typed planning과 renderer boundary를 도입합니다.

- `capabilities.py`에 capability ID, support level, renderer owner, required proof, block reason registry를 추가합니다.
- `operations.py`에 immutable `ChangeIntent`, `TargetIdentity`, `PatchOperation`, `PatchPlan` schema v2를 추가합니다.
- `planner.py`가 기존 `build_patches()`를 `legacy-patch-builder-v2` adapter로 감싸고 raw dict를 typed plan에 격리합니다.
- MDX content hash와 line range가 모두 일치하는 유일한 sidecar provenance를 operation target과 결합합니다.
- exact intent provenance가 없거나 하나의 intent가 여러 operation에 대응하면 `intent_complete`를 허용하지 않습니다.
- push 경로의 `raw_html_table_edit`와 `unknown_macro_mutation`을 `unsupported_capability`로 차단합니다.
- source formatting용 empty block이 `<p></p>` insert mutation으로 바뀌지 않도록 제거합니다.
- `render_patch_plan_preserving()`이 target fragment hash, sidecar MDX hash, line range를 base와 다시 비교한 뒤에만 raw renderer input을 복원합니다.
- CLI와 local proof가 raw patch dict 대신 typed plan을 소비하도록 전환하고 tool version을 `reverse-sync-cli-v5`로 올립니다.

## OpenSpec
- 기준 change: `openspec/changes/complete-reverse-sync`
- 완료: P1 typed `PatchPlan`/operation 및 raw patch boundary
- 계속 남는 범위: `patch_builder.py`의 capability별 strategy 추출, visible model 확장, 모든 table/macro skip reason의 capability 표준화
- 이 PR은 현재 migration adapter의 완료 범위를 design과 tasks에 정확히 기록합니다.

## Safety impact
- legacy builder가 target을 제안하더라도 strict plan의 exact provenance와 일치하지 않으면 renderer에서 실행하지 않습니다.
- 검증 후 target identity가 바뀌거나 다른 base에 plan을 적용하면 `PatchApplicationError`로 차단합니다.
- blocked capability는 candidate에 일부 적용하지 않고 stable reason code로 남깁니다.
- offline diagnostic은 기존 text fallback과 renderer 호환성을 유지하지만 push eligibility를 부여하지 않습니다.

## Test plan
- [x] 전체 Python test: 1096 passed, 2 skipped
- [x] reverse-sync Python test: 773 passed
- [x] `make test-convert`: 21 passed
- [x] `make test-reverse-sync`: golden 16 passed, regression 43 passed
- [x] `make test-byte-verify`: fast/splice 각각 21/21 passed
- [x] `openspec validate complete-reverse-sync --strict`
- [x] `git diff --check`
- [x] Python `compileall`

## Stack
- Base: #1032
- Input/dependency gates: #1031
- Strict proof: #1030
- Publisher foundation: #1029
- 선행 PR merge 후 base를 순차적으로 `main`으로 변경할 수 있습니다.

🤖 Generated with Codex

Co-Authored-By: Atlas <atlas@jk.agent>
