### PR TITLE
mdx: Kubernetes namespace 정책 안내를 보완합니다

### DIFF
--- a/src/content/en/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-yaml-code-syntax-guide.mdx
+++ b/src/content/en/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-yaml-code-syntax-guide.mdx
@@ -283,8 +283,8 @@ Each action requires `apiGroups`, `resources`, `namespace`, `name`, `verbs` entr
     1. By defining namespaces in actions, you can control allowed target namespaces within the cluster for each resource.
     2. Both wildcards and regular expressions are allowed.
         * `namespace: "*"`
-    3. For resources that do not belong to namespaces other than namespaces, you do not need to write the namespace.
-        1. Examples) `persistentvolumes`, `persistentvolumeclaims`, `serviceaccounts`, `customresourcedefinitions`, `endpoints`, `nodes`, `clusterroles`, `clusterrolebindings`, etc.
+    3. For resources that are not namespace-scoped, you can omit the namespace.
+        1. Examples) `persistentvolumes`, `customresourcedefinitions`, `nodes`, `clusterroles`, `clusterrolebindings`, etc. (resources whose Namespaced value is False in [https://kubernetes.io/docs/reference/kubectl/#resource-types](https://kubernetes.io/docs/reference/kubectl/#resource-types))
 4. `name` : By defining target resource names, you can control based on naming among allowed resources within the cluster.
     1. Both wildcards and regular expressions are allowed.
         * `name: "pods-*"`

--- a/src/content/ja/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-yaml-code-syntax-guide.mdx
+++ b/src/content/ja/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-yaml-code-syntax-guide.mdx
@@ -283,8 +283,8 @@ KubernetesクラスターAPIサーバー内で許可/拒否するResource APIを
     1. ネームスペースをアクションで定義することで、クラスター内の許可対象ネームスペースをリソースごとに制御できます。
     2. ワイルドカードと正規表現の両方を許可します。
         * `namespace: "*"`
-    3. namespaces以外のネームスペースに属さないリソースの場合、該当namespaceを記述しなくても構いません。
-        1. 対象例）`persistentvolumes`、`persistentvolumeclaims`、`serviceaccounts`、`customresourcedefinitions`、`endpoints`、`nodes`、`clusterroles`、`clusterrolebindings`など
+    3. Namespaceに属さないリソースの場合、namespaceを記述する必要はありません。
+        1. 対象例）`persistentvolumes`、`customresourcedefinitions`、`nodes`、`clusterroles`、`clusterrolebindings`など（[https://kubernetes.io/docs/reference/kubectl/#resource-types](https://kubernetes.io/docs/reference/kubectl/#resource-types)でNamespacedがFalseのリソース）
 4. `name` : 対象リソース名を定義して、クラスター内の許可リソースの中からネーミングに基づいて制御が可能です。
     1. ワイルドカードと正規表現の両方を許可します。
         * `name: "pods-*"`

--- a/src/content/ko/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-yaml-code-syntax-guide.mdx
+++ b/src/content/ko/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-yaml-code-syntax-guide.mdx
@@ -283,8 +283,8 @@ O
     1. 네임스페이스를 액션에서 정의하여 클러스터 내 허용 대상 네임스페이스를 리소스별로 제어할 수 있습니다.
     2. 와일드카드와 정규표현식 모두 허용합니다.
         * `namespace: "*"`
-    3. namespaces 외 네임스페이스에 존속되지 않는 리소스의 경우, 해당 namespace를 작성하지 않아도 됩니다.
-        1. 대상 예) `persistentvolumes`, `persistentvolumeclaims`, `serviceaccounts`, `customresourcedefinitions`, `endpoints`, `nodes`, `clusterroles`, `clusterrolebindings` 등
+    3. namespaces 외 네임스페이스에 종속되지 않는 리소스의 경우, 해당 namespace를 작성하지 않아도 됩니다.
+        1. 대상 예) `persistentvolumes`, `customresourcedefinitions`, `nodes`, `clusterroles`, `clusterrolebindings` 등 ([https://kubernetes.io/docs/reference/kubectl/#resource-types](https://kubernetes.io/docs/reference/kubectl/#resource-types) 의 Namespaced 가 False 인 대상)
 4. `name` : 대상 리소스명을 정의하여 클러스터 내 허용 리소스 중 네이밍을 바탕으로 제어가 가능합니다.
     1. 와일드카드와 정규표현식 모두 허용합니다.
         * `name: "pods-*"`


### PR DESCRIPTION
## Summary
Confluence에서 변경된 Kubernetes 정책 YAML 문법 안내를 동기화하고 영어·일본어 문서에도 동일하게 반영합니다.

- namespace에 종속되지 않는 cluster-scoped 리소스 설명을 바로잡습니다.
- 예시에서 namespace-scoped 리소스를 제외합니다.
- Kubernetes 공식 resource-types 링크와 Namespaced 판별 기준을 추가합니다.
- 한국어 변경을 영어와 일본어 문서에 번역하여 동기화합니다.

## Test plan
- [x] Confluence 최근 변경 fetch 및 페이지 544382364 버전 11 → 12 갱신 확인
- [x] 315개 Confluence 문서 전체 변환 성공
- [x] 영어·일본어 Skeleton 비교 통과
- [x] git diff --check 통과
- [x] npm run build 성공
- [x] PR scope gate에서 단일 커밋과 의도한 3개 파일만 포함하는지 확인

## Additional notes
- build 중 기존 Turbopack broad file pattern 경고와 sitemap Git 조회 ENOBUFS 경고가 발생했지만 build는 성공했습니다.

🤖 Generated with Codex