### PR TITLE
confluence-mdx: strict planner를 provenance-first로 전환합니다

### DIFF
--- a/confluence-mdx/bin/reverse_sync/planner.py
+++ b/confluence-mdx/bin/reverse_sync/planner.py
@@ -30,19 +30,47 @@ def _strict_sidecar_identity(
     sidecar: Optional[RoundtripSidecar],
 ) -> Optional[SidecarBlock]:
     """hash와 line range가 모두 같은 유일한 provenance만 반환합니다."""
-    if sidecar is None or not block.content:
+    matches = _strict_sidecar_matches(block, sidecar)
+    if len(matches) != 1:
         return None
+    return matches[0]
+
+
+def _strict_sidecar_matches(
+    block: MdxBlock,
+    sidecar: Optional[RoundtripSidecar],
+) -> list[SidecarBlock]:
+    """MDX hash와 line range가 모두 같은 sidecar provenance를 반환합니다."""
+    if sidecar is None or not block.content:
+        return []
     content_hash = sha256_text(block.content)
     line_range = (block.line_start, block.line_end)
-    matches = [
+    return [
         candidate
         for candidate in sidecar.blocks
         if candidate.mdx_content_hash == content_hash
         and tuple(candidate.mdx_line_range) == line_range
     ]
-    if len(matches) != 1:
-        return None
-    return matches[0]
+
+
+def _build_strict_provenance_index(
+    original_blocks: list[MdxBlock],
+    sidecar: Optional[RoundtripSidecar],
+) -> dict[int, SidecarEntry]:
+    """renderer 전략 선택 전에 exact sidecar provenance index를 구축합니다."""
+    result: dict[int, SidecarEntry] = {}
+    for index, block in enumerate(original_blocks):
+        if block.type in NON_CONTENT_TYPES:
+            continue
+        identity = _strict_sidecar_identity(block, sidecar)
+        if identity is None:
+            continue
+        result[index] = SidecarEntry(
+            xhtml_xpath=identity.xhtml_xpath,
+            xhtml_type="",
+            mdx_blocks=[index],
+        )
+    return result
 
 
 def _build_intents(
@@ -88,6 +116,24 @@ def _build_intents(
             )
         )
     return tuple(intents)
+
+
+def _intent_identity_reasons(
+    changes: list[BlockChange],
+    sidecar: Optional[RoundtripSidecar],
+) -> dict[int, str]:
+    """기존 fragment가 필요한 intent의 provenance 실패를 typed reason으로 분류합니다."""
+    reasons: dict[int, str] = {}
+    for ordinal, change in enumerate(changes):
+        block = change.old_block
+        if block is None or block.type in NON_CONTENT_TYPES:
+            continue
+        matches = _strict_sidecar_matches(block, sidecar)
+        if len(matches) > 1:
+            reasons[ordinal] = "ambiguous_target"
+        elif not matches:
+            reasons[ordinal] = "missing_identity"
+    return reasons
 
 
 def _sidecar_index(sidecar: Optional[RoundtripSidecar]) -> dict[str, SidecarBlock]:
@@ -290,11 +336,18 @@ def _legacy_skip_issue(
     intents: tuple[ChangeIntent, ...],
     mappings: list[BlockMapping],
     mdx_to_sidecar: Optional[dict[int, SidecarEntry]],
+    identity_reasons: dict[int, str],
     enforce_capabilities: bool,
     enforce_provenance: bool,
 ) -> PlanIssue:
     """legacy skip을 strict typed reason/capability boundary로 정규화합니다."""
     legacy_reason = str(item.get("reason", "incomplete_patch_plan"))
+    intent_ordinal = _legacy_skip_intent_ordinal(
+        item,
+        intents,
+        mappings,
+        mdx_to_sidecar,
+    )
     capability_id = ""
     reason_code = legacy_reason
     if enforce_capabilities and legacy_reason in _LEGACY_UNSUPPORTED_CAPABILITIES:
@@ -304,7 +357,7 @@ def _legacy_skip_issue(
         enforce_provenance
         and legacy_reason in _LEGACY_MISSING_IDENTITY_REASONS
     ):
-        reason_code = "missing_identity"
+        reason_code = identity_reasons.get(intent_ordinal, "missing_identity")
     return PlanIssue(
         reason_code=reason_code,
         description=str(
@@ -315,12 +368,7 @@ def _legacy_skip_issue(
         ),
         block_id=str(item.get("block_id", "")),
         capability_id=capability_id,
-        intent_ordinal=_legacy_skip_intent_ordinal(
-            item,
-            intents,
-            mappings,
-            mdx_to_sidecar,
-        ),
+        intent_ordinal=intent_ordinal,
     )
 
 
@@ -342,12 +390,20 @@ def plan_patches(
     enforce_provenance: bool = False,
 ) -> tuple[PatchPlan, list[BlockMapping]]:
     """legacy builder output을 capability/provenance가 있는 typed plan으로 바꿉니다."""
+    effective_mdx_to_sidecar = mdx_to_sidecar
+    if enforce_provenance:
+        # Push-eligible planning은 caller가 제공한 legacy mapping을 신뢰하지 않고,
+        # base sidecar의 exact hash + line range identity를 먼저 확정합니다.
+        effective_mdx_to_sidecar = _build_strict_provenance_index(
+            original_blocks,
+            roundtrip_sidecar,
+        )
     raw_patches, resolved_mappings, legacy_skips = build_patches(
         changes,
         original_blocks,
         improved_blocks,
         mappings=mappings,
-        mdx_to_sidecar=mdx_to_sidecar,
+        mdx_to_sidecar=effective_mdx_to_sidecar,
         xpath_to_mapping=xpath_to_mapping,
         alignment=alignment,
         page_lost_info=page_lost_info,
@@ -358,16 +414,46 @@ def plan_patches(
         allow_text_identity_fallback=allow_text_identity_fallback,
     )
     intents = _build_intents(changes, roundtrip_sidecar)
-    issues = [
+    identity_reasons = (
+        _intent_identity_reasons(changes, roundtrip_sidecar)
+        if enforce_provenance
+        else {}
+    )
+    identity_issues = [
+        PlanIssue(
+            reason_code=reason_code,
+            description=(
+                "base sidecar에서 MDX intent의 target provenance가 중복됩니다"
+                if reason_code == "ambiguous_target"
+                else "base sidecar에서 MDX intent의 exact target identity가 없습니다"
+            ),
+            block_id=f"idx-{intent.index}",
+            intent_ordinal=intent.ordinal,
+        )
+        for intent in intents
+        if (reason_code := identity_reasons.get(intent.ordinal)) is not None
+    ]
+    identity_issue_ordinals = {
+        issue.intent_ordinal
+        for issue in identity_issues
+        if issue.intent_ordinal is not None
+    }
+    legacy_issues = [
         _legacy_skip_issue(
             item,
             intents=intents,
             mappings=resolved_mappings,
-            mdx_to_sidecar=mdx_to_sidecar,
+            mdx_to_sidecar=effective_mdx_to_sidecar,
+            identity_reasons=identity_reasons,
             enforce_capabilities=enforce_capabilities,
             enforce_provenance=enforce_provenance,
         )
         for item in legacy_skips
+    ]
+    issues = identity_issues + [
+        issue
+        for issue in legacy_issues
+        if issue.intent_ordinal not in identity_issue_ordinals
     ]
     sidecar_by_xpath = _sidecar_index(roundtrip_sidecar)
     assigned_inserts: set[int] = set()
@@ -399,7 +485,7 @@ def plan_patches(
                         },
                         intents,
                         resolved_mappings,
-                        mdx_to_sidecar,
+                        effective_mdx_to_sidecar,
                     )
                 )
                 issues.append(

--- a/confluence-mdx/bin/reverse_sync/planner.py
+++ b/confluence-mdx/bin/reverse_sync/planner.py
@@ -211,6 +211,37 @@ def _target_identity(
     )
 
 
+def _strict_insert_anchor_reason(
+    *,
+    patch: dict[str, Any],
+    intent_ordinals: tuple[int, ...],
+    changes: list[BlockChange],
+    original_blocks: list[MdxBlock],
+    alignment: Optional[dict[int, int]],
+    sidecar: Optional[RoundtripSidecar],
+) -> str:
+    """document start가 아닌 insert의 predecessor provenance 누락을 분류합니다."""
+    if (
+        patch.get("action") != "insert"
+        or patch.get("after_xpath") is not None
+        or len(intent_ordinals) != 1
+    ):
+        return ""
+    change = changes[intent_ordinals[0]]
+    for improved_index in range(change.index - 1, -1, -1):
+        if alignment is None or improved_index not in alignment:
+            continue
+        original_index = alignment[improved_index]
+        if not 0 <= original_index < len(original_blocks):
+            return "missing_identity"
+        matches = _strict_sidecar_matches(
+            original_blocks[original_index],
+            sidecar,
+        )
+        return "ambiguous_target" if len(matches) > 1 else "missing_identity"
+    return ""
+
+
 def _intent_ordinals_for_patch(
     *,
     patch: dict[str, Any],
@@ -470,6 +501,30 @@ def plan_patches(
             already_assigned_inserts=assigned_inserts,
         )
         if intent_ordinals == (-1,):
+            continue
+        insert_anchor_reason = (
+            _strict_insert_anchor_reason(
+                patch=patch,
+                intent_ordinals=intent_ordinals,
+                changes=changes,
+                original_blocks=original_blocks,
+                alignment=alignment,
+                sidecar=roundtrip_sidecar,
+            )
+            if enforce_provenance
+            else ""
+        )
+        if insert_anchor_reason:
+            issues.append(
+                PlanIssue(
+                    reason_code=insert_anchor_reason,
+                    description=(
+                        "insert predecessor의 exact target provenance가 없습니다"
+                    ),
+                    block_id="$document-start",
+                    intent_ordinal=intent_ordinals[0],
+                )
+            )
             continue
         target = _target_identity(patch, roundtrip_sidecar)
         if target is None:

--- a/confluence-mdx/bin/reverse_sync/planner.py
+++ b/confluence-mdx/bin/reverse_sync/planner.py
@@ -398,6 +398,9 @@ def plan_patches(
             original_blocks,
             roundtrip_sidecar,
         )
+    effective_text_identity_fallback = (
+        allow_text_identity_fallback and not enforce_provenance
+    )
     raw_patches, resolved_mappings, legacy_skips = build_patches(
         changes,
         original_blocks,
@@ -411,7 +414,7 @@ def plan_patches(
         page_xhtml=page_xhtml,
         link_resolver=link_resolver,
         attachment_filenames=attachment_filenames,
-        allow_text_identity_fallback=allow_text_identity_fallback,
+        allow_text_identity_fallback=effective_text_identity_fallback,
     )
     intents = _build_intents(changes, roundtrip_sidecar)
     identity_reasons = (

--- a/confluence-mdx/tests/test_reverse_sync_planner.py
+++ b/confluence-mdx/tests/test_reverse_sync_planner.py
@@ -407,6 +407,37 @@ def test_insert_skips_added_intent_already_covered_by_replacement():
     assert plan.to_patch_dicts()[1]["new_element_xhtml"] == "<p>Second</p>"
 
 
+def test_strict_insert_blocks_when_predecessor_provenance_is_missing():
+    original = _block("Before")
+    inserted = Block(
+        type="paragraph",
+        content="Added",
+        line_start=3,
+        line_end=3,
+    )
+    xhtml = "<p>Before</p>"
+    sidecar = _sidecar(xhtml, original)
+    sidecar.blocks[0].mdx_content_hash = sha256_text("Different source")
+
+    plan, _ = plan_patches(
+        [BlockChange(1, "added", None, inserted)],
+        [original],
+        [original, inserted],
+        page_xhtml=xhtml,
+        alignment={0: 0},
+        roundtrip_sidecar=sidecar,
+        allow_text_identity_fallback=False,
+        enforce_capabilities=True,
+        enforce_provenance=True,
+    )
+
+    assert plan.intent_complete is False
+    assert plan.operations == ()
+    assert len(plan.issues) == 1
+    assert plan.issues[0].reason_code == "missing_identity"
+    assert plan.issues[0].intent_ordinal == 0
+
+
 def test_plan_serialization_is_deterministic_and_contains_no_untyped_top_level_patch():
     old = _block("Before")
     new = _block("After")

--- a/confluence-mdx/tests/test_reverse_sync_planner.py
+++ b/confluence-mdx/tests/test_reverse_sync_planner.py
@@ -212,8 +212,106 @@ def test_hash_mismatched_sidecar_target_is_not_executable():
 
     assert plan.intent_complete is False
     assert plan.to_patch_dicts() == []
-    assert plan.operations[0].reason_code == "missing_identity"
-    assert {issue.reason_code for issue in plan.issues} == {"missing_identity"}
+    assert plan.operations == ()
+    assert len(plan.issues) == 1
+    assert plan.issues[0].reason_code == "missing_identity"
+    assert plan.issues[0].intent_ordinal == 0
+
+
+def test_push_planner_resolves_exact_provenance_before_renderer_strategy():
+    old = _block("Before")
+    new = _block("After")
+    change = BlockChange(0, "modified", old, new)
+    xhtml = "<p>Wrong</p><p>Before</p>"
+    sidecar = RoundtripSidecar(
+        page_id="123",
+        mdx_sha256=sha256_text(old.content),
+        source_xhtml_sha256=sha256_text(xhtml),
+        blocks=[
+            SidecarBlock(
+                block_index=1,
+                xhtml_xpath="p[2]",
+                xhtml_fragment="<p>Before</p>",
+                mdx_content_hash=sha256_text(old.content),
+                mdx_line_range=(old.line_start, old.line_end),
+            ),
+            SidecarBlock(
+                block_index=0,
+                xhtml_xpath="p[1]",
+                xhtml_fragment="<p>Wrong</p>",
+                mdx_content_hash=sha256_text("Wrong"),
+                mdx_line_range=(old.line_start, old.line_end),
+            ),
+        ],
+        separators=[],
+        document_envelope=DocumentEnvelope(),
+    )
+
+    plan, _ = plan_patches(
+        [change],
+        [old],
+        [new],
+        page_xhtml=xhtml,
+        # strict mode는 이 legacy caller mapping을 무시해야 합니다.
+        mdx_to_sidecar={
+            0: SidecarEntry(
+                xhtml_xpath="p[1]",
+                xhtml_type="paragraph",
+                mdx_blocks=[0],
+            )
+        },
+        roundtrip_sidecar=sidecar,
+        allow_text_identity_fallback=False,
+        enforce_capabilities=True,
+        enforce_provenance=True,
+    )
+
+    assert plan.intent_complete is True
+    assert plan.issues == ()
+    assert len(plan.operations) == 1
+    assert plan.operations[0].target.xpath == "p[2]"
+    assert plan.operations[0].intent_ordinals == (0,)
+
+
+def test_push_planner_blocks_duplicate_exact_provenance_as_ambiguous():
+    old = _block("Repeated")
+    new = _block("Changed")
+    change = BlockChange(0, "modified", old, new)
+    xhtml = "<p>Repeated</p><p>Repeated</p>"
+    sidecar = RoundtripSidecar(
+        page_id="123",
+        mdx_sha256=sha256_text(old.content),
+        source_xhtml_sha256=sha256_text(xhtml),
+        blocks=[
+            SidecarBlock(
+                block_index=index,
+                xhtml_xpath=f"p[{index + 1}]",
+                xhtml_fragment="<p>Repeated</p>",
+                mdx_content_hash=sha256_text(old.content),
+                mdx_line_range=(old.line_start, old.line_end),
+            )
+            for index in range(2)
+        ],
+        separators=[],
+        document_envelope=DocumentEnvelope(),
+    )
+
+    plan, _ = plan_patches(
+        [change],
+        [old],
+        [new],
+        page_xhtml=xhtml,
+        roundtrip_sidecar=sidecar,
+        allow_text_identity_fallback=False,
+        enforce_capabilities=True,
+        enforce_provenance=True,
+    )
+
+    assert plan.intent_complete is False
+    assert plan.operations == ()
+    assert len(plan.issues) == 1
+    assert plan.issues[0].reason_code == "ambiguous_target"
+    assert plan.issues[0].intent_ordinal == 0
 
 
 def test_empty_source_line_insert_is_removed_before_typed_renderer_boundary():

--- a/confluence-mdx/tests/test_reverse_sync_planner.py
+++ b/confluence-mdx/tests/test_reverse_sync_planner.py
@@ -314,6 +314,31 @@ def test_push_planner_blocks_duplicate_exact_provenance_as_ambiguous():
     assert plan.issues[0].intent_ordinal == 0
 
 
+def test_enforce_provenance_disables_legacy_list_text_fallback():
+    old = _block("1. Before\n", "list")
+    new = _block("1. After\n", "list")
+    change = BlockChange(0, "modified", old, new)
+    xhtml = "<ul><li><p>Before</p></li></ul>"
+    sidecar = _sidecar(xhtml, old)
+    sidecar.blocks[0].mdx_content_hash = sha256_text("Different source")
+
+    plan, _ = plan_patches(
+        [change],
+        [old],
+        [new],
+        page_xhtml=xhtml,
+        roundtrip_sidecar=sidecar,
+        # allow_text_identity_fallback의 default가 True여도 strict flag가 우선합니다.
+        enforce_capabilities=True,
+        enforce_provenance=True,
+    )
+
+    assert plan.intent_complete is False
+    assert plan.operations == ()
+    assert len(plan.issues) == 1
+    assert plan.issues[0].reason_code == "missing_identity"
+
+
 def test_empty_source_line_insert_is_removed_before_typed_renderer_boundary():
     original = _block("Before")
     empty = _block("\n", "empty")

--- a/openspec/changes/complete-reverse-sync/design.md
+++ b/openspec/changes/complete-reverse-sync/design.md
@@ -226,12 +226,16 @@ text prefix fallback을 유지합니다. online verify는
 호출에 강제하고, provenance mapping을 찾지 못하면 `no_mapping`으로 기록하여
 `intent_complete` gate에서 block합니다.
 
-`legacy-patch-builder-v2` adapter는 `build_patches()`가 선택한 target을 그대로
-신뢰하지 않습니다. online plan에서 MDX content hash와 line range가 모두 일치하는
-유일한 sidecar provenance를 `ChangeIntent`에 기록하고, renderer operation의 root
-fragment와 대응하지 않으면 operation을 `missing_identity`로 non-executable
-처리합니다. 따라서 migration 중에는 legacy builder가 잘못된 candidate를
-제안하더라도 strict proof의 `intent_complete`를 얻을 수 없습니다.
+`legacy-patch-builder-v2` adapter의 online plan은 renderer strategy를 선택하기
+전에 MDX content hash와 line range가 모두 일치하는 유일한 sidecar provenance
+index를 구축합니다. caller가 넘긴 legacy MDX mapping은 strict path에서 사용하지
+않으며, 이 exact index만 `build_patches()`의 target 입력으로 전달합니다. exact
+후보가 없으면 `missing_identity`, 둘 이상이면 `ambiguous_target`으로 operation
+생성 전에 block합니다.
+
+planner는 같은 provenance를 `ChangeIntent`에도 기록하고, renderer operation의
+root fragment와 다시 대응시킵니다. 이 사후 검사는 provenance-first target
+selection을 대체하지 않는 defense-in-depth 경계입니다.
 
 추가/삭제/reorder는 stable neighbor identity를 기준으로 계획합니다.
 

--- a/openspec/changes/complete-reverse-sync/tasks.md
+++ b/openspec/changes/complete-reverse-sync/tasks.md
@@ -314,13 +314,13 @@ provenance-first branch 검증 결과:
 - `make test-convert`: 21 passed
 - `make test-reverse-sync`: golden 16 passed, regression 43 passed
 - `make test-byte-verify`: fast/splice 각각 21/21 passed
-- reverse-sync Python test: 796 passed
-- 전체 Python test: 1119 passed, 2 skipped
+- reverse-sync Python test: 797 passed
+- 전체 Python test: 1120 passed, 2 skipped
 
 - [x] 영향도에 따라 전체 Python test와 render test를 실행합니다.
 
 이번 변경은 Python planner 범위이므로 전체 Python test
-(`1119 passed, 2 skipped`)를 실행했고 frontend render test는 영향 범위에서
+(`1120 passed, 2 skipped`)를 실행했고 frontend render test는 영향 범위에서
 제외했습니다.
 
 ```bash

--- a/openspec/changes/complete-reverse-sync/tasks.md
+++ b/openspec/changes/complete-reverse-sync/tasks.md
@@ -160,7 +160,12 @@
   - push path는 exact sidecar provenance와 intent가 대응하지 않는 operation을
     `missing_identity`로 non-executable 처리합니다.
   - capability별 renderer strategy 추출은 아래 task에 계속 남습니다.
-- [ ] block identity를 provenance-first 순서로 바꿉니다.
+- [x] block identity를 provenance-first 순서로 바꿉니다.
+  - strict planner는 caller의 legacy mapping 대신 MDX content hash와 line range가
+    유일하게 일치하는 sidecar provenance index를 renderer strategy 전에
+    구축합니다.
+  - exact 후보가 없으면 `missing_identity`, 중복되면 `ambiguous_target`으로
+    operation 생성 전에 block합니다.
 - [x] normalized text prefix fallback을 push-eligible path에서 제거합니다.
 - [ ] visible segment model을 paragraph, heading, list에 확장합니다.
 - [ ] strategy를 text block, list, preserved anchor, container, table로 분리합니다.
@@ -304,10 +309,18 @@ lifecycle guide branch 검증 결과:
 - `make test-reverse-sync`: golden 16 passed, regression 43 passed
 - 전체 Python test: 1117 passed, 2 skipped
 
+provenance-first branch 검증 결과:
+
+- `make test-convert`: 21 passed
+- `make test-reverse-sync`: golden 16 passed, regression 43 passed
+- `make test-byte-verify`: fast/splice 각각 21/21 passed
+- reverse-sync Python test: 796 passed
+- 전체 Python test: 1119 passed, 2 skipped
+
 - [x] 영향도에 따라 전체 Python test와 render test를 실행합니다.
 
-이번 변경은 Python CLI/planner 범위이므로 전체 Python test
-(`1117 passed, 2 skipped`)를 실행했고 frontend render test는 영향 범위에서
+이번 변경은 Python planner 범위이므로 전체 Python test
+(`1119 passed, 2 skipped`)를 실행했고 frontend render test는 영향 범위에서
 제외했습니다.
 
 ```bash


### PR DESCRIPTION
## Summary

- strict planner가 caller의 legacy MDX mapping을 신뢰하지 않고 exact sidecar provenance index를 먼저 구축하도록 변경합니다.
- MDX content hash와 line range가 유일하게 일치하는 target만 renderer strategy에 전달합니다.
- exact 후보가 없으면 `missing_identity`, 둘 이상이면 `ambiguous_target`으로 operation 생성 전에 차단합니다.
- `enforce_provenance=true`이면 caller option과 무관하게 normalized text fallback을 비활성화합니다.
- 오염된 legacy mapping, 중복 provenance, strict list fallback을 고정하는 회귀 테스트를 추가합니다.

## OpenSpec

- `complete-reverse-sync`의 provenance-first block identity task를 완료 처리합니다.
- provenance-first target selection과 operation 단계의 defense-in-depth 재검증 경계를 design에 기록합니다.

## Safety impact

- strict/online planning에서만 exact provenance index를 강제하며 offline diagnostic의 legacy fallback은 유지합니다.
- 잘못되거나 모호한 target은 XHTML operation으로 변환하지 않습니다.
- Confluence remote PUT이나 canary 실행은 수행하지 않았습니다.

## Test plan

- `../venv/bin/python3 -m pytest -q test_reverse_sync*.py test_lost_info_patcher.py` — 797 passed
- `../venv/bin/python3 -m pytest -q` — 1120 passed, 2 skipped
- `make test-convert` — 21 passed
- `make test-reverse-sync` — golden 16 passed, regression 43 passed
- `make test-byte-verify` — fast/splice 각각 21/21 passed
- `openspec validate complete-reverse-sync --strict`
- `git diff --check`

## Stack

- Base: #1037
- 이 PR은 #1037 위에 쌓인 후속 PR입니다.

🤖 Generated with Codex

Co-Authored-By: Atlas <atlas@jk.agent>
