### PR TITLE
confluence-mdx: compatibility artifact를 run에 결합합니다

### DIFF
--- a/confluence-mdx/bin/reverse_sync/manifest.py
+++ b/confluence-mdx/bin/reverse_sync/manifest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from collections import Counter
 from pathlib import Path
 from typing import Iterable
@@ -45,6 +46,12 @@ REQUIRED_ARTIFACTS = frozenset(
         "local_proof",
     }
 )
+RUN_BACKED_COMPATIBILITY_OUTPUTS = {
+    "reverse-sync.manifest.json": None,
+    "reverse-sync.patched.xhtml": "candidate_xhtml",
+    "reverse-sync.plan.json": "patch_plan",
+    "reverse-sync.proof.json": "local_proof",
+}
 
 
 class ArtifactTamperedError(ValueError):
@@ -188,6 +195,59 @@ def create_sync_manifest(
     _write_immutable(manifest_path, manifest_content)
     _write_immutable(run_dir / "manifest.sha256", sha256_text(manifest_content) + "\n")
     return manifest_path
+
+
+def update_run_backed_compatibility_outputs(
+    manifest_path: Path,
+    page_dir: Path,
+) -> dict[str, Path]:
+    """최신 immutable run을 가리키는 read-only compatibility symlink를 갱신합니다.
+
+    이 출력은 운영자 진단과 기존 도구 호환 전용입니다. Publisher는 이 경로를
+    입력으로 사용하지 않고 explicit ``manifest_path``만 받습니다.
+    """
+    path = Path(manifest_path).resolve()
+    page = Path(page_dir).resolve()
+    manifest = load_sync_manifest(path)
+    run_dir = path.parent
+    if run_dir.name != manifest.run_id:
+        raise ArtifactTamperedError(
+            "manifest run_id와 artifact directory가 다릅니다"
+        )
+    if run_dir.parent.parent.resolve() != page:
+        raise ArtifactTamperedError(
+            "compatibility output page directory와 manifest run이 다릅니다"
+        )
+
+    targets: dict[str, Path] = {}
+    for output_name, artifact_name in RUN_BACKED_COMPATIBILITY_OUTPUTS.items():
+        target = (
+            path
+            if artifact_name is None
+            else run_dir / manifest.artifact(artifact_name).path
+        )
+        resolved_target = target.resolve()
+        try:
+            resolved_target.relative_to(run_dir.resolve())
+        except ValueError as exc:
+            raise ArtifactTamperedError(
+                f"compatibility target이 run directory를 벗어납니다: {output_name}"
+            ) from exc
+
+        output_path = page / output_name
+        temporary = page / f".{output_name}.{manifest.run_id}.tmp"
+        if temporary.exists() or temporary.is_symlink():
+            temporary.unlink()
+        try:
+            temporary.symlink_to(
+                os.path.relpath(resolved_target, start=page),
+            )
+            temporary.replace(output_path)
+        finally:
+            if temporary.exists() or temporary.is_symlink():
+                temporary.unlink()
+        targets[output_name] = resolved_target
+    return targets
 
 
 def load_sync_manifest(path: Path) -> SyncManifest:

--- a/confluence-mdx/bin/reverse_sync_cli.py
+++ b/confluence-mdx/bin/reverse_sync_cli.py
@@ -663,7 +663,10 @@ def run_verify(
         skipped_changes=skipped_changes)
 
     if for_push:
-        from reverse_sync.manifest import create_sync_manifest
+        from reverse_sync.manifest import (
+            create_sync_manifest,
+            update_run_backed_compatibility_outputs,
+        )
         from reverse_sync.models import sha256_text
         from reverse_sync.preserving_patcher import render_patch_plan_preserving
         from reverse_sync.proof import build_local_proof
@@ -813,6 +816,7 @@ def run_verify(
             push_eligible=True,
             gates=proof.gates,
         )
+        update_run_backed_compatibility_outputs(manifest_path, var_dir)
         result.update(
             push_eligible=True,
             manifest_path=str(manifest_path),
@@ -821,7 +825,6 @@ def run_verify(
             base_storage_sha256=base_snapshot.storage_sha256,
             candidate_sha256=sha256_text(patched_xhtml),
         )
-        (var_dir / "reverse-sync.manifest.path").write_text(str(manifest_path) + "\n")
 
     (var_dir / "reverse-sync.result.yaml").write_text(
         yaml.dump(result, allow_unicode=True, default_flow_style=False)

--- a/confluence-mdx/tests/test_reverse_sync_push_transaction.py
+++ b/confluence-mdx/tests/test_reverse_sync_push_transaction.py
@@ -30,6 +30,7 @@ from reverse_sync.manifest import (
     StaleVerificationError,
     create_sync_manifest,
     load_sync_manifest,
+    update_run_backed_compatibility_outputs,
 )
 from reverse_sync.models import (
     AttachmentCatalog,
@@ -254,6 +255,34 @@ def test_manifest_is_deterministic_and_uses_run_scoped_artifacts(tmp_path):
     assert first.read_bytes() == second.read_bytes()
     assert (first.parent / "base.xhtml").read_text() == "<p>Before</p>"
     assert (first.parent / "candidate.xhtml").read_text() == "<p>After</p>"
+
+
+def test_compatibility_outputs_follow_latest_immutable_run(tmp_path):
+    first = _manifest(tmp_path, _snapshot(version=5))
+    (tmp_path / "reverse-sync.patched.xhtml").write_text("legacy copy")
+
+    first_targets = update_run_backed_compatibility_outputs(first, tmp_path)
+
+    assert (tmp_path / "reverse-sync.patched.xhtml").is_symlink()
+    assert (tmp_path / "reverse-sync.patched.xhtml").resolve() == (
+        first.parent / "candidate.xhtml"
+    ).resolve()
+    assert first_targets["reverse-sync.manifest.json"] == first.resolve()
+
+    second = _manifest(tmp_path, _snapshot(version=6))
+    assert second.parent != first.parent
+    update_run_backed_compatibility_outputs(second, tmp_path)
+
+    assert (tmp_path / "reverse-sync.patched.xhtml").resolve() == (
+        second.parent / "candidate.xhtml"
+    ).resolve()
+    assert (tmp_path / "reverse-sync.manifest.json").resolve() == second.resolve()
+    assert (tmp_path / "reverse-sync.plan.json").resolve() == (
+        second.parent / "patch-plan.json"
+    ).resolve()
+    assert (tmp_path / "reverse-sync.proof.json").resolve() == (
+        second.parent / "local-proof.json"
+    ).resolve()
 
 
 def test_candidate_tampering_blocks_before_remote_read(tmp_path):
@@ -1196,9 +1225,18 @@ def test_online_verify_builds_manifest_from_remote_snapshot(tmp_path, monkeypatc
         sha256_text("<p>Before</p>")
     )
     assert (manifest_path.parent / "local-proof.json").is_file()
-    assert (manifest_path.parent / "candidate.xhtml").read_text() == (
-        tmp_path / "var" / page_id / "reverse-sync.patched.xhtml"
-    ).read_text()
+    page_dir = tmp_path / "var" / page_id
+    compatibility_outputs = {
+        "reverse-sync.manifest.json": manifest_path,
+        "reverse-sync.patched.xhtml": manifest_path.parent / "candidate.xhtml",
+        "reverse-sync.plan.json": manifest_path.parent / "patch-plan.json",
+        "reverse-sync.proof.json": manifest_path.parent / "local-proof.json",
+    }
+    for output_name, target in compatibility_outputs.items():
+        output = page_dir / output_name
+        assert output.is_symlink()
+        assert output.resolve() == target.resolve()
+    assert not (page_dir / "reverse-sync.manifest.path").exists()
 
 
 def test_online_verify_proves_insert_idempotent_by_replanning(

--- a/openspec/changes/complete-reverse-sync/design.md
+++ b/openspec/changes/complete-reverse-sync/design.md
@@ -450,7 +450,13 @@ push는 file name이 아니라 manifest가 가리키는 candidate hash를 읽습
 - candidate body hash
 - verifier policy/tool version
 
-artifact는 `var/<page_id>/reverse-sync/<run_id>/`에 실행별로 저장합니다. “최근 파일”을 덮어쓰는 방식은 호환 bridge로만 유지합니다.
+artifact는 `var/<page_id>/reverse-sync/<run_id>/`에 실행별로 저장합니다.
+online prepare의 `reverse-sync.patched.xhtml`, `reverse-sync.plan.json`,
+`reverse-sync.proof.json`, `reverse-sync.manifest.json`은 최신 immutable run의
+대응 artifact를 가리키는 상대 symlink인 read-only compatibility output으로만
+유지합니다. 폐기된 `reverse-sync.manifest.path` pointer는 생성하지 않습니다.
+offline diagnostic의 diff/result/mapping/verify output은 push 비대상 호환
+artifact로 유지합니다.
 publisher는 local proof manifest를 수정하지 않고, manifest hash를 참조하는 별도 `PushReceipt`와 post-snapshot을 기록합니다.
 
 CLI에서 verify와 publish를 분리할 때는 `push --manifest

--- a/openspec/changes/complete-reverse-sync/tasks.md
+++ b/openspec/changes/complete-reverse-sync/tasks.md
@@ -42,7 +42,14 @@
   - referenced artifact integrity 검사
   - schema version 및 verifier policy 검사
 - [x] artifact를 `var/<page_id>/reverse-sync/<run_id>/`에 실행별로 저장합니다.
-- [ ] 기존 `reverse-sync.*` 경로는 최신 run을 가리키는 read-only compatibility output으로 제한합니다.
+- [x] 기존 run-backed `reverse-sync.*` 경로는 최신 immutable run을 가리키는
+  read-only compatibility output으로 제한합니다.
+  - online prepare의 patched XHTML, patch plan, local proof, manifest는
+    run directory artifact를 가리키는 상대 symlink로만 노출합니다.
+  - publisher는 compatibility output을 입력으로 사용하지 않으며 폐기된
+    `reverse-sync.manifest.path` pointer를 생성하지 않습니다.
+  - offline diagnostic의 diff/result/mapping/verify output은 push 비대상
+    compatibility artifact로 유지합니다.
 - [x] email, token, Authorization header redaction test를 추가합니다.
 
 완료 gate:
@@ -405,10 +412,19 @@ validated patcher boundary branch 검증 결과:
 - 전체 Python test: 1145 passed, 2 skipped
 - `openspec validate complete-reverse-sync --strict`: passed
 
+run-backed compatibility artifact branch 검증 결과:
+
+- `make test-convert`: 21 passed
+- `make test-reverse-sync`: golden 16 passed, regression 43 passed
+- `make test-byte-verify`: fast/splice 각각 21/21 passed
+- `test_reverse_sync*.py`: 793 passed
+- 전체 Python test: 1146 passed, 2 skipped
+- `openspec validate complete-reverse-sync --strict`: passed
+
 - [x] 영향도에 따라 전체 Python test와 render test를 실행합니다.
 
 이번 변경은 Python renderer 범위이므로 전체 Python test
-(`1145 passed, 2 skipped`)를 실행했고 frontend render test는 영향 범위에서
+(`1146 passed, 2 skipped`)를 실행했고 frontend render test는 영향 범위에서
 제외했습니다.
 
 ```bash


### PR DESCRIPTION
## Summary
online prepare가 남기는 flat compatibility output을 독립 복사본이 아니라 최신 immutable run을 가리키는 read-only bridge로 제한합니다.

- `reverse-sync.patched.xhtml`, `reverse-sync.plan.json`, `reverse-sync.proof.json`, `reverse-sync.manifest.json`을 run artifact의 상대 symlink로 갱신합니다.
- compatibility 갱신 전에 manifest run ID, page directory, target containment를 검증합니다.
- 임시 symlink를 원자 교체하여 여러 compatibility 경로가 최신 성공 run을 가리키도록 합니다.
- publisher fallback이 제거된 `reverse-sync.manifest.path` pointer를 더 이상 생성하지 않습니다.
- offline diagnostic의 diff/result/mapping/verify 파일은 push 비대상 compatibility output으로 유지합니다.

## Impact

- online prepare 후 flat 파일과 immutable manifest candidate가 서로 달라질 수 있는 복사본 drift를 제거합니다.
- publisher는 계속 explicit `manifest_path`만 사용하므로 compatibility output이 push authority를 갖지 않습니다.
- Confluence PUT이나 production batch는 실행하지 않았습니다.

## OpenSpec / stacked PR

- 기준 change: `openspec/changes/complete-reverse-sync`
- 수행 task: P0 run-backed `reverse-sync.*` read-only compatibility output
- Base PR: #1044
- 열린 PR diff를 확인했으며 같은 artifact bridge를 다루는 중복 PR은 없습니다.
- CLI orchestration 축소와 P2 capability 확대는 이번 PR에서 제외합니다.
- reviewer 결정과 canary 승인이 필요한 항목은 변경하지 않았습니다.

## Test plan

- [x] push transaction/CLI focused tests — 159 passed
- [x] `cd confluence-mdx && venv/bin/pytest -q tests/test_reverse_sync*.py` — 793 passed
- [x] `cd confluence-mdx && venv/bin/pytest -q` — 1146 passed, 2 skipped
- [x] `cd confluence-mdx/tests && make test-reverse-sync` — golden 16 passed, regression 43 passed
- [x] `cd confluence-mdx/tests && make test-convert` — 21 passed
- [x] `cd confluence-mdx/tests && make test-byte-verify` — fast/splice 각각 21/21 passed
- [x] `openspec validate complete-reverse-sync --strict`
- [x] `git diff --check`

## Related tickets & links

- #1044

🤖 Generated with Codex
