### PR TITLE
confluence-mdx: capability 판별을 typed intent 기반으로 전환합니다

### DIFF
--- a/confluence-mdx/bin/reverse_sync/capabilities.py
+++ b/confluence-mdx/bin/reverse_sync/capabilities.py
@@ -269,35 +269,48 @@ def select_renderer_strategy(
     return StrategyDecision(RendererStrategy.TEXT_BLOCK, block_type)
 
 
-def _is_container(
-    mapping: Optional[BlockMapping],
-    sidecar_block: Optional[SidecarBlock],
-) -> bool:
-    if mapping is not None and mapping.children:
-        return True
-    reconstruction = sidecar_block.reconstruction if sidecar_block is not None else None
-    return bool(reconstruction and reconstruction.get("kind") == "container")
+_LEGACY_UNSUPPORTED_CAPABILITIES = {
+    "not_markdown_table": "raw_html_table_edit",
+    "preserved_anchor_table": "unknown_macro_mutation",
+    "raw_html_table": "raw_html_table_edit",
+    "unknown_preservation_unit": "unknown_macro_mutation",
+    "unsafe_html_table_edit": "raw_html_table_edit",
+}
+
+
+def capability_for_legacy_skip(reason_code: str) -> Optional[CapabilitySpec]:
+    """legacy renderer skip을 canonical blocked capability로 변환합니다."""
+    capability_id = _LEGACY_UNSUPPORTED_CAPABILITIES.get(reason_code)
+    return get_capability(capability_id) if capability_id else None
+
+
+def _has_supported_preserved_template(mapping: Optional[BlockMapping]) -> bool:
+    if mapping is None:
+        return False
+    return (
+        "<ac:link" in mapping.xhtml_text
+        or "<ri:attachment" in mapping.xhtml_text
+    )
 
 
 def classify_capability(
     *,
     action: str,
+    strategy: StrategyDecision,
     mapping: Optional[BlockMapping],
-    sidecar_block: Optional[SidecarBlock],
-    source_block_types: tuple[str, ...],
-    contains_raw_html_table: bool,
+    block_type: str,
 ) -> CapabilitySpec:
-    """legacy patch 하나를 명시적인 capability로 분류합니다.
+    """typed intent와 renderer strategy를 capability로 분류합니다.
 
-    분류할 수 없는 macro/HTML mutation은 generic success로 흘려보내지 않고
-    blocked capability로 닫습니다.
+    raw patch shape은 capability source로 사용하지 않습니다. 분류할 수 없는
+    macro/HTML mutation은 generic success로 흘려보내지 않고 blocked
+    capability로 닫습니다.
     """
-    if contains_raw_html_table:
+    if strategy.source_kind == "raw_html_table":
         return get_capability("raw_html_table_edit")
 
     mapping_type = mapping.type if mapping is not None else ""
-    source_types = set(source_block_types)
-    unknown_html = mapping_type == "html_block" or "html_block" in source_types
+    unknown_html = mapping_type == "html_block" or block_type == "html_block"
 
     if action == "insert":
         if unknown_html:
@@ -309,20 +322,30 @@ def classify_capability(
             return get_capability("unknown_macro_mutation")
         return get_capability("delete_exact_block")
 
-    if _is_container(mapping, sidecar_block):
+    if strategy.strategy is RendererStrategy.CONTAINER:
         return get_capability("container_body_reconstruct")
     if unknown_html:
         return get_capability("unknown_macro_mutation")
-    if mapping_type == "table" or "table" in source_types:
+    if strategy.strategy is RendererStrategy.TABLE:
+        if _contains_preservation_unit(mapping):
+            return get_capability("unknown_macro_mutation")
         return get_capability("simple_markdown_table_replace")
-    if _contains_preservation_unit(mapping):
-        return get_capability("preserved_anchor_template_rewrite")
-    if mapping_type == "list" or "list" in source_types:
+    if strategy.strategy is RendererStrategy.PRESERVED_ANCHOR:
+        if _has_supported_preserved_template(mapping):
+            return get_capability("preserved_anchor_template_rewrite")
+        return get_capability("unknown_macro_mutation")
+    if strategy.strategy is RendererStrategy.LIST:
+        if _contains_preservation_unit(mapping):
+            if _has_supported_preserved_template(mapping):
+                return get_capability("preserved_anchor_template_rewrite")
+            return get_capability("unknown_macro_mutation")
         return get_capability("clean_list_reconstruct")
-    if mapping_type == "heading" or "heading" in source_types:
+    if strategy.strategy is RendererStrategy.BLOCKED:
+        return get_capability("unknown_macro_mutation")
+    if mapping_type == "heading" or block_type == "heading":
         return get_capability("heading_visible_edit")
-    if mapping_type == "code" or "code_block" in source_types:
+    if mapping_type == "code" or block_type == "code_block":
         return get_capability("code_block_replace")
-    if mapping_type == "paragraph" or "paragraph" in source_types:
+    if mapping_type == "paragraph" or block_type == "paragraph":
         return get_capability("paragraph_visible_edit")
     return get_capability("unknown_macro_mutation")

--- a/confluence-mdx/bin/reverse_sync/planner.py
+++ b/confluence-mdx/bin/reverse_sync/planner.py
@@ -305,22 +305,24 @@ def _capability_for_operation(
         if ordinal < 0 or ordinal >= len(changes):
             continue
         change = changes[ordinal]
-        block = change.old_block or change.new_block
-        if block is None or block.type in NON_CONTENT_TYPES:
-            continue
-        strategy = select_renderer_strategy(
-            block_type=block.type,
-            block_content=block.content,
-            mapping=mapping,
-            sidecar_block=sidecar_block,
-        )
-        capability = classify_capability(
-            action=action,
-            strategy=strategy,
-            mapping=mapping,
-            block_type=block.type,
-        )
-        classified[capability.capability_id] = capability
+        for block in (change.old_block, change.new_block):
+            if block is None or block.type in NON_CONTENT_TYPES:
+                continue
+            strategy = select_renderer_strategy(
+                block_type=block.type,
+                block_content=block.content,
+                mapping=mapping,
+                sidecar_block=sidecar_block,
+            )
+            capability = classify_capability(
+                action=action,
+                strategy=strategy,
+                mapping=mapping,
+                block_type=block.type,
+            )
+            if capability.capability_id == "raw_html_table_edit":
+                return capability
+            classified[capability.capability_id] = capability
     if len(classified) == 1:
         return next(iter(classified.values()))
     return get_capability("unknown_macro_mutation")

--- a/confluence-mdx/bin/reverse_sync/planner.py
+++ b/confluence-mdx/bin/reverse_sync/planner.py
@@ -7,7 +7,14 @@ from typing import Any, Optional
 from mdx_to_storage.link_resolver import LinkResolver
 from mdx_to_storage.parser import Block as MdxBlock
 from reverse_sync.block_diff import BlockChange, NON_CONTENT_TYPES
-from reverse_sync.capabilities import SupportLevel, classify_capability
+from reverse_sync.capabilities import (
+    CapabilitySpec,
+    SupportLevel,
+    capability_for_legacy_skip,
+    classify_capability,
+    get_capability,
+    select_renderer_strategy,
+)
 from reverse_sync.mapping_recorder import BlockMapping
 from reverse_sync.models import sha256_text
 from reverse_sync.operations import (
@@ -284,37 +291,41 @@ def _intent_ordinals_for_patch(
     return matched
 
 
-def _source_details(
+def _capability_for_operation(
+    *,
+    action: str,
     intent_ordinals: tuple[int, ...],
-    intents: tuple[ChangeIntent, ...],
     changes: list[BlockChange],
-) -> tuple[tuple[str, ...], bool]:
-    by_ordinal = {intent.ordinal: intent for intent in intents}
-    block_types: list[str] = []
-    contains_raw_html_table = False
+    mapping: Optional[BlockMapping],
+    sidecar_block: Optional[SidecarBlock],
+) -> CapabilitySpec:
+    """operation에 대응하는 MDX intent를 typed capability로 분류합니다."""
+    classified: dict[str, CapabilitySpec] = {}
     for ordinal in intent_ordinals:
-        intent = by_ordinal.get(ordinal)
-        if intent is None:
+        if ordinal < 0 or ordinal >= len(changes):
             continue
-        block_types.append(intent.block_type)
         change = changes[ordinal]
-        for block in (change.old_block, change.new_block):
-            if (
-                block is not None
-                and block.type == "html_block"
-                and block.content.lstrip().lower().startswith("<table")
-            ):
-                contains_raw_html_table = True
-    return tuple(block_types), contains_raw_html_table
+        block = change.old_block or change.new_block
+        if block is None or block.type in NON_CONTENT_TYPES:
+            continue
+        strategy = select_renderer_strategy(
+            block_type=block.type,
+            block_content=block.content,
+            mapping=mapping,
+            sidecar_block=sidecar_block,
+        )
+        capability = classify_capability(
+            action=action,
+            strategy=strategy,
+            mapping=mapping,
+            block_type=block.type,
+        )
+        classified[capability.capability_id] = capability
+    if len(classified) == 1:
+        return next(iter(classified.values()))
+    return get_capability("unknown_macro_mutation")
 
 
-_LEGACY_UNSUPPORTED_CAPABILITIES = {
-    "not_markdown_table": "raw_html_table_edit",
-    "preserved_anchor_table": "unknown_macro_mutation",
-    "raw_html_table": "raw_html_table_edit",
-    "unknown_preservation_unit": "unknown_macro_mutation",
-    "unsafe_html_table_edit": "raw_html_table_edit",
-}
 _LEGACY_MISSING_IDENTITY_REASONS = frozenset(
     {"missing_roundtrip_sidecar", "no_mapping"}
 )
@@ -382,9 +393,10 @@ def _legacy_skip_issue(
     )
     capability_id = ""
     reason_code = legacy_reason
-    if enforce_capabilities and legacy_reason in _LEGACY_UNSUPPORTED_CAPABILITIES:
+    unsupported = capability_for_legacy_skip(legacy_reason)
+    if enforce_capabilities and unsupported is not None:
         reason_code = "unsupported_capability"
-        capability_id = _LEGACY_UNSUPPORTED_CAPABILITIES[legacy_reason]
+        capability_id = unsupported.capability_id
     elif (
         enforce_provenance
         and legacy_reason in _LEGACY_MISSING_IDENTITY_REASONS
@@ -578,17 +590,12 @@ def plan_patches(
             )
 
         mapping = _mapping_for_patch(patch, resolved_mappings)
-        source_types, contains_raw_html_table = _source_details(
-            intent_ordinals,
-            intents,
-            changes,
-        )
-        capability = classify_capability(
+        capability = _capability_for_operation(
             action=str(patch.get("action", "modify")),
+            intent_ordinals=intent_ordinals,
+            changes=changes,
             mapping=mapping,
             sidecar_block=sidecar_by_xpath.get(target.root_xpath),
-            source_block_types=source_types,
-            contains_raw_html_table=contains_raw_html_table,
         )
         capability_blocked = (
             enforce_capabilities
@@ -624,6 +631,11 @@ def plan_patches(
                     ),
                     block_id=target.xpath,
                     capability_id=capability.capability_id,
+                    intent_ordinal=(
+                        intent_ordinals[0]
+                        if len(intent_ordinals) == 1
+                        else None
+                    ),
                 )
             )
         elif provenance_blocked:
@@ -636,6 +648,11 @@ def plan_patches(
                     ),
                     block_id=target.xpath,
                     capability_id=capability.capability_id,
+                    intent_ordinal=(
+                        intent_ordinals[0]
+                        if len(intent_ordinals) == 1
+                        else None
+                    ),
                 )
             )
 

--- a/confluence-mdx/tests/test_reverse_sync_capabilities.py
+++ b/confluence-mdx/tests/test_reverse_sync_capabilities.py
@@ -1,0 +1,136 @@
+"""typed renderer strategy와 capability 분류 경계 테스트."""
+
+import pytest
+
+from reverse_sync.capabilities import (
+    RendererStrategy,
+    StrategyDecision,
+    capability_for_legacy_skip,
+    classify_capability,
+)
+from reverse_sync.mapping_recorder import record_mapping
+
+
+def _mapping(xhtml: str):
+    return record_mapping(xhtml)[0]
+
+
+def test_text_block_strategy_classifies_mdx_owned_link_as_paragraph():
+    mapping = _mapping(
+        '<p>Before <ac:link><ri:page ri:content-title="Target"/>'
+        '<ac:link-body>Link</ac:link-body></ac:link></p>'
+    )
+
+    capability = classify_capability(
+        action="modify",
+        strategy=StrategyDecision(RendererStrategy.TEXT_BLOCK, "paragraph"),
+        mapping=mapping,
+        block_type="paragraph",
+    )
+
+    assert capability.capability_id == "paragraph_visible_edit"
+
+
+def test_preserved_anchor_strategy_classifies_supported_template_rewrite():
+    mapping = _mapping(
+        '<p><ac:link><ri:page ri:content-title="Target"/>'
+        '<ac:link-body>Before</ac:link-body></ac:link></p>'
+    )
+
+    capability = classify_capability(
+        action="modify",
+        strategy=StrategyDecision(
+            RendererStrategy.PRESERVED_ANCHOR,
+            "paragraph",
+        ),
+        mapping=mapping,
+        block_type="paragraph",
+    )
+
+    assert capability.capability_id == "preserved_anchor_template_rewrite"
+
+
+def test_preserved_anchor_strategy_blocks_unknown_macro():
+    mapping = _mapping(
+        '<p><ac:structured-macro ac:name="unknown">'
+        '<ac:parameter ac:name="value">Before</ac:parameter>'
+        '</ac:structured-macro></p>'
+    )
+
+    capability = classify_capability(
+        action="modify",
+        strategy=StrategyDecision(
+            RendererStrategy.PRESERVED_ANCHOR,
+            "paragraph",
+        ),
+        mapping=mapping,
+        block_type="paragraph",
+    )
+
+    assert capability.capability_id == "unknown_macro_mutation"
+    assert capability.block_reason == "unsupported_capability"
+
+
+def test_raw_html_table_source_is_blocked_independently_of_patch_shape():
+    mapping = _mapping("<table><tbody><tr><td>Before</td></tr></tbody></table>")
+
+    capability = classify_capability(
+        action="modify",
+        strategy=StrategyDecision(RendererStrategy.TABLE, "raw_html_table"),
+        mapping=mapping,
+        block_type="html_block",
+    )
+
+    assert capability.capability_id == "raw_html_table_edit"
+    assert capability.block_reason == "unsupported_capability"
+
+
+def test_markdown_table_with_preserved_unit_is_unknown_macro_capability():
+    mapping = _mapping(
+        '<table><tbody><tr><td><ac:structured-macro ac:name="status"/>'
+        '</td></tr></tbody></table>'
+    )
+
+    capability = classify_capability(
+        action="modify",
+        strategy=StrategyDecision(RendererStrategy.TABLE, "table"),
+        mapping=mapping,
+        block_type="paragraph",
+    )
+
+    assert capability.capability_id == "unknown_macro_mutation"
+    assert capability.block_reason == "unsupported_capability"
+
+
+def test_list_with_preserved_attachment_uses_preserved_anchor_capability():
+    mapping = _mapping(
+        '<ul><li><p>Before <ac:image>'
+        '<ri:attachment ri:filename="screen.png"/></ac:image></p></li></ul>'
+    )
+
+    capability = classify_capability(
+        action="modify",
+        strategy=StrategyDecision(RendererStrategy.LIST, "list"),
+        mapping=mapping,
+        block_type="list",
+    )
+
+    assert capability.capability_id == "preserved_anchor_template_rewrite"
+
+
+@pytest.mark.parametrize(
+    ("reason_code", "capability_id"),
+    [
+        ("unsafe_html_table_edit", "raw_html_table_edit"),
+        ("preserved_anchor_table", "unknown_macro_mutation"),
+        ("unknown_preservation_unit", "unknown_macro_mutation"),
+    ],
+)
+def test_legacy_skip_reason_uses_canonical_capability_registry(
+    reason_code,
+    capability_id,
+):
+    capability = capability_for_legacy_skip(reason_code)
+
+    assert capability is not None
+    assert capability.capability_id == capability_id

--- a/confluence-mdx/tests/test_reverse_sync_planner.py
+++ b/confluence-mdx/tests/test_reverse_sync_planner.py
@@ -89,6 +89,37 @@ def test_supported_paragraph_plan_has_capability_and_exact_target_identity():
     assert plan.to_patch_dicts()[0]["new_inner_xhtml"] == "After"
 
 
+def test_mdx_owned_link_uses_text_block_capability_not_preserved_anchor():
+    old = _block("Before [Link](target)")
+    new = _block("After [Link](target)")
+    change = BlockChange(0, "modified", old, new)
+    xhtml = (
+        '<p>Before <ac:link><ri:page ri:content-title="Target"/>'
+        '<ac:link-body>Link</ac:link-body></ac:link></p>'
+    )
+    sidecar = _sidecar(xhtml, old)
+    sidecar.blocks[0].reconstruction = {
+        "kind": "paragraph",
+        "old_plain_text": "Before Link",
+        "anchors": [],
+    }
+
+    plan, _ = plan_patches(
+        [change],
+        [old],
+        [new],
+        page_xhtml=xhtml,
+        roundtrip_sidecar=sidecar,
+        allow_text_identity_fallback=False,
+        enforce_capabilities=True,
+        enforce_provenance=True,
+    )
+
+    assert plan.intent_complete is True
+    assert plan.issues == ()
+    assert plan.operations[0].capability_id == "paragraph_visible_edit"
+
+
 def test_raw_html_table_is_explicit_unsupported_capability_in_push_plan():
     old = _block(
         "<table><tr><td>Before</td></tr></table>",
@@ -119,6 +150,7 @@ def test_raw_html_table_is_explicit_unsupported_capability_in_push_plan():
     assert plan.operations[0].reason_code == "unsupported_capability"
     assert plan.issues[0].capability_id == "raw_html_table_edit"
     assert plan.issues[0].reason_code == "unsupported_capability"
+    assert plan.issues[0].intent_ordinal == 0
     assert json.loads(plan.to_canonical_json())["issues"][0]["reason_code"] == (
         "unsupported_capability"
     )

--- a/confluence-mdx/tests/test_reverse_sync_planner.py
+++ b/confluence-mdx/tests/test_reverse_sync_planner.py
@@ -159,6 +159,34 @@ def test_raw_html_table_is_explicit_unsupported_capability_in_push_plan():
     )
 
 
+def test_replacing_paragraph_with_raw_html_table_is_blocked():
+    old = _block("Before")
+    new = _block(
+        "<table><tr><td>After</td></tr></table>",
+        "html_block",
+    )
+    change = BlockChange(0, "modified", old, new)
+    xhtml = "<p>Before</p>"
+
+    plan, _ = plan_patches(
+        [change],
+        [old],
+        [new],
+        page_xhtml=xhtml,
+        roundtrip_sidecar=_sidecar(xhtml, old),
+        allow_text_identity_fallback=False,
+        enforce_capabilities=True,
+        enforce_provenance=True,
+    )
+
+    assert plan.intent_complete is False
+    assert len(plan.operations) == 1
+    assert plan.operations[0].executable is False
+    assert plan.operations[0].capability_id == "raw_html_table_edit"
+    assert plan.operations[0].reason_code == "unsupported_capability"
+    assert plan.issues[0].capability_id == "raw_html_table_edit"
+
+
 def test_legacy_table_skip_is_one_typed_capability_issue():
     old = _block(
         "<table><tr><td>Before</td></tr></table>",

--- a/openspec/changes/complete-reverse-sync/design.md
+++ b/openspec/changes/complete-reverse-sync/design.md
@@ -320,9 +320,15 @@ exact target mapping 이후 `text_block`, `list`, `preserved_anchor`, `container
 `table`, `blocked` 중 하나를 선택합니다. raw HTML table은 generic text block
 fallback에서 분리합니다. `preserved_anchor` strategy와 raw HTML table의 보존
 분기는 공통 template rewrite helper를 사용합니다. 알려지지 않은 preservation
-unit은 `unknown_macro_mutation`으로 fail-closed합니다. 각 strategy handler와
-capability 판별을 `patch_builder.py` 밖의 모듈로 추출하는 작업은 계속 남아
-있습니다.
+unit은 `unknown_macro_mutation`으로 fail-closed합니다.
+
+capability 판별은 renderer output의 raw patch payload shape를 재해석하지
+않습니다. canonical operation action만 action contract로 사용합니다.
+planner가 operation에 대응하는 MDX `ChangeIntent`와 typed
+`StrategyDecision`을 `classify_capability()`에 전달하고, legacy renderer skip
+reason의 capability 대응도 `capabilities.py` registry boundary에서 수행합니다.
+각 strategy handler를 `patch_builder.py` 밖의 `reverse_sync/strategies/**`
+모듈로 추출하는 작업은 계속 남아 있습니다.
 
 `render_patch_plan_preserving()`은 executable operation을 raw renderer input으로
 복원하기 직전에 target root fragment hash, sidecar MDX hash, line range를 base

--- a/openspec/changes/complete-reverse-sync/tasks.md
+++ b/openspec/changes/complete-reverse-sync/tasks.md
@@ -153,7 +153,18 @@
 
 ### 2.8 P1 — planner / renderer 책임 분리
 
-- [ ] `patch_builder.py`의 capability 판별을 `capabilities.py`와 planner로 추출합니다.
+- [x] `patch_builder.py`의 capability 판별을 `capabilities.py`와 planner로 추출합니다.
+  - `classify_capability()`은 raw patch payload shape를 재해석하지 않고 typed
+    `StrategyDecision`, MDX block type, canonical action을 입력으로 capability를
+    결정합니다.
+  - planner는 operation에 대응하는 `ChangeIntent` ordinal에서 capability를
+    계산하고 여러 intent가 서로 다른 capability로 분류되면 fail-closed합니다.
+  - legacy renderer skip reason과 blocked capability의 대응표도
+    `capabilities.py`의 registry boundary로 이동합니다.
+  - MDX-owned link의 text block operation을 preservation capability로 잘못
+    분류하지 않도록 integration test를 고정합니다.
+- [ ] `build_patches()`의 strategy handler를 `reverse_sync/strategies/**`로
+  추출하고 typed strategy dispatch만 남깁니다.
 - [x] planning output을 typed `PatchPlan`/operation으로 바꾸고 raw patch dict를 boundary 안에 가둡니다.
   - `legacy-patch-builder-v2` adapter가 `ChangeIntent`, `TargetIdentity`,
     capability, required proof, reason code를 canonical schema v2 plan에 기록합니다.
@@ -181,8 +192,7 @@
     helper를 사용합니다.
   - 계약이 없는 `ac:`/`ri:` preservation unit은 text fallback으로 흘리지 않고
     `unknown_macro_mutation` capability로 fail-closed 처리합니다.
-  - capability 판별과 strategy handler 자체의 모듈 추출은 위 task에 계속
-    남아 있습니다.
+  - strategy handler 자체의 모듈 추출은 위의 별도 task에 계속 남아 있습니다.
 - [x] unsupported table/macro 구조를 explicit block reason으로 전환합니다.
   - operation 생성 전 legacy skip도 원래 intent에 연결합니다.
   - table/macro 내부 분기 reason은 `unsupported_capability`와
@@ -360,10 +370,19 @@ typed renderer strategy branch 검증 결과:
 - 전체 Python test: 1132 passed, 2 skipped
 - `openspec validate complete-reverse-sync --strict`: passed
 
+typed capability planning branch 검증 결과:
+
+- `make test-convert`: 21 passed
+- `make test-reverse-sync`: golden 16 passed, regression 43 passed
+- `make test-byte-verify`: fast/splice 각각 21/21 passed
+- `test_reverse_sync*.py`: 789 passed
+- 전체 Python test: 1142 passed, 2 skipped
+- `openspec validate complete-reverse-sync --strict`: passed
+
 - [x] 영향도에 따라 전체 Python test와 render test를 실행합니다.
 
 이번 변경은 Python renderer 범위이므로 전체 Python test
-(`1132 passed, 2 skipped`)를 실행했고 frontend render test는 영향 범위에서
+(`1142 passed, 2 skipped`)를 실행했고 frontend render test는 영향 범위에서
 제외했습니다.
 
 ```bash


### PR DESCRIPTION
## Summary
capability 분류를 raw renderer payload의 구조가 아니라 typed renderer strategy와 MDX intent에 결합합니다.

- `classify_capability()`이 canonical operation action, `StrategyDecision`, MDX block type을 입력으로 사용합니다.
- planner가 operation에 대응하는 `ChangeIntent` ordinal별 capability를 계산합니다.
- 하나의 operation에 서로 다른 capability가 대응하면 `unknown_macro_mutation`으로 fail-closed합니다.
- legacy renderer skip reason의 blocked capability 대응을 `capabilities.py`로 이동합니다.
- MDX-owned link가 `preserved_anchor_template_rewrite`로 오분류되던 경계를 `paragraph_visible_edit`로 바로잡습니다.

## 기존 문제
기존 planner는 renderer가 raw patch를 만든 뒤 action, mapping type, source type과 raw HTML 포함 여부를 다시 조합해 capability를 추론했습니다. 이 방식은 실제 renderer strategy와 capability가 어긋날 수 있고 legacy skip reason 대응표도 planner 내부에 중복시켰습니다.

## Impact
- capability ID와 support level을 renderer payload body와 독립적으로 결정합니다.
- preserved list/link/attachment와 unknown macro의 fail-closed 경계를 registry 테스트로 고정합니다.
- renderer strategy handler의 `reverse_sync/strategies/**` 모듈 추출은 다음 P1 task로 분리합니다.
- remote PUT이나 production batch 활성화는 포함하지 않습니다.

## OpenSpec
- `complete-reverse-sync`의 capability 판별 추출 task를 완료 처리합니다.
- strategy handler 모듈 추출을 별도 P1 task로 명시합니다.

## Test plan
- [x] focused capability/planner/patch builder — 152 passed
- [x] `../venv/bin/python3 -m pytest -q test_reverse_sync*.py` — 789 passed
- [x] `make test-reverse-sync` — golden 16 passed, regression 43 passed
- [x] `make test-convert` — 21 passed
- [x] `make test-byte-verify` — fast/splice 각각 21/21 passed
- [x] `../venv/bin/python3 -m pytest -q` — 1142 passed, 2 skipped
- [x] `openspec validate complete-reverse-sync --strict`
- [x] `git diff --check`

## Stack
- Base: #1041

🤖 Generated with Codex
