### PR TITLE
mdx: 운영 로그 수집 명령을 보완합니다

### DIFF
--- a/src/content/en/support/operational-log-collection-guide.mdx
+++ b/src/content/en/support/operational-log-collection-guide.mdx
@@ -80,9 +80,9 @@ Along with file logs, collect the container's `stdout` and `stderr` logs.
 
 1. Save the app container logs.
 2. If the `tools` profile is running, save the tools logs as well.
-```
+```bash
 mkdir -p support-logs
-docker logs querypie-app-1 > support-logs/app.docker.log
+docker logs querypie-app-1 > support-logs/app.docker.log 2>&1 || true
 docker logs querypie-tools-1 > support-logs/tools.docker.log 2>&1 || true
 ```
 

--- a/src/content/en/support/operational-log-collection-guide.mdx
+++ b/src/content/en/support/operational-log-collection-guide.mdx
@@ -82,7 +82,7 @@ Along with file logs, collect the container's `stdout` and `stderr` logs.
 2. If the `tools` profile is running, save the tools logs as well.
 ```
 mkdir -p support-logs
-docker logs querypie-app-1 > support-logs/app.docker.log 2>&1
+docker logs querypie-app-1 > support-logs/app.docker.log
 docker logs querypie-tools-1 > support-logs/tools.docker.log 2>&1 || true
 ```
 

--- a/src/content/ja/support/operational-log-collection-guide.mdx
+++ b/src/content/ja/support/operational-log-collection-guide.mdx
@@ -80,9 +80,9 @@ tar -czf support-logs/querypie-file-logs.tar.gz /var/log/querypie
 
 1. appコンテナのログを保存します。
 2. `tools` profileが実行中の場合は、toolsログも保存します。
-```
+```bash
 mkdir -p support-logs
-docker logs querypie-app-1 > support-logs/app.docker.log
+docker logs querypie-app-1 > support-logs/app.docker.log 2>&1 || true
 docker logs querypie-tools-1 > support-logs/tools.docker.log 2>&1 || true
 ```
 

--- a/src/content/ja/support/operational-log-collection-guide.mdx
+++ b/src/content/ja/support/operational-log-collection-guide.mdx
@@ -82,7 +82,7 @@ tar -czf support-logs/querypie-file-logs.tar.gz /var/log/querypie
 2. `tools` profileが実行中の場合は、toolsログも保存します。
 ```
 mkdir -p support-logs
-docker logs querypie-app-1 > support-logs/app.docker.log 2>&1
+docker logs querypie-app-1 > support-logs/app.docker.log
 docker logs querypie-tools-1 > support-logs/tools.docker.log 2>&1 || true
 ```
 

--- a/src/content/ko/support/operational-log-collection-guide.mdx
+++ b/src/content/ko/support/operational-log-collection-guide.mdx
@@ -82,7 +82,7 @@ tar -czf support-logs/querypie-file-logs.tar.gz /var/log/querypie
 2. `tools` profile이 실행 중이면 tools 로그도 함께 저장합니다.
 ```
 mkdir -p support-logs
-docker logs querypie-app-1 > support-logs/app.docker.log 2>&1
+docker logs querypie-app-1 > support-logs/app.docker.log
 docker logs querypie-tools-1 > support-logs/tools.docker.log 2>&1 || true
 ```
 

--- a/src/content/ko/support/operational-log-collection-guide.mdx
+++ b/src/content/ko/support/operational-log-collection-guide.mdx
@@ -80,9 +80,9 @@ tar -czf support-logs/querypie-file-logs.tar.gz /var/log/querypie
 
 1. app 컨테이너 로그를 저장합니다.
 2. `tools` profile이 실행 중이면 tools 로그도 함께 저장합니다.
-```
+```bash
 mkdir -p support-logs
-docker logs querypie-app-1 > support-logs/app.docker.log
+docker logs querypie-app-1 > support-logs/app.docker.log 2>&1 || true
 docker logs querypie-tools-1 > support-logs/tools.docker.log 2>&1 || true
 ```
 


### PR DESCRIPTION
## Summary
수정된 Confluence 원문을 기준으로 운영 로그 수집 절차를 KO/EN/JA MDX 문서에 다시 동기화합니다.

- Confluence의 운영 로그 수집 가이드 version 4를 fetch하고 MDX catalog를 재생성합니다.
- container 로그 code block에 `bash` 언어를 지정합니다.
- app 로그 수집 명령을 `docker logs querypie-app-1 > support-logs/app.docker.log 2>&1 || true`로 보완합니다.
- 동일한 code block 변경을 영어와 일본어 문서에 반영합니다.
- 변환 과정에서 발생한 후행 공백 변경은 실제 콘텐츠 변경이 아니므로 제외합니다.

## Test plan
- [x] `venv/bin/python bin/skeleton/cli.py target/en/support/operational-log-collection-guide.mdx`
- [x] `venv/bin/python bin/skeleton/cli.py target/ja/support/operational-log-collection-guide.mdx`
- [x] `venv/bin/python bin/skeleton/cli.py --reset`
- [x] `git diff --check`
- [x] `npm run build`

## Additional notes
- build는 성공했으며 기존 broad file-pattern 및 sitemap Git 조회 `ENOBUFS` 경고가 출력됐습니다.

🤖 Generated with Codex