### PR TITLE
confluence-mdx: renderer strategy를 typed decision으로 분리합니다

### DIFF
--- a/confluence-mdx/bin/reverse_sync/capabilities.py
+++ b/confluence-mdx/bin/reverse_sync/capabilities.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
+import re
 from typing import Optional
 
 from reverse_sync.mapping_recorder import BlockMapping
 from reverse_sync.sidecar import SidecarBlock
+from reverse_sync.visible_segments import extract_visible_model_from_mdx
 
 
 class SupportLevel(str, Enum):
@@ -16,6 +18,26 @@ class SupportLevel(str, Enum):
     SUPPORTED = "supported"
     CONDITIONAL = "conditional"
     BLOCKED = "blocked"
+
+
+class RendererStrategy(str, Enum):
+    """planner와 legacy adapter가 공유하는 renderer strategy."""
+
+    TEXT_BLOCK = "text_block"
+    LIST = "list"
+    PRESERVED_ANCHOR = "preserved_anchor"
+    CONTAINER = "container"
+    TABLE = "table"
+    BLOCKED = "blocked"
+
+
+@dataclass(frozen=True)
+class StrategyDecision:
+    """target mapping을 기준으로 확정한 renderer strategy."""
+
+    strategy: RendererStrategy
+    source_kind: str
+    reason_code: str = ""
 
 
 @dataclass(frozen=True)
@@ -135,6 +157,116 @@ def _contains_preservation_unit(mapping: Optional[BlockMapping]) -> bool:
     if mapping is None:
         return False
     return "<ac:" in mapping.xhtml_text or "<ri:" in mapping.xhtml_text
+
+
+def _contains_only_mdx_owned_links(
+    block_content: str,
+    block_type: str,
+    mapping: BlockMapping,
+) -> bool:
+    """XHTML preservation unit이 MDX link emitter 소유인지 판별합니다."""
+    if block_type not in {"paragraph", "heading"}:
+        return False
+
+    link_fragments = re.findall(
+        r"<ac:link(?:\s|>).*?</ac:link>",
+        mapping.xhtml_text,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    if not link_fragments:
+        return False
+    remainder = mapping.xhtml_text
+    for fragment in link_fragments:
+        remainder = remainder.replace(fragment, "", 1)
+    if "<ac:" in remainder or "<ri:" in remainder:
+        return False
+
+    mdx_model = extract_visible_model_from_mdx(block_content, block_type)
+    mdx_link_count = sum(
+        1
+        for segment in mdx_model.segments
+        if segment.kind == "anchor" and segment.meta.get("kind") == "link"
+    )
+    return mdx_link_count >= len(link_fragments)
+
+
+def is_markdown_table(content: str) -> bool:
+    """MDX content가 pipe table인지 판별합니다."""
+    lines = [line.strip() for line in content.strip().split("\n") if line.strip()]
+    if len(lines) < 2:
+        return False
+    pipe_lines = sum(
+        1
+        for line in lines
+        if line.startswith("|") and line.endswith("|")
+    )
+    return pipe_lines >= 2
+
+
+def is_raw_html_table(content: str, block_type: str) -> bool:
+    return (
+        block_type == "html_block"
+        and bool(re.match(r"^\s*<table(?:\s|>)", content, flags=re.IGNORECASE))
+    )
+
+
+def select_renderer_strategy(
+    *,
+    block_type: str,
+    block_content: str,
+    mapping: Optional[BlockMapping],
+    sidecar_block: Optional[SidecarBlock] = None,
+) -> StrategyDecision:
+    """mapping 이후 renderer 전략을 typed category로 결정합니다.
+
+    identity resolution은 이 함수보다 먼저 수행합니다. mapping이 없으면 list/table
+    diagnostic fallback만 category를 유지하고, 나머지는 fail-closed합니다.
+    """
+    list_source = block_type == "list"
+    raw_html_table = is_raw_html_table(block_content, block_type)
+    markdown_table = is_markdown_table(block_content)
+    table_source = raw_html_table or markdown_table
+
+    if mapping is None:
+        if list_source:
+            return StrategyDecision(RendererStrategy.LIST, "list")
+        if table_source:
+            source_kind = "raw_html_table" if raw_html_table else "table"
+            return StrategyDecision(RendererStrategy.TABLE, source_kind)
+        return StrategyDecision(
+            RendererStrategy.BLOCKED,
+            block_type,
+            reason_code="missing_identity",
+        )
+
+    if block_type == "callout" or mapping.children:
+        if list_source:
+            return StrategyDecision(RendererStrategy.LIST, "list")
+        return StrategyDecision(RendererStrategy.CONTAINER, block_type)
+    if list_source:
+        return StrategyDecision(RendererStrategy.LIST, "list")
+    if table_source:
+        source_kind = "raw_html_table" if raw_html_table else "table"
+        return StrategyDecision(RendererStrategy.TABLE, source_kind)
+    if (
+        _contains_preservation_unit(mapping)
+        and not (
+            sidecar_block is not None
+            and sidecar_block.reconstruction is not None
+            and sidecar_block.reconstruction.get("kind") == "paragraph"
+            and not sidecar_block.reconstruction.get("anchors", [])
+            and _contains_only_mdx_owned_links(
+                block_content,
+                block_type,
+                mapping,
+            )
+        )
+    ):
+        return StrategyDecision(
+            RendererStrategy.PRESERVED_ANCHOR,
+            block_type,
+        )
+    return StrategyDecision(RendererStrategy.TEXT_BLOCK, block_type)
 
 
 def _is_container(

--- a/confluence-mdx/bin/reverse_sync/patch_builder.py
+++ b/confluence-mdx/bin/reverse_sync/patch_builder.py
@@ -1221,7 +1221,7 @@ def build_patches(
                 mapping_via_v3_fallback = True
         elif (
             not allow_text_identity_fallback
-            and strategy == 'list'
+            and strategy is RendererStrategy.LIST
             and mapping is not None
             and _contains_preserved_anchor_markup(mapping.xhtml_text)
             and old_plain[:40].strip() not in mapping.xhtml_plain_text

--- a/confluence-mdx/bin/reverse_sync/patch_builder.py
+++ b/confluence-mdx/bin/reverse_sync/patch_builder.py
@@ -6,6 +6,7 @@ from pathlib import PurePosixPath
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import unquote, urlparse
 
+from bs4 import BeautifulSoup
 from mdx_to_storage.emitter import emit_block
 from mdx_to_storage.link_resolver import LinkResolver
 from mdx_to_storage.parser import parse_mdx
@@ -111,6 +112,26 @@ def _contains_preserved_anchor_markup(xhtml_text: str) -> bool:
 def _contains_preserved_link_markup(xhtml_text: str) -> bool:
     """링크 계열 preserved anchor가 포함된 경우만 가시 공백 raw transfer 대상이다."""
     return "<ac:link" in xhtml_text
+
+
+def _contains_only_supported_preservation_units(xhtml_text: str) -> bool:
+    """template rewrite 계약이 있는 link/attachment unit만 포함하는지 확인한다."""
+    supported = {
+        "ac:caption",
+        "ac:image",
+        "ac:link",
+        "ac:link-body",
+        "ri:attachment",
+        "ri:page",
+        "ri:space",
+    }
+    soup = BeautifulSoup(xhtml_text, "html.parser")
+    preservation_tags = {
+        tag.name
+        for tag in soup.find_all()
+        if tag.name.startswith(("ac:", "ri:"))
+    }
+    return bool(preservation_tags) and preservation_tags <= supported
 
 
 def _resolve_generated_links(
@@ -1508,6 +1529,18 @@ def build_patches(
                         mapping_lost_info=mapping_lost_info,
                     )
                 )
+                continue
+            if not _contains_only_supported_preservation_units(
+                mapping.xhtml_text
+            ):
+                skipped_changes.append({
+                    'block_id': mapping.block_id,
+                    'reason': 'unknown_preservation_unit',
+                    'description': (
+                        f"블록 {mapping.block_id}: 지원 계약이 없는 Confluence "
+                        f"preservation unit을 변경할 수 없어 건너뜁니다."
+                    ),
+                })
                 continue
             if (
                 '<ac:link' in mapping.xhtml_text

--- a/confluence-mdx/bin/reverse_sync/patch_builder.py
+++ b/confluence-mdx/bin/reverse_sync/patch_builder.py
@@ -10,6 +10,12 @@ from mdx_to_storage.emitter import emit_block
 from mdx_to_storage.link_resolver import LinkResolver
 from mdx_to_storage.parser import parse_mdx
 from reverse_sync.block_diff import BlockChange, NON_CONTENT_TYPES
+from reverse_sync.capabilities import (
+    RendererStrategy,
+    StrategyDecision,
+    is_markdown_table,
+    select_renderer_strategy,
+)
 from reverse_sync.mapping_recorder import BlockMapping, record_mapping
 from mdx_to_storage.parser import Block as MdxBlock
 from text_utils import (
@@ -36,16 +42,6 @@ from reverse_sync.visible_segments import (
     extract_visible_model_from_mdx,
     extract_visible_model_from_xhtml,
 )
-
-
-def is_markdown_table(content: str) -> bool:
-    """Content가 Markdown table 형식인지 판별한다."""
-    lines = [l.strip() for l in content.strip().split('\n') if l.strip()]
-    if len(lines) < 2:
-        return False
-    pipe_lines = sum(1 for l in lines if l.startswith('|') and l.endswith('|'))
-    return pipe_lines >= 2
-
 
 _CLEAN_BLOCK_TYPES = frozenset(("heading", "code_block", "hr"))
 _GENERATED_LINK = re.compile(
@@ -465,6 +461,26 @@ def _is_safe_cell_text_edit(old_cells: List[str], new_cells: List[str]) -> bool:
         if oc and oc in new_cells[:i] + new_cells[i + 1:]:
             return False
     return True
+
+
+def _build_preserved_template_patch(
+    mapping: BlockMapping,
+    new_plain: str,
+    mapping_lost_info: dict,
+) -> Dict[str, str]:
+    """원본 Confluence inline unit을 보존하는 fragment patch를 생성합니다."""
+    preserved = rewrite_on_stored_template(
+        mapping.xhtml_text,
+        new_plain,
+    )
+    block_lost = mapping_lost_info.get(mapping.block_id, {})
+    if block_lost:
+        preserved = apply_lost_info(preserved, block_lost)
+    return {
+        'action': 'replace_fragment',
+        'xhtml_xpath': mapping.xhtml_xpath,
+        'new_element_xhtml': preserved,
+    }
 
 
 def _can_replace_table_fragment(
@@ -898,51 +914,34 @@ def _find_best_list_mapping_by_text(
 
 def _resolve_mapping_for_change(
     change: BlockChange,
-    old_plain: str,
-    mappings: List[BlockMapping],
-    used_ids: set,
     mdx_to_sidecar: Dict[int, SidecarEntry],
     xpath_to_mapping: Dict[str, 'BlockMapping'],
-) -> tuple:
-    """변경에 대한 매핑과 처리 전략을 결정한다.
+    roundtrip_sidecar: Optional[RoundtripSidecar] = None,
+    xpath_to_sidecar_block: Optional[Dict[str, SidecarBlock]] = None,
+) -> Tuple[StrategyDecision, Optional[BlockMapping]]:
+    """exact mapping을 찾은 뒤 typed renderer strategy를 결정합니다.
 
     Returns:
-        (strategy, mapping) 튜플.
-        strategy: 'direct' | 'containing' | 'list' | 'table' | 'skip'
+        (StrategyDecision, mapping) 튜플.
         mapping: 해당 BlockMapping 또는 None
     """
-
-    # Sidecar 직접 조회 (O(1))
     mapping = find_mapping_by_sidecar(
         change.index, mdx_to_sidecar, xpath_to_mapping)
-
-    if mapping is None:
-        if change.old_block.type == 'list':
-            return ('list', None)
-        if is_markdown_table(change.old_block.content):
-            return ('table', None)
-        return ('skip', None)
-
-    # callout 블록은 항상 containing 전략 사용
-    # (_convert_callout_inner가 <li><p> 구조를 생성할 수 없으므로)
-    if change.old_block.type == 'callout':
-        return ('containing', mapping)
-
-    # Parent mapping이 children을 가지면 containing 전략으로 위임
-    if mapping.children:
-        if change.old_block.type == 'list':
-            return ('list', mapping)
-        return ('containing', mapping)
-
-    # list 블록은 list 전략 사용 (direct 교체 시 <ac:image> 등 Confluence 태그 손실 방지)
-    if change.old_block.type == 'list':
-        return ('list', mapping)
-
-    # table 블록은 table 전략 사용 (direct 교체 시 <ac:link> 등 Confluence 태그 손실 방지)
-    if is_markdown_table(change.old_block.content):
-        return ('table', mapping)
-
-    return ('direct', mapping)
+    sidecar_block = _find_roundtrip_sidecar_block(
+        change,
+        mapping,
+        roundtrip_sidecar,
+        xpath_to_sidecar_block or {},
+    )
+    return (
+        select_renderer_strategy(
+            block_type=change.old_block.type,
+            block_content=change.old_block.content,
+            mapping=mapping,
+            sidecar_block=sidecar_block,
+        ),
+        mapping,
+    )
 
 
 def build_patches(
@@ -1145,14 +1144,23 @@ def build_patches(
 
         old_plain = _mdx_visible_text(change.old_block)
 
-        strategy, mapping = _resolve_mapping_for_change(
-            change, old_plain, mappings, used_ids,
-            mdx_to_sidecar, xpath_to_mapping)
+        strategy_decision, mapping = _resolve_mapping_for_change(
+            change,
+            mdx_to_sidecar,
+            xpath_to_mapping,
+            roundtrip_sidecar,
+            xpath_to_sidecar_block,
+        )
+        strategy = strategy_decision.strategy
 
         # legacy sidecar mapping이 커버하지 못한 list 블록:
         # roundtrip sidecar v3 identity로 fallback하여 mapping 복원
         mapping_via_v3_fallback = False
-        if mapping is None and strategy == 'list' and roundtrip_sidecar is not None:
+        if (
+            mapping is None
+            and strategy is RendererStrategy.LIST
+            and roundtrip_sidecar is not None
+        ):
             id_block = change.old_block or change.new_block
             if id_block and id_block.content:
                 fallback_sc = find_sidecar_block_by_identity(
@@ -1171,7 +1179,7 @@ def build_patches(
         if (
             allow_text_identity_fallback
             and mapping is None
-            and strategy == 'list'
+            and strategy is RendererStrategy.LIST
         ):
             text_fallback = _find_best_list_mapping_by_text(
                 old_plain, mappings, used_ids)
@@ -1182,7 +1190,7 @@ def build_patches(
         # sidecar가 잘못된 list mapping을 반환한 경우 (ac: 포함 + plain text 불일치):
         # plain text prefix로 올바른 mapping 복원
         if (allow_text_identity_fallback
-                and strategy == 'list' and mapping is not None
+                and strategy is RendererStrategy.LIST and mapping is not None
                 and _contains_preserved_anchor_markup(mapping.xhtml_text)
                 and old_plain[:40].strip() not in mapping.xhtml_plain_text):
             text_fallback = _find_best_list_mapping_by_text(
@@ -1202,7 +1210,7 @@ def build_patches(
         if mapping is None:
             block = change.old_block or change.new_block
             block_id = f"idx-{change.index}"
-            block_kind = strategy if strategy in ('list', 'table') else block.type
+            block_kind = strategy_decision.source_kind or block.type
             skipped_changes.append({
                 'block_id': block_id,
                 'reason': 'no_mapping',
@@ -1213,7 +1221,7 @@ def build_patches(
             })
             continue
 
-        if strategy == 'list':
+        if strategy is RendererStrategy.LIST:
             list_sidecar = _find_roundtrip_sidecar_block(
                 change, mapping, roundtrip_sidecar, xpath_to_sidecar_block,
             )
@@ -1328,7 +1336,47 @@ def build_patches(
                 _mark_used(mapping.block_id, mapping)
             continue
 
-        if strategy == 'table':
+        if strategy is RendererStrategy.TABLE:
+            if strategy_decision.source_kind == "raw_html_table":
+                if (
+                    '<ac:link' in mapping.xhtml_text
+                    or '<ri:attachment' in mapping.xhtml_text
+                ):
+                    _mark_used(mapping.block_id, mapping)
+                    patches.append(
+                        _build_preserved_template_patch(
+                            mapping,
+                            _mdx_visible_text(change.new_block),
+                            mapping_lost_info,
+                        )
+                    )
+                    continue
+                old_cells = _extract_html_table_cells(change.old_block.content)
+                new_cells = _extract_html_table_cells(change.new_block.content)
+                if not _is_safe_cell_text_edit(old_cells, new_cells):
+                    skipped_changes.append({
+                        'block_id': mapping.block_id,
+                        'reason': 'unsafe_html_table_edit',
+                        'description': (
+                            f"블록 {mapping.block_id}: raw HTML 테이블의 셀 구조 변경"
+                            f"(셀 수 변경 또는 셀 내용 재배치)은 안전하지 않아 "
+                            f"건너뜁니다."
+                        ),
+                    })
+                    continue
+                _mark_used(mapping.block_id, mapping)
+                mapping_visible_text = mapping.xhtml_plain_text
+                patches.append({
+                    'xhtml_xpath': mapping.xhtml_xpath,
+                    'old_plain_text': mapping_visible_text,
+                    'new_plain_text': _apply_mdx_diff_to_xhtml(
+                        old_plain,
+                        _mdx_visible_text(change.new_block),
+                        mapping_visible_text,
+                    ),
+                })
+                continue
+
             table_skip = _classify_table_fragment_skip(
                 change, mapping, roundtrip_sidecar)
             if table_skip is None:
@@ -1346,7 +1394,7 @@ def build_patches(
 
         new_plain = _mdx_visible_text(change.new_block)
 
-        if strategy == 'containing':
+        if strategy is RendererStrategy.CONTAINER:
             if mapping is not None:
                 bid = mapping.block_id
                 first_visit = bid not in used_ids
@@ -1433,7 +1481,7 @@ def build_patches(
                             )
             continue
 
-        # strategy == 'direct'
+        # RendererStrategy.TEXT_BLOCK / PRESERVED_ANCHOR
         _mark_used(mapping.block_id, mapping)
         mapping_visible_text = _xhtml_visible_text(
             mapping,
@@ -1449,14 +1497,38 @@ def build_patches(
         sidecar_block = _find_roundtrip_sidecar_block(
             change, mapping, roundtrip_sidecar, xpath_to_sidecar_block,
         )
-        if _can_replace_table_fragment(change, mapping, roundtrip_sidecar):
-            patches.append(
-                _build_replace_fragment_patch(
-                    mapping,
-                    change.new_block,
-                    mapping_lost_info=mapping_lost_info,
+
+        if strategy is RendererStrategy.PRESERVED_ANCHOR:
+            if sidecar_block_requires_reconstruction(sidecar_block):
+                patches.append(
+                    _build_replace_fragment_patch(
+                        mapping,
+                        change.new_block,
+                        sidecar_block=sidecar_block,
+                        mapping_lost_info=mapping_lost_info,
+                    )
                 )
-            )
+                continue
+            if (
+                '<ac:link' in mapping.xhtml_text
+                or '<ri:attachment' in mapping.xhtml_text
+            ):
+                patches.append(
+                    _build_preserved_template_patch(
+                        mapping,
+                        new_plain,
+                        mapping_lost_info,
+                    )
+                )
+                continue
+            skipped_changes.append({
+                'block_id': mapping.block_id,
+                'reason': 'unknown_preservation_unit',
+                'description': (
+                    f"블록 {mapping.block_id}: 지원 계약이 없는 Confluence "
+                    f"preservation unit을 변경할 수 없어 건너뜁니다."
+                ),
+            })
             continue
 
         if _is_clean_block(change.old_block.type, mapping, sidecar_block):
@@ -1479,48 +1551,6 @@ def build_patches(
                     mapping_lost_info=mapping_lost_info,
                 )
             )
-            continue
-
-        # <ac:link> / <ri:attachment> 포함 블록은 inner XHTML 재생성 시 소실 위험
-        # 원본 XHTML 구조를 template으로 사용하여 텍스트만 갱신
-        if ('<ac:link' in mapping.xhtml_text
-                or '<ri:attachment' in mapping.xhtml_text):
-            preserved = rewrite_on_stored_template(mapping.xhtml_text, new_plain)
-            block_lost = mapping_lost_info.get(mapping.block_id, {})
-            if block_lost:
-                preserved = apply_lost_info(preserved, block_lost)
-            patches.append({
-                'action': 'replace_fragment',
-                'xhtml_xpath': mapping.xhtml_xpath,
-                'new_element_xhtml': preserved,
-            })
-            continue
-
-        # raw HTML table은 text-level 패치로 처리하여 XHTML 구조를 보존한다.
-        # mdx_block_to_inner_xhtml 경로는 forward converter가 markdown table로 변환하여
-        # 원본 HTML table 구조가 파괴된다.
-        # text-level 패치는 셀 경계를 인식하지 못하므로, 셀 내 텍스트 교정만 안전하다.
-        # 셀 수 변경이나 셀 간 내용 재배치는 skip하여 silent corruption을 방지한다.
-        if (change.old_block.type == "html_block"
-                and change.old_block.content.lstrip().startswith("<table")):
-            old_cells = _extract_html_table_cells(change.old_block.content)
-            new_cells = _extract_html_table_cells(change.new_block.content)
-            if not _is_safe_cell_text_edit(old_cells, new_cells):
-                skipped_changes.append({
-                    'block_id': mapping.block_id,
-                    'reason': 'unsafe_html_table_edit',
-                    'description': (
-                        f"블록 {mapping.block_id}: raw HTML 테이블의 셀 구조 변경"
-                        f"(셀 수 변경 또는 셀 내용 재배치)은 안전하지 않아 건너뜁니다."
-                    ),
-                })
-                continue
-            patches.append({
-                'xhtml_xpath': mapping.xhtml_xpath,
-                'old_plain_text': mapping_visible_text,
-                'new_plain_text': _apply_mdx_diff_to_xhtml(
-                    old_plain, new_plain, mapping_visible_text),
-            })
             continue
 
         # inner XHTML 재생성 + 블록 레벨 lost_info 적용

--- a/confluence-mdx/bin/reverse_sync/planner.py
+++ b/confluence-mdx/bin/reverse_sync/planner.py
@@ -312,6 +312,7 @@ _LEGACY_UNSUPPORTED_CAPABILITIES = {
     "not_markdown_table": "raw_html_table_edit",
     "preserved_anchor_table": "unknown_macro_mutation",
     "raw_html_table": "raw_html_table_edit",
+    "unknown_preservation_unit": "unknown_macro_mutation",
     "unsafe_html_table_edit": "raw_html_table_edit",
 }
 _LEGACY_MISSING_IDENTITY_REASONS = frozenset(

--- a/confluence-mdx/tests/test_reverse_sync_patch_builder.py
+++ b/confluence-mdx/tests/test_reverse_sync_patch_builder.py
@@ -6,8 +6,8 @@ build_patches 분기 경로
 from pathlib import Path
 from bs4 import BeautifulSoup
 
-from reverse_sync.block_diff import BlockChange
-from reverse_sync.block_diff import diff_blocks
+from reverse_sync.block_diff import BlockChange, diff_blocks
+from reverse_sync.capabilities import RendererStrategy
 from reverse_sync.mapping_recorder import BlockMapping
 from reverse_sync.mapping_recorder import record_mapping
 from mdx_to_storage.parser import parse_mdx_blocks
@@ -1665,42 +1665,30 @@ class TestBuildInsertPatch:
 class TestResolveMappingForChange:
     """_resolve_mapping_for_change 매핑 해석 함수 테스트."""
 
-    def _make_context(self, mappings=None, mdx_to_sidecar=None,
-                      xpath_to_mapping=None):
+    def _make_context(self, mdx_to_sidecar=None, xpath_to_mapping=None):
         """공통 컨텍스트 dict를 구성한다."""
-        mappings = mappings or []
         return {
-            'mappings': mappings,
-            'used_ids': set(),
             'mdx_to_sidecar': mdx_to_sidecar or {},
             'xpath_to_mapping': xpath_to_mapping or {},
         }
 
-    def _old_plain(self, change):
-        """change에서 old_plain을 계산한다."""
-        return normalize_mdx_to_plain(
-            change.old_block.content, change.old_block.type)
-
     def test_no_sidecar_match_no_containing_returns_skip(self):
         change = _make_change(0, 'hello', 'world')
         ctx = self._make_context()
-        strategy, mapping = _resolve_mapping_for_change(
-            change, self._old_plain(change), **ctx)
-        assert strategy == 'skip'
+        decision, mapping = _resolve_mapping_for_change(change, **ctx)
+        assert decision.strategy is RendererStrategy.BLOCKED
         assert mapping is None
 
     def test_sidecar_direct_match_returns_direct(self):
         m = _make_mapping('b1', 'hello', xpath='p[1]')
         se = _make_sidecar('p[1]', [{'mdx_index': 0}])
         ctx = self._make_context(
-            mappings=[m],
             mdx_to_sidecar={0: se},
             xpath_to_mapping={'p[1]': m},
         )
         change = _make_change(0, 'hello', 'world')
-        strategy, mapping = _resolve_mapping_for_change(
-            change, self._old_plain(change), **ctx)
-        assert strategy == 'direct'
+        decision, mapping = _resolve_mapping_for_change(change, **ctx)
+        assert decision.strategy is RendererStrategy.TEXT_BLOCK
         assert mapping.block_id == 'b1'
 
     def test_sidecar_match_with_children_returns_containing(self):
@@ -1709,39 +1697,115 @@ class TestResolveMappingForChange:
                                children=['c1'])
         se = _make_sidecar('ul[1]', [{'mdx_index': 0}])
         ctx = self._make_context(
-            mappings=[parent, child],
             mdx_to_sidecar={0: se},
             xpath_to_mapping={'ul[1]': parent},
         )
         change = _make_change(0, 'child text', 'new child')
-        strategy, mapping = _resolve_mapping_for_change(
-            change, self._old_plain(change), **ctx)
-        assert strategy == 'containing'
+        decision, mapping = _resolve_mapping_for_change(change, **ctx)
+        assert decision.strategy is RendererStrategy.CONTAINER
         assert mapping.block_id == 'p1'
 
     def test_no_sidecar_list_type_returns_list(self):
         change = _make_change(0, '- item1\n- item2', '- item1\n- changed', type_='list')
         ctx = self._make_context()
-        strategy, mapping = _resolve_mapping_for_change(
-            change, self._old_plain(change), **ctx)
-        assert strategy == 'list'
+        decision, mapping = _resolve_mapping_for_change(change, **ctx)
+        assert decision.strategy is RendererStrategy.LIST
 
     def test_no_sidecar_table_type_returns_table(self):
         table = '| a | b |\n| --- | --- |\n| 1 | 2 |'
         change = _make_change(0, table, table.replace('1', 'X'))
         ctx = self._make_context()
-        strategy, mapping = _resolve_mapping_for_change(
-            change, self._old_plain(change), **ctx)
-        assert strategy == 'table'
+        decision, mapping = _resolve_mapping_for_change(change, **ctx)
+        assert decision.strategy is RendererStrategy.TABLE
+        assert decision.source_kind == 'table'
 
     def test_no_sidecar_containing_match_returns_skip(self):
         m = _make_mapping('b1', 'hello world full text here', xpath='div[1]')
         change = _make_change(0, 'hello world', 'hi world')
-        ctx = self._make_context(mappings=[m])
-        strategy, mapping = _resolve_mapping_for_change(
-            change, self._old_plain(change), **ctx)
-        assert strategy == 'skip'
+        ctx = self._make_context()
+        decision, mapping = _resolve_mapping_for_change(change, **ctx)
+        assert decision.strategy is RendererStrategy.BLOCKED
         assert mapping is None
+
+    def test_raw_html_table_uses_table_strategy(self):
+        mapping = _make_mapping(
+            'table-1',
+            'Before',
+            xpath='table[1]',
+            type_='table',
+        )
+        sidecar = _make_sidecar('table[1]', [{'mdx_index': 0}])
+        change = _make_change(
+            0,
+            '<table><tr><td>Before</td></tr></table>',
+            '<table><tr><td>After</td></tr></table>',
+            type_='html_block',
+        )
+
+        decision, resolved = _resolve_mapping_for_change(
+            change,
+            {0: sidecar},
+            {'table[1]': mapping},
+        )
+
+        assert decision.strategy is RendererStrategy.TABLE
+        assert decision.source_kind == 'raw_html_table'
+        assert resolved is mapping
+
+    def test_preservation_unit_uses_dedicated_strategy(self):
+        mapping = _make_mapping('p1', 'Before', xpath='p[1]')
+        mapping.xhtml_text = (
+            '<p><ac:link><ri:page ri:content-title="Target"/>'
+            '<ac:link-body>Before</ac:link-body></ac:link></p>'
+        )
+        sidecar = _make_sidecar('p[1]', [{'mdx_index': 0}])
+        change = _make_change(0, 'Before', 'After')
+
+        decision, resolved = _resolve_mapping_for_change(
+            change,
+            {0: sidecar},
+            {'p[1]': mapping},
+        )
+
+        assert decision.strategy is RendererStrategy.PRESERVED_ANCHOR
+        assert resolved is mapping
+
+    def test_mdx_owned_link_stays_text_block_strategy(self):
+        mapping = _make_mapping('p1', 'Before Link', xpath='p[1]')
+        mapping.xhtml_text = (
+            'Before <ac:link><ri:page ri:content-title="Target"/>'
+            '<ac:link-body>Link</ac:link-body></ac:link>'
+        )
+        sidecar = _make_sidecar('p[1]', [{'mdx_index': 0}])
+        sidecar_block = SidecarBlock(
+            0,
+            'p[1]',
+            mapping.xhtml_text,
+            '',
+            (1, 1),
+            reconstruction={
+                'kind': 'paragraph',
+                'old_plain_text': 'Before Link',
+                'anchors': [],
+            },
+        )
+        roundtrip_sidecar = _make_roundtrip_sidecar([sidecar_block])
+        change = _make_change(
+            0,
+            'Before [Link](target)',
+            'After [Link](target)',
+        )
+
+        decision, resolved = _resolve_mapping_for_change(
+            change,
+            {0: sidecar},
+            {'p[1]': mapping},
+            roundtrip_sidecar,
+            {'p[1]': sidecar_block},
+        )
+
+        assert decision.strategy is RendererStrategy.TEXT_BLOCK
+        assert resolved is mapping
 
 
 # ── build_patches 멱등성 (idempotency) 테스트 ──

--- a/confluence-mdx/tests/test_reverse_sync_planner.py
+++ b/confluence-mdx/tests/test_reverse_sync_planner.py
@@ -186,6 +186,36 @@ def test_unknown_preservation_unit_is_blocked_before_text_block_fallback():
     assert plan.issues[0].intent_ordinal == 0
 
 
+def test_mixed_supported_and_unknown_preservation_units_are_blocked():
+    old = _block("Before Link")
+    new = _block("After Link")
+    change = BlockChange(0, "modified", old, new)
+    xhtml = (
+        '<p><ac:structured-macro ac:name="unknown">'
+        "<ac:rich-text-body>"
+        '<ac:link><ri:page ri:content-title="Target"></ri:page>'
+        "<ac:link-body>Before Link</ac:link-body></ac:link>"
+        "</ac:rich-text-body>"
+        "</ac:structured-macro></p>"
+    )
+
+    plan, _ = plan_patches(
+        [change],
+        [old],
+        [new],
+        page_xhtml=xhtml,
+        roundtrip_sidecar=_sidecar(xhtml, old),
+        enforce_capabilities=True,
+        enforce_provenance=True,
+    )
+
+    assert plan.operations == ()
+    assert len(plan.issues) == 1
+    assert plan.issues[0].reason_code == "unsupported_capability"
+    assert plan.issues[0].capability_id == "unknown_macro_mutation"
+    assert plan.issues[0].intent_ordinal == 0
+
+
 def test_push_plan_blocks_operation_without_sidecar_provenance():
     old = _block("Before")
     new = _block("After")

--- a/confluence-mdx/tests/test_reverse_sync_planner.py
+++ b/confluence-mdx/tests/test_reverse_sync_planner.py
@@ -159,6 +159,33 @@ def test_legacy_table_skip_is_one_typed_capability_issue():
     assert issue.to_legacy_dict()["reason"] == "unsupported_capability"
 
 
+def test_unknown_preservation_unit_is_blocked_before_text_block_fallback():
+    old = _block("Before")
+    new = _block("After")
+    change = BlockChange(0, "modified", old, new)
+    xhtml = (
+        '<p><ac:structured-macro ac:name="unknown">'
+        '<ac:parameter ac:name="value">Before</ac:parameter>'
+        '</ac:structured-macro></p>'
+    )
+
+    plan, _ = plan_patches(
+        [change],
+        [old],
+        [new],
+        page_xhtml=xhtml,
+        roundtrip_sidecar=_sidecar(xhtml, old),
+        enforce_capabilities=True,
+        enforce_provenance=True,
+    )
+
+    assert plan.operations == ()
+    assert len(plan.issues) == 1
+    assert plan.issues[0].reason_code == "unsupported_capability"
+    assert plan.issues[0].capability_id == "unknown_macro_mutation"
+    assert plan.issues[0].intent_ordinal == 0
+
+
 def test_push_plan_blocks_operation_without_sidecar_provenance():
     old = _block("Before")
     new = _block("After")

--- a/openspec/changes/complete-reverse-sync/design.md
+++ b/openspec/changes/complete-reverse-sync/design.md
@@ -315,8 +315,14 @@ legacy builder가 operation 생성 전에 table/macro 변경을 skip한 경우�
 sidecar 또는 mapping 부재는 `missing_identity`로 정규화합니다. 하나의 legacy
 skip과 같은 intent에서 파생한 추가 `missing_identity` issue를 중복 생성하지
 않습니다.
-capability별 renderer strategy 자체를 `patch_builder.py`에서 추출하는 작업은
-계속 남아 있습니다.
+`reverse_sync/capabilities.py`의 `RendererStrategy`와 `StrategyDecision`은
+exact target mapping 이후 `text_block`, `list`, `preserved_anchor`, `container`,
+`table`, `blocked` 중 하나를 선택합니다. raw HTML table은 generic text block
+fallback에서 분리합니다. `preserved_anchor` strategy와 raw HTML table의 보존
+분기는 공통 template rewrite helper를 사용합니다. 알려지지 않은 preservation
+unit은 `unknown_macro_mutation`으로 fail-closed합니다. 각 strategy handler와
+capability 판별을 `patch_builder.py` 밖의 모듈로 추출하는 작업은 계속 남아
+있습니다.
 
 `render_patch_plan_preserving()`은 executable operation을 raw renderer input으로
 복원하기 직전에 target root fragment hash, sidecar MDX hash, line range를 base

--- a/openspec/changes/complete-reverse-sync/tasks.md
+++ b/openspec/changes/complete-reverse-sync/tasks.md
@@ -173,7 +173,16 @@
   - list는 기존 item path, marker, ordered start, anchor fingerprint를 같은 공통
     dispatcher로 제공합니다.
   - arbitrary macro/container는 기존 capability 경계에 남기고 일반화하지 않습니다.
-- [ ] strategy를 text block, list, preserved anchor, container, table로 분리합니다.
+- [x] strategy를 text block, list, preserved anchor, container, table로 분리합니다.
+  - `capabilities.py`의 typed `RendererStrategy`와 `StrategyDecision`이 exact
+    mapping 이후 renderer category를 한 곳에서 결정합니다.
+  - raw HTML table 처리를 generic text block에서 table strategy로 이동하고,
+    preserved anchor와 raw table의 link 보존 분기는 공통 template rewrite
+    helper를 사용합니다.
+  - 계약이 없는 `ac:`/`ri:` preservation unit은 text fallback으로 흘리지 않고
+    `unknown_macro_mutation` capability로 fail-closed 처리합니다.
+  - capability 판별과 strategy handler 자체의 모듈 추출은 위 task에 계속
+    남아 있습니다.
 - [x] unsupported table/macro 구조를 explicit block reason으로 전환합니다.
   - operation 생성 전 legacy skip도 원래 intent에 연결합니다.
   - table/macro 내부 분기 reason은 `unsupported_capability`와
@@ -342,10 +351,19 @@ strict renderer branch 검증 결과:
 - reverse-sync Python test: 805 passed
 - 전체 Python test: 1128 passed, 2 skipped
 
+typed renderer strategy branch 검증 결과:
+
+- `make test-convert`: 21 passed
+- `make test-reverse-sync`: golden 16 passed, regression 43 passed
+- `make test-byte-verify`: fast/splice 각각 21/21 passed
+- `test_reverse_sync*.py`: 779 passed
+- 전체 Python test: 1132 passed, 2 skipped
+- `openspec validate complete-reverse-sync --strict`: passed
+
 - [x] 영향도에 따라 전체 Python test와 render test를 실행합니다.
 
 이번 변경은 Python renderer 범위이므로 전체 Python test
-(`1128 passed, 2 skipped`)를 실행했고 frontend render test는 영향 범위에서
+(`1132 passed, 2 skipped`)를 실행했고 frontend render test는 영향 범위에서
 제외했습니다.
 
 ```bash


### PR DESCRIPTION
## Summary
renderer category 선택을 typed decision으로 통합하여 `patch_builder.py`의 heuristic fallback 경계를 명시합니다.

- `RendererStrategy`와 `StrategyDecision`으로 text block, list, preserved anchor, container, table, blocked category를 정의합니다.
- exact mapping과 roundtrip sidecar 증거를 확인한 뒤 한 곳에서 renderer strategy를 선택합니다.
- raw HTML table 처리를 generic text block에서 분리하고 preserved anchor와 공통 template rewrite helper를 사용합니다.
- MDX emitter가 소유한 link와 미소유 Confluence preservation unit을 구분합니다.
- 계약이 없는 `ac:`/`ri:` unit은 `unknown_macro_mutation` capability로 fail-closed 처리합니다.

## 기존 문제
문자열 strategy와 분산된 tag heuristic 때문에 raw HTML table, MDX-owned link, unknown macro가 generic text path에서 서로 다른 의미로 처리될 수 있었습니다. 특히 미지원 preservation unit도 inner XHTML 재생성으로 흘러 Confluence 전용 구조를 손실할 가능성이 있었습니다.

## Impact
- offline fixture의 기존 link/table 보존 동작을 유지합니다.
- strict planner는 unknown macro 변경에 executable operation을 만들지 않습니다.
- capability 판별과 strategy handler의 모듈 추출은 후속 P1 task로 유지합니다.
- remote PUT이나 production batch 활성화는 포함하지 않습니다.

## OpenSpec
- `complete-reverse-sync`의 renderer strategy 분리 task를 완료 처리합니다.
- typed decision, raw table 경계, unknown preservation fail-closed 계약과 검증 결과를 기록합니다.

## Test plan
- [x] `make test-reverse-sync` — golden 16 passed, regression 43 passed
- [x] `../venv/bin/python3 -m pytest -q test_reverse_sync*.py` — 779 passed
- [x] `make test-convert` — 21 passed
- [x] `make test-byte-verify` — fast/splice 각각 21/21 passed
- [x] `../venv/bin/python3 -m pytest -q` — 1132 passed, 2 skipped
- [x] `openspec validate complete-reverse-sync --strict`
- [x] `git diff --check`

## Stack
- Base: #1040

🤖 Generated with Codex
