### PR TITLE
confluence-mdx: renderer strategy handler를 분리합니다

### DIFF
--- a/confluence-mdx/.gitignore
+++ b/confluence-mdx/.gitignore
@@ -5,6 +5,7 @@
 /bin/skeleton/__pycache__/
 /bin/fetch/__pycache__/
 /bin/reverse_sync/__pycache__/
+/bin/reverse_sync/**/__pycache__/
 /bin/mdx_to_storage/__pycache__/
 /tests/__pycache__/
 /tests/test_mdx_to_storage/__pycache__/

--- a/confluence-mdx/bin/reverse_sync/patch_builder.py
+++ b/confluence-mdx/bin/reverse_sync/patch_builder.py
@@ -39,6 +39,11 @@ from reverse_sync.reconstructors import (
     reconstruct_fragment_with_sidecar,
     rewrite_on_stored_template,
 )
+from reverse_sync.strategies import (
+    StrategyPrimitives,
+    StrategyRenderContext,
+    dispatch_strategy,
+)
 from reverse_sync.visible_segments import (
     extract_visible_model_from_mdx,
     extract_visible_model_from_xhtml,
@@ -1138,6 +1143,24 @@ def build_patches(
     # 같은 부모에 대한 text-level 변경을 순차 집계하는 dict (block_id → patch dict)
     # preserved anchor list와 containing case에서 공용 사용
     _text_change_patches: Dict[str, Dict] = {}
+    strategy_primitives = StrategyPrimitives(
+        apply_mdx_diff_to_xhtml=_apply_mdx_diff_to_xhtml,
+        build_inline_fixups=_build_inline_fixups,
+        offset_inline_fixup_match_indexes=_offset_inline_fixup_match_indexes,
+        detect_list_item_space_change=_detect_list_item_space_change,
+        build_list_item_merge_patch=_build_list_item_merge_patch,
+        build_replace_fragment_patch=_build_replace_fragment_patch,
+        build_preserved_template_patch=_build_preserved_template_patch,
+        classify_table_fragment_skip=_classify_table_fragment_skip,
+        extract_html_table_cells=_extract_html_table_cells,
+        is_safe_cell_text_edit=_is_safe_cell_text_edit,
+        is_clean_block=_is_clean_block,
+        contains_preserved_anchor_markup=_contains_preserved_anchor_markup,
+        contains_only_supported_preservation_units=(
+            _contains_only_supported_preservation_units
+        ),
+        xhtml_visible_text=_xhtml_visible_text,
+    )
 
     for change in changes:
         if change.index in _paired_indices:
@@ -1242,362 +1265,31 @@ def build_patches(
             })
             continue
 
-        if strategy is RendererStrategy.LIST:
-            list_sidecar = _find_roundtrip_sidecar_block(
-                change, mapping, roundtrip_sidecar, xpath_to_sidecar_block,
-            )
-            old_list_model = extract_visible_model_from_mdx(
-                change.old_block.content,
-                "list",
-            )
-            new_list_model = extract_visible_model_from_mdx(
-                change.new_block.content,
-                "list",
-            )
-            xhtml_list_model = extract_visible_model_from_xhtml(
-                mapping.xhtml_text,
-                "list",
-            )
-            has_content_change = old_list_model.visible_text != new_list_model.visible_text
-            has_structure_change = (
-                old_list_model.structural_fingerprint
-                != new_list_model.structural_fingerprint
-            )
-            old_visible = old_list_model.visible_text
-            new_visible = new_list_model.visible_text
-            # ol start 변경 감지: 숫자 목록의 시작 번호가 달라진 경우
-            _old_start = re.match(r'^\s*(\d+)\.', change.old_block.content)
-            _new_start = re.match(r'^\s*(\d+)\.', change.new_block.content)
-            has_ol_start_change = bool(
-                _old_start and _new_start
-                and int(_old_start.group(1)) != int(_new_start.group(1))
-            )
-            # 인라인 마커 경계 변경 감지 (bold/italic 경계 이동)를
-            # replace_fragment 판단 전에 수행하여 clean list도 재생성하도록 함
-            inline_fixups = _build_inline_fixups(
-                change.old_block.content,
-                change.new_block.content,
-                block_type=change.old_block.type,
-            )
-            has_inline_boundary = bool(inline_fixups)
-            has_patchable_text_change = (
-                has_content_change or has_ol_start_change or has_inline_boundary
-            )
-            has_rebuild_change = has_patchable_text_change or has_structure_change
-            requires_anchor_rebuild = sidecar_block_requires_reconstruction(
-                list_sidecar,
-            )
-            should_replace_clean_list = (
-                mapping is not None
-                and not _contains_preserved_anchor_markup(mapping.xhtml_text)
-                # sidecar 있으면 항상 허용; 없으면 실제 변경(텍스트 또는 번호 시작값)이 있을 때만 허용
-                and (roundtrip_sidecar is not None or has_rebuild_change)
-                and (list_sidecar is None or mapping_via_v3_fallback or has_rebuild_change)
-            )
-            # preserved anchor list의 구조 변경은 item merge를 우선 시도하고,
-            # 실패한 경우에만 fragment 재구성으로 내려간다.
-            if (mapping is not None
-                    and _contains_preserved_anchor_markup(mapping.xhtml_text)):
-                merge_patch = _build_list_item_merge_patch(
-                    mapping,
-                    change.old_block.content,
-                    change.new_block.content,
-                    old_visible,
-                    new_visible,
-                )
-                if merge_patch is not None:
-                    _mark_used(mapping.block_id, mapping)
-                    patches.append(merge_patch)
-                    continue
-            if (mapping is not None
-                    and (
-                        # anchor case: text-only preserved anchor list는 modify로 처리한다.
-                        requires_anchor_rebuild
-                        # clean case: preserved anchor 없는 clean list
-                        or should_replace_clean_list
-                    )):
-                _mark_used(mapping.block_id, mapping)
-                patches.append(
-                    _build_replace_fragment_patch(
-                        mapping,
-                        change.new_block,
-                        sidecar_block=list_sidecar,
-                        mapping_lost_info=mapping_lost_info,
-                    )
-                )
-                continue
-            # preserved anchor list: text-level 패치로 ac:/ri: XHTML 구조 보존
-            # (_apply_mdx_diff_to_xhtml 경로)
-            # 같은 부모의 다중 변경은 순차 집계한다 (이전 결과에 누적 적용)
-            # inline_fixups, has_inline_boundary는 상단에서 이미 계산됨
-            if mapping is not None and has_patchable_text_change:
-                bid = mapping.block_id
-                if bid not in _text_change_patches:
-                    patch_entry: Dict[str, Any] = {
-                        'xhtml_xpath': mapping.xhtml_xpath,
-                        'old_plain_text': xhtml_list_model.visible_text,
-                        'new_plain_text': xhtml_list_model.visible_text,
-                    }
-                    patches.append(patch_entry)
-                    _text_change_patches[bid] = patch_entry
-                if has_content_change:
-                    transfer_xhtml_plain = _text_change_patches[bid]['new_plain_text']
-                    _text_change_patches[bid]['new_plain_text'] = _apply_mdx_diff_to_xhtml(
-                        old_visible,
-                        new_visible,
-                        transfer_xhtml_plain,
-                    )
-                if has_ol_start_change:
-                    _text_change_patches[bid]['ol_start'] = int(_new_start.group(1))
-                if has_inline_boundary:
-                    existing = _text_change_patches[bid].get(
-                        'inline_fixups', [])
-                    existing.extend(inline_fixups)
-                    _text_change_patches[bid]['inline_fixups'] = existing
-                _mark_used(mapping.block_id, mapping)
-            continue
-
-        if strategy is RendererStrategy.TABLE:
-            if strategy_decision.source_kind == "raw_html_table":
-                if (
-                    '<ac:link' in mapping.xhtml_text
-                    or '<ri:attachment' in mapping.xhtml_text
-                ):
-                    _mark_used(mapping.block_id, mapping)
-                    patches.append(
-                        _build_preserved_template_patch(
-                            mapping,
-                            _mdx_visible_text(change.new_block),
-                            mapping_lost_info,
-                        )
-                    )
-                    continue
-                old_cells = _extract_html_table_cells(change.old_block.content)
-                new_cells = _extract_html_table_cells(change.new_block.content)
-                if not _is_safe_cell_text_edit(old_cells, new_cells):
-                    skipped_changes.append({
-                        'block_id': mapping.block_id,
-                        'reason': 'unsafe_html_table_edit',
-                        'description': (
-                            f"블록 {mapping.block_id}: raw HTML 테이블의 셀 구조 변경"
-                            f"(셀 수 변경 또는 셀 내용 재배치)은 안전하지 않아 "
-                            f"건너뜁니다."
-                        ),
-                    })
-                    continue
-                _mark_used(mapping.block_id, mapping)
-                mapping_visible_text = mapping.xhtml_plain_text
-                patches.append({
-                    'xhtml_xpath': mapping.xhtml_xpath,
-                    'old_plain_text': mapping_visible_text,
-                    'new_plain_text': _apply_mdx_diff_to_xhtml(
-                        old_plain,
-                        _mdx_visible_text(change.new_block),
-                        mapping_visible_text,
-                    ),
-                })
-                continue
-
-            table_skip = _classify_table_fragment_skip(
-                change, mapping, roundtrip_sidecar)
-            if table_skip is None:
-                _mark_used(mapping.block_id, mapping)
-                patches.append(
-                    _build_replace_fragment_patch(
-                        mapping,
-                        change.new_block,
-                        mapping_lost_info=mapping_lost_info,
-                    )
-                )
-            else:
-                skipped_changes.append(table_skip)
-            continue
-
-        new_plain = _mdx_visible_text(change.new_block)
-
-        if strategy is RendererStrategy.CONTAINER:
-            if mapping is not None:
-                bid = mapping.block_id
-                first_visit = bid not in used_ids
-                _mark_used(bid, mapping)
-                sidecar_block = _find_roundtrip_sidecar_block(
-                    change, mapping, roundtrip_sidecar, xpath_to_sidecar_block,
-                )
-                if sidecar_block_requires_reconstruction(sidecar_block):
-                    # anchor 재구성이 필요한 경우: 첫 번째 변경만 replace_fragment
-                    if first_visit:
-                        patches.append(
-                            _build_replace_fragment_patch(
-                                mapping,
-                                change.new_block,
-                                sidecar_block=sidecar_block,
-                                mapping_lost_info=mapping_lost_info,
-                            )
-                        )
-                else:
-                    # clean container / child-of-parent: text-level 누적
-                    # (_apply_mdx_diff_to_xhtml 경로)
-                    if bid not in _text_change_patches:
-                        patch_entry: Dict[str, Any] = {
-                            'xhtml_xpath': mapping.xhtml_xpath,
-                            'old_plain_text': mapping.xhtml_plain_text,
-                            'new_plain_text': mapping.xhtml_plain_text,
-                        }
-                        patches.append(patch_entry)
-                        _text_change_patches[bid] = patch_entry
-                    _text_change_patches[bid]['new_plain_text'] = _apply_mdx_diff_to_xhtml(
-                        old_plain, new_plain,
-                        _text_change_patches[bid]['new_plain_text'])
-                    # 인라인 마커 경계 변경 (bold/italic) 감지 및 누적
-                    inline_fixups = _build_inline_fixups(
-                        change.old_block.content,
-                        change.new_block.content,
-                        block_type=change.old_block.type,
-                    )
-                    if inline_fixups:
-                        existing = _text_change_patches[bid].get(
-                            'inline_fixups', [])
-                        existing.extend(_offset_inline_fixup_match_indexes(
-                            existing, inline_fixups,
-                            parent_xpath=mapping.xhtml_xpath,
-                            change_index=change.index,
-                            improved_blocks=improved_blocks,
-                            mdx_to_sidecar=mdx_to_sidecar,
-                        ))
-                        _text_change_patches[bid]['inline_fixups'] = existing
-                # callout child list의 마커 공백 변경 → replace_fragment 패치
-                # (text transfer는 normalize_mdx_to_plain이 마커를 제거하여 감지 불가)
-                if (change.old_block.type == 'callout'
-                        and hasattr(change.old_block, 'children')
-                        and hasattr(change.new_block, 'children')):
-                    old_lists = [c for c in change.old_block.children
-                                 if c.type == 'list']
-                    new_lists = [c for c in change.new_block.children
-                                 if c.type == 'list']
-                    child_list_mappings = [
-                        id_to_mapping[cid]
-                        for cid in mapping.children
-                        if cid in id_to_mapping
-                        and id_to_mapping[cid].type == 'list'
-                    ]
-                    for old_child, new_child, child_map in zip(
-                            old_lists, new_lists, child_list_mappings):
-                        if _detect_list_item_space_change(
-                                old_child.content, new_child.content):
-                            # preserved anchor 마크업이 있으면 건너뜀
-                            # (replace_fragment가 ac:link 등을 손실시킴)
-                            if _contains_preserved_anchor_markup(
-                                    child_map.xhtml_text):
-                                continue
-                            child_block = MdxBlock(
-                                type='list',
-                                content=new_child.content,
-                                line_start=0, line_end=0,
-                            )
-                            patches.append(
-                                _build_replace_fragment_patch(
-                                    child_map, child_block,
-                                    mapping_lost_info=mapping_lost_info,
-                                )
-                            )
-            continue
-
-        # RendererStrategy.TEXT_BLOCK / PRESERVED_ANCHOR
-        _mark_used(mapping.block_id, mapping)
-        mapping_visible_text = _xhtml_visible_text(
-            mapping,
-            change.old_block.type,
-        )
-
-        # 멱등성 체크: push 후 XHTML이 이미 업데이트된 경우 건너뜀
-        # (old != xhtml 이고 new == xhtml → 이미 적용된 변경)
-        if (collapse_ws(old_plain) != collapse_ws(mapping_visible_text)
-                and collapse_ws(new_plain) == collapse_ws(mapping_visible_text)):
-            continue
-
         sidecar_block = _find_roundtrip_sidecar_block(
             change, mapping, roundtrip_sidecar, xpath_to_sidecar_block,
         )
-
-        if strategy is RendererStrategy.PRESERVED_ANCHOR:
-            if sidecar_block_requires_reconstruction(sidecar_block):
-                patches.append(
-                    _build_replace_fragment_patch(
-                        mapping,
-                        change.new_block,
-                        sidecar_block=sidecar_block,
-                        mapping_lost_info=mapping_lost_info,
-                    )
-                )
-                continue
-            if not _contains_only_supported_preservation_units(
-                mapping.xhtml_text
-            ):
-                skipped_changes.append({
-                    'block_id': mapping.block_id,
-                    'reason': 'unknown_preservation_unit',
-                    'description': (
-                        f"블록 {mapping.block_id}: 지원 계약이 없는 Confluence "
-                        f"preservation unit을 변경할 수 없어 건너뜁니다."
-                    ),
-                })
-                continue
-            if (
-                '<ac:link' in mapping.xhtml_text
-                or '<ri:attachment' in mapping.xhtml_text
-            ):
-                patches.append(
-                    _build_preserved_template_patch(
-                        mapping,
-                        new_plain,
-                        mapping_lost_info,
-                    )
-                )
-                continue
-            skipped_changes.append({
-                'block_id': mapping.block_id,
-                'reason': 'unknown_preservation_unit',
-                'description': (
-                    f"블록 {mapping.block_id}: 지원 계약이 없는 Confluence "
-                    f"preservation unit을 변경할 수 없어 건너뜁니다."
-                ),
-            })
-            continue
-
-        if _is_clean_block(change.old_block.type, mapping, sidecar_block):
-            patches.append(
-                _build_replace_fragment_patch(
-                    mapping,
-                    change.new_block,
-                    sidecar_block=sidecar_block,
-                    mapping_lost_info=mapping_lost_info,
-                )
+        dispatch_strategy(
+            StrategyRenderContext(
+                decision=strategy_decision,
+                change=change,
+                mapping=mapping,
+                old_plain=old_plain,
+                new_plain=_mdx_visible_text(change.new_block),
+                mapping_via_v3_fallback=mapping_via_v3_fallback,
+                roundtrip_sidecar=roundtrip_sidecar,
+                sidecar_block=sidecar_block,
+                mapping_lost_info=mapping_lost_info,
+                improved_blocks=improved_blocks,
+                mdx_to_sidecar=mdx_to_sidecar,
+                id_to_mapping=id_to_mapping,
+                used_ids=used_ids,
+                patches=patches,
+                skipped_changes=skipped_changes,
+                text_change_patches=_text_change_patches,
+                mark_used_callback=_mark_used,
+                primitives=strategy_primitives,
             )
-            continue
-
-        if sidecar_block_requires_reconstruction(sidecar_block):
-            patches.append(
-                _build_replace_fragment_patch(
-                    mapping,
-                    change.new_block,
-                    sidecar_block=sidecar_block,
-                    mapping_lost_info=mapping_lost_info,
-                )
-            )
-            continue
-
-        # inner XHTML 재생성 + 블록 레벨 lost_info 적용
-        new_inner = mdx_block_to_inner_xhtml(
-            change.new_block.content, change.new_block.type)
-        block_lost = mapping_lost_info.get(mapping.block_id, {})
-        if block_lost:
-            new_inner = apply_lost_info(new_inner, block_lost)
-
-        patches.append({
-            'xhtml_xpath': mapping.xhtml_xpath,
-            'old_plain_text': mapping_visible_text,
-            'new_inner_xhtml': new_inner,
-        })
+        )
 
     return (
         _resolve_patch_links(

--- a/confluence-mdx/bin/reverse_sync/strategies/__init__.py
+++ b/confluence-mdx/bin/reverse_sync/strategies/__init__.py
@@ -1,0 +1,13 @@
+"""Typed renderer strategy dispatch boundary."""
+
+from reverse_sync.strategies.contracts import (
+    StrategyPrimitives,
+    StrategyRenderContext,
+)
+from reverse_sync.strategies.dispatch import dispatch_strategy
+
+__all__ = [
+    "StrategyPrimitives",
+    "StrategyRenderContext",
+    "dispatch_strategy",
+]

--- a/confluence-mdx/bin/reverse_sync/strategies/container_strategy.py
+++ b/confluence-mdx/bin/reverse_sync/strategies/container_strategy.py
@@ -1,0 +1,96 @@
+"""Container renderer strategy."""
+
+from typing import Any, Dict
+
+from mdx_to_storage.parser import Block as MdxBlock
+from reverse_sync.reconstructors import sidecar_block_requires_reconstruction
+from reverse_sync.strategies.contracts import StrategyRenderContext
+
+
+def render_container(context: StrategyRenderContext) -> None:
+    """container 본문 변경과 child list 변경을 보존적으로 렌더링합니다."""
+    mapping = context.mapping
+    primitives = context.primitives
+    block_id = mapping.block_id
+    first_visit = block_id not in context.used_ids
+    context.mark_used()
+
+    if sidecar_block_requires_reconstruction(context.sidecar_block):
+        if first_visit:
+            context.append_replace_fragment(sidecar_block=context.sidecar_block)
+    else:
+        if block_id not in context.text_change_patches:
+            patch_entry: Dict[str, Any] = {
+                "xhtml_xpath": mapping.xhtml_xpath,
+                "old_plain_text": mapping.xhtml_plain_text,
+                "new_plain_text": mapping.xhtml_plain_text,
+            }
+            context.patches.append(patch_entry)
+            context.text_change_patches[block_id] = patch_entry
+
+        patch_entry = context.text_change_patches[block_id]
+        patch_entry["new_plain_text"] = primitives.apply_mdx_diff_to_xhtml(
+            context.old_plain,
+            context.new_plain,
+            patch_entry["new_plain_text"],
+        )
+        inline_fixups = primitives.build_inline_fixups(
+            context.old_block.content,
+            context.new_block.content,
+            block_type=context.old_block.type,
+        )
+        if inline_fixups:
+            existing = patch_entry.get("inline_fixups", [])
+            existing.extend(
+                primitives.offset_inline_fixup_match_indexes(
+                    existing,
+                    inline_fixups,
+                    parent_xpath=mapping.xhtml_xpath,
+                    change_index=context.change.index,
+                    improved_blocks=context.improved_blocks,
+                    mdx_to_sidecar=context.mdx_to_sidecar,
+                )
+            )
+            patch_entry["inline_fixups"] = existing
+
+    if (
+        context.old_block.type != "callout"
+        or not hasattr(context.old_block, "children")
+        or not hasattr(context.new_block, "children")
+    ):
+        return
+
+    old_lists = [
+        child for child in context.old_block.children if child.type == "list"
+    ]
+    new_lists = [
+        child for child in context.new_block.children if child.type == "list"
+    ]
+    child_list_mappings = [
+        context.id_to_mapping[child_id]
+        for child_id in mapping.children
+        if child_id in context.id_to_mapping
+        and context.id_to_mapping[child_id].type == "list"
+    ]
+    for old_child, new_child, child_mapping in zip(
+        old_lists,
+        new_lists,
+        child_list_mappings,
+    ):
+        if not primitives.detect_list_item_space_change(
+            old_child.content,
+            new_child.content,
+        ):
+            continue
+        if primitives.contains_preserved_anchor_markup(child_mapping.xhtml_text):
+            continue
+        child_block = MdxBlock(
+            type="list",
+            content=new_child.content,
+            line_start=0,
+            line_end=0,
+        )
+        context.append_replace_fragment(
+            mapping=child_mapping,
+            block=child_block,
+        )

--- a/confluence-mdx/bin/reverse_sync/strategies/contracts.py
+++ b/confluence-mdx/bin/reverse_sync/strategies/contracts.py
@@ -1,0 +1,105 @@
+"""Renderer strategy handler가 공유하는 typed 실행 계약."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Mapping, Optional
+
+from mdx_to_storage.parser import Block as MdxBlock
+from reverse_sync.block_diff import BlockChange
+from reverse_sync.capabilities import StrategyDecision
+from reverse_sync.mapping_recorder import BlockMapping
+from reverse_sync.sidecar import RoundtripSidecar, SidecarBlock, SidecarEntry
+
+Patch = Dict[str, Any]
+SkippedChange = Dict[str, str]
+
+
+@dataclass(frozen=True)
+class StrategyPrimitives:
+    """기존 patch primitive를 handler에 주입하는 migration seam."""
+
+    apply_mdx_diff_to_xhtml: Callable[[str, str, str], str]
+    build_inline_fixups: Callable[..., List[Patch]]
+    offset_inline_fixup_match_indexes: Callable[..., List[Patch]]
+    detect_list_item_space_change: Callable[[str, str], bool]
+    build_list_item_merge_patch: Callable[
+        [BlockMapping, str, str, str, str],
+        Optional[Patch],
+    ]
+    build_replace_fragment_patch: Callable[
+        [BlockMapping, MdxBlock, Optional[SidecarBlock], Optional[dict]],
+        Patch,
+    ]
+    build_preserved_template_patch: Callable[[BlockMapping, str, dict], Patch]
+    classify_table_fragment_skip: Callable[
+        [BlockChange, Optional[BlockMapping], Optional[RoundtripSidecar]],
+        Optional[SkippedChange],
+    ]
+    extract_html_table_cells: Callable[[str], List[str]]
+    is_safe_cell_text_edit: Callable[[List[str], List[str]], bool]
+    is_clean_block: Callable[
+        [str, Optional[BlockMapping], Optional[SidecarBlock]],
+        bool,
+    ]
+    contains_preserved_anchor_markup: Callable[[str], bool]
+    contains_only_supported_preservation_units: Callable[[str], bool]
+    xhtml_visible_text: Callable[[BlockMapping, str], str]
+
+
+@dataclass
+class StrategyRenderContext:
+    """한 modified MDX block을 렌더링하는 데 필요한 명시적 입력과 출력."""
+
+    decision: StrategyDecision
+    change: BlockChange
+    mapping: BlockMapping
+    old_plain: str
+    new_plain: str
+    mapping_via_v3_fallback: bool
+    roundtrip_sidecar: Optional[RoundtripSidecar]
+    sidecar_block: Optional[SidecarBlock]
+    mapping_lost_info: dict
+    improved_blocks: List[MdxBlock]
+    mdx_to_sidecar: Mapping[int, SidecarEntry]
+    id_to_mapping: Mapping[str, BlockMapping]
+    used_ids: set[str]
+    patches: List[Patch]
+    skipped_changes: List[SkippedChange]
+    text_change_patches: Dict[str, Patch]
+    mark_used_callback: Callable[[str, BlockMapping], None]
+    primitives: StrategyPrimitives
+
+    @property
+    def old_block(self) -> MdxBlock:
+        if self.change.old_block is None:
+            raise ValueError("renderer strategy에는 old_block이 필요합니다")
+        return self.change.old_block
+
+    @property
+    def new_block(self) -> MdxBlock:
+        if self.change.new_block is None:
+            raise ValueError("renderer strategy에는 new_block이 필요합니다")
+        return self.change.new_block
+
+    def mark_used(self, mapping: Optional[BlockMapping] = None) -> None:
+        target = mapping or self.mapping
+        self.mark_used_callback(target.block_id, target)
+
+    def append_replace_fragment(
+        self,
+        *,
+        mapping: Optional[BlockMapping] = None,
+        block: Optional[MdxBlock] = None,
+        sidecar_block: Optional[SidecarBlock] = None,
+    ) -> None:
+        target = mapping or self.mapping
+        new_block = block or self.new_block
+        self.patches.append(
+            self.primitives.build_replace_fragment_patch(
+                target,
+                new_block,
+                sidecar_block,
+                self.mapping_lost_info,
+            )
+        )

--- a/confluence-mdx/bin/reverse_sync/strategies/dispatch.py
+++ b/confluence-mdx/bin/reverse_sync/strategies/dispatch.py
@@ -1,0 +1,40 @@
+"""RendererStrategy를 concrete handler로 연결하는 typed dispatch."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Callable, Mapping
+
+from reverse_sync.capabilities import RendererStrategy
+from reverse_sync.strategies.container_strategy import render_container
+from reverse_sync.strategies.contracts import StrategyRenderContext
+from reverse_sync.strategies.list_strategy import render_list
+from reverse_sync.strategies.table_strategy import render_table
+from reverse_sync.strategies.text_strategy import (
+    render_preserved_anchor,
+    render_text_block,
+)
+
+StrategyHandler = Callable[[StrategyRenderContext], None]
+
+STRATEGY_HANDLERS: Mapping[RendererStrategy, StrategyHandler] = MappingProxyType(
+    {
+        RendererStrategy.TEXT_BLOCK: render_text_block,
+        RendererStrategy.LIST: render_list,
+        RendererStrategy.PRESERVED_ANCHOR: render_preserved_anchor,
+        RendererStrategy.CONTAINER: render_container,
+        RendererStrategy.TABLE: render_table,
+    }
+)
+
+
+def dispatch_strategy(context: StrategyRenderContext) -> None:
+    """typed strategy의 handler를 호출하고 미등록 strategy는 fail-closed합니다."""
+    try:
+        handler = STRATEGY_HANDLERS[context.decision.strategy]
+    except KeyError as exc:
+        raise ValueError(
+            "등록되지 않은 renderer strategy는 실행할 수 없습니다: "
+            f"{context.decision.strategy.value}"
+        ) from exc
+    handler(context)

--- a/confluence-mdx/bin/reverse_sync/strategies/list_strategy.py
+++ b/confluence-mdx/bin/reverse_sync/strategies/list_strategy.py
@@ -1,0 +1,123 @@
+"""List renderer strategy."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
+
+from reverse_sync.reconstructors import sidecar_block_requires_reconstruction
+from reverse_sync.strategies.contracts import StrategyRenderContext
+from reverse_sync.visible_segments import (
+    extract_visible_model_from_mdx,
+    extract_visible_model_from_xhtml,
+)
+
+
+def render_list(context: StrategyRenderContext) -> None:
+    """list 변경을 fragment 재구성 또는 누적 text patch로 렌더링합니다."""
+    mapping = context.mapping
+    old_block = context.old_block
+    new_block = context.new_block
+    primitives = context.primitives
+    list_sidecar = context.sidecar_block
+
+    old_list_model = extract_visible_model_from_mdx(
+        old_block.content,
+        "list",
+    )
+    new_list_model = extract_visible_model_from_mdx(
+        new_block.content,
+        "list",
+    )
+    xhtml_list_model = extract_visible_model_from_xhtml(
+        mapping.xhtml_text,
+        "list",
+    )
+    has_content_change = (
+        old_list_model.visible_text != new_list_model.visible_text
+    )
+    has_structure_change = (
+        old_list_model.structural_fingerprint
+        != new_list_model.structural_fingerprint
+    )
+    old_visible = old_list_model.visible_text
+    new_visible = new_list_model.visible_text
+
+    old_start = re.match(r"^\s*(\d+)\.", old_block.content)
+    new_start = re.match(r"^\s*(\d+)\.", new_block.content)
+    has_ol_start_change = bool(
+        old_start
+        and new_start
+        and int(old_start.group(1)) != int(new_start.group(1))
+    )
+    inline_fixups = primitives.build_inline_fixups(
+        old_block.content,
+        new_block.content,
+        block_type=old_block.type,
+    )
+    has_inline_boundary = bool(inline_fixups)
+    has_patchable_text_change = (
+        has_content_change or has_ol_start_change or has_inline_boundary
+    )
+    has_rebuild_change = has_patchable_text_change or has_structure_change
+    requires_anchor_rebuild = sidecar_block_requires_reconstruction(
+        list_sidecar,
+    )
+    has_preserved_anchor = primitives.contains_preserved_anchor_markup(
+        mapping.xhtml_text
+    )
+    should_replace_clean_list = (
+        not has_preserved_anchor
+        and (context.roundtrip_sidecar is not None or has_rebuild_change)
+        and (
+            list_sidecar is None
+            or context.mapping_via_v3_fallback
+            or has_rebuild_change
+        )
+    )
+
+    if has_preserved_anchor:
+        merge_patch = primitives.build_list_item_merge_patch(
+            mapping,
+            old_block.content,
+            new_block.content,
+            old_visible,
+            new_visible,
+        )
+        if merge_patch is not None:
+            context.mark_used()
+            context.patches.append(merge_patch)
+            return
+
+    if requires_anchor_rebuild or should_replace_clean_list:
+        context.mark_used()
+        context.append_replace_fragment(sidecar_block=list_sidecar)
+        return
+
+    if not has_patchable_text_change:
+        return
+
+    block_id = mapping.block_id
+    if block_id not in context.text_change_patches:
+        patch_entry: Dict[str, Any] = {
+            "xhtml_xpath": mapping.xhtml_xpath,
+            "old_plain_text": xhtml_list_model.visible_text,
+            "new_plain_text": xhtml_list_model.visible_text,
+        }
+        context.patches.append(patch_entry)
+        context.text_change_patches[block_id] = patch_entry
+
+    patch_entry = context.text_change_patches[block_id]
+    if has_content_change:
+        patch_entry["new_plain_text"] = primitives.apply_mdx_diff_to_xhtml(
+            old_visible,
+            new_visible,
+            patch_entry["new_plain_text"],
+        )
+    if has_ol_start_change and new_start is not None:
+        patch_entry["ol_start"] = int(new_start.group(1))
+    if has_inline_boundary:
+        existing = patch_entry.get("inline_fixups", [])
+        existing.extend(inline_fixups)
+        patch_entry["inline_fixups"] = existing
+    context.mark_used()

--- a/confluence-mdx/bin/reverse_sync/strategies/table_strategy.py
+++ b/confluence-mdx/bin/reverse_sync/strategies/table_strategy.py
@@ -1,0 +1,64 @@
+"""Table renderer strategy."""
+
+from reverse_sync.strategies.contracts import StrategyRenderContext
+
+
+def render_table(context: StrategyRenderContext) -> None:
+    """table 변경을 source kind에 맞는 안전 경로로 렌더링합니다."""
+    mapping = context.mapping
+    primitives = context.primitives
+
+    if context.decision.source_kind == "raw_html_table":
+        if "<ac:link" in mapping.xhtml_text or "<ri:attachment" in mapping.xhtml_text:
+            context.mark_used()
+            context.patches.append(
+                primitives.build_preserved_template_patch(
+                    mapping,
+                    context.new_plain,
+                    context.mapping_lost_info,
+                )
+            )
+            return
+
+        old_cells = primitives.extract_html_table_cells(context.old_block.content)
+        new_cells = primitives.extract_html_table_cells(context.new_block.content)
+        if not primitives.is_safe_cell_text_edit(old_cells, new_cells):
+            context.skipped_changes.append(
+                {
+                    "block_id": mapping.block_id,
+                    "reason": "unsafe_html_table_edit",
+                    "description": (
+                        f"블록 {mapping.block_id}: raw HTML 테이블의 셀 구조 변경"
+                        f"(셀 수 변경 또는 셀 내용 재배치)은 안전하지 않아 "
+                        f"건너뜁니다."
+                    ),
+                }
+            )
+            return
+
+        context.mark_used()
+        mapping_visible_text = mapping.xhtml_plain_text
+        context.patches.append(
+            {
+                "xhtml_xpath": mapping.xhtml_xpath,
+                "old_plain_text": mapping_visible_text,
+                "new_plain_text": primitives.apply_mdx_diff_to_xhtml(
+                    context.old_plain,
+                    context.new_plain,
+                    mapping_visible_text,
+                ),
+            }
+        )
+        return
+
+    table_skip = primitives.classify_table_fragment_skip(
+        context.change,
+        mapping,
+        context.roundtrip_sidecar,
+    )
+    if table_skip is not None:
+        context.skipped_changes.append(table_skip)
+        return
+
+    context.mark_used()
+    context.append_replace_fragment()

--- a/confluence-mdx/bin/reverse_sync/strategies/text_strategy.py
+++ b/confluence-mdx/bin/reverse_sync/strategies/text_strategy.py
@@ -1,0 +1,106 @@
+"""Text block와 preserved anchor renderer strategy."""
+
+from reverse_sync.lost_info_patcher import apply_lost_info
+from reverse_sync.mdx_to_xhtml_inline import mdx_block_to_inner_xhtml
+from reverse_sync.reconstructors import sidecar_block_requires_reconstruction
+from reverse_sync.strategies.contracts import StrategyRenderContext
+from text_utils import collapse_ws
+
+
+def _already_applied(context: StrategyRenderContext, mapping_visible_text: str) -> bool:
+    return (
+        collapse_ws(context.old_plain) != collapse_ws(mapping_visible_text)
+        and collapse_ws(context.new_plain) == collapse_ws(mapping_visible_text)
+    )
+
+
+def render_preserved_anchor(context: StrategyRenderContext) -> None:
+    """알려진 preservation unit만 보존 template 또는 sidecar로 재구성합니다."""
+    mapping = context.mapping
+    mapping_visible_text = context.primitives.xhtml_visible_text(
+        mapping,
+        context.old_block.type,
+    )
+    context.mark_used()
+    if _already_applied(context, mapping_visible_text):
+        return
+
+    if sidecar_block_requires_reconstruction(context.sidecar_block):
+        context.append_replace_fragment(sidecar_block=context.sidecar_block)
+        return
+
+    if not context.primitives.contains_only_supported_preservation_units(
+        mapping.xhtml_text
+    ):
+        context.skipped_changes.append(
+            {
+                "block_id": mapping.block_id,
+                "reason": "unknown_preservation_unit",
+                "description": (
+                    f"블록 {mapping.block_id}: 지원 계약이 없는 Confluence "
+                    f"preservation unit을 변경할 수 없어 건너뜁니다."
+                ),
+            }
+        )
+        return
+
+    if "<ac:link" in mapping.xhtml_text or "<ri:attachment" in mapping.xhtml_text:
+        context.patches.append(
+            context.primitives.build_preserved_template_patch(
+                mapping,
+                context.new_plain,
+                context.mapping_lost_info,
+            )
+        )
+        return
+
+    context.skipped_changes.append(
+        {
+            "block_id": mapping.block_id,
+            "reason": "unknown_preservation_unit",
+            "description": (
+                f"블록 {mapping.block_id}: 지원 계약이 없는 Confluence "
+                f"preservation unit을 변경할 수 없어 건너뜁니다."
+            ),
+        }
+    )
+
+
+def render_text_block(context: StrategyRenderContext) -> None:
+    """일반 text block을 fragment 또는 inner XHTML patch로 렌더링합니다."""
+    mapping = context.mapping
+    mapping_visible_text = context.primitives.xhtml_visible_text(
+        mapping,
+        context.old_block.type,
+    )
+    context.mark_used()
+    if _already_applied(context, mapping_visible_text):
+        return
+
+    if context.primitives.is_clean_block(
+        context.old_block.type,
+        mapping,
+        context.sidecar_block,
+    ):
+        context.append_replace_fragment(sidecar_block=context.sidecar_block)
+        return
+
+    if sidecar_block_requires_reconstruction(context.sidecar_block):
+        context.append_replace_fragment(sidecar_block=context.sidecar_block)
+        return
+
+    new_inner = mdx_block_to_inner_xhtml(
+        context.new_block.content,
+        context.new_block.type,
+    )
+    block_lost = context.mapping_lost_info.get(mapping.block_id, {})
+    if block_lost:
+        new_inner = apply_lost_info(new_inner, block_lost)
+
+    context.patches.append(
+        {
+            "xhtml_xpath": mapping.xhtml_xpath,
+            "old_plain_text": mapping_visible_text,
+            "new_inner_xhtml": new_inner,
+        }
+    )

--- a/confluence-mdx/tests/test_reverse_sync_strategies.py
+++ b/confluence-mdx/tests/test_reverse_sync_strategies.py
@@ -1,0 +1,34 @@
+"""Typed renderer strategy dispatch contract tests."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from reverse_sync.capabilities import RendererStrategy, StrategyDecision
+from reverse_sync.strategies.dispatch import (
+    STRATEGY_HANDLERS,
+    dispatch_strategy,
+)
+
+
+def test_strategy_registry_covers_every_executable_strategy_once():
+    assert set(STRATEGY_HANDLERS) == set(RendererStrategy) - {
+        RendererStrategy.BLOCKED,
+    }
+    assert len(set(STRATEGY_HANDLERS.values())) == len(STRATEGY_HANDLERS)
+
+
+def test_blocked_strategy_cannot_cross_renderer_dispatch_boundary():
+    context = SimpleNamespace(
+        decision=StrategyDecision(
+            RendererStrategy.BLOCKED,
+            "unknown",
+            reason_code="missing_identity",
+        )
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="등록되지 않은 renderer strategy는 실행할 수 없습니다: blocked",
+    ):
+        dispatch_strategy(context)

--- a/openspec/changes/complete-reverse-sync/design.md
+++ b/openspec/changes/complete-reverse-sync/design.md
@@ -327,8 +327,13 @@ capability 판별은 renderer output의 raw patch payload shape를 재해석하�
 planner가 operation에 대응하는 MDX `ChangeIntent`와 typed
 `StrategyDecision`을 `classify_capability()`에 전달하고, legacy renderer skip
 reason의 capability 대응도 `capabilities.py` registry boundary에서 수행합니다.
-각 strategy handler를 `patch_builder.py` 밖의 `reverse_sync/strategies/**`
-모듈로 추출하는 작업은 계속 남아 있습니다.
+각 strategy handler는 `patch_builder.py` 밖의 `reverse_sync/strategies/**`
+모듈에 둡니다. `StrategyRenderContext`는 한 modified block의 decision, exact
+mapping, sidecar, 누적 patch state를 전달하고, `StrategyPrimitives`는 migration
+중인 기존 patch primitive를 callback으로 주입합니다. 따라서 handler는
+`patch_builder.py`를 역참조하지 않으며 `build_patches()`의 modified block
+rendering path에는 typed context 구성과 registry dispatch만 남습니다.
+`blocked` 또는 미등록 strategy는 dispatch 경계에서 fail-closed합니다.
 
 `render_patch_plan_preserving()`은 executable operation을 raw renderer input으로
 복원하기 직전에 target root fragment hash, sidecar MDX hash, line range를 base

--- a/openspec/changes/complete-reverse-sync/tasks.md
+++ b/openspec/changes/complete-reverse-sync/tasks.md
@@ -163,8 +163,13 @@
     `capabilities.py`의 registry boundary로 이동합니다.
   - MDX-owned link의 text block operation을 preservation capability로 잘못
     분류하지 않도록 integration test를 고정합니다.
-- [ ] `build_patches()`의 strategy handler를 `reverse_sync/strategies/**`로
+- [x] `build_patches()`의 strategy handler를 `reverse_sync/strategies/**`로
   추출하고 typed strategy dispatch만 남깁니다.
+  - `StrategyRenderContext`와 `StrategyPrimitives`가 기존 patch primitive를
+    handler에 주입하며 handler는 `patch_builder.py`를 역참조하지 않습니다.
+  - text block, list, preserved anchor, container, table은 독립 handler와
+    registry를 가지며 `blocked` 또는 미등록 strategy는 dispatch 경계에서
+    fail-closed합니다.
 - [x] planning output을 typed `PatchPlan`/operation으로 바꾸고 raw patch dict를 boundary 안에 가둡니다.
   - `legacy-patch-builder-v2` adapter가 `ChangeIntent`, `TargetIdentity`,
     capability, required proof, reason code를 canonical schema v2 plan에 기록합니다.
@@ -192,7 +197,8 @@
     helper를 사용합니다.
   - 계약이 없는 `ac:`/`ri:` preservation unit은 text fallback으로 흘리지 않고
     `unknown_macro_mutation` capability로 fail-closed 처리합니다.
-  - strategy handler 자체의 모듈 추출은 위의 별도 task에 계속 남아 있습니다.
+  - strategy handler는 `reverse_sync/strategies/**`의 typed registry로
+    추출되어 `build_patches()` 본체에 category별 분기를 추가하지 않습니다.
 - [x] unsupported table/macro 구조를 explicit block reason으로 전환합니다.
   - operation 생성 전 legacy skip도 원래 intent에 연결합니다.
   - table/macro 내부 분기 reason은 `unsupported_capability`와
@@ -379,10 +385,19 @@ typed capability planning branch 검증 결과:
 - 전체 Python test: 1142 passed, 2 skipped
 - `openspec validate complete-reverse-sync --strict`: passed
 
+strategy handler extraction branch 검증 결과:
+
+- `make test-convert`: 21 passed
+- `make test-reverse-sync`: golden 16 passed, regression 43 passed
+- `make test-byte-verify`: fast/splice 각각 21/21 passed
+- `test_reverse_sync*.py`: 791 passed
+- 전체 Python test: 1144 passed, 2 skipped
+- `openspec validate complete-reverse-sync --strict`: passed
+
 - [x] 영향도에 따라 전체 Python test와 render test를 실행합니다.
 
 이번 변경은 Python renderer 범위이므로 전체 Python test
-(`1142 passed, 2 skipped`)를 실행했고 frontend render test는 영향 범위에서
+(`1144 passed, 2 skipped`)를 실행했고 frontend render test는 영향 범위에서
 제외했습니다.
 
 ```bash


### PR DESCRIPTION
## Summary
`build_patches()`에 모여 있던 modified block의 renderer 정책을 typed strategy handler로 분리하여 capability 확장 시 본체의 heuristic branch가 늘어나지 않도록 합니다.

- `StrategyRenderContext`로 exact mapping, sidecar, 누적 patch state를 명시적으로 전달합니다.
- `StrategyPrimitives`로 기존 patch primitive를 주입하여 handler가 `patch_builder.py`를 역참조하지 않도록 합니다.
- text block, list, preserved anchor, container, table을 독립 handler와 typed registry로 연결합니다.
- `blocked` 또는 미등록 strategy를 dispatch 경계에서 fail-closed합니다.
- nested strategy package가 생성하는 `__pycache__`를 ignore하고 OpenSpec design/task를 구현 상태에 맞게 갱신합니다.

## Impact

- 새 renderer strategy는 registry와 독립 handler를 추가하는 방식으로 확장할 수 있습니다.
- identity resolution과 legacy patch primitive의 동작은 유지하며, 기존 fixture 결과를 변경하지 않습니다.
- Confluence PUT이나 production batch는 실행하지 않았습니다.

## OpenSpec / stacked PR

- 기준 change: `openspec/changes/complete-reverse-sync`
- 수행 task: `build_patches()` strategy handler의 `reverse_sync/strategies/**` 추출
- Base PR: #1042
- 열린 PR을 확인했으며 같은 handler 추출을 다루는 중복 PR은 없습니다.
- 관련 없는 `xhtml_patcher.py` 축소와 P2 capability 확대는 이번 PR에서 제외합니다.
- OpenSpec과 구현 사이에 추가 blocker 또는 미해결 drift는 없습니다.

## Test plan

- [x] `cd confluence-mdx && venv/bin/pytest -q tests/test_reverse_sync_strategies.py tests/test_reverse_sync_patch_builder.py tests/test_reverse_sync_capabilities.py tests/test_reverse_sync_planner.py` — 155 passed
- [x] `cd confluence-mdx && venv/bin/pytest -q tests/test_reverse_sync*.py` — 791 passed
- [x] `cd confluence-mdx && venv/bin/pytest -q` — 1144 passed, 2 skipped
- [x] `cd confluence-mdx/tests && make test-reverse-sync` — golden 16 passed, regression 43 passed
- [x] `cd confluence-mdx/tests && make test-convert` — 21 passed
- [x] `cd confluence-mdx/tests && make test-byte-verify` — fast/splice 각각 21/21 passed
- [x] `openspec validate complete-reverse-sync --strict`
- [x] `git diff --check`

## Related tickets & links

- #1042

🤖 Generated with Codex
