### PR TITLE
confluence-mdx: reverse-sync capability 차단 사유를 정규화합니다

### DIFF
--- a/confluence-mdx/bin/reverse_sync/planner.py
+++ b/confluence-mdx/bin/reverse_sync/planner.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
 from typing import Any, Optional
 
 from mdx_to_storage.link_resolver import LinkResolver
@@ -232,6 +231,99 @@ def _source_details(
     return tuple(block_types), contains_raw_html_table
 
 
+_LEGACY_UNSUPPORTED_CAPABILITIES = {
+    "not_markdown_table": "raw_html_table_edit",
+    "preserved_anchor_table": "unknown_macro_mutation",
+    "raw_html_table": "raw_html_table_edit",
+    "unsafe_html_table_edit": "raw_html_table_edit",
+}
+_LEGACY_MISSING_IDENTITY_REASONS = frozenset(
+    {"missing_roundtrip_sidecar", "no_mapping"}
+)
+
+
+def _legacy_skip_intent_ordinal(
+    item: dict[str, Any],
+    intents: tuple[ChangeIntent, ...],
+    mappings: list[BlockMapping],
+    mdx_to_sidecar: Optional[dict[int, SidecarEntry]],
+) -> int | None:
+    """legacy skip의 block ID를 원래 ChangeIntent에 유일하게 연결합니다."""
+    block_id = str(item.get("block_id", ""))
+    candidates: list[ChangeIntent] = []
+    if block_id.startswith("idx-"):
+        try:
+            index = int(block_id.removeprefix("idx-"))
+        except ValueError:
+            return None
+        candidates = [intent for intent in intents if intent.index == index]
+    else:
+        roots = {
+            _root_xpath(mapping.xhtml_xpath)
+            for mapping in mappings
+            if mapping.block_id == block_id
+        }
+        candidates = [
+            intent
+            for intent in intents
+            if intent.provenance_xpath in roots
+        ]
+        if not candidates and mdx_to_sidecar:
+            mapped_indexes = {
+                index
+                for index, entry in mdx_to_sidecar.items()
+                if _root_xpath(entry.xhtml_xpath) in roots
+            }
+            candidates = [
+                intent
+                for intent in intents
+                if intent.index in mapped_indexes
+            ]
+    if len(candidates) != 1:
+        return None
+    return candidates[0].ordinal
+
+
+def _legacy_skip_issue(
+    item: dict[str, Any],
+    *,
+    intents: tuple[ChangeIntent, ...],
+    mappings: list[BlockMapping],
+    mdx_to_sidecar: Optional[dict[int, SidecarEntry]],
+    enforce_capabilities: bool,
+    enforce_provenance: bool,
+) -> PlanIssue:
+    """legacy skip을 strict typed reason/capability boundary로 정규화합니다."""
+    legacy_reason = str(item.get("reason", "incomplete_patch_plan"))
+    capability_id = ""
+    reason_code = legacy_reason
+    if enforce_capabilities and legacy_reason in _LEGACY_UNSUPPORTED_CAPABILITIES:
+        reason_code = "unsupported_capability"
+        capability_id = _LEGACY_UNSUPPORTED_CAPABILITIES[legacy_reason]
+    elif (
+        enforce_provenance
+        and legacy_reason in _LEGACY_MISSING_IDENTITY_REASONS
+    ):
+        reason_code = "missing_identity"
+    return PlanIssue(
+        reason_code=reason_code,
+        description=str(
+            item.get(
+                "description",
+                "legacy planner가 변경을 적용하지 못했습니다",
+            )
+        ),
+        block_id=str(item.get("block_id", "")),
+        capability_id=capability_id,
+        intent_ordinal=_legacy_skip_intent_ordinal(
+            item,
+            intents,
+            mappings,
+            mdx_to_sidecar,
+        ),
+    )
+
+
 def plan_patches(
     changes: list[BlockChange],
     original_blocks: list[MdxBlock],
@@ -267,15 +359,13 @@ def plan_patches(
     )
     intents = _build_intents(changes, roundtrip_sidecar)
     issues = [
-        PlanIssue(
-            reason_code=str(item.get("reason", "incomplete_patch_plan")),
-            description=str(
-                item.get(
-                    "description",
-                    "legacy planner가 변경을 적용하지 못했습니다",
-                )
-            ),
-            block_id=str(item.get("block_id", "")),
+        _legacy_skip_issue(
+            item,
+            intents=intents,
+            mappings=resolved_mappings,
+            mdx_to_sidecar=mdx_to_sidecar,
+            enforce_capabilities=enforce_capabilities,
+            enforce_provenance=enforce_provenance,
         )
         for item in legacy_skips
     ]
@@ -284,9 +374,34 @@ def plan_patches(
     operations: list[PatchOperation] = []
 
     for operation_index, patch in enumerate(raw_patches):
+        intent_ordinals = _intent_ordinals_for_patch(
+            patch=patch,
+            intents=intents,
+            changes=changes,
+            already_assigned_inserts=assigned_inserts,
+        )
+        if intent_ordinals == (-1,):
+            continue
         target = _target_identity(patch, roundtrip_sidecar)
         if target is None:
             if enforce_provenance:
+                mapping = _mapping_for_patch(patch, resolved_mappings)
+                issue_intent_ordinal = (
+                    intent_ordinals[0]
+                    if len(intent_ordinals) == 1
+                    else _legacy_skip_intent_ordinal(
+                        {
+                            "block_id": (
+                                mapping.block_id
+                                if mapping is not None
+                                else ""
+                            )
+                        },
+                        intents,
+                        resolved_mappings,
+                        mdx_to_sidecar,
+                    )
+                )
                 issues.append(
                     PlanIssue(
                         reason_code="missing_identity",
@@ -298,6 +413,7 @@ def plan_patches(
                             or patch.get("after_xpath")
                             or "$document-start"
                         ),
+                        intent_ordinal=issue_intent_ordinal,
                     )
                 )
                 continue
@@ -316,14 +432,6 @@ def plan_patches(
                 base_fragment_sha256="",
             )
 
-        intent_ordinals = _intent_ordinals_for_patch(
-            patch=patch,
-            intents=intents,
-            changes=changes,
-            already_assigned_inserts=assigned_inserts,
-        )
-        if intent_ordinals == (-1,):
-            continue
         mapping = _mapping_for_patch(patch, resolved_mappings)
         source_types, contains_raw_html_table = _source_details(
             intent_ordinals,
@@ -392,18 +500,15 @@ def plan_patches(
             for operation in operations
             for ordinal in operation.intent_ordinals
         }
-        legacy_skip_indexes: dict[int, int] = defaultdict(int)
-        for item in legacy_skips:
-            block_id = str(item.get("block_id", ""))
-            if block_id.startswith("idx-"):
-                try:
-                    legacy_skip_indexes[int(block_id.removeprefix("idx-"))] += 1
-                except ValueError:
-                    pass
+        issued_intents = {
+            issue.intent_ordinal
+            for issue in issues
+            if issue.intent_ordinal is not None
+        }
         for intent in intents:
             if intent.ordinal in mapped:
                 continue
-            if legacy_skip_indexes.get(intent.index):
+            if intent.ordinal in issued_intents:
                 continue
             issues.append(
                 PlanIssue(

--- a/confluence-mdx/tests/test_reverse_sync_planner.py
+++ b/confluence-mdx/tests/test_reverse_sync_planner.py
@@ -127,6 +127,38 @@ def test_raw_html_table_is_explicit_unsupported_capability_in_push_plan():
     )
 
 
+def test_legacy_table_skip_is_one_typed_capability_issue():
+    old = _block(
+        "<table><tr><td>Before</td></tr></table>",
+        "html_block",
+    )
+    new = _block(
+        "<table><tr><td>After</td><td>Added</td></tr></table>",
+        "html_block",
+    )
+    change = BlockChange(0, "modified", old, new)
+    xhtml = "<table><tr><td>Before</td></tr></table>"
+
+    plan, _ = plan_patches(
+        [change],
+        [old],
+        [new],
+        page_xhtml=xhtml,
+        roundtrip_sidecar=_sidecar(xhtml, old),
+        allow_text_identity_fallback=False,
+        enforce_capabilities=True,
+        enforce_provenance=True,
+    )
+
+    assert plan.operations == ()
+    assert len(plan.issues) == 1
+    issue = plan.issues[0]
+    assert issue.reason_code == "unsupported_capability"
+    assert issue.capability_id == "raw_html_table_edit"
+    assert issue.intent_ordinal == 0
+    assert issue.to_legacy_dict()["reason"] == "unsupported_capability"
+
+
 def test_push_plan_blocks_operation_without_sidecar_provenance():
     old = _block("Before")
     new = _block("After")
@@ -154,7 +186,9 @@ def test_push_plan_blocks_operation_without_sidecar_provenance():
 
     assert plan.intent_complete is False
     assert plan.operations == ()
-    assert {issue.reason_code for issue in plan.issues} == {"missing_identity"}
+    assert len(plan.issues) == 1
+    assert plan.issues[0].reason_code == "missing_identity"
+    assert plan.issues[0].intent_ordinal == 0
 
 
 def test_hash_mismatched_sidecar_target_is_not_executable():

--- a/openspec/changes/complete-reverse-sync/design.md
+++ b/openspec/changes/complete-reverse-sync/design.md
@@ -297,6 +297,14 @@ XHTML renderer boundary로만 복원합니다.
 `raw_html_table_edit`와 `unknown_macro_mutation`은
 `unsupported_capability`로 non-executable 처리하며, source formatting을 나타내는
 empty block insert가 `<p></p>` mutation으로 바뀌지 않도록 plan에서 제거합니다.
+legacy builder가 operation 생성 전에 table/macro 변경을 skip한 경우에도
+`unsafe_html_table_edit`, `preserved_anchor_table` 같은 내부 분기명은 strict
+`PatchPlan` reason으로 노출하지 않습니다. adapter는 skip을 원래
+`ChangeIntent`에 연결하고 `unsupported_capability`와
+`raw_html_table_edit`/`unknown_macro_mutation` capability ID로 정규화합니다.
+sidecar 또는 mapping 부재는 `missing_identity`로 정규화합니다. 하나의 legacy
+skip과 같은 intent에서 파생한 추가 `missing_identity` issue를 중복 생성하지
+않습니다.
 capability별 renderer strategy 자체를 `patch_builder.py`에서 추출하는 작업은
 계속 남아 있습니다.
 

--- a/openspec/changes/complete-reverse-sync/tasks.md
+++ b/openspec/changes/complete-reverse-sync/tasks.md
@@ -164,7 +164,12 @@
 - [x] normalized text prefix fallback을 push-eligible path에서 제거합니다.
 - [ ] visible segment model을 paragraph, heading, list에 확장합니다.
 - [ ] strategy를 text block, list, preserved anchor, container, table로 분리합니다.
-- [ ] unsupported table/macro 구조를 explicit block reason으로 전환합니다.
+- [x] unsupported table/macro 구조를 explicit block reason으로 전환합니다.
+  - operation 생성 전 legacy skip도 원래 intent에 연결합니다.
+  - table/macro 내부 분기 reason은 `unsupported_capability`와
+    `raw_html_table_edit`/`unknown_macro_mutation` capability ID로 정규화합니다.
+  - mapping/sidecar 부재는 `missing_identity`로 정규화하고 같은 intent의 중복
+    issue를 제거합니다.
 - [ ] 기존 `xhtml_patcher.py`는 validated operation 적용에 집중하도록 축소합니다.
 
 완료 gate:
@@ -216,7 +221,7 @@ cd confluence-mdx/tests
 
 기준선: 2026-07-24 `origin/main`에서 676 passed입니다.
 
-batch report 변경 결과: 790 passed입니다.
+capability reason 변경 결과: 791 passed입니다.
 
 ### 3.3 Page fixture regression
 
@@ -287,10 +292,17 @@ batch report branch 검증 결과:
 - `make test-byte-verify`: fast/splice 각각 21/21 passed
 - 전체 Python test: 1113 passed, 2 skipped
 
+capability reason branch 검증 결과:
+
+- `make test-convert`: 21 passed
+- `make test-reverse-sync`: golden 16 passed, regression 43 passed
+- `make test-byte-verify`: fast/splice 각각 21/21 passed
+- 전체 Python test: 1114 passed, 2 skipped
+
 - [x] 영향도에 따라 전체 Python test와 render test를 실행합니다.
 
 이번 변경은 Python CLI/planner 범위이므로 전체 Python test
-(`1113 passed, 2 skipped`)를 실행했고 frontend render test는 영향 범위에서
+(`1114 passed, 2 skipped`)를 실행했고 frontend render test는 영향 범위에서
 제외했습니다.
 
 ```bash


### PR DESCRIPTION
## Summary
legacy patch builder가 operation 생성 전에 skip한 table/macro 변경도 typed PatchPlan의 stable capability contract로 정규화합니다.

- `unsafe_html_table_edit`, `raw_html_table`, `not_markdown_table`을 `unsupported_capability` + `raw_html_table_edit`로 변환합니다.
- `preserved_anchor_table`을 `unsupported_capability` + `unknown_macro_mutation`으로 변환합니다.
- `no_mapping`, `missing_roundtrip_sidecar`를 strict plan의 `missing_identity`로 변환합니다.
- legacy skip의 block ID를 exact sidecar provenance 또는 legacy MDX-sidecar 진단 mapping으로 원래 `ChangeIntent`에 연결합니다.
- operation target identity가 없는 경우에도 issue를 intent에 연결하되 operation 실행 provenance에는 legacy fallback을 사용하지 않습니다.
- 이미 issue가 연결된 intent에 후속 generic `missing_identity`를 중복 생성하지 않습니다.

## OpenSpec
- 기준 change: `openspec/changes/complete-reverse-sync`
- 완료: unsupported table/macro 구조의 explicit block reason 전환
- 계속 남는 범위: capability별 renderer strategy 추출, provenance-first planner 전환, visible segment model 확장

## Safety impact
- push 결과와 자동화가 legacy 내부 분기명에 의존하지 않고 stable reason/capability ID를 사용할 수 있습니다.
- 하나의 unsupported 변경이 여러 issue로 보이는 진단 중복을 제거합니다.
- raw table/macro 변경은 계속 fail-closed이며 이 PR에서 새 capability를 실행 가능하게 만들지 않습니다.
- legacy mapping은 issue attribution에만 사용하며 executable target identity gate를 우회하지 않습니다.

## Test plan
- [x] 전체 Python test: 1114 passed, 2 skipped
- [x] reverse-sync Python test: 791 passed
- [x] `make test-convert`: 21 passed
- [x] `make test-reverse-sync`: golden 16 passed, regression 43 passed
- [x] `make test-byte-verify`: fast/splice 각각 21/21 passed
- [x] `openspec validate complete-reverse-sync --strict`
- [x] `git diff --check`
- [x] Python `compileall`

## Stack
- Base: #1035
- Explicit manifest publish: #1034
- Typed plan: #1033
- Strict provenance identity: #1032
- Input/dependency gates: #1031
- Strict proof: #1030
- Publisher foundation: #1029
- 선행 PR merge 후 base를 순차적으로 `main`으로 변경할 수 있습니다.

🤖 Generated with Codex

Co-Authored-By: Atlas <atlas@jk.agent>
