### PR TITLE
confluence-mdx: publish lifecycle을 service로 분리합니다

### DIFF
--- a/confluence-mdx/bin/reverse_sync/publish_service.py
+++ b/confluence-mdx/bin/reverse_sync/publish_service.py
@@ -1,0 +1,184 @@
+"""검증된 immutable manifest를 Confluence에 발행하는 lifecycle service."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from reverse_sync.equivalence import verify_push_equivalence
+from reverse_sync.verification_service import strip_frontmatter
+
+
+@dataclass(frozen=True)
+class ManifestPushSummary:
+    """explicit manifest 발행 전 확인에 필요한 immutable identity."""
+
+    manifest_path: Path
+    run_id: str
+    page_id: str
+    title: str
+    base_version: int
+    candidate_sha256: str
+    change_count: int
+    operation_count: int
+
+
+class PushConflictError(Exception):
+    """Confluence page가 preflight 이후 변경된 경우 발생합니다."""
+
+
+@dataclass(frozen=True)
+class PublishRuntime:
+    """CLI 환경 의존성을 publish lifecycle에 주입합니다."""
+
+    project_dir: Path
+    forward_convert: Callable[..., str]
+    detect_language: Callable[[str], str]
+    load_manifest_summary: Callable[[str], ManifestPushSummary]
+
+
+def load_manifest_push_summary(manifest_path: str) -> ManifestPushSummary:
+    """explicit manifest의 integrity와 typed plan schema를 PUT 전에 검증합니다."""
+
+    from reverse_sync.manifest import (
+        ArtifactTamperedError,
+        load_sync_manifest,
+        verify_manifest_integrity,
+    )
+
+    resolved_path = Path(manifest_path).expanduser().resolve()
+    manifest = load_sync_manifest(resolved_path)
+    verify_manifest_integrity(resolved_path, manifest)
+    if not manifest.push_eligible:
+        raise ValueError("push eligible이 아닌 manifest는 발행할 수 없습니다")
+
+    plan_ref = manifest.artifact("patch_plan")
+    try:
+        plan = json.loads((resolved_path.parent / plan_ref.path).read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ArtifactTamperedError("patch plan JSON을 읽을 수 없습니다") from exc
+    if not isinstance(plan, dict) or plan.get("schema_version") != 2:
+        raise ArtifactTamperedError("explicit push는 PatchPlan schema v2가 필요합니다")
+    if plan.get("intent_complete") is not True:
+        raise ArtifactTamperedError(
+            "intent_complete가 아닌 PatchPlan은 발행할 수 없습니다"
+        )
+    intents = plan.get("intents")
+    operations = plan.get("operations")
+    if not isinstance(intents, list) or not isinstance(operations, list):
+        raise ArtifactTamperedError(
+            "PatchPlan intents/operations 형식이 올바르지 않습니다"
+        )
+    operation_count = sum(
+        1
+        for operation in operations
+        if isinstance(operation, dict) and operation.get("executable") is True
+    )
+    if operation_count < 1:
+        raise ArtifactTamperedError("PatchPlan에 executable operation이 없습니다")
+
+    candidate_ref = manifest.artifact("candidate_xhtml")
+    return ManifestPushSummary(
+        manifest_path=resolved_path,
+        run_id=manifest.run_id,
+        page_id=manifest.page_id,
+        title=manifest.base_title,
+        base_version=manifest.base_version,
+        candidate_sha256=candidate_ref.sha256,
+        change_count=len(intents),
+        operation_count=operation_count,
+    )
+
+
+def publish_verified_run(
+    page_id: str,
+    config,
+    *,
+    manifest_path: str,
+    runtime: PublishRuntime,
+) -> dict:
+    """검증된 manifest에 결합된 candidate를 한 번만 발행하고 재검증합니다."""
+
+    from reverse_sync.confluence_client import (
+        ConfluenceGateway,
+        VersionConflictError,
+    )
+    from reverse_sync.manifest import load_sync_manifest
+    from reverse_sync.publisher import publish_verified_manifest
+
+    if not manifest_path:
+        raise ValueError("push에는 explicit manifest_path가 필요합니다")
+
+    var_dir = runtime.project_dir / "var" / page_id
+    summary = runtime.load_manifest_summary(manifest_path)
+    resolved_manifest_path = summary.manifest_path
+    manifest = load_sync_manifest(resolved_manifest_path)
+    if manifest.page_id != str(page_id):
+        raise ValueError(
+            f"manifest page ID({manifest.page_id})와 요청 page ID({page_id})가 다릅니다."
+        )
+
+    def semantic_verifier(snapshot, verified_manifest_path: Path) -> bool:
+        improved_ref = manifest.artifact("improved_mdx")
+        expected_mdx = (
+            verified_manifest_path.parent / improved_ref.path
+        ).read_text()
+        persisted_xhtml_path = (
+            verified_manifest_path.parent / "postcondition.xhtml"
+        )
+        persisted_mdx_path = verified_manifest_path.parent / "postcondition.mdx"
+        persisted_xhtml_path.write_text(snapshot.storage_xhtml)
+        runtime.forward_convert(
+            str(persisted_xhtml_path),
+            str(persisted_mdx_path),
+            page_id,
+            language=runtime.detect_language(manifest.improved_descriptor),
+            page_dir=str(var_dir),
+        )
+        actual_mdx = persisted_mdx_path.read_text()
+
+        from reverse_sync.base_parity import verify_source_identity
+
+        identity = verify_source_identity(
+            snapshot,
+            expected_mdx,
+            actual_mdx,
+            require_confluence_url=True,
+        )
+        if not identity.passed:
+            return False
+        return verify_push_equivalence(
+            strip_frontmatter(expected_mdx),
+            strip_frontmatter(actual_mdx),
+        ).passed
+
+    try:
+        receipt = publish_verified_manifest(
+            resolved_manifest_path,
+            ConfluenceGateway(config),
+            semantic_verifier=semantic_verifier,
+        )
+    except VersionConflictError as exc:
+        raise PushConflictError(
+            f"페이지 {page_id} ({manifest.base_title})가 preflight 이후 변경되었습니다. "
+            "최신 snapshot으로 online verify를 다시 실행하세요."
+        ) from exc
+
+    backup_path = var_dir / "reverse-sync.backup.xhtml"
+    var_dir.mkdir(parents=True, exist_ok=True)
+    base_ref = manifest.artifact("base_xhtml")
+    shutil.copy2(resolved_manifest_path.parent / base_ref.path, backup_path)
+
+    return {
+        "page_id": page_id,
+        "status": receipt.status.value,
+        "title": receipt.title,
+        "version": receipt.version,
+        "url": "",
+        "backup": str(backup_path),
+        "manifest_path": str(resolved_manifest_path),
+        "manifest_sha256": receipt.manifest_sha256,
+    }

--- a/confluence-mdx/bin/reverse_sync_cli.py
+++ b/confluence-mdx/bin/reverse_sync_cli.py
@@ -5,10 +5,8 @@
 """
 import argparse
 import json
-import shutil
 import subprocess
 import sys
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Any, List
 
@@ -24,9 +22,13 @@ if str(_SCRIPT_DIR) not in sys.path:
 
 from reverse_sync.batch_report import BatchReport
 from reverse_sync.planner import plan_patches
-from reverse_sync.equivalence import (
-    PUSH_EQUIVALENCE_POLICY,
-    verify_push_equivalence,
+from reverse_sync.equivalence import PUSH_EQUIVALENCE_POLICY
+from reverse_sync.publish_service import (
+    ManifestPushSummary,
+    PublishRuntime,
+    PushConflictError,
+    load_manifest_push_summary,
+    publish_verified_run,
 )
 from reverse_sync.verification_service import (
     MdxSource,
@@ -45,20 +47,6 @@ from reverse_sync.verification_service import (
 
 _PUSH_VERIFIER_POLICY = PUSH_EQUIVALENCE_POLICY
 _TOOL_VERSION = "reverse-sync-cli-v5"
-
-
-@dataclass(frozen=True)
-class ManifestPushSummary:
-    """explicit manifest push의 확인 화면에 필요한 immutable identity."""
-
-    manifest_path: Path
-    run_id: str
-    page_id: str
-    title: str
-    base_version: int
-    candidate_sha256: str
-    change_count: int
-    operation_count: int
 
 
 def _is_valid_git_ref(ref: str) -> bool:
@@ -790,11 +778,6 @@ def _do_verify_batch(branch: str, limit: int = 0, failures_only: bool = False,
     return results
 
 
-class PushConflictError(Exception):
-    """Confluence 페이지 버전 충돌 (409)."""
-    pass
-
-
 def _ensure_confluence_config():
     """Confluence 인증 설정을 확인하고 (config, ) 튜플을 반환한다."""
     from reverse_sync.confluence_client import ConfluenceConfig
@@ -807,136 +790,28 @@ def _ensure_confluence_config():
 
 
 def _load_manifest_push_summary(manifest_path: str) -> ManifestPushSummary:
-    """explicit manifest의 integrity와 typed plan schema를 PUT 전에 검증합니다."""
-    from reverse_sync.manifest import (
-        ArtifactTamperedError,
-        load_sync_manifest,
-        verify_manifest_integrity,
-    )
+    """explicit manifest의 발행 identity와 integrity를 검증합니다."""
 
-    resolved_path = Path(manifest_path).expanduser().resolve()
-    manifest = load_sync_manifest(resolved_path)
-    verify_manifest_integrity(resolved_path, manifest)
-    if not manifest.push_eligible:
-        raise ValueError("push eligible이 아닌 manifest는 발행할 수 없습니다")
-
-    plan_ref = manifest.artifact("patch_plan")
-    try:
-        plan = json.loads((resolved_path.parent / plan_ref.path).read_text())
-    except (OSError, json.JSONDecodeError) as exc:
-        raise ArtifactTamperedError("patch plan JSON을 읽을 수 없습니다") from exc
-    if not isinstance(plan, dict) or plan.get("schema_version") != 2:
-        raise ArtifactTamperedError("explicit push는 PatchPlan schema v2가 필요합니다")
-    if plan.get("intent_complete") is not True:
-        raise ArtifactTamperedError(
-            "intent_complete가 아닌 PatchPlan은 발행할 수 없습니다"
-        )
-    intents = plan.get("intents")
-    operations = plan.get("operations")
-    if not isinstance(intents, list) or not isinstance(operations, list):
-        raise ArtifactTamperedError(
-            "PatchPlan intents/operations 형식이 올바르지 않습니다"
-        )
-    operation_count = sum(
-        1
-        for operation in operations
-        if isinstance(operation, dict) and operation.get("executable") is True
-    )
-    if operation_count < 1:
-        raise ArtifactTamperedError("PatchPlan에 executable operation이 없습니다")
-
-    candidate_ref = manifest.artifact("candidate_xhtml")
-    return ManifestPushSummary(
-        manifest_path=resolved_path,
-        run_id=manifest.run_id,
-        page_id=manifest.page_id,
-        title=manifest.base_title,
-        base_version=manifest.base_version,
-        candidate_sha256=candidate_ref.sha256,
-        change_count=len(intents),
-        operation_count=operation_count,
-    )
+    return load_manifest_push_summary(manifest_path)
 
 
 def _do_push(page_id: str, config=None, *, manifest_path: str):
-    """verified manifest에 결합된 candidate만 안전하게 push한다."""
-    from reverse_sync.confluence_client import ConfluenceGateway, VersionConflictError
-    from reverse_sync.manifest import load_sync_manifest
-    from reverse_sync.publisher import publish_verified_manifest
+    """CLI 환경을 주입하여 immutable manifest publish lifecycle을 실행합니다."""
 
     if config is None:
         config = _ensure_confluence_config()
-
-    if not manifest_path:
-        raise ValueError("push에는 explicit manifest_path가 필요합니다")
-
-    var_dir = _PROJECT_DIR / 'var' / page_id
-    summary = _load_manifest_push_summary(manifest_path)
-    resolved_manifest_path = summary.manifest_path
-    manifest = load_sync_manifest(resolved_manifest_path)
-    if manifest.page_id != str(page_id):
-        raise ValueError(
-            f"manifest page ID({manifest.page_id})와 요청 page ID({page_id})가 다릅니다."
-        )
-
-    def semantic_verifier(snapshot, verified_manifest_path: Path) -> bool:
-        improved_ref = manifest.artifact("improved_mdx")
-        expected_mdx = (
-            verified_manifest_path.parent / improved_ref.path
-        ).read_text()
-        persisted_xhtml_path = verified_manifest_path.parent / "postcondition.xhtml"
-        persisted_mdx_path = verified_manifest_path.parent / "postcondition.mdx"
-        persisted_xhtml_path.write_text(snapshot.storage_xhtml)
-        _forward_convert(
-            str(persisted_xhtml_path),
-            str(persisted_mdx_path),
-            page_id,
-            language=_detect_language(manifest.improved_descriptor),
-            page_dir=str(var_dir),
-        )
-        actual_mdx = persisted_mdx_path.read_text()
-        from reverse_sync.base_parity import verify_source_identity
-
-        identity = verify_source_identity(
-            snapshot,
-            expected_mdx,
-            actual_mdx,
-            require_confluence_url=True,
-        )
-        if not identity.passed:
-            return False
-        return verify_push_equivalence(
-            _strip_frontmatter(expected_mdx),
-            _strip_frontmatter(actual_mdx),
-        ).passed
-
-    try:
-        receipt = publish_verified_manifest(
-            resolved_manifest_path,
-            ConfluenceGateway(config),
-            semantic_verifier=semantic_verifier,
-        )
-    except VersionConflictError as exc:
-        raise PushConflictError(
-            f"페이지 {page_id} ({manifest.base_title})가 preflight 이후 변경되었습니다. "
-            "최신 snapshot으로 online verify를 다시 실행하세요."
-        ) from exc
-
-    backup_path = var_dir / 'reverse-sync.backup.xhtml'
-    var_dir.mkdir(parents=True, exist_ok=True)
-    base_ref = manifest.artifact("base_xhtml")
-    shutil.copy2(resolved_manifest_path.parent / base_ref.path, backup_path)
-
-    return {
-        'page_id': page_id,
-        'status': receipt.status.value,
-        'title': receipt.title,
-        'version': receipt.version,
-        'url': '',
-        'backup': str(backup_path),
-        'manifest_path': str(resolved_manifest_path),
-        'manifest_sha256': receipt.manifest_sha256,
-    }
+    runtime = PublishRuntime(
+        project_dir=_PROJECT_DIR,
+        forward_convert=_forward_convert,
+        detect_language=_detect_language,
+        load_manifest_summary=_load_manifest_push_summary,
+    )
+    return publish_verified_run(
+        page_id,
+        config,
+        manifest_path=manifest_path,
+        runtime=runtime,
+    )
 
 
 def main():

--- a/confluence-mdx/tests/test_reverse_sync_cli.py
+++ b/confluence-mdx/tests/test_reverse_sync_cli.py
@@ -564,6 +564,51 @@ def test_do_push_requires_explicit_manifest_path():
         _do_push("page-with-pointer", config=MagicMock())
 
 
+def test_do_push_delegates_to_publish_service(tmp_path, monkeypatch):
+    """CLI adapter는 환경 의존성만 주입하고 publish lifecycle을 위임합니다."""
+    captured = {}
+    config = object()
+
+    def forward_convert(*args, **kwargs):
+        raise AssertionError("publish service stub에서는 converter를 호출하지 않습니다.")
+
+    def load_summary(manifest_path):
+        raise AssertionError("publish service stub에서는 summary를 읽지 않습니다.")
+
+    def publish_stub(page_id, received_config, **kwargs):
+        captured.update(
+            page_id=page_id,
+            config=received_config,
+            kwargs=kwargs,
+        )
+        return {"status": "delegated"}
+
+    monkeypatch.setattr("reverse_sync_cli._PROJECT_DIR", tmp_path)
+    monkeypatch.setattr("reverse_sync_cli._forward_convert", forward_convert)
+    monkeypatch.setattr(
+        "reverse_sync_cli._load_manifest_push_summary",
+        load_summary,
+    )
+    monkeypatch.setattr("reverse_sync_cli.publish_verified_run", publish_stub)
+
+    result = _do_push(
+        "page-1",
+        config=config,
+        manifest_path="/tmp/run/manifest.json",
+    )
+
+    runtime = captured["kwargs"].pop("runtime")
+    assert result == {"status": "delegated"}
+    assert captured == {
+        "page_id": "page-1",
+        "config": config,
+        "kwargs": {"manifest_path": "/tmp/run/manifest.json"},
+    }
+    assert runtime.project_dir == tmp_path
+    assert runtime.forward_convert is forward_convert
+    assert runtime.load_manifest_summary is load_summary
+
+
 def test_verify_is_dry_run_alias(monkeypatch):
     """verify 커맨드는 push --dry-run과 동일하게 동작한다."""
     mdx_arg = 'src/content/ko/test/page.mdx'

--- a/openspec/changes/complete-reverse-sync/design.md
+++ b/openspec/changes/complete-reverse-sync/design.md
@@ -593,6 +593,7 @@ Confluence update는 외부 side effect이며 postcondition 실패 후 완전한
 | local proof/equivalence | `reverse_sync/proof.py`, `roundtrip_verifier.py` |
 | manifest read/write/integrity | `reverse_sync/manifest.py` |
 | preflight/update/postcondition | `reverse_sync/publisher.py` |
+| manifest publish lifecycle | `reverse_sync/publish_service.py` |
 | CLI orchestration/display | `reverse_sync_cli.py` |
 
 분리는 한 번에 수행하지 않습니다. 먼저 snapshot/manifest/publisher safety seam을

--- a/openspec/changes/complete-reverse-sync/tasks.md
+++ b/openspec/changes/complete-reverse-sync/tasks.md
@@ -131,9 +131,10 @@
   - [x] candidate 준비, roundtrip 검증, local proof/manifest 생성을
     `reverse_sync/verification_service.py`로 분리하고 CLI는 runtime dependency를
     주입하는 호환 adapter만 유지합니다.
-  - [ ] batch 대상 선택, online snapshot 준비, publisher 호출의 state 전환을
-    package service로 분리하고 CLI에는 argument parsing, display, orchestration만
-    유지합니다.
+  - [x] explicit manifest integrity/identity 검증, publisher 호출, semantic
+    postcondition, backup 생성을 `reverse_sync/publish_service.py`로 분리합니다.
+  - [ ] batch 대상 선택과 online snapshot 준비의 state 전환을 package service로
+    분리하고 CLI에는 argument parsing, display, orchestration만 유지합니다.
 - [x] online verify(`push --dry-run`) 출력에 run ID, base version/hash, local gates,
   push eligibility, reason code를 표시합니다.
 - [x] `push`가 explicit run/manifest를 받도록 합니다.


### PR DESCRIPTION
## Summary

immutable manifest 발행 lifecycle을 `reverse_sync_cli.py`에서 package service로 분리합니다.

- manifest integrity와 typed PatchPlan identity 검증을 `publish_service.py`로 이동합니다.
- publisher 호출, semantic postcondition, backup 생성을 하나의 service 경계로 묶습니다.
- 기존 `_load_manifest_push_summary`, `_do_push`, `PushConflictError` 표면은 호환 adapter로 유지합니다.
- OpenSpec에는 완료 범위와 남은 batch/online prepare 분리를 구분해 기록합니다.

## Verification

- `confluence-mdx/venv/bin/pytest -q confluence-mdx/tests` — 1148 passed, 2 skipped
- `openspec validate complete-reverse-sync --strict`
- `git diff --check`

## Stack

- Base: #1046
- 이 PR은 #1046이 merge된 뒤 merge합니다.

🤖 Generated with Codex