### PR TITLE
confluence-mdx: reverse-sync batch 결과 계약을 명시합니다

### DIFF
--- a/confluence-mdx/bin/reverse_sync/batch_report.py
+++ b/confluence-mdx/bin/reverse_sync/batch_report.py
@@ -1,0 +1,200 @@
+"""reverse-sync branch batch의 versioned JSON report 계약."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+
+BATCH_REPORT_SCHEMA_VERSION = 1
+BATCH_REPORT_KIND = "reverse-sync-batch-report"
+
+_SUCCESS_STATUSES = frozenset(
+    {
+        "already_applied",
+        "diagnostic_pass",
+        "no_changes",
+        "remote_verified",
+        "verified_local",
+    }
+)
+_KNOWN_STATUSES = (
+    "already_applied",
+    "blocked",
+    "diagnostic_pass",
+    "local_error",
+    "local_failed",
+    "no_changes",
+    "not_attempted",
+    "postcondition_failed",
+    "push_conflict",
+    "push_failed",
+    "remote_verified",
+    "unknown",
+    "verified_local",
+)
+
+
+def _push_status(result: dict[str, Any]) -> str:
+    push = result.get("push")
+    if not isinstance(push, dict):
+        return ""
+    status = push.get("status")
+    if status in ("remote_verified", "already_applied"):
+        return str(status)
+    if status == "conflict":
+        return "push_conflict"
+    if status == "error":
+        return "push_failed"
+    if status == "postcondition_failed":
+        return "postcondition_failed"
+    if status == "not_attempted":
+        return "not_attempted"
+    # 이전 test adapter와의 compatibility boundary입니다. production publisher는
+    # 성공 시 항상 remote_verified/already_applied를 반환합니다.
+    if status is None and isinstance(push.get("version"), int):
+        return "remote_verified"
+    return "unknown"
+
+
+def batch_status(result: dict[str, Any]) -> str:
+    """page의 local/publish 상태를 stable batch status로 정규화합니다."""
+    publish_status = _push_status(result)
+    if publish_status:
+        return publish_status
+    local_status = result.get("status")
+    if local_status == "pass":
+        return "diagnostic_pass"
+    if local_status in ("verified_local", "no_changes", "blocked"):
+        return str(local_status)
+    if local_status == "fail":
+        return "local_failed"
+    if local_status == "error":
+        return "local_error"
+    return "unknown"
+
+
+def _reason_code(result: dict[str, Any], status: str) -> str:
+    push = result.get("push")
+    if isinstance(push, dict):
+        reason_code = push.get("reason_code")
+        if isinstance(reason_code, str) and reason_code:
+            return reason_code
+    local_reason = result.get("reason_code")
+    if isinstance(local_reason, str) and local_reason:
+        return local_reason
+    defaults = {
+        "local_error": "local_error",
+        "local_failed": "local_verification_failed",
+        "not_attempted": "not_attempted",
+        "postcondition_failed": "postcondition_failed",
+        "push_conflict": "version_conflict",
+        "push_failed": "push_error",
+        "unknown": "unknown",
+    }
+    return defaults.get(status, "")
+
+
+def _is_user_cancelled(result: dict[str, Any]) -> bool:
+    push = result.get("push")
+    return (
+        isinstance(push, dict)
+        and push.get("status") == "not_attempted"
+        and push.get("reason_code") == "user_cancelled"
+    )
+
+
+@dataclass(frozen=True)
+class BatchReport:
+    """page별 결과와 process outcome을 함께 직렬화하는 immutable view."""
+
+    command: str
+    branch: str
+    results: tuple[dict[str, Any], ...]
+
+    @classmethod
+    def from_results(
+        cls,
+        *,
+        command: str,
+        branch: str,
+        results: Iterable[dict[str, Any]],
+    ) -> "BatchReport":
+        if command not in ("verify", "push", "debug"):
+            raise ValueError(f"지원하지 않는 batch command입니다: {command}")
+        return cls(command=command, branch=branch, results=tuple(results))
+
+    @property
+    def statuses(self) -> tuple[str, ...]:
+        return tuple(batch_status(result) for result in self.results)
+
+    @property
+    def outcome(self) -> str:
+        if self.results and all(
+            status in _SUCCESS_STATUSES or _is_user_cancelled(result)
+            for result, status in zip(self.results, self.statuses)
+        ) and any(_is_user_cancelled(result) for result in self.results):
+            return "cancelled"
+
+        succeeded = sum(status in _SUCCESS_STATUSES for status in self.statuses)
+        failed = len(self.statuses) - succeeded
+        if failed == 0:
+            return "success"
+        if succeeded:
+            return "partial_success"
+        return "failed"
+
+    @property
+    def exit_code(self) -> int:
+        return 0 if self.outcome in ("success", "cancelled") else 1
+
+    def _result_view(self, result: dict[str, Any]) -> dict[str, Any]:
+        status = batch_status(result)
+        view = dict(result)
+        view["batch_status"] = status
+        reason_code = _reason_code(result, status)
+        if reason_code:
+            view["reason_code"] = reason_code
+        return view
+
+    def to_dict(self, *, failures_only: bool = False) -> dict[str, Any]:
+        statuses = self.statuses
+        counts = Counter(statuses)
+        cancelled = sum(_is_user_cancelled(result) for result in self.results)
+        succeeded = sum(status in _SUCCESS_STATUSES for status in statuses)
+        failed = len(statuses) - succeeded - cancelled
+        summary = {
+            "total": len(statuses),
+            "succeeded": succeeded,
+            "failed": failed,
+            "cancelled": cancelled,
+            **{status: counts[status] for status in _KNOWN_STATUSES},
+        }
+        result_views = [
+            self._result_view(result)
+            for result in self.results
+            if not failures_only or batch_status(result) not in _SUCCESS_STATUSES
+        ]
+        resume_manifests = sorted(
+            {
+                str(result["manifest_path"])
+                for result in self.results
+                if batch_status(result) == "not_attempted"
+                and isinstance(result.get("push"), dict)
+                and result["push"].get("reason_code")
+                == "batch_halted_after_postcondition_failure"
+                and result.get("manifest_path")
+            }
+        )
+        return {
+            "branch": self.branch,
+            "command": self.command,
+            "exit_code": self.exit_code,
+            "kind": BATCH_REPORT_KIND,
+            "outcome": self.outcome,
+            "results": result_views,
+            "resume_manifests": resume_manifests,
+            "schema_version": BATCH_REPORT_SCHEMA_VERSION,
+            "summary": summary,
+        }

--- a/confluence-mdx/bin/reverse_sync_cli.py
+++ b/confluence-mdx/bin/reverse_sync_cli.py
@@ -25,6 +25,7 @@ if str(_SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPT_DIR))
 
 from mdx_to_storage.parser import parse_mdx_blocks
+from reverse_sync.batch_report import BatchReport
 from reverse_sync.block_diff import diff_blocks
 from reverse_sync.mapping_recorder import record_mapping
 from reverse_sync.xhtml_patcher import patch_xhtml
@@ -859,26 +860,42 @@ def _print_diff_block(lines: str, label: str, c, BOLD, CYAN, RED, GREEN, DIM) ->
 
 
 def _display_status(result: Dict[str, Any]) -> str:
-    """출력/요약용 상태를 계산한다. push 실패가 있으면 verify 결과보다 우선한다."""
+    """출력/요약용 상태를 계산하며 publish 상태를 local 결과보다 우선합니다."""
     push_status = (result.get('push') or {}).get('status')
+    if push_status in ('remote_verified', 'already_applied'):
+        return push_status
     if push_status == 'conflict':
         return 'push_conflict'
     if push_status == 'error':
         return 'push_error'
     if push_status == 'postcondition_failed':
         return 'push_postcondition_failed'
+    if push_status == 'not_attempted':
+        return 'push_not_attempted'
     return result.get('status', 'unknown')
 
 
 def _is_success_status(status: str) -> bool:
     """offline diagnostic pass와 online verified_local을 성공으로 분류한다."""
-    return status in ("pass", "verified_local", "no_changes")
+    return status in (
+        "already_applied",
+        "no_changes",
+        "pass",
+        "remote_verified",
+        "verified_local",
+    )
 
 
 def _display_error(result: Dict[str, Any], status: str) -> str:
     """출력용 에러 메시지를 반환한다."""
-    if status in ('push_conflict', 'push_error', 'push_postcondition_failed'):
-        return (result.get('push') or {}).get('error', '')
+    if status in (
+        'push_conflict',
+        'push_error',
+        'push_postcondition_failed',
+        'push_not_attempted',
+    ):
+        push = result.get('push') or {}
+        return push.get('error') or push.get('reason_code', '')
     return result.get('error', '')
 
 
@@ -905,7 +922,11 @@ def _print_results(results: List[Dict[str, Any]], *, show_all_diffs: bool = Fals
         changes = r.get('changes_count', 0)
 
         # 상태별 컬러 배지
-        if status == 'verified_local':
+        if status == 'remote_verified':
+            badge = c(GREEN, 'REMOTE VERIFIED')
+        elif status == 'already_applied':
+            badge = c(GREEN, 'ALREADY APPLIED')
+        elif status == 'verified_local':
             badge = c(GREEN, 'VERIFIED LOCAL')
         elif status == 'pass':
             badge = c(GREEN, 'PASS')
@@ -917,6 +938,8 @@ def _print_results(results: List[Dict[str, Any]], *, show_all_diffs: bool = Fals
             badge = c(YELLOW, 'PUSH ERROR')
         elif status == 'push_postcondition_failed':
             badge = c(RED, 'POSTCONDITION FAILED')
+        elif status == 'push_not_attempted':
+            badge = c(YELLOW, 'NOT ATTEMPTED')
         elif status == 'error':
             badge = c(YELLOW, 'ERROR')
         elif status == 'blocked':
@@ -931,9 +954,12 @@ def _print_results(results: List[Dict[str, Any]], *, show_all_diffs: bool = Fals
             'error',
             'push_conflict',
             'push_error',
+            'push_not_attempted',
             'push_postcondition_failed',
         ):
             print(f'  {c(RED, _display_error(r, status))}')
+            if status == 'push_not_attempted' and r.get('manifest_path'):
+                print(f'  resume manifest: {r["manifest_path"]}')
             continue
         if status == "blocked":
             reason_code = r.get("reason_code", "unknown")
@@ -980,6 +1006,12 @@ def _print_results(results: List[Dict[str, Any]], *, show_all_diffs: bool = Fals
     total = len(results)
     display_statuses = [_display_status(r) for r in results]
     passed = sum(1 for status in display_statuses if status == 'pass')
+    remote_verified = sum(
+        1 for status in display_statuses if status == 'remote_verified'
+    )
+    already_applied = sum(
+        1 for status in display_statuses if status == 'already_applied'
+    )
     verified_local = sum(
         1 for status in display_statuses if status == 'verified_local'
     )
@@ -990,11 +1022,18 @@ def _print_results(results: List[Dict[str, Any]], *, show_all_diffs: bool = Fals
     postcondition_failures = sum(
         1 for status in display_statuses if status == 'push_postcondition_failed'
     )
+    not_attempted = sum(
+        1 for status in display_statuses if status == 'push_not_attempted'
+    )
     no_chg = sum(1 for status in display_statuses if status == 'no_changes')
 
     parts = []
     if passed:
         parts.append(c(GREEN, f'{passed} passed'))
+    if remote_verified:
+        parts.append(c(GREEN, f'{remote_verified} remote verified'))
+    if already_applied:
+        parts.append(c(GREEN, f'{already_applied} already applied'))
     if verified_local:
         parts.append(c(GREEN, f'{verified_local} verified local'))
     if failed:
@@ -1007,6 +1046,8 @@ def _print_results(results: List[Dict[str, Any]], *, show_all_diffs: bool = Fals
         parts.append(c(YELLOW, f'{push_errors} push errors'))
     if postcondition_failures:
         parts.append(c(RED, f'{postcondition_failures} postcondition failures'))
+    if not_attempted:
+        parts.append(c(YELLOW, f'{not_attempted} not attempted'))
     if no_chg:
         parts.append(c(DIM, f'{no_chg} no changes'))
 
@@ -1300,11 +1341,16 @@ def _do_verify_batch(branch: str, limit: int = 0, failures_only: bool = False,
         )
         if not _confirm(f"{len(pushable)}건을 Confluence에 push 할까요? [y/N] "):
             print("Push 취소", file=sys.stderr)
+            for result in pushable:
+                result["push"] = {
+                    "status": "not_attempted",
+                    "reason_code": "user_cancelled",
+                }
             return results
 
     # 일괄 push
     push_count = 0
-    for r in pushable:
+    for push_index, r in enumerate(pushable):
         page_id = r['page_id']
         try:
             push_result = _do_push(
@@ -1316,14 +1362,34 @@ def _do_verify_batch(branch: str, limit: int = 0, failures_only: bool = False,
             push_count += 1
             print(f"  pushed {page_id} (v{push_result.get('version', '?')})", file=sys.stderr)
         except PushConflictError as e:
-            r['push'] = {'status': 'conflict', 'error': str(e)}
+            r['push'] = {
+                'status': 'conflict',
+                'reason_code': 'version_conflict',
+                'error': str(e),
+            }
             print(f"  conflict {page_id}: {e}", file=sys.stderr)
         except Exception as e:
-            if getattr(e, "reason_code", "") == "postcondition_failed":
-                r['push'] = {'status': 'postcondition_failed', 'error': str(e)}
+            reason_code = getattr(e, "reason_code", "") or "push_error"
+            if reason_code == "postcondition_failed":
+                r['push'] = {
+                    'status': 'postcondition_failed',
+                    'reason_code': reason_code,
+                    'error': str(e),
+                }
+                for pending in pushable[push_index + 1:]:
+                    pending['push'] = {
+                        'status': 'not_attempted',
+                        'reason_code': (
+                            'batch_halted_after_postcondition_failure'
+                        ),
+                    }
                 print(f"  postcondition failed {page_id}: {e}", file=sys.stderr)
                 break
-            r['push'] = {'status': 'error', 'error': str(e)}
+            r['push'] = {
+                'status': 'error',
+                'reason_code': reason_code,
+                'error': str(e),
+            }
             print(f"  error {page_id}: {e}", file=sys.stderr)
 
     print(f"\nPushed {push_count}/{len(pushable)} file(s)", file=sys.stderr)
@@ -1617,30 +1683,30 @@ def main():
                 if args.command == "push" and dry_run:
                     batch_kwargs["prepare_push"] = True
                 results = _do_verify_batch(args.branch, **batch_kwargs)
+                batch_report = BatchReport.from_results(
+                    command=args.command,
+                    branch=args.branch,
+                    results=results,
+                )
                 if use_json:
-                    output = results
-                    if failures_only:
-                        output = [r for r in results
-                                  if not _is_success_status(
-                                      r.get('status', 'unknown')
-                                  )
-                                  or r.get('push', {}).get('status')
-                                  in ('conflict', 'error', 'postcondition_failed')]
-                    print(json.dumps(output, ensure_ascii=False, indent=2))
+                    print(
+                        json.dumps(
+                            batch_report.to_dict(
+                                failures_only=failures_only,
+                            ),
+                            ensure_ascii=False,
+                            indent=2,
+                        )
+                    )
                 else:
                     _print_results(results, show_all_diffs=show_all_diffs,
                                    failures_only=failures_only)
-                has_failure = any(
-                    not _is_success_status(r.get('status', 'unknown'))
-                    for r in results
-                )
-                has_push_failure = any(
-                    r.get('push', {}).get('status')
-                    in ('conflict', 'error', 'postcondition_failed')
-                    for r in results
-                )
-                if has_failure or has_push_failure:
-                    sys.exit(1)
+                    print(
+                        f"Batch outcome: {batch_report.outcome} "
+                        f"(exit {batch_report.exit_code})"
+                    )
+                if batch_report.exit_code:
+                    sys.exit(batch_report.exit_code)
             else:
                 # 기존 단일 파일 모드
                 config = _ensure_confluence_config() if args.command == 'push' else None

--- a/confluence-mdx/tests/test_reverse_sync_batch_report.py
+++ b/confluence-mdx/tests/test_reverse_sync_batch_report.py
@@ -1,0 +1,132 @@
+"""versioned reverse-sync batch report 계약 테스트."""
+
+from reverse_sync.batch_report import BatchReport
+
+
+def test_partial_success_keeps_page_status_and_nonzero_exit():
+    report = BatchReport.from_results(
+        command="push",
+        branch="proofread/fix",
+        results=[
+            {
+                "file": "src/content/ko/a.mdx",
+                "page_id": "1",
+                "status": "verified_local",
+                "push": {"status": "remote_verified", "version": 6},
+            },
+            {
+                "file": "src/content/ko/b.mdx",
+                "page_id": "2",
+                "status": "verified_local",
+                "push": {
+                    "status": "conflict",
+                    "reason_code": "version_conflict",
+                    "error": "remote changed",
+                },
+            },
+        ],
+    )
+
+    value = report.to_dict()
+
+    assert value["kind"] == "reverse-sync-batch-report"
+    assert value["schema_version"] == 1
+    assert value["outcome"] == "partial_success"
+    assert value["exit_code"] == 1
+    assert value["summary"]["remote_verified"] == 1
+    assert value["summary"]["push_conflict"] == 1
+    assert [item["batch_status"] for item in value["results"]] == [
+        "remote_verified",
+        "push_conflict",
+    ]
+
+
+def test_halted_pages_expose_explicit_resume_manifests():
+    report = BatchReport.from_results(
+        command="push",
+        branch="proofread/fix",
+        results=[
+            {
+                "page_id": "1",
+                "status": "verified_local",
+                "push": {
+                    "status": "postcondition_failed",
+                    "reason_code": "postcondition_failed",
+                },
+            },
+            {
+                "page_id": "2",
+                "status": "verified_local",
+                "manifest_path": "/tmp/p2/manifest.json",
+                "push": {
+                    "status": "not_attempted",
+                    "reason_code": "batch_halted_after_postcondition_failure",
+                },
+            },
+        ],
+    )
+
+    value = report.to_dict()
+
+    assert value["outcome"] == "failed"
+    assert value["summary"]["postcondition_failed"] == 1
+    assert value["summary"]["not_attempted"] == 1
+    assert value["resume_manifests"] == ["/tmp/p2/manifest.json"]
+
+
+def test_all_success_has_zero_exit_code():
+    report = BatchReport.from_results(
+        command="verify",
+        branch="proofread/fix",
+        results=[
+            {"status": "pass"},
+            {"status": "no_changes"},
+        ],
+    )
+
+    value = report.to_dict()
+
+    assert value["outcome"] == "success"
+    assert value["exit_code"] == 0
+    assert value["summary"]["succeeded"] == 2
+    assert value["summary"]["failed"] == 0
+
+
+def test_user_cancel_is_zero_exit_without_claiming_success():
+    report = BatchReport.from_results(
+        command="push",
+        branch="proofread/fix",
+        results=[
+            {
+                "status": "verified_local",
+                "push": {
+                    "status": "not_attempted",
+                    "reason_code": "user_cancelled",
+                },
+            }
+        ],
+    )
+
+    value = report.to_dict()
+
+    assert value["outcome"] == "cancelled"
+    assert value["exit_code"] == 0
+    assert value["summary"]["cancelled"] == 1
+    assert value["summary"]["failed"] == 0
+
+
+def test_failures_only_filters_results_but_not_summary():
+    report = BatchReport.from_results(
+        command="push",
+        branch="proofread/fix",
+        results=[
+            {"status": "no_changes"},
+            {"status": "blocked", "reason_code": "unsupported_capability"},
+        ],
+    )
+
+    value = report.to_dict(failures_only=True)
+
+    assert value["summary"]["total"] == 2
+    assert len(value["results"]) == 1
+    assert value["results"][0]["batch_status"] == "blocked"

--- a/confluence-mdx/tests/test_reverse_sync_cli.py
+++ b/confluence-mdx/tests/test_reverse_sync_cli.py
@@ -764,10 +764,15 @@ def test_main_push_branch(tmp_path, monkeypatch):
     ]
 
     with patch('reverse_sync_cli._do_verify_batch', return_value=batch_results) as mock_batch, \
-         patch('builtins.print'):
+         patch('builtins.print') as output:
         main()
 
     mock_batch.assert_called_once_with('proofread/fix-typo', limit=0, failures_only=False, push=True, yes=True, lenient=False, no_normalize=False)
+    assert any(
+        call.args
+        and call.args[0] == 'Batch outcome: success (exit 0)'
+        for call in output.call_args_list
+    )
 
 
 def test_main_push_branch_with_failure(monkeypatch):
@@ -786,6 +791,51 @@ def test_main_push_branch_with_failure(monkeypatch):
 
     assert exc_info.value.code == 1
     mock_batch.assert_called_once_with('proofread/fix-typo', limit=0, failures_only=False, push=True, yes=True, lenient=False, no_normalize=False)
+
+
+def test_main_push_branch_json_returns_versioned_partial_report(monkeypatch):
+    monkeypatch.setattr(
+        'sys.argv',
+        [
+            'reverse_sync_cli.py',
+            'push',
+            '--yes',
+            '--json',
+            '--branch',
+            'proofread/fix-typo',
+        ],
+    )
+    batch_results = [
+        {
+            'status': 'verified_local',
+            'page_id': 'p1',
+            'push': {'status': 'remote_verified', 'version': 2},
+        },
+        {
+            'status': 'verified_local',
+            'page_id': 'p2',
+            'push': {
+                'status': 'conflict',
+                'reason_code': 'version_conflict',
+                'error': 'remote changed',
+            },
+        },
+    ]
+
+    with patch(
+        'reverse_sync_cli._do_verify_batch',
+        return_value=batch_results,
+    ), patch('builtins.print') as output:
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+    report = json.loads(output.call_args.args[0])
+    assert exc_info.value.code == 1
+    assert report['schema_version'] == 1
+    assert report['outcome'] == 'partial_success'
+    assert report['exit_code'] == 1
+    assert report['summary']['remote_verified'] == 1
+    assert report['summary']['push_conflict'] == 1
 
 
 def test_main_branch_mutual_exclusive(monkeypatch):
@@ -1810,7 +1860,10 @@ class TestPushConfirmPrompt:
             results = _do_verify_batch('test-branch', push=True, yes=False)
 
         mock_push.assert_not_called()
-        assert 'push' not in results[0]
+        assert results[0]['push'] == {
+            'status': 'not_attempted',
+            'reason_code': 'user_cancelled',
+        }
 
     def test_batch_yes_skips_confirm(self, tmp_path, monkeypatch):
         """배치 push --yes 시 확인 없이 push."""
@@ -1879,7 +1932,10 @@ class TestPushConfirmPrompt:
 
         push.assert_called_once()
         assert results[0]['push']['status'] == 'postcondition_failed'
-        assert 'push' not in results[1]
+        assert results[1]['push'] == {
+            'status': 'not_attempted',
+            'reason_code': 'batch_halted_after_postcondition_failure',
+        }
 
 
 class TestPushNonTtyRequiresYes:
@@ -2014,6 +2070,35 @@ class TestPrintResultsPushStatus:
         assert 'version conflict' in out
         assert '1 conflicts' in out
         assert '1 passed' not in out
+
+    def test_halted_page_is_not_reported_as_verified_local(
+        self,
+        monkeypatch,
+        capsys,
+    ):
+        monkeypatch.setattr('reverse_sync_cli._supports_color', lambda: False)
+
+        _print_results([
+            {
+                'file': 'src/content/ko/pending.mdx',
+                'manifest_path': '/tmp/pending/manifest.json',
+                'status': 'verified_local',
+                'changes_count': 1,
+                'push': {
+                    'status': 'not_attempted',
+                    'reason_code': (
+                        'batch_halted_after_postcondition_failure'
+                    ),
+                },
+            }
+        ])
+
+        out = capsys.readouterr().out
+        assert 'NOT ATTEMPTED' in out
+        assert 'batch_halted_after_postcondition_failure' in out
+        assert 'resume manifest: /tmp/pending/manifest.json' in out
+        assert '1 not attempted' in out
+        assert 'VERIFIED LOCAL' not in out
 
     def test_summary_counts_push_error_as_failure(self, monkeypatch, capsys):
         monkeypatch.setattr('reverse_sync_cli._supports_color', lambda: False)

--- a/openspec/changes/complete-reverse-sync/design.md
+++ b/openspec/changes/complete-reverse-sync/design.md
@@ -473,6 +473,20 @@ batch는 다음 순서로 동작합니다.
 
 `--all-or-nothing`처럼 보이는 표현을 사용하지 않습니다. 진정한 원자성이 필요하면 별도의 staging/publishing architecture가 필요합니다.
 
+branch batch의 `--json` 출력은 raw result array가 아니라
+`reverse-sync-batch-report` schema v1 object입니다. top-level에는 `command`,
+`branch`, `outcome`, `exit_code`, 고정된 counter를 가진 `summary`, page별
+`results`, `resume_manifests`가 있습니다. page result는 기존 진단 field를
+보존하되 `batch_status`를 추가합니다. 성공과 실패가 함께 있으면
+`partial_success`, 실패만 있으면 `failed`, 전부 통과하면 `success`입니다.
+사용자 confirmation 취소는 side effect가 없는 정상 종료이므로 `cancelled`와 exit
+code 0으로 기록합니다.
+
+postcondition failure 뒤의 남은 verified manifest는 `push.status=not_attempted`,
+`reason_code=batch_halted_after_postcondition_failure`로 명시하고
+`resume_manifests`에 경로를 기록합니다. conflict나 원격 drift가 발생한 manifest는
+같은 base로 재발행하면 안 되므로 resume 목록에 포함하지 않습니다.
+
 ### Decision: 상태와 reason code를 분리합니다
 
 상태는 workflow lifecycle을 표현합니다.

--- a/openspec/changes/complete-reverse-sync/specs/contract-reverse-sync/spec.md
+++ b/openspec/changes/complete-reverse-sync/specs/contract-reverse-sync/spec.md
@@ -321,6 +321,16 @@ batch reverse-sync는 각 page를 독립 transaction으로 처리하고 전체 b
 - WHEN batch push가 종료됩니다.
 - THEN 첫 page의 성공을 rollback된 것처럼 표시해서는 안 됩니다(SHALL NOT).
 - AND 전체 상태를 partial success로 표시하고 page별 상태를 반환해야 합니다(SHALL).
+- AND process exit code는 non-zero여야 합니다(SHALL).
+
+#### Scenario: versioned batch JSON report
+
+- GIVEN 사용자가 branch batch에 `--json`을 지정합니다.
+- WHEN batch가 종료됩니다.
+- THEN 도구는 raw page list가 아니라 schema version, command, branch, overall outcome, exit code, summary, page별 result를 가진 JSON object를 반환해야 합니다(SHALL).
+- AND page별 result는 local status와 publish status를 합성한 stable batch status와 reason code를 포함해야 합니다(SHALL).
+- AND overall outcome은 `success`, `partial_success`, `failed`, `cancelled` 중 하나여야 합니다(SHALL).
+- AND `partial_success` 또는 `failed`의 process exit code는 non-zero이고 `success` 또는 사용자 `cancelled`의 process exit code는 zero여야 합니다(SHALL).
 
 #### Scenario: postcondition failure
 
@@ -328,6 +338,7 @@ batch reverse-sync는 각 page를 독립 transaction으로 처리하고 전체 b
 - WHEN 다음 page를 처리하려고 합니다.
 - THEN 기본 동작은 남은 push를 중단해야 합니다(SHALL).
 - AND 사용자가 별도 실행으로 재개할 수 있는 manifest 목록을 제공해야 합니다(SHALL).
+- AND 아직 시도하지 않은 page를 success 또는 단순 `verified_local`로 보고하지 않고 `not_attempted`와 중단 reason으로 표시해야 합니다(SHALL).
 
 ### Requirement: Recoverable and Auditable Operation
 

--- a/openspec/changes/complete-reverse-sync/tasks.md
+++ b/openspec/changes/complete-reverse-sync/tasks.md
@@ -133,8 +133,17 @@
     base/candidate/plan hash와 gate를 manifest에 교차 검증합니다.
 - [x] interactive confirmation에 page ID, base version, target version, change count, candidate hash를 표시합니다.
 - [x] batch는 모든 local proof 후 page별 transaction을 실행합니다.
-- [ ] batch partial success, conflict, postcondition failure exit code와 JSON schema를 정의합니다.
-- [ ] resume는 `remote_verified`/blocked 상태를 재해석하지 않고 명시적 manifest 목록으로 수행합니다.
+- [x] batch partial success, conflict, postcondition failure exit code와 JSON schema를 정의합니다.
+  - branch `--json`은 `reverse-sync-batch-report` schema v1 envelope를
+    반환합니다.
+  - `outcome`, `exit_code`, stable summary, page별 `batch_status`와 reason
+    code를 함께 기록합니다.
+  - partial/failed는 exit 1, success와 사용자 cancellation은 exit 0입니다.
+- [x] resume는 `remote_verified`/blocked 상태를 재해석하지 않고 명시적 manifest 목록으로 수행합니다.
+  - postcondition failure 뒤 미시도 page는
+    `batch_halted_after_postcondition_failure`로 표시합니다.
+  - batch report의 `resume_manifests`에는 이 미시도 run만 포함하고 각 run은
+    `push --manifest`로 명시적으로 재개합니다.
 - [x] `--yes`가 safety gate를 우회하지 못하도록 테스트합니다.
 
 완료 gate:
@@ -207,7 +216,7 @@ cd confluence-mdx/tests
 
 기준선: 2026-07-24 `origin/main`에서 676 passed입니다.
 
-explicit manifest 변경 결과: 783 passed입니다.
+batch report 변경 결과: 790 passed입니다.
 
 ### 3.3 Page fixture regression
 
@@ -271,10 +280,17 @@ explicit manifest branch 검증 결과:
 - `make test-byte-verify`: fast/splice 각각 21/21 passed
 - 전체 Python test: 1106 passed, 2 skipped
 
+batch report branch 검증 결과:
+
+- `make test-convert`: 21 passed
+- `make test-reverse-sync`: golden 16 passed, regression 43 passed
+- `make test-byte-verify`: fast/splice 각각 21/21 passed
+- 전체 Python test: 1113 passed, 2 skipped
+
 - [x] 영향도에 따라 전체 Python test와 render test를 실행합니다.
 
 이번 변경은 Python CLI/planner 범위이므로 전체 Python test
-(`1106 passed, 2 skipped`)를 실행했고 frontend render test는 영향 범위에서
+(`1113 passed, 2 skipped`)를 실행했고 frontend render test는 영향 범위에서
 제외했습니다.
 
 ```bash


### PR DESCRIPTION
## Summary
reverse-sync branch batch의 page별 결과와 전체 partial success를 자동화 도구가 안정적으로 판별할 수 있는 versioned report로 만듭니다.

- `BatchReport`와 `reverse-sync-batch-report` schema v1을 추가합니다.
- branch `--json` 출력이 raw array 대신 command, branch, outcome, exit code, summary, page별 result를 가진 object를 반환합니다.
- page별 local/publish 상태를 stable `batch_status`와 reason code로 정규화합니다.
- 성공과 실패가 섞이면 `partial_success`, 실패만 있으면 `failed`, 전부 통과하면 `success`로 분류합니다.
- partial/failed는 exit 1, success와 사용자 cancellation은 exit 0으로 고정합니다.
- postcondition failure 뒤 남은 verified page를 `not_attempted`로 표시하고 `resume_manifests`에 explicit manifest 경로를 기록합니다.
- conflict, publish error, cancellation에도 stable reason code를 기록합니다.
- text 출력도 `REMOTE VERIFIED`, `ALREADY APPLIED`, `NOT ATTEMPTED`와 overall batch outcome을 구분합니다.

## OpenSpec
- 기준 change: `openspec/changes/complete-reverse-sync`
- 완료: batch partial success/conflict/postcondition exit-code 및 JSON schema
- 완료: postcondition 중단 뒤 explicit manifest 목록 기반 resume 경계
- conflict나 remote drift manifest는 stale base일 수 있으므로 resume 목록에 포함하지 않습니다.

## Safety impact
- 이미 성공한 page를 batch 전체 실패처럼 숨기거나 rollback된 것처럼 표시하지 않습니다.
- postcondition 실패 뒤 실제 PUT하지 않은 page를 단순 `verified_local` 성공으로 오인하지 않습니다.
- resume 대상은 원격 발행을 시도하지 않은 immutable manifest로 제한합니다.
- `--yes`와 사용자 cancellation은 local proof/preflight/postcondition gate 의미를 바꾸지 않습니다.

## Test plan
- [x] 전체 Python test: 1113 passed, 2 skipped
- [x] reverse-sync Python test: 790 passed
- [x] `make test-convert`: 21 passed
- [x] `make test-reverse-sync`: golden 16 passed, regression 43 passed
- [x] `make test-byte-verify`: fast/splice 각각 21/21 passed
- [x] `openspec validate complete-reverse-sync --strict`
- [x] `git diff --check`
- [x] Python `compileall`

## Stack
- Base: #1034
- Typed plan: #1033
- Strict provenance identity: #1032
- Input/dependency gates: #1031
- Strict proof: #1030
- Publisher foundation: #1029
- 선행 PR merge 후 base를 순차적으로 `main`으로 변경할 수 있습니다.

🤖 Generated with Codex

Co-Authored-By: Atlas <atlas@jk.agent>
