### PR TITLE
confluence-mdx: text block visible segment 모델을 확장합니다

### DIFF
--- a/confluence-mdx/bin/reverse_sync/patch_builder.py
+++ b/confluence-mdx/bin/reverse_sync/patch_builder.py
@@ -33,8 +33,8 @@ from reverse_sync.reconstructors import (
     rewrite_on_stored_template,
 )
 from reverse_sync.visible_segments import (
-    extract_list_model_from_mdx,
-    extract_list_model_from_xhtml,
+    extract_visible_model_from_mdx,
+    extract_visible_model_from_xhtml,
 )
 
 
@@ -52,6 +52,24 @@ _GENERATED_LINK = re.compile(
     r"<a\b([^>]*)>(.*?)</a>",
     flags=re.DOTALL | re.IGNORECASE,
 )
+
+
+def _mdx_visible_text(block: MdxBlock) -> str:
+    if block.type in {"paragraph", "heading"}:
+        return extract_visible_model_from_mdx(
+            block.content,
+            block.type,
+        ).visible_text
+    return normalize_mdx_to_plain(block.content, block.type)
+
+
+def _xhtml_visible_text(mapping: BlockMapping, block_type: str) -> str:
+    if block_type in {"paragraph", "heading"}:
+        return extract_visible_model_from_xhtml(
+            mapping.xhtml_text,
+            block_type,
+        ).visible_text
+    return mapping.xhtml_plain_text
 
 
 def _is_container_sidecar(sidecar_block: Optional[SidecarBlock]) -> bool:
@@ -1125,8 +1143,7 @@ def build_patches(
         if change.old_block.type in NON_CONTENT_TYPES:
             continue
 
-        old_plain = normalize_mdx_to_plain(
-            change.old_block.content, change.old_block.type)
+        old_plain = _mdx_visible_text(change.old_block)
 
         strategy, mapping = _resolve_mapping_for_change(
             change, old_plain, mappings, used_ids,
@@ -1200,9 +1217,18 @@ def build_patches(
             list_sidecar = _find_roundtrip_sidecar_block(
                 change, mapping, roundtrip_sidecar, xpath_to_sidecar_block,
             )
-            old_list_model = extract_list_model_from_mdx(change.old_block.content)
-            new_list_model = extract_list_model_from_mdx(change.new_block.content)
-            xhtml_list_model = extract_list_model_from_xhtml(mapping.xhtml_text)
+            old_list_model = extract_visible_model_from_mdx(
+                change.old_block.content,
+                "list",
+            )
+            new_list_model = extract_visible_model_from_mdx(
+                change.new_block.content,
+                "list",
+            )
+            xhtml_list_model = extract_visible_model_from_xhtml(
+                mapping.xhtml_text,
+                "list",
+            )
             has_content_change = old_list_model.visible_text != new_list_model.visible_text
             has_structure_change = (
                 old_list_model.structural_fingerprint
@@ -1318,8 +1344,7 @@ def build_patches(
                 skipped_changes.append(table_skip)
             continue
 
-        new_plain = normalize_mdx_to_plain(
-            change.new_block.content, change.new_block.type)
+        new_plain = _mdx_visible_text(change.new_block)
 
         if strategy == 'containing':
             if mapping is not None:
@@ -1410,11 +1435,15 @@ def build_patches(
 
         # strategy == 'direct'
         _mark_used(mapping.block_id, mapping)
+        mapping_visible_text = _xhtml_visible_text(
+            mapping,
+            change.old_block.type,
+        )
 
         # 멱등성 체크: push 후 XHTML이 이미 업데이트된 경우 건너뜀
         # (old != xhtml 이고 new == xhtml → 이미 적용된 변경)
-        if (collapse_ws(old_plain) != collapse_ws(mapping.xhtml_plain_text)
-                and collapse_ws(new_plain) == collapse_ws(mapping.xhtml_plain_text)):
+        if (collapse_ws(old_plain) != collapse_ws(mapping_visible_text)
+                and collapse_ws(new_plain) == collapse_ws(mapping_visible_text)):
             continue
 
         sidecar_block = _find_roundtrip_sidecar_block(
@@ -1488,9 +1517,9 @@ def build_patches(
                 continue
             patches.append({
                 'xhtml_xpath': mapping.xhtml_xpath,
-                'old_plain_text': mapping.xhtml_plain_text,
+                'old_plain_text': mapping_visible_text,
                 'new_plain_text': _apply_mdx_diff_to_xhtml(
-                    old_plain, new_plain, mapping.xhtml_plain_text),
+                    old_plain, new_plain, mapping_visible_text),
             })
             continue
 
@@ -1503,7 +1532,7 @@ def build_patches(
 
         patches.append({
             'xhtml_xpath': mapping.xhtml_xpath,
-            'old_plain_text': mapping.xhtml_plain_text,
+            'old_plain_text': mapping_visible_text,
             'new_inner_xhtml': new_inner,
         })
 

--- a/confluence-mdx/bin/reverse_sync/visible_segments.py
+++ b/confluence-mdx/bin/reverse_sync/visible_segments.py
@@ -1,9 +1,8 @@
-"""Lossless visible segment extraction for reverse sync.
+"""Lossless visible segment extraction for reverse sync text-bearing blocks.
 
-Phase 1 migrates list handling first. The abstraction is intentionally small:
-- keep visible whitespace as explicit segments
-- keep list/item structure in a fingerprint for rebuild decisions
-- expose actual XHTML-visible text without the lossy normalize_mdx_to_plain step
+The model keeps visible whitespace as explicit segments, records preservation
+units separately from visible text, and exposes structural fingerprints for
+paragraph, heading, and list planning.
 """
 
 from __future__ import annotations
@@ -17,6 +16,7 @@ SegmentKind = Literal["list_marker", "ws", "text", "item_boundary", "anchor"]
 
 from bs4 import BeautifulSoup, Tag
 from reverse_sync.mapping_recorder import get_text_with_emoticons
+from reverse_sync.mdx_to_xhtml_inline import mdx_block_to_inner_xhtml
 
 
 @dataclass(frozen=True)
@@ -46,6 +46,133 @@ class _MdxListEntry:
     marker_ws: str
     body: str
     continuation_lines: Tuple[str, ...]
+
+
+_TEXT_BLOCK_TYPES = frozenset({"paragraph", "heading"})
+_PRESERVATION_TAGS = frozenset(
+    {"a", "ac:link", "ac:image", "ac:structured-macro", "ri:attachment"}
+)
+
+
+def extract_visible_model_from_mdx(
+    content: str,
+    block_type: str,
+) -> VisibleContentModel:
+    """MDX paragraph, heading, list를 공통 visible-content model로 변환합니다."""
+    if block_type == "list":
+        return extract_list_model_from_mdx(content)
+    if block_type not in _TEXT_BLOCK_TYPES:
+        raise ValueError(f"지원하지 않는 visible MDX block type입니다: {block_type}")
+
+    rendered_inner = mdx_block_to_inner_xhtml(content, block_type)
+    heading_level = _mdx_heading_level(content) if block_type == "heading" else None
+    return _extract_text_model(
+        rendered_inner,
+        block_type=block_type,
+        heading_level=heading_level,
+        source="mdx",
+    )
+
+
+def extract_visible_model_from_xhtml(
+    fragment: str,
+    block_type: str,
+) -> VisibleContentModel:
+    """Storage XHTML paragraph, heading, list의 visible-content model을 만듭니다."""
+    if block_type == "list":
+        return extract_list_model_from_xhtml(fragment)
+    if block_type not in _TEXT_BLOCK_TYPES:
+        raise ValueError(f"지원하지 않는 visible XHTML block type입니다: {block_type}")
+
+    soup = BeautifulSoup(fragment, "html.parser")
+    heading = soup.find(re.compile(r"^h[1-6]$"))
+    heading_level = (
+        int(heading.name[1])
+        if block_type == "heading" and isinstance(heading, Tag)
+        else None
+    )
+    return _extract_text_model(
+        fragment,
+        block_type=block_type,
+        heading_level=heading_level,
+        source="xhtml",
+    )
+
+
+def _extract_text_model(
+    fragment: str,
+    *,
+    block_type: str,
+    heading_level: int | None,
+    source: str,
+) -> VisibleContentModel:
+    soup = BeautifulSoup(fragment, "html.parser")
+    visible_text = get_text_with_emoticons(soup)
+    segments = _tokenize_visible_text(visible_text)
+    units = _collect_preservation_units(soup)
+    segments.extend(
+        VisibleSegment(
+            kind="anchor",
+            text="",
+            visible=False,
+            structural=True,
+            meta={"kind": kind, "source": source, **metadata},
+        )
+        for kind, metadata in units
+    )
+    return VisibleContentModel(
+        segments=segments,
+        visible_text=visible_text,
+        structural_fingerprint=(
+            block_type,
+            heading_level,
+            tuple(kind for kind, _ in units),
+        ),
+    )
+
+
+def _collect_preservation_units(
+    soup: BeautifulSoup,
+) -> List[Tuple[str, dict[str, Any]]]:
+    units: List[Tuple[str, dict[str, Any]]] = []
+    for tag in soup.find_all(sorted(_PRESERVATION_TAGS)):
+        if tag.name in {"a", "ac:link"}:
+            kind = "link"
+            page = tag.find("ri:page")
+            metadata = {
+                "href": str(tag.get("href", "")),
+                "anchor": str(tag.get("ac:anchor", "")),
+                "page_title": (
+                    str(page.get("ri:content-title", ""))
+                    if isinstance(page, Tag)
+                    else ""
+                ),
+            }
+        elif tag.name == "ac:image":
+            kind = "attachment"
+            attachment = tag.find("ri:attachment")
+            metadata = {
+                "filename": (
+                    str(attachment.get("ri:filename", ""))
+                    if isinstance(attachment, Tag)
+                    else ""
+                ),
+            }
+        elif tag.name == "ri:attachment":
+            if tag.find_parent("ac:image") is not None:
+                continue
+            kind = "attachment"
+            metadata = {"filename": str(tag.get("ri:filename", ""))}
+        else:
+            kind = "macro"
+            metadata = {"name": str(tag.get("ac:name", ""))}
+        units.append((kind, metadata))
+    return units
+
+
+def _mdx_heading_level(content: str) -> int | None:
+    match = re.match(r"^\s*(#{1,6})\s+", content)
+    return len(match.group(1)) if match is not None else None
 
 
 def extract_list_model_from_mdx(content: str) -> VisibleContentModel:

--- a/confluence-mdx/tests/test_reverse_sync_patch_builder.py
+++ b/confluence-mdx/tests/test_reverse_sync_patch_builder.py
@@ -532,6 +532,41 @@ class TestBuildPatches:
         # ac:link 구조가 보존되어야 함
         assert '<ac:link>' in patches[0]['new_element_xhtml']
 
+    def test_multiline_preserved_anchor_uses_rendered_visible_model(self):
+        """paragraph source line break를 rendered space로 계획하고 anchor를 보존한다."""
+        m1 = _make_mapping(
+            'm1',
+            'Before Link',
+            xpath='p[1]',
+        )
+        m1.xhtml_text = (
+            '<p>Before <ac:link>'
+            '<ri:page ri:content-title="Target" />'
+            '<ac:link-body>Link</ac:link-body>'
+            '</ac:link></p>'
+        )
+        mappings = [m1]
+        xpath_to_mapping = {m.xhtml_xpath: m for m in mappings}
+        change = _make_change(
+            0,
+            'Before\n[Link](target)',
+            'After\n[Link](target)',
+        )
+
+        patches, *_ = build_patches(
+            [change],
+            [change.old_block],
+            [change.new_block],
+            mappings,
+            self._setup_sidecar('p[1]', 0),
+            xpath_to_mapping,
+        )
+
+        assert len(patches) == 1
+        assert '<ac:link>' in patches[0]['new_element_xhtml']
+        assert 'After ' in patches[0]['new_element_xhtml']
+        assert '\n' not in patches[0]['new_element_xhtml']
+
     def test_roundtrip_sidecar_paragraph_without_anchors_uses_replace_fragment(self):
         m1 = _make_mapping('m1', 'hello world', xpath='p[1]')
         mappings = [m1]

--- a/confluence-mdx/tests/test_reverse_sync_visible_segments.py
+++ b/confluence-mdx/tests/test_reverse_sync_visible_segments.py
@@ -1,9 +1,72 @@
-"""Visible segment extraction tests for reverse sync list phase 1."""
+"""Visible segment extraction tests for reverse sync text-bearing blocks."""
 
 from reverse_sync.visible_segments import (
     extract_list_model_from_mdx,
     extract_list_model_from_xhtml,
+    extract_visible_model_from_mdx,
+    extract_visible_model_from_xhtml,
 )
+
+
+class TestExtractTextBlockModel:
+    def test_paragraph_uses_rendered_visible_whitespace_and_tracks_link(self):
+        model = extract_visible_model_from_mdx(
+            "  Before **bold**\nnext [Link](https://example.com)  \n",
+            "paragraph",
+        )
+
+        assert model.visible_text == "Before bold next Link"
+        assert model.structural_fingerprint == (
+            "paragraph",
+            None,
+            ("link",),
+        )
+        assert any(
+            segment.kind == "ws" and segment.text == " "
+            for segment in model.segments
+        )
+        link = next(
+            segment
+            for segment in model.segments
+            if segment.kind == "anchor"
+        )
+        assert link.meta["href"] == "https://example.com"
+        assert link.meta["source"] == "mdx"
+
+    def test_heading_tracks_level_and_emitted_visible_text(self):
+        model = extract_visible_model_from_mdx(
+            "### **Title** `Code`\n",
+            "heading",
+        )
+
+        assert model.visible_text == "Title Code"
+        assert model.structural_fingerprint == ("heading", 3, ())
+
+    def test_xhtml_tracks_preservation_units_and_target_metadata(self):
+        model = extract_visible_model_from_xhtml(
+            "<p>앞 <ac:link ac:anchor=\"section\">"
+            "<ri:page ri:content-title=\"Target\"/>"
+            "<ac:link-body>링크</ac:link-body></ac:link> 뒤"
+            "<ac:image><ri:attachment ri:filename=\"screen.png\"/></ac:image>"
+            "</p>",
+            "paragraph",
+        )
+
+        assert model.visible_text == "앞 링크 뒤"
+        assert model.structural_fingerprint == (
+            "paragraph",
+            None,
+            ("link", "attachment"),
+        )
+        anchors = [
+            segment
+            for segment in model.segments
+            if segment.kind == "anchor"
+        ]
+        assert anchors[0].meta["anchor"] == "section"
+        assert anchors[0].meta["page_title"] == "Target"
+        assert anchors[1].meta["filename"] == "screen.png"
+        assert all(segment.meta["source"] == "xhtml" for segment in anchors)
 
 
 class TestExtractListModelFromMdx:

--- a/openspec/changes/complete-reverse-sync/design.md
+++ b/openspec/changes/complete-reverse-sync/design.md
@@ -258,7 +258,13 @@ changed fragment는 capability registry에 따라 다음 전략 중 하나를 �
 | `delete_exact_fragment` | 삭제 대상 identity가 exact하고 보호 metadata 정책을 충족함 | fragment 삭제 |
 | `blocked` | identity 또는 preservation proof가 부족함 | XHTML을 만들지 않고 reason code 반환 |
 
-기존 `visible_segments.py`의 개념은 paragraph, heading, list 등 text-bearing block의 planning model로 확장합니다. 다만 arbitrary Confluence macro를 universal visible model로 일반화하지 않습니다.
+`visible_segments.py`는 paragraph, heading, list 등 text-bearing block의 planning
+model을 제공합니다. paragraph와 heading은 실제 MDX inline emitter의 결과에서
+visible text와 whitespace segment를 추출하고, link, attachment, macro
+preservation unit의 target metadata를 별도 structural segment로 기록합니다.
+list는 item path, marker kind, ordered start, anchor path를 fingerprint로 유지합니다.
+planner adapter는 이 모델의 visible text를 사용하되 arbitrary Confluence macro와
+container를 universal visible model로 일반화하지 않습니다.
 
 ### Decision: capability registry를 code와 test의 공통 언어로 둡니다
 

--- a/openspec/changes/complete-reverse-sync/tasks.md
+++ b/openspec/changes/complete-reverse-sync/tasks.md
@@ -167,7 +167,12 @@
   - exact 후보가 없으면 `missing_identity`, 중복되면 `ambiguous_target`으로
     operation 생성 전에 block합니다.
 - [x] normalized text prefix fallback을 push-eligible path에서 제거합니다.
-- [ ] visible segment model을 paragraph, heading, list에 확장합니다.
+- [x] visible segment model을 paragraph, heading, list에 확장합니다.
+  - paragraph와 heading은 실제 inline emitter 결과에서 visible whitespace와
+    link/attachment/macro preservation unit metadata를 추출합니다.
+  - list는 기존 item path, marker, ordered start, anchor fingerprint를 같은 공통
+    dispatcher로 제공합니다.
+  - arbitrary macro/container는 기존 capability 경계에 남기고 일반화하지 않습니다.
 - [ ] strategy를 text block, list, preserved anchor, container, table로 분리합니다.
 - [x] unsupported table/macro 구조를 explicit block reason으로 전환합니다.
   - operation 생성 전 legacy skip도 원래 intent에 연결합니다.
@@ -317,10 +322,18 @@ provenance-first branch 검증 결과:
 - reverse-sync Python test: 797 passed
 - 전체 Python test: 1120 passed, 2 skipped
 
+visible segment branch 검증 결과:
+
+- `make test-convert`: 21 passed
+- `make test-reverse-sync`: golden 16 passed, regression 43 passed
+- `make test-byte-verify`: fast/splice 각각 21/21 passed
+- reverse-sync Python test: 801 passed
+- 전체 Python test: 1124 passed, 2 skipped
+
 - [x] 영향도에 따라 전체 Python test와 render test를 실행합니다.
 
-이번 변경은 Python planner 범위이므로 전체 Python test
-(`1120 passed, 2 skipped`)를 실행했고 frontend render test는 영향 범위에서
+이번 변경은 Python planner/renderer adapter 범위이므로 전체 Python test
+(`1124 passed, 2 skipped`)를 실행했고 frontend render test는 영향 범위에서
 제외했습니다.
 
 ```bash


### PR DESCRIPTION
## Summary

- list 전용 `VisibleContentModel`을 paragraph와 heading까지 확장합니다.
- MDX paragraph/heading은 실제 inline emitter 결과에서 visible text와 whitespace segment를 추출합니다.
- XHTML 모델은 link, attachment, macro preservation unit과 target metadata를 structural segment로 기록합니다.
- patch builder가 paragraph/heading의 planning text와 direct target text를 공통 visible model에서 사용하도록 변경합니다.
- multiline paragraph의 rendered space와 preserved Confluence link를 함께 검증하는 통합 테스트를 추가합니다.

## OpenSpec

- `complete-reverse-sync`의 paragraph/heading/list visible segment task를 완료 처리합니다.
- arbitrary macro/container는 공통 visible 모델로 일반화하지 않고 기존 capability 경계에 남긴다는 결정을 기록합니다.

## Safety impact

- text-bearing block의 visible text가 source 줄바꿈이 아니라 실제 emitter rendering 기준으로 결정됩니다.
- preservation unit은 visible text와 분리되어 target metadata를 잃지 않고 planning에서 관찰할 수 있습니다.
- unsupported macro/container의 기존 fail-closed 동작은 변경하지 않습니다.
- Confluence remote PUT이나 canary 실행은 수행하지 않았습니다.

## Test plan

- `../venv/bin/python3 -m pytest -q test_reverse_sync*.py test_lost_info_patcher.py` — 801 passed
- `../venv/bin/python3 -m pytest -q` — 1124 passed, 2 skipped
- `make test-convert` — 21 passed
- `make test-reverse-sync` — golden 16 passed, regression 43 passed
- `make test-byte-verify` — fast/splice 각각 21/21 passed
- `openspec validate complete-reverse-sync --strict`
- `git diff --check`

## Stack

- Base: #1038
- 이 PR은 #1038 위에 쌓인 후속 PR입니다.

🤖 Generated with Codex

Co-Authored-By: Atlas <atlas@jk.agent>
